### PR TITLE
feat: harden swig session settlement lifecycle + add swig session demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ With fee sponsorship, the client partially signs (transfer authority only) and t
 
 An interactive playground with a React frontend and Express backend, running against [Surfpool](https://surfpool.run).
 
+- Charge flow demo: `http://localhost:5173/playground`
+- Swig session demo: `http://localhost:5173/swig`
+
 ```bash
 surfpool start
 npm run demo:install
@@ -204,6 +207,10 @@ npm run test:all           # All tests
 ## Spec
 
 This SDK implements the [Solana Charge Intent](https://github.com/tempoxyz/mpp-specs/pull/188) for the [HTTP Payment Authentication Scheme](https://paymentauth.org).
+
+Session method docs and implementation notes:
+
+- [docs/methods/sessions.md](docs/methods/sessions.md)
 
 ## License
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -39,6 +39,9 @@ npm run demo:app
 
 Open http://localhost:5173 in your browser.
 
+- Charge demo: http://localhost:5173/playground
+- Swig session demo: http://localhost:5173/swig
+
 ### Importing a Wallet
 
 In the browser, you can **drag & drop** any Solana keypair JSON file onto the
@@ -77,6 +80,28 @@ on behalf of clients. Clients only pay the transfer amount.
 
 The faucet uses Surfpool's `surfnet_setAccount` and `surfnet_setTokenAccount`
 cheatcodes to give the client 100 SOL + 100 USDC instantly.
+
+## Swig Session Demo
+
+The Swig demo shows session-based API payments with on-chain role enforcement.
+
+Session endpoints:
+
+| Method | Path                           | Cost                  |
+| ------ | ------------------------------ | --------------------- |
+| GET    | `/api/v1/swig/research/:topic` | 0.01 USDC / request   |
+| GET    | `/api/v1/swig/risk/:symbol`    | 0.01 USDC / request   |
+| GET    | `/api/v1/swig/status`          | Free                  |
+
+Flow in the UI:
+
+1. Open `/swig`.
+2. Click **Initialize Swig** to create/fetch a Swig wallet role on-chain.
+3. Send requests repeatedly to watch session open/update events.
+4. Use **Close Session** to submit a close action and settle USDC on-chain.
+
+The client uses `SwigSessionAuthorizer` and creates delegated session keys on-chain.
+The server only accepts `swig_session` mode for these endpoints and verifies close-settlement transactions.
 
 ## How It Works
 

--- a/demo/app/package-lock.json
+++ b/demo/app/package-lock.json
@@ -7,6 +7,8 @@
       "name": "solana-mpp-demo-app",
       "dependencies": {
         "@solana/kit": "^6.4.0",
+        "@swig-wallet/kit": "^1.7.1",
+        "@swig-wallet/lib": "^1.7.1",
         "mppx": "^0.3.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -29,6 +31,8 @@
       },
       "devDependencies": {
         "@solana/kit": "^6.4.0",
+        "@swig-wallet/kit": "^1.7.1",
+        "@swig-wallet/lib": "^1.7.1",
         "@types/node": "^25.5.0",
         "mppx": "^0.3.15",
         "tsx": "^4.19.0",
@@ -36,7 +40,13 @@
       },
       "peerDependencies": {
         "@solana/kit": ">=6.1.0",
+        "@swig-wallet/kit": ">=1.7.0",
         "mppx": ">=0.3.15"
+      },
+      "peerDependenciesMeta": {
+        "@swig-wallet/kit": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -93,7 +103,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2387,6 +2396,2053 @@
         }
       }
     },
+    "node_modules/@swig-wallet/coder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swig-wallet/coder/-/coder-1.7.1.tgz",
+      "integrity": "sha512-A+KtXK4y44iNnY2P9HxLEG2X/8z73Y6eHiHc7UsUjj2OW7GOA7NsGGG+BeeWsphnohGXAbqxhos2LlQTfFgHjQ==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/coder/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swig-wallet/kit/-/kit-1.7.1.tgz",
+      "integrity": "sha512-x3ctB31xjHvDw44N90mfhSiKQEIsWGs+4Epg35ZtDfTUAn8HyjbnjFtvEInfGO4UQ/Ch2ZBQl3KA65RrvulQ3A==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@noble/curves": "^1.8.2",
+        "@solana-program/token": "^0.5.1",
+        "@solana/kit": "^2.1.0",
+        "@swig-wallet/coder": "1.7.1",
+        "@swig-wallet/lib": "1.7.1",
+        "bn.js": "^5.2.2"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/kit/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@swig-wallet/lib/-/lib-1.7.1.tgz",
+      "integrity": "sha512-FJFmJV79ilhSnZ+uEog9O9oLWLbcQZsiJ3YYhlgS1qrVrcmSWU9HneUoAE3/RFBXrj0LIwpPbdn0cuARGH67RQ==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@noble/curves": "^1.8.2",
+        "@noble/hashes": "^1.7.0",
+        "@solana-program/token": "^0.5.1",
+        "@solana/kit": "^2.1.0",
+        "@swig-wallet/coder": "1.7.1",
+        "bn.js": "^5.2.2"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@swig-wallet/lib/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
     "node_modules/@toon-format/toon": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.1.0.tgz",
@@ -2449,8 +4505,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2465,7 +4520,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2541,7 +4595,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2603,6 +4656,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -2647,7 +4706,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3018,7 +5076,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3096,6 +5153,13 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3266,7 +5330,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3372,6 +5435,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -3734,7 +5798,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3837,7 +5900,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3850,7 +5912,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4238,9 +6299,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4315,6 +6374,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -4345,6 +6405,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -4369,6 +6430,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4391,7 +6453,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4487,7 +6548,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4531,7 +6591,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/demo/app/package.json
+++ b/demo/app/package.json
@@ -4,10 +4,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
+    "@swig-wallet/kit": "^1.7.1",
+    "@swig-wallet/lib": "^1.7.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.13.1",

--- a/demo/app/src/App.tsx
+++ b/demo/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Landing from './Landing.js'
+import SwigPlayground from './SwigPlayground.js'
 import WalletSetup from './components/WalletSetup.js'
 import WalletModal from './components/WalletModal.js'
 import CodeBlock from './components/CodeBlock.js'
@@ -291,6 +292,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Landing />} />
       <Route path="/playground" element={<Playground />} />
+      <Route path="/swig" element={<SwigPlayground />} />
     </Routes>
   )
 }

--- a/demo/app/src/Landing.tsx
+++ b/demo/app/src/Landing.tsx
@@ -17,6 +17,10 @@ export default function Landing() {
           <span style={{ ...s.flowStep, color: '#FFD700' }}>{'\u2713'} Access</span>
         </div>
 
+        <div style={s.sessionTag}>
+          Also includes Swig-backed session payments with delegated keys.
+        </div>
+
         <pre style={s.codePreview}>{`// Server: charge 0.001 SOL per request
 const mppx = Mppx.create({
   methods: [solana.charge({ recipient, network: 'devnet' })],
@@ -35,9 +39,14 @@ const response = await mppx.fetch(url)`}</pre>
           <a style={s.link} href="https://github.com/solana-foundation/solana-mpp-sdk" target="_blank" rel="noopener">GitHub</a>
         </div>
 
-        <button style={s.cta} onClick={() => nav('/playground')}>
-          Try the Playground
-        </button>
+        <div style={s.ctaRow}>
+          <button style={s.cta} onClick={() => nav('/playground')}>
+            Try Charge Demo
+          </button>
+          <button style={s.ctaAlt} onClick={() => nav('/swig')}>
+            Try Swig Session Demo
+          </button>
+        </div>
       </div>
     </div>
   )
@@ -90,6 +99,12 @@ const s: Record<string, React.CSSProperties> = {
     fontSize: 14,
     color: '#E0E0E0',
   },
+  sessionTag: {
+    marginTop: -8,
+    marginBottom: 24,
+    color: '#7b83a2',
+    fontSize: 13,
+  },
   codePreview: {
     textAlign: 'left',
     background: '#111',
@@ -115,8 +130,14 @@ const s: Record<string, React.CSSProperties> = {
     margin: '0 8px',
     color: '#333',
   },
-  cta: {
+  ctaRow: {
     marginTop: 24,
+    display: 'flex',
+    justifyContent: 'center',
+    gap: 10,
+    flexWrap: 'wrap',
+  },
+  cta: {
     padding: '14px 32px',
     background: '#9945FF',
     border: 'none',
@@ -127,5 +148,17 @@ const s: Record<string, React.CSSProperties> = {
     fontWeight: 600,
     cursor: 'pointer',
     letterSpacing: 0.5,
+  },
+  ctaAlt: {
+    padding: '14px 22px',
+    background: '#13221d',
+    border: '1px solid #1f5f4c',
+    borderRadius: 10,
+    color: '#14F195',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 14,
+    fontWeight: 600,
+    cursor: 'pointer',
+    letterSpacing: 0.3,
   },
 }

--- a/demo/app/src/SwigPlayground.tsx
+++ b/demo/app/src/SwigPlayground.tsx
@@ -1,0 +1,600 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import WalletSetup from './components/WalletSetup.js'
+import WalletModal from './components/WalletModal.js'
+import CodeBlock from './components/CodeBlock.js'
+import { useWindowWidth } from './hooks.js'
+import { SWIG_ENDPOINTS, buildSwigSnippet, buildSwigUrl } from './swigEndpoints.js'
+import {
+  getSwigSnapshot,
+  initializeSwigWallet,
+  payAndFetchSwigSession,
+  resetSwigDemoState,
+  type SwigStep,
+} from './swigWallet.js'
+import {
+  getBalances,
+  loadSecretKey,
+  requestAirdrop,
+  type Balances,
+} from './wallet.js'
+import type { Kind, LogLine } from './types.js'
+
+export default function SwigPlayground() {
+  const width = useWindowWidth()
+  const compact = width < 980
+
+  const [ready, setReady] = useState(!!loadSecretKey())
+  const [showWallet, setShowWallet] = useState(false)
+  const [balances, setBalances] = useState<Balances | null>(null)
+  const [selectedIdx, setSelectedIdx] = useState(0)
+  const [paramValues, setParamValues] = useState<Record<string, string>>({})
+  const [logs, setLogs] = useState<LogLine[]>([])
+  const [running, setRunning] = useState(false)
+  const [initializing, setInitializing] = useState(false)
+  const [showCode, setShowCode] = useState(false)
+  const [airdropping, setAirdropping] = useState(false)
+  const [requestCount, setRequestCount] = useState(0)
+  const [snapshot, setSnapshot] = useState(getSwigSnapshot())
+
+  const logRef = useRef<HTMLDivElement>(null)
+  const logId = useRef(0)
+
+  const endpoint = SWIG_ENDPOINTS[selectedIdx]
+
+  const refresh = useCallback(async () => {
+    try {
+      setBalances(await getBalances())
+    } catch {
+      setBalances(null)
+    }
+    setSnapshot(getSwigSnapshot())
+  }, [])
+
+  useEffect(() => {
+    if (ready) {
+      refresh()
+    }
+  }, [ready, refresh])
+
+  const addLog = useCallback((text: string, kind: Kind) => {
+    setLogs((prev: LogLine[]) => [...prev, { id: logId.current++, text, kind }])
+    setTimeout(() => logRef.current?.scrollTo(0, logRef.current.scrollHeight), 10)
+  }, [])
+
+  const consumeStep = useCallback(
+    (step: SwigStep) => {
+      switch (step.type) {
+        case 'request':
+          addLog(`GET ${step.url}`, 'req')
+          return
+        case 'setup':
+          addLog(step.message, 'dim')
+          return
+        case 'challenge':
+          addLog(
+            `402 Session challenge (${step.network}) for ${shortAddress(step.recipient)}`,
+            '402',
+          )
+          return
+        case 'opening':
+          addLog(`Opening channel ${step.channelId}`, 'info')
+          return
+        case 'opened':
+          addLog(`Opened channel ${step.channelId}`, 'ok')
+          return
+        case 'updating':
+          addLog(
+            `Updating ${step.channelId} -> cumulative ${step.cumulativeAmount}`,
+            'info',
+          )
+          return
+        case 'updated':
+          addLog(
+            `Updated ${step.channelId} -> cumulative ${step.cumulativeAmount}`,
+            'ok',
+          )
+          return
+        case 'closing':
+          addLog(`Closing channel ${step.channelId}`, 'info')
+          return
+        case 'closed':
+          addLog(`Closed channel ${step.channelId}`, 'ok')
+          return
+        case 'success': {
+          addLog(`${step.status} OK`, 'ok')
+          if (step.receipt) {
+            addLog(`Payment-Receipt: ${step.receipt.slice(0, 80)}...`, 'dim')
+          }
+          addLog(JSON.stringify(step.data, null, 2).slice(0, 600), 'dim')
+          return
+        }
+        case 'error':
+          addLog(`Error: ${step.message}`, 'error')
+          return
+      }
+    },
+    [addLog],
+  )
+
+  const runSessionCall = useCallback(
+    async (options?: { context?: Record<string, unknown> }) => {
+      const url = buildSwigUrl(endpoint, paramValues)
+      setRunning(true)
+
+      for await (const step of payAndFetchSwigSession(url, options)) {
+        consumeStep(step)
+      }
+
+      setRunning(false)
+      setRequestCount((n: number) => n + 1)
+      await refresh()
+    },
+    [consumeStep, endpoint, paramValues, refresh],
+  )
+
+  const handleInitialize = useCallback(async () => {
+    setInitializing(true)
+    try {
+      const next = await initializeSwigWallet()
+      setSnapshot(next)
+      addLog(
+        `Swig wallet initialized at ${shortAddress(next.swigAddress ?? null)}`,
+        'ok',
+      )
+    } catch (err: any) {
+      addLog(`Swig init failed: ${err?.message ?? String(err)}`, 'error')
+    } finally {
+      setInitializing(false)
+    }
+  }, [addLog])
+
+  if (!ready) {
+    return (
+      <WalletSetup
+        onReady={() => {
+          setReady(true)
+          refresh()
+        }}
+      />
+    )
+  }
+
+  const kindColor: Record<Kind, string> = {
+    req: '#9945FF',
+    '402': '#FFD700',
+    ok: '#14F195',
+    error: '#f88',
+    info: '#4FC3F7',
+    dim: '#666',
+  }
+
+  return (
+    <div style={{ ...s.layout, ...(compact ? s.layoutCompact : {}) }}>
+      <aside style={{ ...s.sidebar, ...(compact ? s.sidebarCompact : {}) }}>
+        <div style={s.sidebarHeader}>
+          <div>
+            <div style={s.title}>Swig Session Demo</div>
+            <div style={s.sub}>On-chain role enforced API access</div>
+          </div>
+          <button style={s.walletBtn} onClick={() => setShowWallet(true)}>
+            wallet
+          </button>
+        </div>
+
+        {SWIG_ENDPOINTS.map((entry, index) => (
+          <button
+            key={entry.path}
+            style={{
+              ...s.endpointBtn,
+              background: index === selectedIdx ? '#1A1A2A' : 'transparent',
+              borderColor: index === selectedIdx ? '#9945FF' : '#222',
+            }}
+            onClick={() => {
+              setSelectedIdx(index)
+              setParamValues({})
+            }}
+          >
+            <span style={s.endpointMethod}>{entry.method}</span>
+            <span style={s.endpointDesc}>{entry.description}</span>
+          </button>
+        ))}
+
+        <div style={s.sidebarBottom}>
+          <div style={s.infoCard}>
+            <div style={s.label}>Swig account</div>
+            <div style={s.monoLine}>{shortAddress(snapshot.swigAddress)}</div>
+            <div style={s.labelSecondary}>Swig vault</div>
+            <div style={s.monoLine}>{shortAddress(snapshot.swigWalletAddress)}</div>
+            <div style={s.labelSecondary}>Delegated signer</div>
+            <div style={s.monoLine}>{shortAddress(snapshot.delegatedSessionSigner)}</div>
+            <div style={s.labelSecondary}>Delegated role id</div>
+            <div style={s.monoLine}>{snapshot.delegatedSessionRoleId ?? '--'}</div>
+            <div style={s.labelSecondary}>Spend limit</div>
+            <div style={s.valueAccent}>{snapshot.spendLimitBaseUnits} base units (USDC)</div>
+            <div style={s.labelSecondary}>Channel program</div>
+            <div style={s.monoLine}>{shortAddress(snapshot.channelProgram)}</div>
+            {snapshot.lastChannelId && (
+              <>
+                <div style={s.labelSecondary}>Last channel</div>
+                <div style={s.monoLine}>{shortAddress(snapshot.lastChannelId)}</div>
+              </>
+            )}
+          </div>
+
+          <div style={{ ...s.infoCard, marginTop: 10 }}>
+            <div style={s.label}>Client balances</div>
+            <div style={s.valueAccent}>
+              {balances ? balances.sol.toFixed(4) : '--'} SOL
+            </div>
+            <div style={s.valueMuted}>{balances ? balances.usdc.toFixed(2) : '--'} USDC</div>
+            <button
+              style={s.secondaryBtn}
+              disabled={airdropping}
+              onClick={async () => {
+                setAirdropping(true)
+                try {
+                  await requestAirdrop()
+                  addLog('Faucet funded wallet with 100 SOL + 100 USDC', 'ok')
+                } catch (err: any) {
+                  addLog(`Faucet failed: ${err?.message ?? String(err)}`, 'error')
+                } finally {
+                  setAirdropping(false)
+                  await refresh()
+                }
+              }}
+            >
+              {airdropping ? 'Funding...' : 'Fund wallet'}
+            </button>
+          </div>
+
+          <div style={s.meta}>{requestCount} request{requestCount !== 1 ? 's' : ''}</div>
+        </div>
+      </aside>
+
+      <main style={s.main}>
+        <div style={s.requestPanel}>
+          <div style={s.requestHeader}>
+            <span style={s.endpointMethod}>{endpoint.method}</span>
+            <span style={s.endpointPath}>{endpoint.path}</span>
+            <span style={s.endpointCost}>{endpoint.cost}</span>
+          </div>
+
+          <div style={s.params}>
+            {(endpoint.params ?? []).map((param) => (
+              <div key={param.name} style={s.paramRow}>
+                <label style={s.paramLabel}>{param.name}</label>
+                <input
+                  style={s.input}
+                  value={paramValues[param.name] ?? param.default}
+                  onChange={(event) => {
+                    setParamValues((prev) => ({
+                      ...prev,
+                      [param.name]: event.target.value,
+                    }))
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+
+          <div style={s.actions}>
+            <button
+              style={s.primaryBtn}
+              disabled={running || initializing}
+              onClick={handleInitialize}
+            >
+              {initializing ? 'Initializing...' : 'Initialize Swig'}
+            </button>
+            <button
+              style={s.primaryBtn}
+              disabled={running || initializing}
+              onClick={async () => {
+                await runSessionCall()
+              }}
+            >
+              {running ? 'Running...' : 'Send Session Request'}
+            </button>
+            <button
+              style={s.secondaryBtn}
+              disabled={running || initializing}
+              onClick={async () => {
+                await runSessionCall({ context: { action: 'close' } })
+              }}
+            >
+              Close Session
+            </button>
+            <button
+              style={s.secondaryBtn}
+              disabled={running || initializing}
+              onClick={() => {
+                resetSwigDemoState()
+                setSnapshot(getSwigSnapshot())
+                addLog('Cleared local Swig session state', 'dim')
+              }}
+            >
+              Reset Swig State
+            </button>
+            <button
+              style={s.codeBtn}
+              onClick={() => setShowCode((prev) => !prev)}
+            >
+              {'</>'}
+            </button>
+          </div>
+
+          {showCode && (
+            <div style={s.codePane}>
+              <CodeBlock code={buildSwigSnippet(endpoint, paramValues)} />
+            </div>
+          )}
+        </div>
+
+        <div ref={logRef} style={s.terminal}>
+          {logs.length === 0 && (
+            <div style={s.emptyLog}>
+              Initialize Swig and send a request to observe open and update events.
+            </div>
+          )}
+          {logs.map((line) => (
+            <div
+              key={line.id}
+              style={{
+                padding: '2px 16px',
+                fontSize: 12,
+                color: kindColor[line.kind],
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              {line.text}
+            </div>
+          ))}
+        </div>
+      </main>
+
+      {showWallet && (
+        <WalletModal
+          onClose={() => setShowWallet(false)}
+          onReset={() => {
+            resetSwigDemoState()
+            setReady(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function shortAddress(value: string | null): string {
+  if (!value) {
+    return '(not set)'
+  }
+  return `${value.slice(0, 8)}...${value.slice(-6)}`
+}
+
+const s: Record<string, React.CSSProperties> = {
+  layout: {
+    display: 'flex',
+    minHeight: '100vh',
+    background: '#0A0A0A',
+  },
+  layoutCompact: {
+    flexDirection: 'column',
+  },
+  sidebar: {
+    width: 320,
+    borderRight: '1px solid #222',
+    display: 'flex',
+    flexDirection: 'column',
+    background: '#0D0D0D',
+  },
+  sidebarCompact: {
+    width: '100%',
+    borderRight: 'none',
+    borderBottom: '1px solid #222',
+  },
+  sidebarHeader: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+    padding: 16,
+    borderBottom: '1px solid #222',
+  },
+  title: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 700,
+  },
+  sub: {
+    color: '#777',
+    fontSize: 11,
+    marginTop: 4,
+  },
+  walletBtn: {
+    padding: '4px 10px',
+    background: '#14F19522',
+    border: '1px solid #14F19544',
+    borderRadius: 6,
+    color: '#14F195',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 11,
+    cursor: 'pointer',
+  },
+  endpointBtn: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    width: '100%',
+    padding: '10px 16px',
+    border: '1px solid #222',
+    borderWidth: '0 0 1px',
+    fontFamily: 'JetBrains Mono, monospace',
+    cursor: 'pointer',
+    color: '#ddd',
+    textAlign: 'left',
+  },
+  endpointMethod: {
+    color: '#14F195',
+    fontSize: 10,
+    letterSpacing: 0.5,
+  },
+  endpointDesc: {
+    color: '#bbb',
+    fontSize: 12,
+  },
+  sidebarBottom: {
+    marginTop: 'auto',
+    padding: 12,
+    borderTop: '1px solid #222',
+  },
+  infoCard: {
+    padding: 10,
+    border: '1px solid #1D1D1D',
+    borderRadius: 8,
+    background: '#0B0B0B',
+  },
+  label: {
+    color: '#666',
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  labelSecondary: {
+    color: '#555',
+    fontSize: 9,
+    marginTop: 8,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  monoLine: {
+    color: '#9dc4ff',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 11,
+    marginTop: 3,
+  },
+  valueAccent: {
+    color: '#14F195',
+    fontSize: 12,
+    fontWeight: 600,
+    marginTop: 3,
+  },
+  valueMuted: {
+    color: '#888',
+    fontSize: 12,
+    marginTop: 3,
+  },
+  meta: {
+    color: '#555',
+    fontSize: 10,
+    marginTop: 10,
+  },
+  main: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+  },
+  requestPanel: {
+    borderBottom: '1px solid #222',
+    background: '#0D0D0D',
+  },
+  requestHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '12px 16px',
+    borderBottom: '1px solid #1d1d1d',
+  },
+  endpointPath: {
+    color: '#ddd',
+    fontSize: 12,
+    fontFamily: 'JetBrains Mono, monospace',
+  },
+  endpointCost: {
+    color: '#777',
+    fontSize: 11,
+    marginLeft: 'auto',
+  },
+  params: {
+    padding: '12px 16px 6px',
+  },
+  paramRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  paramLabel: {
+    color: '#888',
+    minWidth: 70,
+    fontSize: 12,
+    textTransform: 'lowercase',
+  },
+  input: {
+    flex: 1,
+    height: 32,
+    padding: '0 10px',
+    borderRadius: 6,
+    border: '1px solid #2a2a2a',
+    background: '#111',
+    color: '#ddd',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 12,
+    outline: 'none',
+  },
+  actions: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 8,
+    padding: '0 16px 12px',
+  },
+  primaryBtn: {
+    padding: '8px 12px',
+    borderRadius: 6,
+    border: '1px solid #9945FF55',
+    background: '#9945FF22',
+    color: '#eee',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 11,
+    cursor: 'pointer',
+  },
+  secondaryBtn: {
+    padding: '8px 12px',
+    borderRadius: 6,
+    border: '1px solid #2c2c2c',
+    background: '#151515',
+    color: '#bbb',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 11,
+    cursor: 'pointer',
+  },
+  codeBtn: {
+    padding: '8px 10px',
+    borderRadius: 6,
+    border: '1px solid #2c2c2c',
+    background: '#111',
+    color: '#aaa',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 12,
+    cursor: 'pointer',
+  },
+  codePane: {
+    borderTop: '1px solid #1d1d1d',
+    background: '#0A0A0A',
+    maxHeight: 260,
+    overflow: 'auto',
+  },
+  terminal: {
+    flex: 1,
+    background: '#060606',
+    overflow: 'auto',
+    fontFamily: 'JetBrains Mono, monospace',
+    padding: '8px 0',
+  },
+  emptyLog: {
+    color: '#444',
+    padding: 16,
+    fontSize: 12,
+  },
+}

--- a/demo/app/src/swigEndpoints.ts
+++ b/demo/app/src/swigEndpoints.ts
@@ -1,0 +1,69 @@
+import type { Endpoint } from './types.js'
+
+export const SWIG_ENDPOINTS: Endpoint[] = [
+  {
+    method: 'GET',
+    path: '/api/v1/swig/research/:topic',
+    description: 'Session-backed research capsule',
+    cost: '0.01 USDC / request',
+    params: [{ name: 'topic', default: 'solana-payments' }],
+  },
+  {
+    method: 'GET',
+    path: '/api/v1/swig/risk/:symbol',
+    description: 'Session-backed risk snapshot',
+    cost: '0.01 USDC / request',
+    params: [{ name: 'symbol', default: 'SOL' }],
+  },
+]
+
+export function buildSwigUrl(
+  endpoint: Endpoint,
+  paramValues: Record<string, string>,
+): string {
+  let url = endpoint.path
+  const queryParams: string[] = []
+
+  for (const param of endpoint.params ?? []) {
+    const value = paramValues[param.name] || param.default
+    if (url.includes(`:${param.name}`)) {
+      url = url.replace(`:${param.name}`, encodeURIComponent(value))
+    } else {
+      queryParams.push(`${param.name}=${encodeURIComponent(value)}`)
+    }
+  }
+
+  if (queryParams.length) url += `?${queryParams.join('&')}`
+  return url
+}
+
+export function buildSwigSnippet(
+  endpoint: Endpoint,
+  paramValues: Record<string, string>,
+): string {
+  const url = buildSwigUrl(endpoint, paramValues)
+
+  return `import { Mppx, solana } from 'solana-mpp-sdk/client'
+import { SwigSessionAuthorizer } from 'solana-mpp-sdk'
+
+// 1) Create/fetch Swig role + delegated session key on-chain
+// 2) Wire adapter into SwigSessionAuthorizer
+const authorizer = new SwigSessionAuthorizer({
+  wallet: swigWalletAdapter,
+  policy: {
+    profile: 'swig-time-bound',
+    ttlSeconds: 180,
+    spendLimit: '30000',
+    depositLimit: '30000',
+  },
+  rpcUrl: 'http://localhost:8899',
+  allowedPrograms: ['swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB'],
+})
+
+const method = solana.session({ signer, authorizer })
+const mppx = Mppx.create({ methods: [method] })
+
+const response = await mppx.fetch('${url}')
+const data = await response.json()
+console.log(data)`
+}

--- a/demo/app/src/swigWallet.ts
+++ b/demo/app/src/swigWallet.ts
@@ -1,0 +1,862 @@
+import {
+  address,
+  appendTransactionMessageInstructions,
+  createSolanaRpc,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+  type Instruction,
+  type KeyPairSigner,
+} from '@solana/kit'
+import { getTransferSolInstruction } from '@solana-program/system'
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getTransferCheckedInstruction,
+} from '@solana-program/token'
+import { Mppx, solana } from 'solana-mpp-sdk/client'
+import { SwigSessionAuthorizer } from 'solana-mpp-sdk'
+import {
+  getAddAuthorityInstructions,
+  fetchSwig,
+  findSwigPda,
+  getCreateSessionInstructions,
+  getCreateSwigInstruction,
+  getRemoveAuthorityInstructions,
+  getSignInstructions,
+  getSwigWalletAddress,
+  SWIG_PROGRAM_ADDRESS,
+} from '@swig-wallet/kit'
+import {
+  Actions,
+  createEd25519AuthorityInfo,
+  createEd25519SessionAuthorityInfo,
+} from '@swig-wallet/lib'
+import { getSigner } from './wallet.js'
+
+const RPC_URL = 'http://localhost:8899'
+const SESSION_CHANNEL_PROGRAM = SWIG_PROGRAM_ADDRESS
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const USDC_DECIMALS = 6
+const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+const DEFAULT_SPEND_LIMIT_BASE_UNITS = 30_000n
+const DEFAULT_SOL_LIMIT_LAMPORTS = 1_000_000_000n
+const DEFAULT_SESSION_TTL_SECONDS = 180
+const MANAGER_ROLE_ID = 0
+const SESSION_SIGNER_FEE_BUFFER_LAMPORTS = 5_000_000n
+
+const STORAGE_SWIG_ADDRESS = 'solana-mpp-demo:swig-address'
+const STORAGE_SWIG_LIMIT = 'solana-mpp-demo:swig-limit'
+
+type SwigSessionProgressEvent =
+  | { type: 'challenge'; recipient: string; network: string; asset: { kind: 'sol' | 'spl'; mint?: string; decimals: number; symbol?: string } }
+  | { type: 'opening'; channelId: string }
+  | { type: 'opened'; channelId: string }
+  | { type: 'updating'; channelId: string; cumulativeAmount: string }
+  | { type: 'updated'; channelId: string; cumulativeAmount: string }
+  | { type: 'closing'; channelId: string }
+  | { type: 'closed'; channelId: string }
+
+type DelegatedSessionState = {
+  signer: KeyPairSigner
+  openTx: string
+  swigRoleId: number
+  createdAtMs: number
+}
+
+type RuntimeState = {
+  swigAddress: string | null
+  swigWalletAddress: string | null
+  spendLimitBaseUnits: bigint
+  delegatedSession: DelegatedSessionState | null
+  lastChannelId: string | null
+}
+
+export type SwigSnapshot = {
+  swigAddress: string | null
+  swigWalletAddress: string | null
+  spendLimitBaseUnits: string
+  delegatedSessionSigner: string | null
+  delegatedSessionRoleId: number | null
+  lastChannelId: string | null
+  channelProgram: string
+}
+
+export type SwigStep =
+  | { type: 'request'; url: string }
+  | { type: 'setup'; message: string }
+  | SwigSessionProgressEvent
+  | { type: 'success'; data: unknown; status: number; receipt?: string }
+  | { type: 'error'; message: string }
+
+const runtime: RuntimeState = {
+  swigAddress: localStorage.getItem(STORAGE_SWIG_ADDRESS),
+  swigWalletAddress: null,
+  spendLimitBaseUnits:
+    readStoredBigInt(STORAGE_SWIG_LIMIT) ?? DEFAULT_SPEND_LIMIT_BASE_UNITS,
+  delegatedSession: null,
+  lastChannelId: null,
+}
+
+const channelDeposits = new Map<string, bigint>()
+
+let mppxInstance: ReturnType<typeof Mppx.create> | null = null
+let mppxSignerAddress: string | null = null
+let progressCallback: ((step: SwigStep) => void) | null = null
+
+export function getSwigSnapshot(): SwigSnapshot {
+  return {
+    swigAddress: runtime.swigAddress,
+    swigWalletAddress: runtime.swigWalletAddress,
+    spendLimitBaseUnits: runtime.spendLimitBaseUnits.toString(),
+    delegatedSessionSigner: runtime.delegatedSession?.signer.address ?? null,
+    delegatedSessionRoleId: runtime.delegatedSession?.swigRoleId ?? null,
+    lastChannelId: runtime.lastChannelId,
+    channelProgram: SESSION_CHANNEL_PROGRAM,
+  }
+}
+
+export async function initializeSwigWallet(
+  spendLimitBaseUnits: bigint = runtime.spendLimitBaseUnits,
+): Promise<SwigSnapshot> {
+  await ensureSwigWallet(spendLimitBaseUnits)
+  return getSwigSnapshot()
+}
+
+export function resetSwigDemoState() {
+  runtime.swigAddress = null
+  runtime.swigWalletAddress = null
+  runtime.delegatedSession = null
+  runtime.lastChannelId = null
+  runtime.spendLimitBaseUnits = DEFAULT_SPEND_LIMIT_BASE_UNITS
+
+  localStorage.removeItem(STORAGE_SWIG_ADDRESS)
+  localStorage.removeItem(STORAGE_SWIG_LIMIT)
+
+  channelDeposits.clear()
+  mppxInstance = null
+  mppxSignerAddress = null
+}
+
+export async function* payAndFetchSwigSession(
+  url: string,
+  options?: { context?: Record<string, unknown> },
+): AsyncGenerator<SwigStep> {
+  yield { type: 'request', url }
+
+  const queue: SwigStep[] = []
+  let resolve: (() => void) | null = null
+  let closedChannelDuringRequest = false
+
+  progressCallback = (step) => {
+    if (step.type === 'closed') {
+      closedChannelDuringRequest = true
+    }
+
+    queue.push(step)
+    resolve?.()
+  }
+
+  try {
+    if (!runtime.swigAddress) {
+      queue.push({
+        type: 'setup',
+        message: 'Initializing Swig role on-chain...',
+      })
+    }
+
+    const mppx = await getSwigMppx()
+
+    queue.push({
+      type: 'setup',
+      message: `Swig ready: ${shortAddress(runtime.swigAddress)}`,
+    })
+
+    const fetchPromise: Promise<Response> = mppx.fetch(url, options as any)
+
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!
+        continue
+      }
+
+      const result = await Promise.race([
+        fetchPromise.then((response) => ({ done: true as const, response })),
+        new Promise<{ done: false }>((r) => {
+          resolve = () => r({ done: false })
+        }),
+      ])
+
+      if (!result.done) {
+        continue
+      }
+
+      while (queue.length > 0) {
+        yield queue.shift()!
+      }
+
+      const receipt = result.response.headers.get('payment-receipt') ?? undefined
+
+      const rawBody = await result.response.text()
+      let data: unknown = rawBody
+
+      if (closedChannelDuringRequest && result.response.ok) {
+        await recycleSessionRoleAfterSuccessfulClose()
+      }
+
+      if (rawBody.length === 0) {
+        data = null
+      } else {
+        try {
+          data = JSON.parse(rawBody)
+        } catch {
+          data = rawBody
+        }
+      }
+
+      yield {
+        type: 'success',
+        data,
+        status: result.response.status,
+        receipt,
+      }
+      return
+    }
+  } catch (err: any) {
+    yield { type: 'error', message: err?.message ?? String(err) }
+  } finally {
+    progressCallback = null
+  }
+}
+
+async function recycleSessionRoleAfterSuccessfulClose() {
+  const sessionRoleId = runtime.delegatedSession?.swigRoleId
+
+  try {
+    if (sessionRoleId !== undefined) {
+      await removeSessionRole(sessionRoleId)
+    }
+  } finally {
+    runtime.delegatedSession = null
+    runtime.lastChannelId = null
+    channelDeposits.clear()
+    mppxInstance = null
+    mppxSignerAddress = null
+  }
+}
+
+async function getSwigMppx() {
+  const rootSigner = await getSigner()
+
+  if (mppxInstance && mppxSignerAddress === rootSigner.address) {
+    return mppxInstance
+  }
+
+  if (!runtime.swigAddress) {
+    await ensureSwigWallet(runtime.spendLimitBaseUnits)
+  }
+
+  const buildOpenTx = async (input: any) => {
+    const depositAmount = parseNonNegativeBaseUnits(
+      input.depositAmount,
+      'open.depositAmount',
+    )
+
+    const swigWalletAddress = await ensureSwigWalletAddress()
+    const [sourceAta, destinationAta] = await Promise.all([
+      findUsdcAta(rootSigner.address),
+      findUsdcAta(swigWalletAddress),
+    ])
+
+    const rpc = createSolanaRpc(RPC_URL)
+    const signature = await sendInstructions({
+      rpc,
+      feePayer: rootSigner,
+      instructions: [
+        getCreateAssociatedTokenIdempotentInstruction({
+          payer: rootSigner,
+          ata: address(destinationAta),
+          owner: address(swigWalletAddress),
+          mint: address(USDC_MINT),
+          tokenProgram: address(TOKEN_PROGRAM),
+        }),
+        getTransferCheckedInstruction(
+          {
+            source: address(sourceAta),
+            mint: address(USDC_MINT),
+            destination: address(destinationAta),
+            authority: rootSigner,
+            amount: depositAmount,
+            decimals: USDC_DECIMALS,
+          },
+          {
+            programAddress: address(TOKEN_PROGRAM),
+          },
+        ),
+      ],
+    })
+
+    channelDeposits.set(input.channelId, depositAmount)
+    return signature
+  }
+
+  const buildTopupTx = async (input: any) => {
+    const additionalAmount = parseNonNegativeBaseUnits(
+      input.additionalAmount,
+      'topup.additionalAmount',
+    )
+
+    const swigWalletAddress = await ensureSwigWalletAddress()
+    const [sourceAta, destinationAta] = await Promise.all([
+      findUsdcAta(rootSigner.address),
+      findUsdcAta(swigWalletAddress),
+    ])
+
+    const rpc = createSolanaRpc(RPC_URL)
+    const signature = await sendInstructions({
+      rpc,
+      feePayer: rootSigner,
+      instructions: [
+        getCreateAssociatedTokenIdempotentInstruction({
+          payer: rootSigner,
+          ata: address(destinationAta),
+          owner: address(swigWalletAddress),
+          mint: address(USDC_MINT),
+          tokenProgram: address(TOKEN_PROGRAM),
+        }),
+        getTransferCheckedInstruction(
+          {
+            source: address(sourceAta),
+            mint: address(USDC_MINT),
+            destination: address(destinationAta),
+            authority: rootSigner,
+            amount: additionalAmount,
+            decimals: USDC_DECIMALS,
+          },
+          {
+            programAddress: address(TOKEN_PROGRAM),
+          },
+        ),
+      ],
+    })
+
+    const deposited = channelDeposits.get(input.channelId) ?? 0n
+    channelDeposits.set(input.channelId, deposited + additionalAmount)
+    return signature
+  }
+
+  const buildCloseTx = async (input: any) => {
+    const delegatedSession = runtime.delegatedSession
+    if (!delegatedSession) {
+      throw new Error('No delegated session signer is available to settle close')
+    }
+
+    const swigAddress = runtime.swigAddress
+    if (!swigAddress) {
+      throw new Error('Swig wallet is not initialized')
+    }
+
+    const swigWalletAddress = await ensureSwigWalletAddress()
+    const finalCumulativeAmount = parseNonNegativeBaseUnits(
+      input.finalCumulativeAmount,
+      'close.finalCumulativeAmount',
+    )
+    const deposited = channelDeposits.get(input.channelId) ?? finalCumulativeAmount
+
+    if (finalCumulativeAmount > deposited) {
+      throw new Error(
+        `Close settlement exceeds channel deposit (${deposited.toString()})`,
+      )
+    }
+
+    const [swigUsdcAta, recipientUsdcAta, payerUsdcAta] = await Promise.all([
+      findUsdcAta(swigWalletAddress),
+      findUsdcAta(input.recipient),
+      findUsdcAta(rootSigner.address),
+    ])
+
+    const refundAmount = deposited - finalCumulativeAmount
+    const innerInstructions: any[] = [
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer: delegatedSession.signer,
+        ata: address(recipientUsdcAta),
+        owner: address(input.recipient),
+        mint: address(USDC_MINT),
+        tokenProgram: address(TOKEN_PROGRAM),
+      }),
+      getTransferCheckedInstruction(
+        {
+          source: address(swigUsdcAta),
+          mint: address(USDC_MINT),
+          destination: address(recipientUsdcAta),
+          authority: address(swigWalletAddress) as any,
+          amount: finalCumulativeAmount,
+          decimals: USDC_DECIMALS,
+        },
+        {
+          programAddress: address(TOKEN_PROGRAM),
+        },
+      ),
+    ]
+
+    if (refundAmount > 0n) {
+      innerInstructions.push(
+        getCreateAssociatedTokenIdempotentInstruction({
+          payer: delegatedSession.signer,
+          ata: address(payerUsdcAta),
+          owner: address(rootSigner.address),
+          mint: address(USDC_MINT),
+          tokenProgram: address(TOKEN_PROGRAM),
+        }),
+        getTransferCheckedInstruction(
+          {
+            source: address(swigUsdcAta),
+            mint: address(USDC_MINT),
+            destination: address(payerUsdcAta),
+            authority: address(swigWalletAddress) as any,
+            amount: refundAmount,
+            decimals: USDC_DECIMALS,
+          },
+          {
+            programAddress: address(TOKEN_PROGRAM),
+          },
+        ),
+      )
+    }
+
+    const rpc = createSolanaRpc(RPC_URL)
+    const swig = await (fetchSwig as any)(rpc, swigAddress)
+    const signInstructions = await getSignInstructions(
+      swig,
+      delegatedSession.swigRoleId,
+      innerInstructions as any,
+      false,
+      {
+        payer: delegatedSession.signer.address,
+      },
+    )
+
+    const signature = await sendInstructions({
+      rpc,
+      feePayer: delegatedSession.signer,
+      instructions: signInstructions,
+    })
+
+    channelDeposits.delete(input.channelId)
+    return signature
+  }
+
+  const walletAdapter = {
+    address: rootSigner.address,
+    swigAddress: runtime.swigAddress ?? undefined,
+    swigRoleId: runtime.delegatedSession?.swigRoleId,
+    getSessionKey: async () => {
+      if (!runtime.delegatedSession) {
+        return null
+      }
+
+      return {
+        signer: runtime.delegatedSession.signer,
+        openTx: runtime.delegatedSession.openTx,
+        swigRoleId: runtime.delegatedSession.swigRoleId,
+        createdAt: runtime.delegatedSession.createdAtMs,
+      }
+    },
+    createSessionKey: async ({ ttlSeconds }: { ttlSeconds: number }) => {
+      const delegated = await createDelegatedSession(ttlSeconds)
+      walletAdapter.swigAddress = runtime.swigAddress ?? undefined
+      walletAdapter.swigRoleId = delegated.swigRoleId
+
+      return {
+        signer: delegated.signer,
+        openTx: delegated.openTx,
+        swigRoleId: delegated.swigRoleId,
+        createdAt: delegated.createdAtMs,
+      }
+    },
+  }
+
+  const authorizer = new SwigSessionAuthorizer({
+    wallet: walletAdapter,
+    policy: {
+      profile: 'swig-time-bound',
+      ttlSeconds: DEFAULT_SESSION_TTL_SECONDS,
+      spendLimit: runtime.spendLimitBaseUnits.toString(),
+      depositLimit: runtime.spendLimitBaseUnits.toString(),
+    },
+    rpcUrl: RPC_URL,
+    swigModule: {
+      fetchSwig: fetchSwig as any,
+    },
+    allowedPrograms: [SESSION_CHANNEL_PROGRAM],
+    buildOpenTx,
+    buildTopupTx,
+    buildCloseTx,
+  })
+
+  const method = solana.session({
+    signer: rootSigner,
+    authorizer,
+    autoOpen: true,
+    autoTopup: false,
+    settleOnLimitHit: true,
+    onProgress(event: SwigSessionProgressEvent) {
+      if ('channelId' in event) {
+        runtime.lastChannelId = event.channelId
+      }
+      progressCallback?.(event)
+    },
+  })
+
+  mppxInstance = Mppx.create({ methods: [method] })
+  mppxSignerAddress = rootSigner.address
+
+  return mppxInstance
+}
+
+async function ensureSwigWallet(spendLimitBaseUnits: bigint): Promise<string> {
+  const rootSigner = await getSigner()
+  const rpc = createSolanaRpc(RPC_URL)
+
+  if (runtime.swigAddress) {
+    try {
+      const existingSwig = await (fetchSwig as any)(rpc, runtime.swigAddress)
+
+      const managerRole = existingSwig.findRoleById?.(MANAGER_ROLE_ID)
+      if (!managerRole) {
+        throw new Error('Swig manager role is missing')
+      }
+
+      if (managerRole?.isSessionBased?.()) {
+        throw new Error('Legacy Swig manager role is session-based')
+      }
+
+      runtime.swigWalletAddress = await getSwigWalletAddress(existingSwig)
+      runtime.spendLimitBaseUnits = spendLimitBaseUnits
+      localStorage.setItem(STORAGE_SWIG_LIMIT, spendLimitBaseUnits.toString())
+      return runtime.swigAddress
+    } catch {
+      runtime.swigAddress = null
+      runtime.swigWalletAddress = null
+      runtime.delegatedSession = null
+      runtime.lastChannelId = null
+      channelDeposits.clear()
+      localStorage.removeItem(STORAGE_SWIG_ADDRESS)
+    }
+  }
+
+  const swigId = crypto.getRandomValues(new Uint8Array(32))
+  const createSwigIx = await getCreateSwigInstruction({
+    payer: rootSigner.address,
+    id: swigId,
+    actions: Actions.set().manageAuthority().get(),
+    authorityInfo: createEd25519AuthorityInfo(rootSigner.address),
+  })
+
+  await sendInstructions({
+    rpc,
+    feePayer: rootSigner,
+    instructions: [createSwigIx],
+  })
+
+  const swigAddress = await findSwigPda(swigId)
+  const swig = await (fetchSwig as any)(rpc, swigAddress)
+  const swigWalletAddress = await getSwigWalletAddress(swig)
+
+  runtime.swigAddress = swigAddress
+  runtime.swigWalletAddress = swigWalletAddress
+  runtime.spendLimitBaseUnits = spendLimitBaseUnits
+  runtime.delegatedSession = null
+  runtime.lastChannelId = null
+  channelDeposits.clear()
+
+  localStorage.setItem(STORAGE_SWIG_ADDRESS, swigAddress)
+  localStorage.setItem(STORAGE_SWIG_LIMIT, spendLimitBaseUnits.toString())
+
+  mppxInstance = null
+  mppxSignerAddress = null
+
+  return swigAddress
+}
+
+async function ensureSwigWalletAddress(): Promise<string> {
+  if (!runtime.swigAddress) {
+    await ensureSwigWallet(runtime.spendLimitBaseUnits)
+  }
+
+  if (runtime.swigWalletAddress) {
+    return runtime.swigWalletAddress
+  }
+
+  const swigAddress = runtime.swigAddress
+  if (!swigAddress) {
+    throw new Error('Swig wallet is not initialized')
+  }
+
+  const rpc = createSolanaRpc(RPC_URL)
+  const swig = await (fetchSwig as any)(rpc, swigAddress)
+  const swigWalletAddress = await getSwigWalletAddress(swig)
+  runtime.swigWalletAddress = swigWalletAddress
+  return swigWalletAddress
+}
+
+async function removeSessionRole(roleId: number): Promise<void> {
+  if (roleId === MANAGER_ROLE_ID) {
+    throw new Error('Refusing to remove the Swig manager role')
+  }
+
+  const swigAddress = runtime.swigAddress
+  if (!swigAddress) {
+    return
+  }
+
+  const rootSigner = await getSigner()
+  const rpc = createSolanaRpc(RPC_URL)
+  const swig = await (fetchSwig as any)(rpc, swigAddress)
+
+  if (!swig.findRoleById?.(roleId)) {
+    return
+  }
+
+  const removeRoleInstructions = await getRemoveAuthorityInstructions(
+    swig,
+    MANAGER_ROLE_ID,
+    roleId,
+  )
+
+  await sendInstructions({
+    rpc,
+    feePayer: rootSigner,
+    instructions: removeRoleInstructions,
+  })
+}
+
+function buildDelegatedRoleActions(spendLimitBaseUnits: bigint) {
+  return Actions.set()
+    .programAll()
+    .solLimit({ amount: DEFAULT_SOL_LIMIT_LAMPORTS })
+    .tokenLimit({
+      mint: USDC_MINT,
+      amount: spendLimitBaseUnits,
+    })
+    .get()
+}
+
+async function createSessionRole(parameters: {
+  rpc: ReturnType<typeof createSolanaRpc>
+  swigAddress: string
+  rootSigner: KeyPairSigner
+  ttlSeconds: number
+  spendLimitBaseUnits: bigint
+}): Promise<number> {
+  const { rpc, swigAddress, rootSigner, ttlSeconds, spendLimitBaseUnits } =
+    parameters
+
+  const swigBefore = await (fetchSwig as any)(rpc, swigAddress)
+  const existingRoleIds = new Set<number>(
+    (swigBefore.roles as Array<{ id: number }>).map((role) => role.id),
+  )
+
+  const addRoleInstructions = await getAddAuthorityInstructions(
+    swigBefore,
+    MANAGER_ROLE_ID,
+    createEd25519SessionAuthorityInfo(rootSigner.address, BigInt(ttlSeconds)),
+    buildDelegatedRoleActions(spendLimitBaseUnits),
+  )
+
+  await sendInstructions({
+    rpc,
+    feePayer: rootSigner,
+    instructions: addRoleInstructions,
+  })
+
+  const swigAfter = await (fetchSwig as any)(rpc, swigAddress)
+  const addedRole = (swigAfter.roles as Array<{ id: number }>).find(
+    (role) => !existingRoleIds.has(role.id),
+  )
+
+  if (!addedRole) {
+    throw new Error('Unable to locate the newly added delegated Swig role')
+  }
+
+  return addedRole.id
+}
+
+async function createDelegatedSession(ttlSeconds: number): Promise<DelegatedSessionState> {
+  const rootSigner = await getSigner()
+  const swigAddress = await ensureSwigWallet(runtime.spendLimitBaseUnits)
+  const rpc = createSolanaRpc(RPC_URL)
+
+  const swigRoleId = await createSessionRole({
+    rpc,
+    swigAddress,
+    rootSigner,
+    ttlSeconds,
+    spendLimitBaseUnits: runtime.spendLimitBaseUnits,
+  })
+
+  const swig = await (fetchSwig as any)(rpc, swigAddress)
+  const delegatedSigner = await generateKeyPairSigner()
+  const createSessionInstructions = await getCreateSessionInstructions(
+    swig,
+    swigRoleId,
+    delegatedSigner.address,
+    BigInt(ttlSeconds),
+  )
+
+  const openTx = await sendInstructions({
+    rpc,
+    feePayer: rootSigner,
+    instructions: createSessionInstructions,
+  })
+
+  await sendInstructions({
+    rpc,
+    feePayer: rootSigner,
+    instructions: [
+      getTransferSolInstruction({
+        source: rootSigner,
+        destination: address(delegatedSigner.address),
+        amount: SESSION_SIGNER_FEE_BUFFER_LAMPORTS,
+      }),
+    ],
+  })
+
+  const delegatedSession = {
+    signer: delegatedSigner,
+    openTx,
+    swigRoleId,
+    createdAtMs: Date.now(),
+  }
+
+  runtime.delegatedSession = delegatedSession
+
+  return delegatedSession
+}
+
+async function sendInstructions(parameters: {
+  rpc: ReturnType<typeof createSolanaRpc>
+  feePayer: KeyPairSigner
+  instructions: readonly Instruction[]
+}): Promise<string> {
+  const { rpc, feePayer, instructions } = parameters
+  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send()
+
+  const txMessage = pipe(
+    createTransactionMessage({ version: 0 }),
+    (message) => setTransactionMessageFeePayerSigner(feePayer, message),
+    (message) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, message),
+    (message) => appendTransactionMessageInstructions(instructions, message),
+  )
+
+  const signed = await signTransactionMessageWithSigners(txMessage)
+  const wire = getBase64EncodedWireTransaction(signed)
+  const signature = await rpc
+    .sendTransaction(wire, {
+      encoding: 'base64',
+      skipPreflight: false,
+    })
+    .send()
+
+  await waitForSignatureConfirmation(signature)
+  return signature
+}
+
+async function waitForSignatureConfirmation(signature: string, timeoutMs = 30_000) {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const res = await fetch(RPC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'getSignatureStatuses',
+        params: [[signature]],
+      }),
+    })
+
+    const data = (await res.json()) as {
+      result?: {
+        value: Array<
+          | null
+          | {
+              confirmationStatus?: string
+              err?: unknown
+            }
+        >
+      }
+    }
+
+    const status = data.result?.value?.[0]
+    if (status) {
+      if (status.err) {
+        throw new Error(
+          `Transaction ${signature} failed: ${JSON.stringify(status.err)}`,
+        )
+      }
+
+      if (
+        status.confirmationStatus === 'confirmed' ||
+        status.confirmationStatus === 'finalized'
+      ) {
+        return
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for transaction confirmation: ${signature}`)
+}
+
+function readStoredBigInt(key: string): bigint | null {
+  const raw = localStorage.getItem(key)
+  if (!raw) {
+    return null
+  }
+
+  try {
+    return BigInt(raw)
+  } catch {
+    return null
+  }
+}
+
+function shortAddress(value: string | null): string {
+  if (!value) {
+    return '(not initialized)'
+  }
+
+  return `${value.slice(0, 8)}...${value.slice(-6)}`
+}
+
+async function findUsdcAta(owner: string): Promise<ReturnType<typeof address>> {
+  const [ata] = await findAssociatedTokenPda({
+    owner: address(owner),
+    mint: address(USDC_MINT),
+    tokenProgram: address(TOKEN_PROGRAM),
+  })
+
+  return ata
+}
+
+function parseNonNegativeBaseUnits(value: string, field: string): bigint {
+  let parsed: bigint
+  try {
+    parsed = BigInt(value)
+  } catch {
+    throw new Error(`${field} must be an integer base-unit amount`)
+  }
+
+  if (parsed < 0n) {
+    throw new Error(`${field} must be non-negative`)
+  }
+
+  return parsed
+}

--- a/demo/app/src/wallet.ts
+++ b/demo/app/src/wallet.ts
@@ -53,7 +53,6 @@ export async function generateWallet(): Promise<KeyPairSigner> {
   // PKCS8 for Ed25519 has the 32-byte private key at offset 16
   const pkcs8 = new Uint8Array(await crypto.subtle.exportKey('pkcs8', keyPair.privateKey))
   const privateKey = pkcs8.slice(16, 48)
-
   const combined = new Uint8Array(64)
   combined.set(privateKey)
   combined.set(publicKey, 32)

--- a/demo/server/constants.ts
+++ b/demo/server/constants.ts
@@ -1,2 +1,13 @@
 // Mainnet USDC mint — Surfpool clones it from the datasource network.
 export const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+export const USDC_DECIMALS = 6
+export const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+
+// Swig on-chain program used as session channel program namespace.
+export const SESSION_CHANNEL_PROGRAM =
+  'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB'
+
+// Swig demo pricing is intentionally tiny for repeatable local testing.
+// Values are in USDC base units (6 decimals).
+export const SWIG_SESSION_PRICE_BASE_UNITS = '10000' // 0.01 USDC
+export const SWIG_SESSION_SUGGESTED_DEPOSIT_BASE_UNITS = '30000' // 0.03 USDC

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -3,6 +3,7 @@ import express from 'express'
 import cors from 'cors'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import type { Request, Response } from 'express'
 import {
   generateKeyPairSigner,
   createKeyPairSignerFromBytes,
@@ -13,6 +14,7 @@ import {
 import { registerStocks } from './modules/stocks.js'
 import { registerWeather } from './modules/weather.js'
 import { registerFaucet } from './modules/faucet.js'
+import { registerSwigSession } from './modules/swigSession.js'
 
 // Recipient is the address that receives payments.
 // If not provided, generate one automatically (demo convenience).
@@ -81,7 +83,7 @@ app.use(
 )
 
 // Health check — also exposes fee payer balance for the UI
-app.get('/api/v1/health', async (_req, res) => {
+app.get('/api/v1/health', async (_req: Request, res: Response) => {
   let feePayerBalance: number | undefined
   try {
     const rpc = createSolanaRpc('http://localhost:8899')
@@ -99,12 +101,13 @@ app.get('/api/v1/health', async (_req, res) => {
 registerStocks(app, RECIPIENT, NETWORK, SECRET_KEY, feePayerSigner)
 registerWeather(app, RECIPIENT, NETWORK, SECRET_KEY, feePayerSigner)
 registerFaucet(app, NETWORK)
+registerSwigSession(app, RECIPIENT, NETWORK, SECRET_KEY)
 
 // Serve SPA in production
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const appDist = path.join(__dirname, '../app/dist')
 app.use(express.static(appDist))
-app.get('*splat', (_req, res) => {
+app.get('*splat', (_req: Request, res: Response) => {
   res.sendFile(path.join(appDist, 'index.html'))
 })
 
@@ -133,6 +136,9 @@ app.listen(PORT, () => {
     { method: 'GET',  path: '/api/v1/stocks/search?q=',      cost: '0.01 USDC' },
     { method: 'GET',  path: '/api/v1/stocks/history/:symbol', cost: '0.05 USDC' },
     { method: 'GET',  path: '/api/v1/weather/:city',          cost: '0.01 USDC' },
+    { method: 'GET',  path: '/api/v1/swig/research/:topic',   cost: '0.01 USDC/request (settled on close)' },
+    { method: 'GET',  path: '/api/v1/swig/risk/:symbol',      cost: '0.01 USDC/request (settled on close)' },
+    { method: 'GET',  path: '/api/v1/swig/status',            cost: '' },
     { method: 'POST', path: '/api/v1/faucet/airdrop',         cost: '' },
     { method: 'GET',  path: '/api/v1/faucet/status',           cost: '' },
   ]

--- a/demo/server/modules/swigSession.ts
+++ b/demo/server/modules/swigSession.ts
@@ -1,0 +1,302 @@
+import type {
+  Express,
+  Request,
+  Response as ExpressResponse,
+} from 'express'
+import { address } from '@solana/kit'
+import { findAssociatedTokenPda } from '@solana-program/token'
+import { Mppx, Store, solana } from '../sdk.js'
+import { toWebRequest } from '../utils.js'
+import {
+  SESSION_CHANNEL_PROGRAM,
+  SWIG_SESSION_PRICE_BASE_UNITS,
+  SWIG_SESSION_SUGGESTED_DEPOSIT_BASE_UNITS,
+  TOKEN_PROGRAM,
+  USDC_DECIMALS,
+  USDC_MINT,
+} from '../constants.js'
+
+const SURFPOOL_RPC = 'http://localhost:8899'
+
+export function registerSwigSession(
+  app: Express,
+  recipient: string,
+  network: string,
+  secretKey: string,
+) {
+  const store = Store.memory()
+
+  const mppx = Mppx.create({
+    secretKey,
+    methods: [
+      solana.session({
+        recipient,
+        network,
+        asset: {
+          kind: 'spl',
+          mint: USDC_MINT,
+          decimals: USDC_DECIMALS,
+          symbol: 'USDC',
+        },
+        channelProgram: SESSION_CHANNEL_PROGRAM,
+        pricing: {
+          unit: 'request',
+          amountPerUnit: SWIG_SESSION_PRICE_BASE_UNITS,
+          meter: 'api_calls',
+        },
+        sessionDefaults: {
+          suggestedDeposit: SWIG_SESSION_SUGGESTED_DEPOSIT_BASE_UNITS,
+          ttlSeconds: 180,
+        },
+        verifier: {
+          acceptAuthorizationModes: ['swig_session'],
+        },
+        transactionVerifier: {
+          async verifyOpen(_channelId, openTx, depositAmount) {
+            const tx = await getConfirmedTransaction(openTx)
+            if (!tx) {
+              throw new Error('openTx should resolve to a confirmed on-chain transaction')
+            }
+
+            const expectedDeposit = parseNonNegativeAtomicAmount(
+              depositAmount,
+              'open.depositAmount',
+            )
+            const transferred = sumTokenTransferAmount(tx, { mint: USDC_MINT })
+
+            if (transferred < expectedDeposit) {
+              throw new Error(
+                `openTx must transfer at least ${expectedDeposit.toString()} USDC base units on-chain`,
+              )
+            }
+          },
+          async verifyTopup(_channelId, topupTx, additionalAmount) {
+            const tx = await getConfirmedTransaction(topupTx)
+            if (!tx) {
+              throw new Error('topupTx should resolve to a confirmed on-chain transaction')
+            }
+
+            const expectedAdditional = parseNonNegativeAtomicAmount(
+              additionalAmount,
+              'topup.additionalAmount',
+            )
+            const transferred = sumTokenTransferAmount(tx, { mint: USDC_MINT })
+
+            if (transferred < expectedAdditional) {
+              throw new Error(
+                `topupTx must transfer at least ${expectedAdditional.toString()} USDC base units on-chain`,
+              )
+            }
+          },
+          async verifyClose(_channelId, closeTx, finalCumulativeAmount) {
+            const tx = await getConfirmedTransaction(closeTx)
+            if (!tx) {
+              throw new Error('closeTx should resolve to a confirmed on-chain transaction')
+            }
+
+            const expectedSettlement = parseNonNegativeAtomicAmount(
+              finalCumulativeAmount,
+              'close.finalCumulativeAmount',
+            )
+            const [recipientAta] = await findAssociatedTokenPda({
+              owner: address(recipient),
+              mint: address(USDC_MINT),
+              tokenProgram: address(TOKEN_PROGRAM),
+            })
+            const transferredToRecipient = sumTokenTransferAmount(
+              tx,
+              {
+                mint: USDC_MINT,
+                destination: recipientAta,
+              },
+            )
+
+            if (transferredToRecipient < expectedSettlement) {
+              throw new Error(
+                `closeTx must settle at least ${expectedSettlement.toString()} USDC base units to recipient ${recipient}`,
+              )
+            }
+          },
+        },
+        store,
+      }),
+    ],
+  })
+
+  app.get('/api/v1/swig/status', (_req: Request, res: ExpressResponse) => {
+    res.json({
+      recipient,
+      network,
+      channelProgram: SESSION_CHANNEL_PROGRAM,
+      currency: 'USDC',
+      mint: USDC_MINT,
+      decimals: USDC_DECIMALS,
+      priceBaseUnitsPerRequest: SWIG_SESSION_PRICE_BASE_UNITS,
+      suggestedDepositBaseUnits: SWIG_SESSION_SUGGESTED_DEPOSIT_BASE_UNITS,
+      authorizationMode: 'swig_session',
+      settlement: 'on_close',
+    })
+  })
+
+  app.get('/api/v1/swig/research/:topic', async (req: Request, res: ExpressResponse) => {
+    await handlePaidSessionRequest(mppx, req, res, () => {
+      const topic = String(req.params.topic)
+      return {
+        topic,
+        generatedAt: new Date().toISOString(),
+        summary: `Session-scoped market pulse for ${topic}.`,
+        takeaways: [
+          'Monitor developer activity and retained user cohorts.',
+          'Track unit economics before scaling paid workloads.',
+          'Prefer delegated session keys for repeated API usage.',
+        ],
+      }
+    })
+  })
+
+  app.get('/api/v1/swig/risk/:symbol', async (req: Request, res: ExpressResponse) => {
+    await handlePaidSessionRequest(mppx, req, res, () => {
+      const symbol = String(req.params.symbol).toUpperCase()
+      const score = deterministicScore(symbol)
+
+      return {
+        symbol,
+        generatedAt: new Date().toISOString(),
+        riskScore: score,
+        tier: score > 70 ? 'high' : score > 40 ? 'medium' : 'low',
+        notes: [
+          'This score is demo data for session payment flow visualization.',
+          'Use real risk pipelines in production workloads.',
+        ],
+      }
+    })
+  })
+}
+
+async function handlePaidSessionRequest(
+  mppx: any,
+  req: Request,
+  res: ExpressResponse,
+  responseBody: () => unknown,
+) {
+  const result = await mppx.session({})(toWebRequest(req))
+
+  if (result.status === 402) {
+    const challenge = result.challenge as Response
+    res.writeHead(challenge.status, Object.fromEntries(challenge.headers))
+    res.end(await challenge.text())
+    return
+  }
+
+  const response = result.withReceipt(Response.json(responseBody())) as Response
+  res.writeHead(response.status, Object.fromEntries(response.headers))
+  res.end(await response.text())
+}
+
+function deterministicScore(input: string): number {
+  let hash = 0
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0
+  }
+  return (hash % 100) + 1
+}
+
+async function getConfirmedTransaction(signature: string): Promise<any | null> {
+  const res = await fetch(SURFPOOL_RPC, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getTransaction',
+      params: [
+        signature,
+        {
+          encoding: 'jsonParsed',
+          maxSupportedTransactionVersion: 0,
+        },
+      ],
+    }),
+  })
+
+  const data = (await res.json()) as {
+    result?: unknown
+    error?: unknown
+  }
+
+  if (data.error) {
+    throw new Error(`getTransaction failed: ${JSON.stringify(data.error)}`)
+  }
+
+  return (data.result as any) ?? null
+}
+
+function sumTokenTransferAmount(
+  tx: any,
+  filter: {
+    mint: string
+    destination?: string
+  },
+): bigint {
+  let total = 0n
+
+  for (const instruction of collectParsedInstructions(tx)) {
+    const parsed = instruction?.parsed
+    if (
+      !parsed ||
+      !isTokenTransferInstruction(instruction.program, parsed.type)
+    ) {
+      continue
+    }
+
+    const mint = parsed.info?.mint
+    if (!mint || mint !== filter.mint) {
+      continue
+    }
+
+    const destination = parsed.info?.destination
+    if (filter.destination && destination !== filter.destination) {
+      continue
+    }
+
+    const amountRaw = parsed.info?.tokenAmount?.amount ?? parsed.info?.amount
+    if (amountRaw === undefined) {
+      continue
+    }
+
+    total += BigInt(String(amountRaw))
+  }
+
+  return total
+}
+
+function isTokenTransferInstruction(program: unknown, type: unknown): boolean {
+  return (
+    (program === 'spl-token' || program === 'spl-token-2022') &&
+    (type === 'transfer' || type === 'transferChecked')
+  )
+}
+
+function collectParsedInstructions(tx: any): any[] {
+  const topLevel = tx?.transaction?.message?.instructions ?? []
+  const inner = (tx?.meta?.innerInstructions ?? []).flatMap(
+    (entry: { instructions?: any[] }) => entry.instructions ?? [],
+  )
+
+  return [...topLevel, ...inner]
+}
+
+function parseNonNegativeAtomicAmount(value: string, field: string): bigint {
+  let amount: bigint
+  try {
+    amount = BigInt(value)
+  } catch {
+    throw new Error(`${field} must be a valid integer base-unit amount`)
+  }
+
+  if (amount < 0n) {
+    throw new Error(`${field} must be non-negative`)
+  }
+
+  return amount
+}

--- a/demo/server/package-lock.json
+++ b/demo/server/package-lock.json
@@ -29,6 +29,8 @@
       },
       "devDependencies": {
         "@solana/kit": "^6.4.0",
+        "@swig-wallet/kit": "^1.7.1",
+        "@swig-wallet/lib": "^1.7.1",
         "@types/node": "^25.5.0",
         "mppx": "^0.3.15",
         "tsx": "^4.19.0",
@@ -36,7 +38,13 @@
       },
       "peerDependencies": {
         "@solana/kit": ">=6.1.0",
+        "@swig-wallet/kit": ">=1.7.0",
         "mppx": ">=0.3.15"
+      },
+      "peerDependenciesMeta": {
+        "@swig-wallet/kit": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -1835,8 +1843,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -1929,7 +1936,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2315,7 +2321,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2600,7 +2605,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2718,6 +2722,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -3443,7 +3448,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3506,6 +3510,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -3536,6 +3541,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -3560,6 +3566,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3602,7 +3609,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3658,7 +3664,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/docs/methods/sessions.md
+++ b/docs/methods/sessions.md
@@ -64,6 +64,8 @@ High level flow:
 4. Server verifies voucher, challenge binding, and channel invariants.
 5. Server returns paid response (or `204` for management actions like `topup` and `close`).
 
+`close` payloads can optionally include `closeTx`, an on-chain settlement transaction reference.
+
 ## Server behavior and checks
 
 The server session method (`sdk/src/server/Session.ts`) verifies:
@@ -80,8 +82,9 @@ Optional hooks for stronger on-chain checks:
 
 - `transactionVerifier.verifyOpen(channelId, openTx, deposit)`
 - `transactionVerifier.verifyTopup(channelId, topupTx, amount)`
+- `transactionVerifier.verifyClose(channelId, closeTx, finalCumulativeAmount)`
 
-Use these hooks to ensure `openTx` and `topupTx` are real confirmed transactions with expected semantics.
+Use these hooks to ensure `openTx`, `topupTx`, and `closeTx` are real confirmed transactions with expected semantics.
 
 ## Client behavior
 
@@ -156,7 +159,7 @@ const mppx = Mppx.create({
             network: "devnet",
             rpcUrl: "http://localhost:8899",
             asset: { kind: "sol", decimals: 9, symbol: "SOL" },
-            channelProgram: "Session11111111111111111111111111111111111",
+            channelProgram: "swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB",
             pricing: {
                 unit: "request",
                 amountPerUnit: "10",
@@ -172,6 +175,9 @@ const mppx = Mppx.create({
                 },
                 async verifyTopup(channelId, topupTx, amount) {
                     // Fetch tx by signature and assert expected topup semantics.
+                },
+                async verifyClose(channelId, closeTx, finalCumulativeAmount) {
+                    // Fetch tx by signature and assert settlement transfer semantics.
                 },
             },
         }),
@@ -206,7 +212,7 @@ const authorizer = new SwigSessionAuthorizer({
         spendLimit: "1000",
     },
     rpcUrl: "http://localhost:8899",
-    allowedPrograms: ["Session11111111111111111111111111111111111"],
+    allowedPrograms: ["swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB"],
     buildTopupTx: async () => {
         // Return topup transaction reference.
         return "topup-signature";
@@ -250,4 +256,5 @@ const mppx = Mppx.create({ methods: [method] });
 ## Design notes
 
 - `@swig-wallet/kit` is an optional dependency and loaded dynamically by Swig authorizers.
+- Browser demos can pass `swigModule: { fetchSwig }` to Swig authorizers to avoid runtime bare-specifier import issues in some bundler setups.
 - For production, use `transactionVerifier` to require on-chain proof for open and topup actions.

--- a/sdk/src/Methods.ts
+++ b/sdk/src/Methods.ts
@@ -173,6 +173,8 @@ export const session = Method.from({
           action: z.literal('close'),
           /** Existing channel identifier targeted by this close. */
           channelId: z.string(),
+          /** Optional on-chain settlement transaction reference for this close. */
+          closeTx: z.optional(z.string()),
           /** Signed final voucher payload for close action. */
           voucher: z.object({
             voucher: z.object({

--- a/sdk/src/__tests__/integration.test.ts
+++ b/sdk/src/__tests__/integration.test.ts
@@ -45,7 +45,7 @@ import {
 import * as SessionChannelStore from '../../src/session/ChannelStore.js'
 
 const RPC_URL = 'http://localhost:8899'
-const SESSION_CHANNEL_PROGRAM = 'Session11111111111111111111111111111111111'
+const SESSION_CHANNEL_PROGRAM = 'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB'
 
 type GeneratedSigner = Awaited<ReturnType<typeof generateKeyPairSigner>>
 type SolanaRpcClient = ReturnType<typeof createSolanaRpc>
@@ -852,6 +852,54 @@ test('e2e: session autoTopup returns 204 management response, then resumes updat
   }
 })
 
+test('e2e: session can auto-close when limit is hit and autoTopup is disabled', async () => {
+  const harness = await startSessionHarness({
+    pricing: {
+      unit: 'request',
+      amountPerUnit: '10',
+      meter: 'api_calls',
+    },
+    sessionDefaults: {
+      suggestedDeposit: '10',
+      ttlSeconds: 60,
+    },
+  })
+
+  try {
+    const clientMethod = clientSolana.session({
+      signer: clientSigner,
+      authorizer: createUnboundedSessionAuthorizer(),
+      autoTopup: false,
+      settleOnLimitHit: true,
+    })
+
+    const mppx = ClientMppx.create({ methods: [clientMethod], polyfill: false })
+    const endpoint = `http://localhost:${harness.port}/session`
+
+    const openResponse = await mppx.fetch(endpoint)
+    assert.equal(openResponse.status, 200)
+    const channelId = receiptFromResponse(openResponse).reference
+
+    const updateResponse = await mppx.fetch(endpoint)
+    assert.equal(updateResponse.status, 200)
+    assert.equal(receiptFromResponse(updateResponse).reference, channelId)
+
+    const autoCloseResponse = await mppx.fetch(endpoint)
+    assert.equal(autoCloseResponse.status, 204)
+    assert.equal(receiptFromResponse(autoCloseResponse).reference, channelId)
+
+    const closedChannel = await getSessionChannel(harness.store, channelId)
+    assert.ok(closedChannel)
+    assert.equal(closedChannel!.status, 'closed')
+
+    const reopenedResponse = await mppx.fetch(endpoint)
+    assert.equal(reopenedResponse.status, 200)
+    assert.notEqual(receiptFromResponse(reopenedResponse).reference, channelId)
+  } finally {
+    await harness.close()
+  }
+})
+
 test('e2e: session close action returns 204 and next request opens a new channel', async () => {
   const harness = await startSessionHarness({
     pricing: {
@@ -1018,6 +1066,98 @@ test('e2e: session swig_session mode uses on-chain setup and enforces spend limi
       },
       /Transaction simulation failed/,
       'over-limit Swig spend should fail on-chain',
+    )
+  } finally {
+    await harness.close()
+  }
+})
+
+test('e2e: session close can include on-chain settlement transaction', async () => {
+  const swig = await createSwigHarness({
+    walletSigner: clientSigner,
+    spendLimitLamports: 2_000n,
+    sessionTtlSeconds: 120,
+  })
+
+  let verifiedCloseTx: string | null = null
+  const harness = await startSessionHarness({
+    pricing: {
+      unit: 'request',
+      amountPerUnit: '10',
+      meter: 'api_calls',
+    },
+    sessionDefaults: {
+      suggestedDeposit: '500',
+      ttlSeconds: 60,
+    },
+    verifier: {
+      acceptAuthorizationModes: ['swig_session'],
+    },
+    transactionVerifier: {
+      async verifyClose(_channelId, closeTx) {
+        verifiedCloseTx = closeTx
+        const tx = await getConfirmedTransaction(closeTx)
+        assert.ok(tx, 'closeTx should resolve to a confirmed on-chain transaction')
+      },
+    },
+  })
+
+  try {
+    const authorizer = new SwigSessionAuthorizer({
+      wallet: {
+        address: clientSigner.address,
+        swigAddress: swig.swigAddress,
+        swigRoleId: 0,
+        getSessionKey: async () => {
+          const signer = swig.getCurrentSessionSigner()
+          if (!signer) return null
+          return {
+            signer,
+            swigRoleId: 0,
+          }
+        },
+        createSessionKey: async ({ ttlSeconds }) => {
+          return await swig.createSessionKey(ttlSeconds)
+        },
+      },
+      policy: {
+        profile: 'swig-time-bound',
+        ttlSeconds: 60,
+        spendLimit: '2000',
+      },
+      rpcUrl: RPC_URL,
+      allowedPrograms: [SESSION_CHANNEL_PROGRAM],
+      buildCloseTx: async ({ finalCumulativeAmount, recipient }) =>
+        await swig.spendFromSwig(BigInt(finalCumulativeAmount), recipient),
+    })
+
+    const clientMethod = clientSolana.session({
+      signer: clientSigner,
+      authorizer,
+      autoTopup: false,
+    })
+
+    const mppx = ClientMppx.create({ methods: [clientMethod], polyfill: false })
+    const endpoint = `http://localhost:${harness.port}/session`
+
+    const openResponse = await mppx.fetch(endpoint)
+    assert.equal(openResponse.status, 200)
+
+    const updateResponse = await mppx.fetch(endpoint)
+    assert.equal(updateResponse.status, 200)
+
+    const recipientBalanceBeforeClose = await getBalance(recipientSigner.address)
+
+    const closeResponse = await mppx.fetch(endpoint, {
+      context: { action: 'close' },
+    })
+    assert.equal(closeResponse.status, 204)
+    assert.ok(verifiedCloseTx, 'transaction verifier should receive closeTx signature')
+
+    const recipientBalanceAfterClose = await getBalance(recipientSigner.address)
+    assert.ok(
+      recipientBalanceAfterClose - recipientBalanceBeforeClose >= 10,
+      'recipient should receive settlement transfer on close',
     )
   } finally {
     await harness.close()

--- a/sdk/src/__tests__/session.test.ts
+++ b/sdk/src/__tests__/session.test.ts
@@ -12,7 +12,7 @@ import type {
 } from '../session/Types.js'
 
 const RECIPIENT = '9xAXssX9j7vuK99c7cFwqbixzL3bFrzPy9PUhCtDPAYJ'
-const CHANNEL_PROGRAM = 'Session11111111111111111111111111111111111'
+const CHANNEL_PROGRAM = 'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB'
 const NETWORK = 'devnet'
 
 type ChallengeRequest = {
@@ -62,6 +62,7 @@ type CloseCredentialOptions = {
   serverNonce: string
   cumulativeAmount: string
   sequence: number
+  closeTx?: string
   challengeId?: string
   challengeRequestOverrides?: Partial<ChallengeRequest>
   voucher?: SignedSessionVoucher
@@ -542,6 +543,105 @@ test('open flow supports configurable transactionVerifier callbacks', async () =
   )
 })
 
+test('close flow supports configurable transactionVerifier callbacks', async () => {
+  const channelId = `channel-close-verified-${crypto.randomUUID()}`
+  const serverNonce = crypto.randomUUID()
+
+  let observedCloseTx: string | null = null
+  let observedFinalCumulative: string | null = null
+
+  const method = createMethod({
+    transactionVerifier: {
+      verifyClose: async (_channelId, closeTx, finalCumulativeAmount) => {
+        observedCloseTx = closeTx
+        observedFinalCumulative = finalCumulativeAmount
+      },
+    },
+  })
+
+  await method.verify({
+    credential: await buildOpenCredential({
+      channelId,
+      serverNonce,
+      depositAmount: '1000',
+      cumulativeAmount: '0',
+      sequence: 0,
+    }),
+    request: buildChallengeRequest(),
+  })
+
+  await method.verify({
+    credential: await buildUpdateCredential({
+      channelId,
+      serverNonce,
+      cumulativeAmount: '400',
+      sequence: 1,
+    }),
+    request: buildChallengeRequest(),
+  })
+
+  const receipt = await method.verify({
+    credential: await buildCloseCredential({
+      channelId,
+      serverNonce,
+      cumulativeAmount: '450',
+      sequence: 2,
+      closeTx: 'close-transaction-signature',
+    }),
+    request: buildChallengeRequest(),
+  })
+
+  assert.equal(receipt.reference, 'close-transaction-signature')
+  assert.equal(observedCloseTx, 'close-transaction-signature')
+  assert.equal(observedFinalCumulative, '450')
+})
+
+test('close flow requires closeTx when verifyClose callback is configured', async () => {
+  const channelId = `channel-close-missing-tx-${crypto.randomUUID()}`
+  const serverNonce = crypto.randomUUID()
+
+  const method = createMethod({
+    transactionVerifier: {
+      verifyClose: async () => undefined,
+    },
+  })
+
+  await method.verify({
+    credential: await buildOpenCredential({
+      channelId,
+      serverNonce,
+      depositAmount: '1000',
+      cumulativeAmount: '0',
+      sequence: 0,
+    }),
+    request: buildChallengeRequest(),
+  })
+
+  await method.verify({
+    credential: await buildUpdateCredential({
+      channelId,
+      serverNonce,
+      cumulativeAmount: '400',
+      sequence: 1,
+    }),
+    request: buildChallengeRequest(),
+  })
+
+  await assert.rejects(
+    async () =>
+      method.verify({
+        credential: await buildCloseCredential({
+          channelId,
+          serverNonce,
+          cumulativeAmount: '450',
+          sequence: 2,
+        }),
+        request: buildChallengeRequest(),
+      }),
+    /closeTx is required/,
+  )
+})
+
 test('rejects update when cumulative amount exceeds deposit', async () => {
   const channelId = `channel-exceed-deposit-${crypto.randomUUID()}`
   const serverNonce = crypto.randomUUID()
@@ -840,6 +940,7 @@ async function buildCloseCredential(
     payload: {
       action: 'close',
       channelId: options.channelId,
+      ...(options.closeTx ? { closeTx: options.closeTx } : {}),
       voucher,
     },
     challenge: {

--- a/sdk/src/client/Session.ts
+++ b/sdk/src/client/Session.ts
@@ -57,8 +57,14 @@ export const sessionContextSchema = z.object({
 export type SessionContext = z.infer<typeof sessionContextSchema>
 
 export function session(parameters: session.Parameters) {
-  const { signer, authorizer, autoOpen = true, autoTopup = false, onProgress } =
-    parameters
+  const {
+    signer,
+    authorizer,
+    autoOpen = true,
+    autoTopup = false,
+    settleOnLimitHit = false,
+    onProgress,
+  } = parameters
 
   let activeChannel: ActiveChannel | null = null
 
@@ -347,9 +353,28 @@ export function session(parameters: session.Parameters) {
 
       if (nextCumulativeAmount > scopedActiveChannel.depositAmount) {
         if (!autoTopup) {
-          throw new Error(
-            'Voucher cumulative amount exceeds tracked deposit and autoTopup is disabled',
+          if (!settleOnLimitHit) {
+            throw new Error(
+              'Voucher cumulative amount exceeds tracked deposit and autoTopup is disabled',
+            )
+          }
+
+          const closeCredential = await handleCloseAction(
+            challenge,
+            {
+              action: 'close',
+              channelId: scopedActiveChannel.channelId,
+            },
+            authorizer,
+            scopedActiveChannel,
+            channelProgram,
+            recipient,
+            network,
+            onProgress,
           )
+
+          activeChannel = null
+          return closeCredential
         }
 
         const additionalAmount = resolveAutoTopupAmount(
@@ -505,6 +530,7 @@ async function handleCloseAction(
   const payload: SessionCredentialPayload = {
     action: 'close',
     channelId,
+    ...(closeResult.closeTx ? { closeTx: closeResult.closeTx } : {}),
     voucher: closeResult.voucher,
   }
 
@@ -629,6 +655,7 @@ export declare namespace session {
     authorizer: SessionAuthorizer
     autoOpen?: boolean
     autoTopup?: boolean
+    settleOnLimitHit?: boolean
     onProgress?: (event: ProgressEvent) => void
   }
 

--- a/sdk/src/server/Session.ts
+++ b/sdk/src/server/Session.ts
@@ -62,6 +62,11 @@ type ClosePayload = Extract<SessionCredentialPayload, { action: 'close' }>
 type TransactionVerifier = {
   verifyOpen?(channelId: string, openTx: string, deposit: string): Promise<void>
   verifyTopup?(channelId: string, topupTx: string, amount: string): Promise<void>
+  verifyClose?(
+    channelId: string,
+    closeTx: string,
+    finalCumulativeAmount: string,
+  ): Promise<void>
 }
 
 export function session(parameters: session.Parameters) {
@@ -468,6 +473,18 @@ async function handleClose(
     throw new Error('Voucher cumulative amount exceeds channel deposit')
   }
 
+  if (parameters.transactionVerifier?.verifyClose) {
+    if (!payload.closeTx?.trim()) {
+      throw new Error('closeTx is required for session close')
+    }
+
+    await parameters.transactionVerifier.verifyClose(
+      payload.channelId,
+      payload.closeTx,
+      voucher.voucher.cumulativeAmount,
+    )
+  }
+
   await verifySignedVoucher(voucher, channel, parameters.verifier?.voucherVerifier)
 
   await channelStore.updateChannel(payload.channelId, (current) => {
@@ -512,7 +529,7 @@ async function handleClose(
     }
   })
 
-  return toSuccessReceipt(payload.channelId, challengeId)
+  return toSuccessReceipt(payload.closeTx ?? payload.channelId, challengeId)
 }
 
 function assertSessionParameters(parameters: session.Parameters) {

--- a/sdk/src/session/Types.ts
+++ b/sdk/src/session/Types.ts
@@ -75,6 +75,7 @@ export type SessionCredentialPayload =
   | {
       action: 'close'
       channelId: string
+      closeTx?: string
       voucher: SignedSessionVoucher
     }
 
@@ -148,6 +149,7 @@ export interface AuthorizeCloseInput {
 
 export interface AuthorizedClose {
   voucher: SignedSessionVoucher
+  closeTx?: string
 }
 
 export interface AuthorizerCapabilities {

--- a/sdk/src/session/authorizers/BudgetAuthorizer.ts
+++ b/sdk/src/session/authorizers/BudgetAuthorizer.ts
@@ -42,11 +42,8 @@ type SwigAccount = {
   findRolesByEd25519SignerPk?: (signerPk: string) => SwigRole[]
 }
 
-type SwigModule = {
-  fetchSwig: (
-    rpc: ReturnType<typeof createSolanaRpc>,
-    swigAddress: string,
-  ) => Promise<SwigAccount>
+export type BudgetSwigModule = {
+  fetchSwig: (rpc: unknown, swigAddress: string) => Promise<SwigAccount>
 }
 
 type SwigOnChainRoleConfig = {
@@ -72,8 +69,10 @@ export interface BudgetAuthorizerParameters {
   requireApprovalOnTopup?: boolean
   allowedPrograms?: string[]
   swig: SwigOnChainRoleConfig
+  swigModule?: BudgetSwigModule
   buildOpenTx?: (input: AuthorizeOpenInput) => Promise<string> | string
   buildTopupTx?: (input: AuthorizeTopupInput) => Promise<string> | string
+  buildCloseTx?: (input: AuthorizeCloseInput) => Promise<string> | string
 }
 
 /**
@@ -98,10 +97,13 @@ export class BudgetAuthorizer implements SessionAuthorizer {
   private readonly buildTopupTx?: (
     input: AuthorizeTopupInput,
   ) => Promise<string> | string
+  private readonly buildCloseTx?: (
+    input: AuthorizeCloseInput,
+  ) => Promise<string> | string
   private readonly channels = new Map<string, ChannelProgress>()
   private readonly capabilities: AuthorizerCapabilities
   private swigLoaded = false
-  private swigModule: SwigModule | null = null
+  private swigModule: BudgetSwigModule | null = null
 
   constructor(parameters: BudgetAuthorizerParameters) {
     if (!parameters.swig) {
@@ -143,8 +145,13 @@ export class BudgetAuthorizer implements SessionAuthorizer {
       swigRoleId: parameters.swig.swigRoleId,
       ...(parameters.swig.rpcUrl ? { rpcUrl: parameters.swig.rpcUrl } : {}),
     }
+    if (parameters.swigModule) {
+      this.swigModule = parameters.swigModule
+      this.swigLoaded = true
+    }
     this.buildOpenTx = parameters.buildOpenTx
     this.buildTopupTx = parameters.buildTopupTx
+    this.buildCloseTx = parameters.buildCloseTx
 
     this.capabilities = {
       mode: 'regular_budget',
@@ -374,6 +381,8 @@ export class BudgetAuthorizer implements SessionAuthorizer {
       channelProgram: input.channelProgram,
     })
 
+    const closeTx = await this.resolveCloseTx(input)
+
     this.channels.set(input.channelId, {
       deposited: progress.deposited,
       lastCumulative: finalCumulativeAmount,
@@ -387,7 +396,10 @@ export class BudgetAuthorizer implements SessionAuthorizer {
         : {}),
     })
 
-    return { voucher }
+    return {
+      voucher,
+      ...(closeTx ? { closeTx } : {}),
+    }
   }
 
   private assertNotExpired() {
@@ -576,7 +588,7 @@ export class BudgetAuthorizer implements SessionAuthorizer {
 
     try {
       const swigPackageName = '@swig-wallet/kit'
-      const module = (await import(swigPackageName)) as Partial<SwigModule>
+      const module = (await import(swigPackageName)) as Partial<BudgetSwigModule>
       if (typeof module.fetchSwig !== 'function') {
         throw new Error(
           'Installed `@swig-wallet/kit` does not export fetchSwig() at runtime',
@@ -612,6 +624,16 @@ export class BudgetAuthorizer implements SessionAuthorizer {
     }
 
     return await this.buildTopupTx(input)
+  }
+
+  private async resolveCloseTx(
+    input: AuthorizeCloseInput,
+  ): Promise<string | undefined> {
+    if (!this.buildCloseTx) {
+      return undefined
+    }
+
+    return await this.buildCloseTx(input)
   }
 }
 

--- a/sdk/src/session/authorizers/SwigSessionAuthorizer.ts
+++ b/sdk/src/session/authorizers/SwigSessionAuthorizer.ts
@@ -35,11 +35,8 @@ type SwigAccount = {
   findRoleBySessionKey?: (sessionKey: string) => SwigRole | null
 }
 
-type SwigModule = {
-  fetchSwig: (
-    rpc: ReturnType<typeof createSolanaRpc>,
-    swigAddress: string,
-  ) => Promise<SwigAccount>
+export type SwigSessionModule = {
+  fetchSwig: (rpc: unknown, swigAddress: string) => Promise<SwigAccount>
 }
 
 type SessionSignerState = {
@@ -86,9 +83,11 @@ export interface SwigSessionAuthorizerParameters {
   wallet: SwigWalletAdapter
   policy: SwigPolicy
   rpcUrl?: string
+  swigModule?: SwigSessionModule
   allowedPrograms?: string[]
   buildOpenTx?: (input: AuthorizeOpenInput) => Promise<string> | string
   buildTopupTx?: (input: AuthorizeTopupInput) => Promise<string> | string
+  buildCloseTx?: (input: AuthorizeCloseInput) => Promise<string> | string
 }
 
 /**
@@ -110,10 +109,13 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
   private readonly buildTopupTx?: (
     input: AuthorizeTopupInput,
   ) => Promise<string> | string
+  private readonly buildCloseTx?: (
+    input: AuthorizeCloseInput,
+  ) => Promise<string> | string
   private readonly channels = new Map<string, ChannelProgress>()
 
   private swigLoaded = false
-  private swigModule: SwigModule | null = null
+  private swigModule: SwigSessionModule | null = null
   private sessionSigner: KeyPairSigner | null = null
   private sessionStartedAtMs: number | null = null
   private sessionOpenTx: string | null = null
@@ -128,6 +130,10 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
     this.wallet = parameters.wallet
     this.policy = parameters.policy
     this.rpcUrl = parameters.rpcUrl
+    if (parameters.swigModule) {
+      this.swigModule = parameters.swigModule
+      this.swigLoaded = true
+    }
     this.allowedPrograms = parameters.allowedPrograms
       ? new Set(parameters.allowedPrograms)
       : undefined
@@ -141,6 +147,7 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
         : undefined
     this.buildOpenTx = parameters.buildOpenTx
     this.buildTopupTx = parameters.buildTopupTx
+    this.buildCloseTx = parameters.buildCloseTx
   }
 
   getMode() {
@@ -346,6 +353,8 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
       channelProgram: input.channelProgram,
     })
 
+    const closeTx = await this.resolveCloseTx(input)
+
     this.channels.set(input.channelId, {
       deposited: progress?.deposited ?? 0n,
       lastCumulative: finalCumulativeAmount,
@@ -358,7 +367,10 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
           : {}),
     })
 
-    return { voucher }
+    return {
+      voucher,
+      ...(closeTx ? { closeTx } : {}),
+    }
   }
 
   private async signSwigVoucher(
@@ -512,7 +524,7 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
 
     try {
       const swigPackageName = '@swig-wallet/kit'
-      const module = (await import(swigPackageName)) as Partial<SwigModule>
+      const module = (await import(swigPackageName)) as Partial<SwigSessionModule>
       if (typeof module.fetchSwig !== 'function') {
         throw new Error(
           'Installed `@swig-wallet/kit` does not export fetchSwig() at runtime',
@@ -567,6 +579,14 @@ export class SwigSessionAuthorizer implements SessionAuthorizer {
     }
 
     return await this.buildTopupTx(input)
+  }
+
+  private async resolveCloseTx(input: AuthorizeCloseInput): Promise<string | undefined> {
+    if (!this.buildCloseTx) {
+      return undefined
+    }
+
+    return await this.buildCloseTx(input)
   }
 
   private setSessionState(state: SessionSignerState) {

--- a/sdk/src/session/authorizers/UnboundedAuthorizer.ts
+++ b/sdk/src/session/authorizers/UnboundedAuthorizer.ts
@@ -27,6 +27,7 @@ export interface UnboundedAuthorizerParameters {
   >
   buildOpenTx?: (input: AuthorizeOpenInput) => Promise<string> | string
   buildTopupTx?: (input: AuthorizeTopupInput) => Promise<string> | string
+  buildCloseTx?: (input: AuthorizeCloseInput) => Promise<string> | string
 }
 
 export class UnboundedAuthorizer implements SessionAuthorizer {
@@ -39,6 +40,9 @@ export class UnboundedAuthorizer implements SessionAuthorizer {
   ) => Promise<string> | string
   private readonly buildTopupTx?: (
     input: AuthorizeTopupInput,
+  ) => Promise<string> | string
+  private readonly buildCloseTx?: (
+    input: AuthorizeCloseInput,
   ) => Promise<string> | string
   private readonly channels = new Map<string, ChannelProgress>()
   private readonly capabilities: AuthorizerCapabilities
@@ -55,6 +59,7 @@ export class UnboundedAuthorizer implements SessionAuthorizer {
         : undefined
     this.buildOpenTx = parameters.buildOpenTx
     this.buildTopupTx = parameters.buildTopupTx
+    this.buildCloseTx = parameters.buildCloseTx
 
     const requiresInteractiveApproval = {
       open: parameters.requiresInteractiveApproval?.open ?? false,
@@ -195,12 +200,17 @@ export class UnboundedAuthorizer implements SessionAuthorizer {
       channelProgram: input.channelProgram,
     })
 
+    const closeTx = await this.resolveCloseTx(input)
+
     this.channels.set(input.channelId, {
       lastCumulative: finalCumulativeAmount,
       lastSequence: input.sequence,
     })
 
-    return { voucher }
+    return {
+      voucher,
+      ...(closeTx ? { closeTx } : {}),
+    }
   }
 
   private assertNotExpired() {
@@ -264,6 +274,16 @@ export class UnboundedAuthorizer implements SessionAuthorizer {
     }
 
     return await this.buildTopupTx(input)
+  }
+
+  private async resolveCloseTx(
+    input: AuthorizeCloseInput,
+  ): Promise<string | undefined> {
+    if (!this.buildCloseTx) {
+      return undefined
+    }
+
+    return await this.buildCloseTx(input)
   }
 }
 

--- a/sdk/src/session/authorizers/makeSessionAuthorizer.ts
+++ b/sdk/src/session/authorizers/makeSessionAuthorizer.ts
@@ -23,6 +23,9 @@ export interface MakeSessionAuthorizerParameters {
   buildTopupTx?: (
     input: Parameters<NonNullable<BudgetAuthorizerParameters['buildTopupTx']>>[0],
   ) => Promise<string> | string
+  buildCloseTx?: (
+    input: Parameters<NonNullable<BudgetAuthorizerParameters['buildCloseTx']>>[0],
+  ) => Promise<string> | string
 }
 
 /**
@@ -70,6 +73,9 @@ export function makeSessionAuthorizer(
         ...(parameters.buildTopupTx
           ? { buildTopupTx: parameters.buildTopupTx }
           : {}),
+        ...(parameters.buildCloseTx
+          ? { buildCloseTx: parameters.buildCloseTx }
+          : {}),
       })
     }
 
@@ -83,6 +89,9 @@ export function makeSessionAuthorizer(
         ...(parameters.buildOpenTx ? { buildOpenTx: parameters.buildOpenTx } : {}),
         ...(parameters.buildTopupTx
           ? { buildTopupTx: parameters.buildTopupTx }
+          : {}),
+        ...(parameters.buildCloseTx
+          ? { buildCloseTx: parameters.buildCloseTx }
           : {}),
         requiresInteractiveApproval: {
           update: profile.requireApprovalOnEveryUpdate,
@@ -109,6 +118,9 @@ export function makeSessionAuthorizer(
         ...(parameters.buildOpenTx ? { buildOpenTx: parameters.buildOpenTx } : {}),
         ...(parameters.buildTopupTx
           ? { buildTopupTx: parameters.buildTopupTx }
+          : {}),
+        ...(parameters.buildCloseTx
+          ? { buildCloseTx: parameters.buildCloseTx }
           : {}),
       })
     }


### PR DESCRIPTION
## Summary
- Hardened session settlement semantics across the SDK by carrying `closeTx` through close authorization and server verification, and by adding optional `settleOnLimitHit` behavior when channel limits are reached.
- Created a Swig demo which uses USDC base units end-to-end (pricing, deposits, settlement transfers, and verifier checks) and aligned all Swig references to the real Swig program id.
- Delegated-role lifecycle in the demo creates a fresh delegated Swig role per session, removing that role on successful close settlement, and reinitializing session state so reopened channels do not reuse stale role limits.

## Implementation Details
- Added `closeTx` support in session method schema/types/client/server and added `verifyClose(...)` handling on the server path.
- Added `settleOnLimitHit?: boolean` to the session client so over-limit requests can auto-close/settle instead of throwing when `autoTopup` is disabled.
- Swig demo server enforces USDC SPL asset semantics and validates open/topup/close transactions against expected token transfer behavior.
- Swig demo client now:
  - builds open/topup/close USDC token-transfer flows,
  - uses delegated-role-scoped signing for settlement,
  - recycles delegated roles by removing them on successful close,
  - detects and recreates legacy Swigs with session-based manager role config.
- Updated docs and demo UX text to reflect Swig session + USDC behavior, plus delegated role visibility in the demo UI.
## Validation
- `npm run typecheck`
- `npx tsc --noEmit` (demo app)
- `npm run build` (demo app)
- manually tested demo end 2 end