### PR TITLE
chore: remove namespace types, zero eslint overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ An interactive playground with a React frontend and Express backend, running aga
 
 ```bash
 surfpool start
-npm run demo:install
-npm run demo:server
-npm run demo:app
+pnpm demo:install
+pnpm demo:server
+pnpm demo:app
 ```
 
 See [demo/README.md](demo/README.md) for full details.
@@ -195,13 +195,14 @@ See [demo/README.md](demo/README.md) for full details.
 ## Development
 
 ```bash
-npm install
+pnpm install
 
-npm run typecheck          # TypeScript check
-npm test                   # Unit tests (charge + session, no network)
-npm run test:session       # Session unit tests only
-npm run test:integration   # Integration tests (requires Surfpool)
-npm run test:all           # All tests
+just fmt                   # Lint fix + format
+just build                 # Typecheck
+just test                  # Unit tests (charge + session, no network)
+just test-integration      # Integration tests (requires Surfpool)
+just test-all              # All tests
+just pre-commit            # fmt + build + test (run before committing)
 ```
 
 ## Spec

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,8 @@
 import solanaConfig from '@solana/eslint-config-solana';
 
 export default [
-  {
-    ignores: ['**/dist/**', '**/node_modules/**', '**/*.tsbuildinfo', '**/__tests__/**', 'demo/**'],
-  },
-  ...solanaConfig,
-  {
-    rules: {
-      '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
+    {
+        ignores: ['**/dist/**', '**/node_modules/**', '**/*.tsbuildinfo', '**/__tests__/**', 'demo/**'],
     },
-  },
+    ...solanaConfig,
 ];

--- a/sdk/src/__tests__/session.test.ts
+++ b/sdk/src/__tests__/session.test.ts
@@ -2,7 +2,7 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { generateKeyPairSigner } from '@solana/kit';
 import { Store } from 'mppx/server';
-import { session } from '../server/Session.js';
+import { session, type SessionParameters } from '../server/Session.js';
 import { signVoucher } from '../session/Voucher.js';
 import * as ChannelStore from '../session/ChannelStore.js';
 import type { AuthorizationMode, ChannelState, SignedSessionVoucher } from '../session/Types.js';
@@ -803,7 +803,7 @@ test('rejects actions after channel is closed', async () => {
     );
 });
 
