### PR TITLE
feat: widen signer types for Keychain compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Solana payment method for the [Machine Payments Protocol](https://mpp.dev).
 - [Swig](https://build.onswig.com) smart wallet integration for on-chain spend limits
 
 **General**
-- Works with [ConnectorKit](https://www.connectorkit.dev) and `@solana/kit` keypair signers
+- Works with [ConnectorKit](https://www.connectorkit.dev), `@solana/kit` keypair signers, and [Solana Keychain](https://github.com/solana-foundation/solana-keychain) remote signers
 - Server pre-fetches `recentBlockhash` to save client an RPC round-trip
 - Transaction simulation before broadcast to prevent wasted fees
 
@@ -147,10 +147,10 @@ const response = await mppx.fetch('https://api.example.com/metered-endpoint')
 The server can pay transaction fees on behalf of clients:
 
 ```ts
-// Server — pass a KeyPairSigner to cover fees
+// Server — pass a TransactionPartialSigner to cover fees
 solana.charge({
   recipient: '...',
-  signer: feePayerSigner, // server's KeyPairSigner
+  signer: feePayerSigner, // KeyPairSigner, Keychain SolanaSigner, etc.
 })
 
 // Client — no changes needed, fee payer is handled automatically

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "test": "node --import tsx/esm --test sdk/src/__tests__/charge.test.ts sdk/src/__tests__/session.test.ts",
+    "test": "node --import tsx/esm --test sdk/src/__tests__/charge.test.ts sdk/src/__tests__/session.test.ts sdk/src/__tests__/transactions.test.ts",
     "test:session": "node --import tsx/esm --test sdk/src/__tests__/session.test.ts",
     "test:integration": "node --import tsx/esm --test sdk/src/__tests__/integration.test.ts",
     "test:all": "npm test && npm run test:integration",

--- a/sdk/src/__tests__/transactions.test.ts
+++ b/sdk/src/__tests__/transactions.test.ts
@@ -1,0 +1,113 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  generateKeyPairSigner,
+  pipe,
+  createTransactionMessage,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  appendTransactionMessageInstructions,
+  partiallySignTransactionMessageWithSigners,
+  getBase64EncodedWireTransaction,
+  getTransactionDecoder,
+  getBase64Codec,
+  address,
+  type TransactionPartialSigner,
+  type Blockhash,
+} from '@solana/kit'
+import { getTransferSolInstruction } from '@solana-program/system'
+import { coSignBase64Transaction } from '../utils/transactions.js'
+
+// ── Helpers ──
+
+/**
+ * Build a partially-signed tx that mimics the real fee-payer flow:
+ * client sets fee payer as an address (not a signer), signs the transfer,
+ * and the server co-signs as fee payer afterward.
+ */
+async function buildPartiallySignedTx() {
+  const sender = await generateKeyPairSigner()
+  const feePayer = await generateKeyPairSigner()
+  const recipientSigner = await generateKeyPairSigner()
+  const recipient = recipientSigner.address
+
+  const blockhash = 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N' as Blockhash
+
+  // Client sets fee payer as address only (not signer) — server will co-sign
+  const txMessage = pipe(
+    createTransactionMessage({ version: 0 }),
+    (msg) => setTransactionMessageFeePayer(feePayer.address, msg),
+    (msg) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash, lastValidBlockHeight: 1000n },
+        msg,
+      ),
+    (msg) =>
+      appendTransactionMessageInstructions(
+        [
+          getTransferSolInstruction({
+            source: sender,
+            destination: recipient,
+            amount: 1_000_000n,
+          }),
+        ],
+        msg,
+      ),
+  )
+
+  const partiallySigned =
+    await partiallySignTransactionMessageWithSigners(txMessage)
+  const base64Tx = getBase64EncodedWireTransaction(partiallySigned)
+
+  return { base64Tx, feePayer, sender }
+}
+
+// ── Tests ──
+
+test('coSignBase64Transaction co-signs with a valid TransactionPartialSigner', async () => {
+  const { base64Tx, feePayer } = await buildPartiallySignedTx()
+
+  const result = await coSignBase64Transaction(feePayer, base64Tx)
+
+  assert.ok(typeof result === 'string' && result.length > 0)
+  assert.notEqual(result, base64Tx, 'co-signed tx should differ from input')
+
+  // Verify the fee payer signature is present in the decoded transaction
+  const txBytes = getBase64Codec().encode(result)
+  const decoded = getTransactionDecoder().decode(txBytes)
+  const feePayerSig = decoded.signatures[feePayer.address]
+  assert.ok(feePayerSig, 'fee payer signature should be present')
+  assert.notEqual(
+    feePayerSig,
+    new Uint8Array(64),
+    'fee payer signature should not be empty bytes',
+  )
+})
+
+test('coSignBase64Transaction throws when signer returns no signature', async () => {
+  const { base64Tx } = await buildPartiallySignedTx()
+
+  const brokenSigner: TransactionPartialSigner = {
+    address: address('AM1LZ111111111111111111111111111111111111111'),
+    signTransactions: async () => [{}] as any,
+  }
+
+  await assert.rejects(
+    () => coSignBase64Transaction(brokenSigner, base64Tx),
+    (err: Error) => {
+      assert.ok(
+        err.message.includes('returned no signature'),
+        `expected "returned no signature", got: ${err.message}`,
+      )
+      return true
+    },
+  )
+})
+
+test('coSignBase64Transaction throws on invalid base64 input', async () => {
+  const feePayer = await generateKeyPairSigner()
+
+  await assert.rejects(
+    () => coSignBase64Transaction(feePayer, 'not-valid-base64!!!'),
+  )
+})

--- a/sdk/src/client/Charge.ts
+++ b/sdk/src/client/Charge.ts
@@ -17,6 +17,7 @@ import {
   type Address,
   type TransactionSigner,
   type Instruction,
+  type Blockhash,
 } from '@solana/kit'
 import { getTransferSolInstruction } from '@solana-program/system'
 import {
@@ -184,9 +185,7 @@ export function charge(parameters: charge.Parameters) {
       // Use server-provided blockhash if available, otherwise fetch one.
       const latestBlockhash = serverBlockhash
         ? {
-            blockhash: serverBlockhash as Parameters<
-              typeof setTransactionMessageLifetimeUsingBlockhash
-            >[0]['blockhash'],
+            blockhash: serverBlockhash as Blockhash,
             lastValidBlockHeight: BigInt(0), // Server doesn't provide this; tx lifetime is managed by the blockhash itself.
           }
         : (await rpc.getLatestBlockhash().send()).value
@@ -333,6 +332,7 @@ export declare namespace charge {
      * Solana transaction signer. Compatible with:
      * - ConnectorKit's `useTransactionSigner()` hook
      * - `createKeyPairSignerFromBytes()` from `@solana/kit` for headless usage
+     * - Solana Keychain's `SolanaSigner` for remote signers
      * - Any `TransactionSigner` implementation
      */
     signer: TransactionSigner

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -2,13 +2,11 @@ import { Method, Receipt, Store } from 'mppx'
 import { findAssociatedTokenPda } from '@solana-program/token'
 import {
   address,
-  getTransactionDecoder,
-  partiallySignTransaction,
-  getBase64EncodedWireTransaction,
-  isKeyPairSigner,
-  type TransactionSigner,
+  isTransactionPartialSigner,
+  type TransactionPartialSigner,
 } from '@solana/kit'
 import * as Methods from '../Methods.js'
+import { coSignBase64Transaction } from '../utils/transactions.js'
 import {
   TOKEN_PROGRAM,
   TOKEN_2022_PROGRAM,
@@ -68,9 +66,9 @@ export function charge(parameters: charge.Parameters) {
     throw new Error('decimals is required when splToken is set')
   }
 
-  if (signer && !isKeyPairSigner(signer)) {
+  if (signer && !isTransactionPartialSigner(signer)) {
     throw new Error(
-      'signer must be a KeyPairSigner (created via generateKeyPairSigner or createKeyPairSignerFromBytes) for fee payer mode',
+      'signer must implement signTransactions() for fee payer mode (e.g. KeyPairSigner, SolanaSigner)',
     )
   }
 
@@ -178,7 +176,7 @@ async function verifyTransaction(
   rpcUrl: string,
   recipient: string,
   store: Store.Store,
-  signer?: TransactionSigner,
+  signer?: TransactionPartialSigner,
 ) {
   const { transaction: clientTxBase64 } = credential.payload
   if (!clientTxBase64) {
@@ -193,12 +191,8 @@ async function verifyTransaction(
   // Recipients can close ATAs to reclaim rent, forcing re-creation on the next
   // payment. Servers should verify ATA existence before signing or factor rent
   // into pricing to mitigate this drain vector.
-  if (signer && isKeyPairSigner(signer)) {
-    const txBytes = Uint8Array.from(atob(clientTxBase64), (c) => c.charCodeAt(0))
-    const decoder = getTransactionDecoder()
-    const tx = decoder.decode(txBytes)
-    const cosigned = await partiallySignTransaction([signer.keyPair], tx)
-    txToSend = getBase64EncodedWireTransaction(cosigned)
+  if (signer) {
+    txToSend = await coSignBase64Transaction(signer, clientTxBase64)
   }
 
   // Simulate before broadcast to catch failures without wasting fees.
@@ -540,14 +534,13 @@ export declare namespace charge {
      */
     store?: Store.Store
     /**
-     * Server-side KeyPairSigner for fee sponsorship (feePayer mode).
+     * Server-side signer for fee sponsorship (feePayer mode).
      * When provided, the server's public key is included in the challenge
      * as `feePayerKey`, and the server co-signs the transaction as fee payer
      * before broadcasting.
      *
-     * Must be a KeyPairSigner (from `generateKeyPairSigner` or
-     * `createKeyPairSignerFromBytes`).
+     * Accepts any TransactionPartialSigner — KeyPairSigner, Keychain SolanaSigner, etc.
      */
-    signer?: TransactionSigner
+    signer?: TransactionPartialSigner
   }
 }

--- a/sdk/src/session/Voucher.ts
+++ b/sdk/src/session/Voucher.ts
@@ -6,7 +6,7 @@ import {
   getPublicKeyFromAddress,
   signatureBytes,
   verifySignature,
-  type KeyPairSigner,
+  type MessagePartialSigner,
 } from '@solana/kit'
 import type { SessionVoucher, SignedSessionVoucher } from './Types.js'
 
@@ -21,7 +21,7 @@ export function serializeVoucher(voucher: SessionVoucher): Uint8Array {
 }
 
 export async function signVoucher(
-  signer: KeyPairSigner,
+  signer: MessagePartialSigner,
   voucher: SessionVoucher,
 ): Promise<SignedSessionVoucher> {
   const signable = createSignableMessage(serializeVoucher(voucher))

--- a/sdk/src/session/authorizers/BudgetAuthorizer.ts
+++ b/sdk/src/session/authorizers/BudgetAuthorizer.ts
@@ -1,4 +1,4 @@
-import { createSolanaRpc, type KeyPairSigner } from '@solana/kit'
+import { createSolanaRpc, type MessagePartialSigner } from '@solana/kit'
 import {
   type AuthorizeCloseInput,
   type AuthorizeOpenInput,
@@ -62,7 +62,7 @@ type ChannelProgress = {
 }
 
 export interface BudgetAuthorizerParameters {
-  signer: KeyPairSigner
+  signer: MessagePartialSigner
   maxCumulativeAmount: string
   maxDepositAmount?: string
   validUntil?: string
@@ -84,7 +84,7 @@ export interface BudgetAuthorizerParameters {
  * - Program access and spend caps are validated from Swig role actions.
  */
 export class BudgetAuthorizer implements SessionAuthorizer {
-  private readonly signer: KeyPairSigner
+  private readonly signer: MessagePartialSigner
   private readonly maxCumulativeAmount: bigint
   private readonly maxDepositAmount?: bigint
   private readonly validUntil?: string

--- a/sdk/src/session/authorizers/UnboundedAuthorizer.ts
+++ b/sdk/src/session/authorizers/UnboundedAuthorizer.ts
@@ -1,4 +1,4 @@
-import type { KeyPairSigner } from '@solana/kit'
+import type { MessagePartialSigner } from '@solana/kit'
 import {
   type AuthorizeCloseInput,
   type AuthorizeOpenInput,
@@ -19,7 +19,7 @@ type ChannelProgress = {
 }
 
 export interface UnboundedAuthorizerParameters {
-  signer: KeyPairSigner
+  signer: MessagePartialSigner
   allowedPrograms?: string[]
   expiresAt?: string
   requiresInteractiveApproval?: Partial<
@@ -31,7 +31,7 @@ export interface UnboundedAuthorizerParameters {
 }
 
 export class UnboundedAuthorizer implements SessionAuthorizer {
-  private readonly signer: KeyPairSigner
+  private readonly signer: MessagePartialSigner
   private readonly allowedPrograms?: Set<string>
   private readonly expiresAt?: string
   private readonly expiresAtUnixMs?: number

--- a/sdk/src/session/authorizers/makeSessionAuthorizer.ts
+++ b/sdk/src/session/authorizers/makeSessionAuthorizer.ts
@@ -1,4 +1,4 @@
-import type { KeyPairSigner } from '@solana/kit'
+import type { MessagePartialSigner } from '@solana/kit'
 import type { SessionAuthorizer, SessionPolicyProfile } from '../Types.js'
 import {
   BudgetAuthorizer,
@@ -15,7 +15,7 @@ import {
 
 export interface MakeSessionAuthorizerParameters {
   profile: SessionPolicyProfile
-  signer?: KeyPairSigner
+  signer?: MessagePartialSigner
   swigWallet?: SwigWalletAdapter
   rpcUrl?: string
   allowedPrograms?: string[]
@@ -128,9 +128,9 @@ export function makeSessionAuthorizer(
 }
 
 function requireSigner(
-  signer: KeyPairSigner | undefined,
+  signer: MessagePartialSigner | undefined,
   profile: SessionPolicyProfile['profile'],
-): KeyPairSigner {
+): MessagePartialSigner {
   if (!signer) {
     throw new Error(
       `makeSessionAuthorizer requires \`signer\` for profile "${profile}"`,

--- a/sdk/src/utils/transactions.ts
+++ b/sdk/src/utils/transactions.ts
@@ -1,0 +1,56 @@
+import {
+  getTransactionDecoder,
+  getBase64Codec,
+  getBase64EncodedWireTransaction,
+  getCompiledTransactionMessageCodec,
+  getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+  assertIsTransactionWithinSizeLimit,
+  type TransactionPartialSigner,
+  type Base64EncodedWireTransaction,
+} from '@solana/kit'
+
+/**
+ * Decode a base64 wire transaction, co-sign it with a TransactionPartialSigner,
+ * and return the co-signed base64 wire transaction.
+ *
+ * This bridges the gap between Kit's `partiallySignTransaction` (which takes
+ * raw CryptoKeyPair[]) and the wider `TransactionPartialSigner` interface
+ * (Keychain, Privy, Turnkey, AWS KMS, etc.).
+ */
+export async function coSignBase64Transaction(
+  signer: TransactionPartialSigner,
+  clientTxBase64: string,
+): Promise<Base64EncodedWireTransaction> {
+  // 1. Decode wire bytes → Transaction
+  const txBytes = getBase64Codec().encode(clientTxBase64)
+  const tx = getTransactionDecoder().decode(txBytes)
+
+  // 2. Reconstruct lifetime from compiled message
+  //    (decoded wire transactions lose the type-level lifetime constraint)
+  const compiled = getCompiledTransactionMessageCodec().decode(tx.messageBytes)
+  const lifetimeConstraint =
+    await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiled)
+  const txWithLifetime = { ...tx, lifetimeConstraint }
+
+  // 3. Validate
+  assertIsTransactionWithinSizeLimit(txWithLifetime)
+
+  // 4. Partial-sign via the signer interface
+  const [sigDict] = await signer.signTransactions([txWithLifetime])
+  if (!sigDict?.[signer.address]) {
+    throw new Error(
+      `Co-signer ${signer.address} returned no signature for its address`,
+    )
+  }
+
+  // 5. Merge signatures and return
+  const cosigned = Object.freeze({
+    ...txWithLifetime,
+    signatures: Object.freeze({
+      ...txWithLifetime.signatures,
+      ...sigDict,
+    }),
+  })
+
+  return getBase64EncodedWireTransaction(cosigned)
+}


### PR DESCRIPTION
## Summary
- Replace `KeyPairSigner` with `MessagePartialSigner` for voucher signing (authorizers, `signVoucher`)
- Replace `TransactionSigner` with `TransactionPartialSigner` for server fee payer co-signing
- Properly decode transaction lifetime from wire bytes using `getCompiledTransactionMessageCodec` + `getTransactionLifetimeConstraintFromCompiledTransactionMessage` instead of type casts
- Validate signer return value and use `isTransactionPartialSigner` runtime guard

[Solana Keychain](https://github.com/solana-foundation/solana-keychain)'s `SolanaSigner` (Vault, Privy, Turnkey, AWS KMS, etc.) now works as a drop-in wherever signers are accepted. `KeyPairSigner` remains compatible since it extends both `MessagePartialSigner` and `TransactionPartialSigner`.

## Test plan
- [x] 39/39 unit tests pass
- [x] Typecheck clean (pre-existing zod inference errors only)
- [x] Demo app tested with fee payer co-signing

Closes TOO-195