-function createMethod(overrides: Partial<session.Parameters> = {}) {
+function createMethod(overrides: Partial<SessionParameters> = {}) {
     return session({
         recipient: RECIPIENT,
         network: NETWORK,

--- a/sdk/src/client/Charge.ts
+++ b/sdk/src/client/Charge.ts
@@ -62,7 +62,7 @@ const textEncoder = new TextEncoder();
  * console.log(await response.json())
  * ```
  */
-export function charge(parameters: charge.Parameters) {
+export function charge(parameters: ChargeParameters) {
     const { signer, broadcast = false, onProgress } = parameters;
 
     const method = Method.toClient(Methods.charge, {
@@ -307,47 +307,45 @@ async function confirmTransaction(rpc: ReturnType<typeof createSolanaRpc>, signa
     throw new Error('Transaction confirmation timeout');
 }
 
-export declare namespace charge {
-    type Parameters = {
-        /**
-         * If true, the client broadcasts the transaction and sends the signature
-         * as a `type="signature"` credential. If false (default), the client sends
-         * the signed transaction bytes as a `type="transaction"` credential and the
-         * server broadcasts it.
-         *
-         * Cannot be used with server fee sponsorship (feePayer mode).
-         */
-        broadcast?: boolean;
-        /** Compute unit limit. Defaults to 50,000. */
-        computeUnitLimit?: number;
-        /** Compute unit price in micro-lamports for priority fees. Defaults to 1. */
-        computeUnitPrice?: bigint;
-        /** Called at each step of the payment process. */
-        onProgress?: (event: ProgressEvent) => void;
-        /** Custom RPC URL. If not set, inferred from the challenge's network field. */
-        rpcUrl?: string;
-        /**
-         * Solana transaction signer. Compatible with:
-         * - ConnectorKit's `useTransactionSigner()` hook
-         * - `createKeyPairSignerFromBytes()` from `@solana/kit` for headless usage
-         * - Solana Keychain's `SolanaSigner` for remote signers
-         * - Any `TransactionSigner` implementation
-         */
-        signer: TransactionSigner;
-    };
+export type ChargeParameters = {
+    /**
+     * If true, the client broadcasts the transaction and sends the signature
+     * as a `type="signature"` credential. If false (default), the client sends
+     * the signed transaction bytes as a `type="transaction"` credential and the
+     * server broadcasts it.
+     *
+     * Cannot be used with server fee sponsorship (feePayer mode).
+     */
+    broadcast?: boolean;
+    /** Compute unit limit. Defaults to 50,000. */
+    computeUnitLimit?: number;
+    /** Compute unit price in micro-lamports for priority fees. Defaults to 1. */
+    computeUnitPrice?: bigint;
+    /** Called at each step of the payment process. */
+    onProgress?: (event: ChargeProgressEvent) => void;
+    /** Custom RPC URL. If not set, inferred from the challenge's network field. */
+    rpcUrl?: string;
+    /**
+     * Solana transaction signer. Compatible with:
+     * - ConnectorKit's `useTransactionSigner()` hook
+     * - `createKeyPairSignerFromBytes()` from `@solana/kit` for headless usage
+     * - Solana Keychain's `SolanaSigner` for remote signers
+     * - Any `TransactionSigner` implementation
+     */
+    signer: TransactionSigner;
+};
 
-    type ProgressEvent =
-        | {
-              amount: string;
-              currency: string;
-              feePayerKey?: string;
-              recipient: string;
-              splToken?: string;
-              type: 'challenge';
-          }
-        | { signature: string; type: 'confirming' }
-        | { signature: string; type: 'paid' }
-        | { transaction: string; type: 'signed' }
-        | { type: 'paying' }
-        | { type: 'signing' };
-}
+export type ChargeProgressEvent =
+    | {
+          amount: string;
+          currency: string;
+          feePayerKey?: string;
+          recipient: string;
+          splToken?: string;
+          type: 'challenge';
+      }
+    | { signature: string; type: 'confirming' }
+    | { signature: string; type: 'paid' }
+    | { transaction: string; type: 'signed' }
+    | { type: 'paying' }
+    | { type: 'signing' };

--- a/sdk/src/client/Methods.ts
+++ b/sdk/src/client/Methods.ts
@@ -1,5 +1,8 @@
-import { charge as charge_ } from './Charge.js';
+import { charge as charge_, type ChargeParameters } from './Charge.js';
 import { session as session_ } from './Session.js';
+
+export type { ChargeParameters, ChargeProgressEvent } from './Charge.js';
+export type { SessionParameters, SessionProgressEvent } from './Session.js';
 
 /**
  * Creates a Solana `charge` method for usage on the client.
@@ -18,14 +21,10 @@ import { session as session_ } from './Session.js';
  * ```
  */
 export const solana: {
-    (parameters: solana.Parameters): ReturnType<typeof charge_>;
+    (parameters: ChargeParameters): ReturnType<typeof charge_>;
     charge: typeof charge_;
     session: typeof session_;
-} = Object.assign((parameters: solana.Parameters) => charge_(parameters), {
+} = Object.assign((parameters: ChargeParameters) => charge_(parameters), {
     charge: charge_,
     session: session_,
 });
-
-export declare namespace solana {
-    type Parameters = charge_.Parameters;
-}

--- a/sdk/src/client/Session.ts
+++ b/sdk/src/client/Session.ts
@@ -57,7 +57,7 @@ export const sessionContextSchema = z.object({
 
 export type SessionContext = z.infer<typeof sessionContextSchema>;
 
-export function session(parameters: session.Parameters) {
+export function session(parameters: SessionParameters) {
     const { signer, authorizer, autoOpen = true, autoTopup = false, settleOnLimitHit = false, onProgress } = parameters;
 
     let activeChannel: ActiveChannel | null = null;
@@ -469,7 +469,7 @@ async function handleCloseAction(
     channelProgram: string,
     recipient: string,
     network: string,
-    onProgress?: session.Parameters['onProgress'],
+    onProgress?: SessionParameters['onProgress'],
 ): Promise<string> {
     const channelId = context.channelId ?? activeChannel?.channelId;
     if (!channelId) {
@@ -609,22 +609,20 @@ function resolveOpenPayer(voucherPayer: string, signer?: TransactionSigner): str
     return voucherPayer;
 }
 
-export declare namespace session {
-    type Parameters = {
-        authorizer: SessionAuthorizer;
-        autoOpen?: boolean;
-        autoTopup?: boolean;
-        onProgress?: (event: ProgressEvent) => void;
-        settleOnLimitHit?: boolean;
-        signer?: TransactionSigner;
-    };
+export type SessionParameters = {
+    authorizer: SessionAuthorizer;
+    autoOpen?: boolean;
+    autoTopup?: boolean;
+    onProgress?: (event: SessionProgressEvent) => void;
+    settleOnLimitHit?: boolean;
+    signer?: TransactionSigner;
+};
 
-    type ProgressEvent =
-        | { asset: SessionAsset; network: string; recipient: string; type: 'challenge' }
-        | { channelId: string; cumulativeAmount: string; type: 'updated' }
-        | { channelId: string; cumulativeAmount: string; type: 'updating' }
-        | { channelId: string; type: 'closed' }
-        | { channelId: string; type: 'closing' }
-        | { channelId: string; type: 'opened' }
-        | { channelId: string; type: 'opening' };
-}
+export type SessionProgressEvent =
+    | { asset: SessionAsset; network: string; recipient: string; type: 'challenge' }
+    | { channelId: string; cumulativeAmount: string; type: 'updated' }
+    | { channelId: string; cumulativeAmount: string; type: 'updating' }
+    | { channelId: string; type: 'closed' }
+    | { channelId: string; type: 'closing' }
+    | { channelId: string; type: 'opened' }
+    | { channelId: string; type: 'opening' };

--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -1,5 +1,5 @@
-export { charge } from './Charge.js';
-export { session } from './Session.js';
+export { charge, type ChargeParameters, type ChargeProgressEvent } from './Charge.js';
+export { session, type SessionParameters, type SessionProgressEvent } from './Session.js';
 export { solana } from './Methods.js';
 // Re-export Mppx so consumers can do: import { Mppx, solana } from 'solana-mpp-sdk/client'
 export { Mppx } from 'mppx/client';

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -39,7 +39,7 @@ import { coSignBase64Transaction } from '../utils/transactions.js';
  * }
  * ```
  */
-export function charge(parameters: charge.Parameters) {
+export function charge(parameters: ChargeParameters) {
     const {
         recipient,
         splToken,
@@ -451,33 +451,31 @@ async function waitForConfirmation(rpcUrl: string, signature: string, timeoutMs 
     throw new Error('Transaction confirmation timeout');
 }
 
-export declare namespace charge {
-    type Parameters = {
-        /** Token decimals (required when splToken is set). */
-        decimals?: number;
-        /** Solana network. Defaults to 'mainnet-beta'. */
-        network?: 'devnet' | 'localnet' | 'mainnet-beta' | (string & {});
-        /** Base58-encoded recipient public key that receives payments. */
-        recipient: string;
-        /** Custom RPC URL. Defaults to public RPC for the selected network. */
-        rpcUrl?: string;
-        /**
-         * Server-side signer for fee sponsorship (feePayer mode).
-         * When provided, the server's public key is included in the challenge
-         * as `feePayerKey`, and the server co-signs the transaction as fee payer
-         * before broadcasting.
-         *
-         * Accepts any TransactionPartialSigner — KeyPairSigner, Keychain SolanaSigner, etc.
-         */
-        signer?: TransactionPartialSigner;
-        /** SPL token mint address. If absent, payments are in native SOL. */
-        splToken?: string;
-        /**
-         * Pluggable key-value store for consumed-signature tracking (replay prevention).
-         * Defaults to in-memory. Use a persistent store in production.
-         */
-        store?: Store.Store;
-        /** Token program address. Defaults to TOKEN_PROGRAM. Set to TOKEN_2022_PROGRAM for Token-2022 mints. */
-        tokenProgram?: string;
-    };
-}
+export type ChargeParameters = {
+    /** Token decimals (required when splToken is set). */
+    decimals?: number;
+    /** Solana network. Defaults to 'mainnet-beta'. */
+    network?: 'devnet' | 'localnet' | 'mainnet-beta' | (string & {});
+    /** Base58-encoded recipient public key that receives payments. */
+    recipient: string;
+    /** Custom RPC URL. Defaults to public RPC for the selected network. */
+    rpcUrl?: string;
+    /**
+     * Server-side signer for fee sponsorship (feePayer mode).
+     * When provided, the server's public key is included in the challenge
+     * as `feePayerKey`, and the server co-signs the transaction as fee payer
+     * before broadcasting.
+     *
+     * Accepts any TransactionPartialSigner — KeyPairSigner, Keychain SolanaSigner, etc.
+     */
+    signer?: TransactionPartialSigner;
+    /** SPL token mint address. If absent, payments are in native SOL. */
+    splToken?: string;
+    /**
+     * Pluggable key-value store for consumed-signature tracking (replay prevention).
+     * Defaults to in-memory. Use a persistent store in production.
+     */
+    store?: Store.Store;
+    /** Token program address. Defaults to TOKEN_PROGRAM. Set to TOKEN_2022_PROGRAM for Token-2022 mints. */
+    tokenProgram?: string;
+};

--- a/sdk/src/server/Methods.ts
+++ b/sdk/src/server/Methods.ts
@@ -1,5 +1,8 @@
-import { charge as charge_ } from './Charge.js';
+import { charge as charge_, type ChargeParameters } from './Charge.js';
 import { session as session_ } from './Session.js';
+
+export type { ChargeParameters } from './Charge.js';
+export type { SessionParameters } from './Session.js';
 
 /**
  * Creates Solana payment methods for usage on the server.
@@ -14,14 +17,10 @@ import { session as session_ } from './Session.js';
  * ```
  */
 export const solana: {
-    (parameters: solana.Parameters): ReturnType<typeof charge_>;
+    (parameters: ChargeParameters): ReturnType<typeof charge_>;
     charge: typeof charge_;
     session: typeof session_;
-} = Object.assign((parameters: solana.Parameters) => solana.charge(parameters), {
+} = Object.assign((parameters: ChargeParameters) => solana.charge(parameters), {
     charge: charge_,
     session: session_,
 });
-
-export declare namespace solana {
-    type Parameters = charge_.Parameters;
-}

--- a/sdk/src/server/Session.ts
+++ b/sdk/src/server/Session.ts
@@ -61,7 +61,7 @@ type TransactionVerifier = {
     verifyTopup?(channelId: string, topupTx: string, amount: string): Promise<void>;
 };
 
-export function session(parameters: session.Parameters) {
+export function session(parameters: SessionParameters) {
     const { recipient, network = 'mainnet-beta', asset, channelProgram, store = Store.memory() } = parameters;
 
     assertSessionParameters(parameters);
@@ -141,7 +141,7 @@ async function handleOpen(
     payload: OpenPayload,
     challenge: SessionChallenge,
     configuredRecipient: string,
-    parameters: session.Parameters,
+    parameters: SessionParameters,
     challengeId?: string,
 ) {
     const request = challenge.request;
@@ -239,7 +239,7 @@ async function handleUpdate(
     channelStore: ChannelStore.ChannelStore,
     payload: UpdatePayload,
     challenge: SessionChallenge,
-    parameters: session.Parameters,
+    parameters: SessionParameters,
     challengeId?: string,
 ) {
     const channel = await channelStore.getChannel(payload.channelId);
@@ -313,7 +313,7 @@ async function handleUpdate(
 async function handleTopup(
     channelStore: ChannelStore.ChannelStore,
     payload: TopupPayload,
-    parameters: session.Parameters,
+    parameters: SessionParameters,
     challengeId?: string,
 ) {
     const current = await channelStore.getChannel(payload.channelId);
@@ -358,7 +358,7 @@ async function handleClose(
     channelStore: ChannelStore.ChannelStore,
     payload: ClosePayload,
     challenge: SessionChallenge,
-    parameters: session.Parameters,
+    parameters: SessionParameters,
     challengeId?: string,
 ) {
     const channel = await channelStore.getChannel(payload.channelId);
@@ -450,7 +450,7 @@ async function handleClose(
     return toSuccessReceipt(payload.closeTx ?? payload.channelId, challengeId);
 }
 
-function assertSessionParameters(parameters: session.Parameters) {
+function assertSessionParameters(parameters: SessionParameters) {
     if (!parameters.recipient.trim()) {
         throw new Error('recipient is required');
     }
@@ -479,7 +479,7 @@ function assertSessionParameters(parameters: session.Parameters) {
     }
 }
 
-function toVerifierRequest(verifier: session.Parameters['verifier']) {
+function toVerifierRequest(verifier: SessionParameters['verifier']) {
     if (!verifier) {
         return undefined;
     }
@@ -657,31 +657,29 @@ function toSuccessReceipt(channelId: string, challengeId?: string): Receipt.Rece
     });
 }
 
-export declare namespace session {
-    type Parameters = {
-        asset: { decimals: number; kind: 'sol' | 'spl'; mint?: string; symbol?: string };
-        channelProgram: string;
-        network?: 'devnet' | 'localnet' | 'mainnet-beta' | 'surfnet' | (string & {});
-        pricing?: {
-            amountPerUnit: string;
-            meter: string;
-            minDebit?: string;
-            unit: string;
-        };
-        recipient: string;
-        rpcUrl?: string;
-        sessionDefaults?: {
-            closeBehavior?: 'payer_must_close' | 'server_may_finalize';
-            settleInterval?: { kind: string; minIncrement?: string; seconds?: number };
-            suggestedDeposit?: string;
-            ttlSeconds?: number;
-        };
-        store?: Store.Store;
-        transactionVerifier?: TransactionVerifier;
-        verifier?: {
-            acceptAuthorizationModes?: Array<'regular_budget' | 'regular_unbounded' | 'swig_session'>;
-            maxClockSkewSeconds?: number;
-            voucherVerifier?: VoucherVerifier;
-        };
+export type SessionParameters = {
+    asset: { decimals: number; kind: 'sol' | 'spl'; mint?: string; symbol?: string };
+    channelProgram: string;
+    network?: 'devnet' | 'localnet' | 'mainnet-beta' | 'surfnet' | (string & {});
+    pricing?: {
+        amountPerUnit: string;
+        meter: string;
+        minDebit?: string;
+        unit: string;
     };
-}
+    recipient: string;
+    rpcUrl?: string;
+    sessionDefaults?: {
+        closeBehavior?: 'payer_must_close' | 'server_may_finalize';
+        settleInterval?: { kind: string; minIncrement?: string; seconds?: number };
+        suggestedDeposit?: string;
+        ttlSeconds?: number;
+    };
+    store?: Store.Store;
+    transactionVerifier?: TransactionVerifier;
+    verifier?: {
+        acceptAuthorizationModes?: Array<'regular_budget' | 'regular_unbounded' | 'swig_session'>;
+        maxClockSkewSeconds?: number;
+        voucherVerifier?: VoucherVerifier;
+    };
+};

--- a/sdk/src/server/index.ts
+++ b/sdk/src/server/index.ts
@@ -1,5 +1,5 @@
-export { charge } from './Charge.js';
-export { session } from './Session.js';
+export { charge, type ChargeParameters } from './Charge.js';
+export { session, type SessionParameters } from './Session.js';
 export { solana } from './Methods.js';
 // Re-export Mppx so consumers can do: import { Mppx, solana } from 'solana-mpp-sdk/server'
 export { Mppx, Expires, Store } from 'mppx/server';


### PR DESCRIPTION
## Summary
- Refactor `declare namespace` companion types to module-level exports
  - `charge.Parameters` → `ChargeParameters`
  - `charge.ProgressEvent` → `ChargeProgressEvent`
  - `session.Parameters` → `SessionParameters`
  - `session.ProgressEvent` → `SessionProgressEvent`
- ESLint config now uses `@solana/eslint-config-solana` with **zero overrides**
- Re-export all parameter types from index barrels for consumer access

## Test plan
- [x] `just pre-commit` passes (lint, typecheck, 42/42 tests)
- [ ] CI passes