### PR TITLE
test: migrate to vitest and kit plugin client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
   workflow_call:
 
 jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --production
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -3,6 +3,10 @@ set shell := ["bash", "-uc"]
 default:
     @just --list
 
+# Audit production dependencies for vulnerabilities
+audit:
+    pnpm audit --production
+
 # Format and lint
 fmt:
     pnpm lint:fix
@@ -27,5 +31,5 @@ test-integration:
 # All tests
 test-all: test test-integration
 
-# Pre-commit: fmt + typecheck + unit tests
-pre-commit: fmt typecheck test
+# Pre-commit: audit + fmt + typecheck + unit tests
+pre-commit: audit fmt typecheck test

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "prettier": "@solana/prettier-config-solana",
   "dependencies": {
     "@solana-program/compute-budget": "^0.15.0",
-    "@solana-program/system": "^0.11.0",
+    "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.11.0"
   },
   "peerDependencies": {
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@solana/eslint-config-solana": "^6.0.0",
     "@solana/kit": "^6.5.0",
+    "@solana/kit-client-rpc": "^0.8.0",
     "@solana/prettier-config-solana": "^0.0.6",
     "@swig-wallet/kit": "^1.7.1",
     "@swig-wallet/lib": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "sdk/src/[!_]*"
   ],
   "scripts": {
-    "test": "node --import tsx/esm --test sdk/src/__tests__/charge.test.ts sdk/src/__tests__/session.test.ts sdk/src/__tests__/transactions.test.ts",
-    "test:session": "node --import tsx/esm --test sdk/src/__tests__/session.test.ts",
-    "test:integration": "node --import tsx/esm --test sdk/src/__tests__/integration.test.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.config.integration.ts",
     "test:all": "pnpm test && pnpm test:integration",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
@@ -75,6 +75,7 @@
     "mppx": "^0.3.15",
     "prettier": "^3.8.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.15.0
         version: 0.15.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/system':
-        specifier: ^0.11.0
-        version: 0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+        specifier: ^0.12.0
+        version: 0.12.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/token':
         specifier: ^0.11.0
         version: 0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
@@ -24,6 +24,9 @@ importers:
       '@solana/kit':
         specifier: ^6.5.0
         version: 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/kit-client-rpc':
+        specifier: ^0.8.0
+        version: 0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/prettier-config-solana':
         specifier: ^0.0.6
         version: 0.0.6(prettier@3.8.1)
@@ -771,11 +774,6 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.3.0
 
-  '@solana-program/system@0.11.0':
-    resolution: {integrity: sha512-SJeQVTkqGZzIXd7XHlCxnfpKpvPZghB1IFwddPPG04ydVXtDLRWp9wLoTR5Prkl9FIWRe/c5VgT4nxyzW1cAuQ==}
-    peerDependencies:
-      '@solana/kit': ^6.0.0
-
   '@solana-program/system@0.12.0':
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
@@ -1017,6 +1015,26 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/kit-client-rpc@0.8.0':
+    resolution: {integrity: sha512-YD9x3hZ9TKR8r5evmkfURI1e2BtIudnd6zUWXEakMLi0FhvUfdtPrWjQsHw5ngWUv9Ns9yYlI+h3DEY0xmweUg==}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
+
+  '@solana/kit-plugin-instruction-plan@0.8.0':
+    resolution: {integrity: sha512-/wgyycjhaeMKUuYAymKUGZ+sF3U+rrFHQa80Rz5etThUmVOufR94lnJzRMw9KMzc1kbfOZ+45O2IcceMyTs72A==}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
+
+  '@solana/kit-plugin-payer@0.8.0':
+    resolution: {integrity: sha512-IGHv9TIHxj16WOSKElF2RqdvKNCSdgsRnuJ7vhE0qZ4BZjtW2qGPkdtTO7y/RFSNs+4oDwHJhYFUKJIW04Xzsw==}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
+
+  '@solana/kit-plugin-rpc@0.8.0':
+    resolution: {integrity: sha512-XIg4BqWHwVIVEqEBXN1zZ7BUkjCYmGYUXu8KAjPGvQcJg+gY6oOAWyr5APcbjbWZqzpq6axN5lvC3hhuAJwOXw==}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
 
   '@solana/kit@2.3.0':
     resolution: {integrity: sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==}
@@ -4294,10 +4312,6 @@ snapshots:
     dependencies:
       '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/system@0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
-    dependencies:
-      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
-
   '@solana-program/system@0.12.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -4542,6 +4556,25 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/kit-client-rpc@0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-payer': 0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-rpc': 0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+
+  '@solana/kit-plugin-instruction-plan@0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana/kit-plugin-payer@0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana/kit-plugin-rpc@0.8.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,29 +10,29 @@ importers:
     dependencies:
       '@solana-program/compute-budget':
         specifier: ^0.15.0
-        version: 0.15.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+        version: 0.15.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/system':
         specifier: ^0.11.0
-        version: 0.11.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+        version: 0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/token':
         specifier: ^0.11.0
-        version: 0.11.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+        version: 0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^6.0.0
         version: 6.0.0(@eslint/js@9.39.4)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.4))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.4))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(globals@16.5.0)(jest@30.3.0(@types/node@25.5.0))(typescript-eslint@8.57.1(eslint@9.39.4)(typescript@5.9.3))(typescript@5.9.3)
       '@solana/kit':
         specifier: ^6.5.0
-        version: 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        version: 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/prettier-config-solana':
         specifier: ^0.0.6
         version: 0.0.6(prettier@3.8.1)
       '@swig-wallet/kit':
         specifier: ^1.7.1
-        version: 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+        version: 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@swig-wallet/lib':
         specifier: ^1.7.1
-        version: 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+        version: 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -47,7 +47,7 @@ importers:
         version: 9.39.4
       mppx:
         specifier: ^0.3.15
-        version: 0.3.16(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.5(typescript@5.9.3)(zod@4.3.6))
+        version: 0.3.16(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -590,6 +593,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
@@ -613,6 +619,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.120.0':
+    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -646,6 +655,98 @@ packages:
 
   '@remix-run/node-fetch-server@0.13.0':
     resolution: {integrity: sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.10':
+    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -1304,6 +1405,9 @@ packages:
       typescript:
         optional: true
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swig-wallet/coder@1.7.1':
     resolution: {integrity: sha512-A+KtXK4y44iNnY2P9HxLEG2X/8z73Y6eHiHc7UsUjj2OW7GOA7NsGGG+BeeWsphnohGXAbqxhos2LlQTfFgHjQ==}
 
@@ -1330,6 +1434,12 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -1558,6 +1668,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -1648,6 +1787,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -1717,6 +1860,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1743,6 +1890,10 @@ packages:
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1843,6 +1994,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -1888,6 +2043,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2015,6 +2173,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2041,6 +2202,10 @@ packages:
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
@@ -2529,6 +2694,76 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2548,6 +2783,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2628,6 +2866,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2642,6 +2885,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2664,6 +2911,9 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -2757,6 +3007,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2779,6 +3032,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2853,6 +3110,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.10:
+    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -2907,6 +3169,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2917,6 +3182,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -2932,9 +3201,15 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -2984,9 +3259,20 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -3075,6 +3361,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -3091,12 +3381,95 @@ packages:
       typescript:
         optional: true
 
+  vite@8.0.1:
+    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3781,6 +4154,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.9.1':
@@ -3800,6 +4180,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxc-project/types@0.120.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3836,6 +4218,55 @@ snapshots:
 
   '@remix-run/node-fetch-server@0.13.0': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.10': {}
+
   '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.7.0':
@@ -3859,26 +4290,26 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-program/compute-budget@0.15.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/compute-budget@0.15.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/system@0.11.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/system@0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/system@0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/system@0.12.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/token@0.11.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/token@0.11.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/system': 0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana-program/system': 0.12.0(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))':
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
   '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -4112,7 +4543,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4125,11 +4556,11 @@ snapshots:
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -4137,7 +4568,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/accounts': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4156,11 +4587,11 @@ snapshots:
       '@solana/rpc-api': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
@@ -4370,22 +4801,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.19.0)':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/functional': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/subscribable': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  '@solana/rpc-subscriptions-channel-websocket@6.5.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.5.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/functional': 6.5.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/subscribable': 6.5.0(typescript@5.9.3)
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4409,7 +4840,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 2.3.0(typescript@5.9.3)
@@ -4417,7 +4848,7 @@ snapshots:
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.19.0)
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4427,7 +4858,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-subscriptions@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc-subscriptions@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 6.5.0(typescript@5.9.3)
@@ -4435,7 +4866,7 @@ snapshots:
       '@solana/promises': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.5.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.5.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-transformers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4607,7 +5038,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4615,7 +5046,7 @@ snapshots:
       '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4624,7 +5055,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/transaction-confirmation@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/transaction-confirmation@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4632,7 +5063,7 @@ snapshots:
       '@solana/keys': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 6.5.0(typescript@5.9.3)
       '@solana/rpc': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -4711,34 +5142,36 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@swig-wallet/coder@1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@standard-schema/spec@1.1.0': {}
+
+  '@swig-wallet/coder@1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
       - ws
 
-  '@swig-wallet/kit@1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@swig-wallet/kit@1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@noble/curves': 1.9.1
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
-      '@swig-wallet/coder': 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
-      '@swig-wallet/lib': 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@swig-wallet/coder': 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@swig-wallet/lib': 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       bn.js: 5.2.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
       - ws
 
-  '@swig-wallet/lib@1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@swig-wallet/lib@1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
-      '@swig-wallet/coder': 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@swig-wallet/coder': 1.7.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       bn.js: 5.2.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -4772,6 +5205,13 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint@9.6.1':
     dependencies:
@@ -5011,6 +5451,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
     optionalDependencies:
       typescript: 5.9.3
@@ -5083,6 +5564,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   babel-jest@30.3.0(@babel/core@7.29.0):
     dependencies:
@@ -5189,6 +5672,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -5208,6 +5696,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001780: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5275,6 +5765,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  detect-libc@2.1.2: {}
+
   detect-newline@3.1.0: {}
 
   dir-glob@3.0.1:
@@ -5308,6 +5800,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5477,6 +5971,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -5502,6 +6000,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit-x@0.2.2: {}
+
+  expect-type@1.3.0: {}
 
   expect@30.3.0:
     dependencies:
@@ -5797,9 +6297,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -6192,6 +6692,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lines-and-columns@1.2.4: {}
 
   locate-path@5.0.0:
@@ -6209,6 +6758,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-dir@4.0.0:
     dependencies:
@@ -6255,13 +6808,13 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mppx@0.3.16(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.5(typescript@5.9.3)(zod@4.3.6)):
+  mppx@0.3.16(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
       incur: 0.3.4(openapi-types@12.1.3)
       ox: 0.12.4(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.47.5(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
@@ -6275,6 +6828,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.11: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare-lite@1.4.0: {}
@@ -6282,6 +6837,9 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-int64@0.4.0: {}
 
@@ -6296,6 +6854,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.1: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -6398,6 +6958,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6411,6 +6973,12 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -6465,6 +7033,27 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.10:
+    dependencies:
+      '@oxc-project/types': 0.120.0
+      '@rolldown/pluginutils': 1.0.0-rc.10
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
 
   router@2.2.0:
     dependencies:
@@ -6547,11 +7136,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
     dependencies:
@@ -6566,7 +7159,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.0.0: {}
 
   string-length@4.0.2:
     dependencies:
@@ -6617,10 +7214,16 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tmpl@1.0.5: {}
 
@@ -6720,6 +7323,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -6728,22 +7336,63 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.47.5(typescript@5.9.3)(zod@4.3.6):
+  viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.14.5(typescript@5.9.3)(zod@4.3.6)
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
+
+  vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.10
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
 
   walker@1.0.8:
     dependencies:
@@ -6752,6 +7401,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
@@ -6774,9 +7428,15 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.18.3: {}
+  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
-  ws@8.19.0: {}
+  ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   y18n@5.0.8: {}
 

--- a/sdk/src/__tests__/charge.test.ts
+++ b/sdk/src/__tests__/charge.test.ts
@@ -5,7 +5,7 @@
  * - Push mode (type="signature"): server fetches + verifies on-chain
  * - Pull mode (type="transaction"): server broadcasts, confirms, then verifies on-chain
  */
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { test, expect, beforeEach, afterEach } from 'vitest';
 import { Store } from 'mppx/server';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import { address } from '@solana/kit';

--- a/sdk/src/__tests__/charge.test.ts
+++ b/sdk/src/__tests__/charge.test.ts
@@ -5,8 +5,7 @@
  * - Push mode (type="signature"): server fetches + verifies on-chain
  * - Pull mode (type="transaction"): server broadcasts, confirms, then verifies on-chain
  */
-import { test, beforeEach, afterEach, mock } from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { Store } from 'mppx/server';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import { address } from '@solana/kit';
@@ -163,27 +162,25 @@ afterEach(() => {
 // ── Parameter validation ──
 
 test('charge() throws when splToken is set but decimals is missing', () => {
-    assert.throws(
-        () =>
-            charge({
-                recipient: RECIPIENT,
-                splToken: USDC_MINT,
-                // decimals intentionally omitted
-                network: 'devnet',
-                store,
-            }),
-        /decimals is required/,
-    );
+    expect(() =>
+        charge({
+            recipient: RECIPIENT,
+            splToken: USDC_MINT,
+            // decimals intentionally omitted
+            network: 'devnet',
+            store,
+        }),
+    ).toThrow(/decimals is required/);
 });
 
 test('charge() does not throw for native SOL (no splToken)', () => {
-    assert.doesNotThrow(() =>
+    expect(() =>
         charge({
             recipient: RECIPIENT,
             network: 'devnet',
             store,
         }),
-    );
+    ).not.toThrow();
 });
 
 // ── Request generation ──
@@ -213,14 +210,14 @@ test('request() generates a unique reference and populates fields', async () => 
         request: { amount: '500000', currency: 'USDC', recipient: '', methodDetails: stub },
     });
 
-    assert.equal(request1.recipient, RECIPIENT);
-    assert.equal(request1.methodDetails.network, 'devnet');
-    assert.equal(request1.methodDetails.splToken, USDC_MINT);
-    assert.equal(request1.methodDetails.decimals, 6);
-    assert.ok(request1.methodDetails.reference, 'reference should be set');
-    assert.ok(request1.methodDetails.recentBlockhash, 'recentBlockhash should be set');
+    expect(request1.recipient).toBe(RECIPIENT);
+    expect(request1.methodDetails.network).toBe('devnet');
+    expect(request1.methodDetails.splToken).toBe(USDC_MINT);
+    expect(request1.methodDetails.decimals).toBe(6);
+    expect(request1.methodDetails.reference).toBeTruthy();
+    expect(request1.methodDetails.recentBlockhash).toBeTruthy();
     // Each call generates a fresh reference
-    assert.notEqual(request1.methodDetails.reference, request2.methodDetails.reference);
+    expect(request1.methodDetails.reference).not.toBe(request2.methodDetails.reference);
 });
 
 test('request() returns the challenge request when credential is present', async () => {
@@ -245,13 +242,11 @@ test('request() returns the challenge request when credential is present', async
         request: { amount: '1000000', currency: 'SOL', recipient: '', methodDetails: { reference: '' } },
     });
 
-    assert.equal(result.methodDetails.reference, 'existing-ref');
+    expect(result.methodDetails.reference).toBe('existing-ref');
 });
 
 // ══════════════════════════════════════════════════════════════════════
-// ══════════════════════════════════════════════════════════════════════
 // Push mode (type="signature")
-// ══════════════════════════════════════════════════════════════════════
 // ══════════════════════════════════════════════════════════════════════
 
 // ── Native SOL verification ──
@@ -271,8 +266,8 @@ test('signature: accepts valid native SOL transfer', async () => {
         request: {} as any,
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, SIGNATURE);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(SIGNATURE);
 });
 
 test('signature: rejects SOL transfer with wrong recipient', async () => {
@@ -285,14 +280,12 @@ test('signature: rejects SOL transfer with wrong recipient', async () => {
 
     globalThis.fetch = async () => rpcSuccess(solTransferTx('WrongRecipient111111111111111111111', 1000000));
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /Recipient mismatch/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Recipient mismatch/);
 });
 
 test('signature: rejects SOL transfer with wrong amount', async () => {
@@ -305,14 +298,12 @@ test('signature: rejects SOL transfer with wrong amount', async () => {
 
     globalThis.fetch = async () => rpcSuccess(solTransferTx(RECIPIENT, 500000));
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /Amount mismatch/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Amount mismatch/);
 });
 
 // ── SPL token verification ──
@@ -344,8 +335,8 @@ test('signature: accepts valid SPL token transfer', async () => {
         request: {} as any,
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, SIGNATURE);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(SIGNATURE);
 });
 
 test('signature: rejects SPL transfer with wrong mint', async () => {
@@ -367,18 +358,16 @@ test('signature: rejects SPL transfer with wrong mint', async () => {
     const WRONG_MINT = 'So11111111111111111111111111111111111111112';
     globalThis.fetch = async () => rpcSuccess(splTransferTx(expectedAta, WRONG_MINT, '1000000'));
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, {
-                    amount: '1000000',
-                    splToken: USDC_MINT,
-                    decimals: 6,
-                }),
-                request: {} as any,
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, {
+                amount: '1000000',
+                splToken: USDC_MINT,
+                decimals: 6,
             }),
-        /Token mint mismatch/,
-    );
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Token mint mismatch/);
 });
 
 test('signature: rejects SPL transfer with wrong amount', async () => {
@@ -399,18 +388,16 @@ test('signature: rejects SPL transfer with wrong amount', async () => {
 
     globalThis.fetch = async () => rpcSuccess(splTransferTx(expectedAta, USDC_MINT, '500000'));
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, {
-                    amount: '1000000',
-                    splToken: USDC_MINT,
-                    decimals: 6,
-                }),
-                request: {} as any,
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, {
+                amount: '1000000',
+                splToken: USDC_MINT,
+                decimals: 6,
             }),
-        /Amount mismatch/,
-    );
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Amount mismatch/);
 });
 
 test('signature: rejects SPL transfer with wrong destination ATA', async () => {
@@ -426,18 +413,16 @@ test('signature: rejects SPL transfer with wrong destination ATA', async () => {
     const WRONG_ATA = 'WrongATA11111111111111111111111111111111111';
     globalThis.fetch = async () => rpcSuccess(splTransferTx(WRONG_ATA, USDC_MINT, '1000000'));
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, {
-                    amount: '1000000',
-                    splToken: USDC_MINT,
-                    decimals: 6,
-                }),
-                request: {} as any,
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, {
+                amount: '1000000',
+                splToken: USDC_MINT,
+                decimals: 6,
             }),
-        /Destination token account does not belong to expected recipient/,
-    );
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Destination token account does not belong to expected recipient/);
 });
 
 // ── Replay prevention (type="signature") ──
@@ -459,14 +444,12 @@ test('signature: rejects already-consumed transaction signature', async () => {
     });
 
     // Second call with same signature is rejected
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /already consumed/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/already consumed/);
 });
 
 // ── RPC error handling (type="signature") ──
@@ -481,14 +464,12 @@ test('signature: throws when transaction is not found', async () => {
 
     globalThis.fetch = async () => rpcSuccess(null);
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /Transaction not found/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Transaction not found/);
 });
 
 test('signature: throws when transaction failed on-chain', async () => {
@@ -505,14 +486,12 @@ test('signature: throws when transaction failed on-chain', async () => {
             transaction: { message: { instructions: [] } },
         });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /Transaction failed on-chain/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Transaction failed on-chain/);
 });
 
 test('signature: throws on RPC error response', async () => {
@@ -525,14 +504,12 @@ test('signature: throws on RPC error response', async () => {
 
     globalThis.fetch = async () => rpcError('Transaction version not supported');
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /RPC error/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/RPC error/);
 });
 
 test('signature: throws when no transfer instruction found (SOL)', async () => {
@@ -549,14 +526,12 @@ test('signature: throws when no transfer instruction found (SOL)', async () => {
             transaction: { message: { instructions: [] } },
         });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /No system transfer instruction found/,
-    );
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/No system transfer instruction found/);
 });
 
 test('signature: throws when no TransferChecked instruction found (SPL)', async () => {
@@ -575,18 +550,16 @@ test('signature: throws when no TransferChecked instruction found (SPL)', async 
             transaction: { message: { instructions: [] } },
         });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: signatureCredential(SIGNATURE, {
-                    amount: '1000000',
-                    splToken: USDC_MINT,
-                    decimals: 6,
-                }),
-                request: {} as any,
+    await expect(
+        method.verify({
+            credential: signatureCredential(SIGNATURE, {
+                amount: '1000000',
+                splToken: USDC_MINT,
+                decimals: 6,
             }),
-        /No TransferChecked instruction found/,
-    );
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/No TransferChecked instruction found/);
 });
 
 // ══════════════════════════════════════════════════════════════════════
@@ -642,8 +615,8 @@ test('pull: accepts valid native SOL transfer', async () => {
         request: {} as any,
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, SIGNATURE);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(SIGNATURE);
 });
 
 test('pull: accepts valid SPL token transfer', async () => {
@@ -673,8 +646,8 @@ test('pull: accepts valid SPL token transfer', async () => {
         request: {} as any,
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, SIGNATURE);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(SIGNATURE);
 });
 
 test('transaction: rejects when sendTransaction fails', async () => {
@@ -687,14 +660,12 @@ test('transaction: rejects when sendTransaction fails', async () => {
 
     globalThis.fetch = async () => rpcError('Transaction simulation failed');
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: transactionCredential(FAKE_TX_BASE64, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /RPC error/,
-    );
+    await expect(
+        method.verify({
+            credential: transactionCredential(FAKE_TX_BASE64, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/RPC error/);
 });
 
 test('transaction: rejects when on-chain verification fails (wrong recipient)', async () => {
@@ -707,14 +678,12 @@ test('transaction: rejects when on-chain verification fails (wrong recipient)', 
 
     mockServerBroadcastFetch(solTransferTx('WrongRecipient111111111111111111111', 1000000));
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: transactionCredential(FAKE_TX_BASE64, { amount: '1000000' }),
-                request: {} as any,
-            }),
-        /Recipient mismatch/,
-    );
+    await expect(
+        method.verify({
+            credential: transactionCredential(FAKE_TX_BASE64, { amount: '1000000' }),
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Recipient mismatch/);
 });
 
 test('transaction: throws when transaction data is missing', async () => {
@@ -725,25 +694,23 @@ test('transaction: throws when transaction data is missing', async () => {
         store,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: {
-                    payload: { type: 'transaction' },
-                    challenge: {
-                        request: {
-                            amount: '1000000',
-                            currency: 'SOL',
-                            recipient: RECIPIENT,
-                            methodDetails: {
-                                reference: 'ref-1',
-                                network: 'devnet',
-                            },
+    await expect(
+        method.verify({
+            credential: {
+                payload: { type: 'transaction' },
+                challenge: {
+                    request: {
+                        amount: '1000000',
+                        currency: 'SOL',
+                        recipient: RECIPIENT,
+                        methodDetails: {
+                            reference: 'ref-1',
+                            network: 'devnet',
                         },
                     },
-                } as any,
-                request: {} as any,
-            }),
-        /Missing transaction data/,
-    );
+                },
+            } as any,
+            request: {} as any,
+        }),
+    ).rejects.toThrow(/Missing transaction data/);
 });

--- a/sdk/src/__tests__/integration.test.ts
+++ b/sdk/src/__tests__/integration.test.ts
@@ -8,22 +8,11 @@
  *
  * Run: npm run test:integration
  */
-import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { test, expect, beforeAll, afterAll } from 'vitest';
 import http from 'node:http';
-import {
-    appendTransactionMessageInstructions,
-    createSolanaRpc,
-    createTransactionMessage,
-    generateKeyPairSigner,
-    getBase64EncodedWireTransaction,
-    pipe,
-    setTransactionMessageFeePayerSigner,
-    setTransactionMessageLifetimeUsingBlockhash,
-    signTransactionMessageWithSigners,
-    address,
-    type Instruction,
-} from '@solana/kit';
-import { getTransferSolInstruction } from '@solana-program/system';
+import { generateKeyPairSigner, address, lamports } from '@solana/kit';
+import { createLocalClient } from '@solana/kit-client-rpc';
+import { getTransferSolInstruction, systemProgram } from '@solana-program/system';
 import {
     fetchSwig,
     findSwigPda,
@@ -43,7 +32,7 @@ const RPC_URL = 'http://localhost:8899';
 const SESSION_CHANNEL_PROGRAM = 'swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB';
 
 type GeneratedSigner = Awaited<ReturnType<typeof generateKeyPairSigner>>;
-type SolanaRpcClient = ReturnType<typeof createSolanaRpc>;
+type TestClient = Awaited<ReturnType<typeof createTestClient>>;
 type SwigHarness = {
     swigAddress: string;
     swigWalletAddress: string;
@@ -64,56 +53,22 @@ type SessionHarness = {
 
 // ── Helpers ──
 
-async function airdrop(pubkey: string, lamports: number) {
-    const res = await fetch(RPC_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 1,
-            method: 'requestAirdrop',
-            params: [pubkey, lamports],
-        }),
-    });
-    const data = (await res.json()) as { result?: string; error?: any };
-    if (data.error) throw new Error(`Airdrop failed: ${JSON.stringify(data.error)}`);
-
-    // Wait for confirmation
-    const sig = data.result!;
-    for (let i = 0; i < 30; i++) {
-        const statusRes = await fetch(RPC_URL, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                jsonrpc: '2.0',
-                id: 1,
-                method: 'getSignatureStatuses',
-                params: [[sig]],
-            }),
-        });
-        const statusData = (await statusRes.json()) as { result?: { value: any[] } };
-        const status = statusData.result?.value?.[0];
-        if (status?.confirmationStatus === 'confirmed' || status?.confirmationStatus === 'finalized') {
-            return sig;
-        }
-        await new Promise(r => setTimeout(r, 500));
-    }
-    throw new Error('Airdrop confirmation timeout');
+async function createTestClient(payer?: GeneratedSigner) {
+    return await createLocalClient({ payer, url: RPC_URL }).use(systemProgram());
 }
 
-async function getBalance(pubkey: string): Promise<number> {
-    const res = await fetch(RPC_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 1,
-            method: 'getBalance',
-            params: [pubkey],
-        }),
-    });
-    const data = (await res.json()) as { result?: { value: number } };
-    return data.result?.value ?? 0;
+async function getBalance(client: TestClient, pubkey: string): Promise<bigint> {
+    const { value } = await client.rpc.getBalance(address(pubkey)).send();
+    return value;
+}
+
+async function getConfirmedTransaction(client: TestClient, signature: string) {
+    return await client.rpc
+        .getTransaction(signature as Parameters<typeof client.rpc.getTransaction>[0], {
+            encoding: 'jsonParsed',
+            maxSupportedTransactionVersion: 0,
+        })
+        .send();
 }
 
 async function isSurfpoolRunning(): Promise<boolean> {
@@ -217,133 +172,29 @@ async function getSessionChannel(store: Store.Store, channelId: string) {
     return await SessionChannelStore.fromStore(store).getChannel(channelId);
 }
 
-async function waitForSignatureConfirmation(signature: string, timeoutMs = 30_000) {
-    const startedAt = Date.now();
-
-    while (Date.now() - startedAt < timeoutMs) {
-        const res = await fetch(RPC_URL, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                jsonrpc: '2.0',
-                id: 1,
-                method: 'getSignatureStatuses',
-                params: [[signature]],
-            }),
-        });
-
-        const data = (await res.json()) as {
-            result?: {
-                value: Array<null | {
-                    confirmationStatus?: string;
-                    err?: unknown;
-                }>;
-            };
-        };
-
-        const status = data.result?.value?.[0];
-        if (status) {
-            if (status.err) {
-                throw new Error(`Transaction ${signature} failed: ${JSON.stringify(status.err)}`);
-            }
-
-            if (status.confirmationStatus === 'confirmed' || status.confirmationStatus === 'finalized') {
-                return;
-            }
-        }
-
-        await new Promise(resolve => setTimeout(resolve, 250));
-    }
-
-    throw new Error(`Timed out waiting for transaction confirmation: ${signature}`);
-}
-
-async function sendInstructions(parameters: {
-    rpc: SolanaRpcClient;
-    feePayer: GeneratedSigner;
-    instructions: readonly Instruction[];
-}): Promise<string> {
-    const { rpc, feePayer, instructions } = parameters;
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-    const txMessage = pipe(
-        createTransactionMessage({ version: 0 }),
-        message => setTransactionMessageFeePayerSigner(feePayer, message),
-        message => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, message),
-        message => appendTransactionMessageInstructions(instructions, message),
-    );
-
-    const signed = await signTransactionMessageWithSigners(txMessage);
-    const wire = getBase64EncodedWireTransaction(signed);
-    const signature = await rpc
-        .sendTransaction(wire, {
-            encoding: 'base64',
-            skipPreflight: false,
-        })
-        .send();
-
-    await waitForSignatureConfirmation(signature);
-    return signature;
-}
-
-async function getConfirmedTransaction(signature: string) {
-    const res = await fetch(RPC_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 1,
-            method: 'getTransaction',
-            params: [
-                signature,
-                {
-                    encoding: 'jsonParsed',
-                    maxSupportedTransactionVersion: 0,
-                },
-            ],
-        }),
-    });
-
-    const data = (await res.json()) as {
-        result?: unknown;
-        error?: unknown;
-    };
-
-    if (data.error) {
-        throw new Error(`getTransaction failed: ${JSON.stringify(data.error)}`);
-    }
-
-    return data.result ?? null;
-}
-
 async function sendMarkerTransfer(parameters: {
-    signer: GeneratedSigner;
+    client: TestClient;
     destination: string;
-    lamports?: bigint;
+    amount?: bigint;
 }): Promise<string> {
-    const rpc = createSolanaRpc(RPC_URL);
-    const { signer, destination, lamports = 1n } = parameters;
-
-    return await sendInstructions({
-        rpc,
-        feePayer: signer,
-        instructions: [
-            getTransferSolInstruction({
-                source: signer,
-                destination: address(destination),
-                amount: lamports,
-            }),
-        ],
-    });
+    const { client, destination, amount = 1n } = parameters;
+    const result = await client.system.instructions
+        .transferSol({
+            source: client.payer,
+            destination: address(destination),
+            amount,
+        })
+        .sendTransaction();
+    return result.context.signature;
 }
 
 async function createSwigHarness(parameters: {
-    walletSigner: GeneratedSigner;
+    client: TestClient;
     spendLimitLamports: bigint;
     sessionTtlSeconds: number;
 }): Promise<SwigHarness> {
-    const { walletSigner, spendLimitLamports, sessionTtlSeconds } = parameters;
-    const rpc = createSolanaRpc(RPC_URL);
+    const { client, spendLimitLamports, sessionTtlSeconds } = parameters;
+    const walletSigner = client.payer as GeneratedSigner;
     const swigRoleId = 0;
 
     const swigId = crypto.getRandomValues(new Uint8Array(32));
@@ -354,27 +205,19 @@ async function createSwigHarness(parameters: {
         authorityInfo: createEd25519SessionAuthorityInfo(walletSigner.address, BigInt(sessionTtlSeconds)),
     });
 
-    await sendInstructions({
-        rpc,
-        feePayer: walletSigner,
-        instructions: [createSwigInstruction],
-    });
+    await client.sendTransaction([createSwigInstruction]);
 
     const swigAddress = await findSwigPda(swigId);
-    let swig = await (fetchSwig as any)(rpc, swigAddress);
+    let swig = await (fetchSwig as any)(client.rpc, swigAddress);
     const swigWalletAddress = await getSwigWalletAddress(swig);
 
-    await sendInstructions({
-        rpc,
-        feePayer: walletSigner,
-        instructions: [
-            getTransferSolInstruction({
-                source: walletSigner,
-                destination: address(swigWalletAddress),
-                amount: spendLimitLamports * 4n,
-            }),
-        ],
-    });
+    await client.system.instructions
+        .transferSol({
+            source: walletSigner,
+            destination: address(swigWalletAddress),
+            amount: spendLimitLamports * 4n,
+        })
+        .sendTransaction();
 
     let currentSessionSigner: GeneratedSigner | null = null;
 
@@ -382,7 +225,7 @@ async function createSwigHarness(parameters: {
         swigAddress,
         swigWalletAddress,
         async createSessionKey(ttlSeconds: number) {
-            swig = await (fetchSwig as any)(rpc, swigAddress);
+            swig = await (fetchSwig as any)(client.rpc, swigAddress);
 
             const sessionSigner = await generateKeyPairSigner();
             const createSessionInstructions = await getCreateSessionInstructions(
@@ -392,29 +235,21 @@ async function createSwigHarness(parameters: {
                 BigInt(ttlSeconds),
             );
 
-            const openTx = await sendInstructions({
-                rpc,
-                feePayer: walletSigner,
-                instructions: createSessionInstructions,
-            });
+            const openResult = await client.sendTransaction(createSessionInstructions);
 
-            await sendInstructions({
-                rpc,
-                feePayer: walletSigner,
-                instructions: [
-                    getTransferSolInstruction({
-                        source: walletSigner,
-                        destination: sessionSigner.address,
-                        amount: 5_000_000n,
-                    }),
-                ],
-            });
+            await client.system.instructions
+                .transferSol({
+                    source: walletSigner,
+                    destination: sessionSigner.address,
+                    amount: 5_000_000n,
+                })
+                .sendTransaction();
 
             currentSessionSigner = sessionSigner;
 
             return {
                 signer: sessionSigner,
-                openTx,
+                openTx: openResult.context.signature,
                 swigRoleId,
             };
         },
@@ -426,7 +261,7 @@ async function createSwigHarness(parameters: {
                 throw new Error('No active Swig session signer');
             }
 
-            swig = await (fetchSwig as any)(rpc, swigAddress);
+            swig = await (fetchSwig as any)(client.rpc, swigAddress);
 
             const innerInstructions = [
                 getTransferSolInstruction({
@@ -440,17 +275,16 @@ async function createSwigHarness(parameters: {
                 payer: currentSessionSigner.address,
             });
 
-            return await sendInstructions({
-                rpc,
-                feePayer: currentSessionSigner,
-                instructions: signInstructions,
-            });
+            const sessionClient = await createTestClient(currentSessionSigner);
+            const result = await sessionClient.sendTransaction(signInstructions);
+            return result.context.signature;
         },
     };
 }
 
 // ── Test state ──
 
+let client: TestClient;
 let clientSigner: GeneratedSigner;
 let recipientSigner: GeneratedSigner;
 let server: http.Server;
@@ -468,8 +302,11 @@ beforeAll(async () => {
     clientSigner = await generateKeyPairSigner();
     recipientSigner = await generateKeyPairSigner();
 
+    // Create kit client with systemProgram plugin
+    client = await createTestClient(clientSigner);
+
     // Fund the client with 10 SOL
-    await airdrop(clientSigner.address, 10_000_000_000);
+    await client.airdrop(clientSigner.address, lamports(10_000_000_000n));
 
     // Start a test HTTP server with the mppx charge handler
     // secretKey is required by mppx for signing challenge tokens
@@ -541,7 +378,7 @@ test('e2e: native SOL charge via pull mode (default)', async () => {
 
     const mppx = ClientMppx.create({ methods: [clientMethod] });
 
-    const balanceBefore = await getBalance(recipientSigner.address);
+    const balanceBefore = await getBalance(client, recipientSigner.address);
 
     const response = await mppx.fetch(`http://localhost:${serverPort}/test`);
     const data = await response.json();
@@ -555,9 +392,9 @@ test('e2e: native SOL charge via pull mode (default)', async () => {
     expect(events).toContain('signed');
 
     // Verify recipient received payment
-    const balanceAfter = await getBalance(recipientSigner.address);
+    const balanceAfter = await getBalance(client, recipientSigner.address);
     expect(balanceAfter).toBeGreaterThan(balanceBefore);
-    expect(balanceAfter - balanceBefore).toBeGreaterThanOrEqual(1_000_000);
+    expect(balanceAfter - balanceBefore).toBeGreaterThanOrEqual(1_000_000n);
 });
 
 test('e2e: native SOL charge via push mode', async () => {
@@ -625,7 +462,7 @@ test('e2e: receipt header is present on success', async () => {
 test('e2e: fee payer mode — server co-signs and pays fees', async () => {
     // Generate a dedicated fee payer keypair for the server
     const feePayerSigner = await generateKeyPairSigner();
-    await airdrop(feePayerSigner.address, 10_000_000_000); // Fund fee payer
+    await client.airdrop(feePayerSigner.address, lamports(10_000_000_000n));
 
     const secretKey = 'test-secret-key-feepayer';
 
@@ -670,7 +507,7 @@ test('e2e: fee payer mode — server co-signs and pays fees', async () => {
     });
 
     try {
-        const clientBalanceBefore = await getBalance(clientSigner.address);
+        const clientBalanceBefore = await getBalance(client, clientSigner.address);
 
         const clientMethod = clientSolana.charge({
             signer: clientSigner,
@@ -687,12 +524,12 @@ test('e2e: fee payer mode — server co-signs and pays fees', async () => {
 
         // Client should have paid exactly 1_000_000 lamports for the transfer,
         // but NOT the tx fee (the fee payer covered that).
-        const clientBalanceAfter = await getBalance(clientSigner.address);
+        const clientBalanceAfter = await getBalance(client, clientSigner.address);
         const clientSpent = clientBalanceBefore - clientBalanceAfter;
 
         // The client should have spent exactly the transfer amount (1_000_000 lamports).
         // Without fee payer, they'd also spend ~5000 lamports for the tx fee.
-        expect(clientSpent).toBe(1_000_000);
+        expect(clientSpent).toBe(1_000_000n);
     } finally {
         fpServer.close();
     }
@@ -917,7 +754,7 @@ test('e2e: session close action returns 204 and next request opens a new channel
 test('e2e: session swig_session mode uses on-chain setup and enforces spend limit', async () => {
     const spendLimitLamports = 800n;
     const swig = await createSwigHarness({
-        walletSigner: clientSigner,
+        client,
         spendLimitLamports,
         sessionTtlSeconds: 120,
     });
@@ -939,7 +776,7 @@ test('e2e: session swig_session mode uses on-chain setup and enforces spend limi
         transactionVerifier: {
             async verifyOpen(_channelId, openTx) {
                 verifiedOpenTx = openTx;
-                const tx = await getConfirmedTransaction(openTx);
+                const tx = await getConfirmedTransaction(client, openTx);
                 expect(tx).toBeTruthy();
             },
         },
@@ -1002,18 +839,18 @@ test('e2e: session swig_session mode uses on-chain setup and enforces spend limi
         expect(channel!.lastAuthorizedAmount).toBe('10');
         expect(channel!.lastSequence).toBe(1);
 
-        const recipientBalanceBefore = await getBalance(recipientSigner.address);
+        const recipientBalanceBefore = await getBalance(client, recipientSigner.address);
 
         const withinLimitSignature = await swig.spendFromSwig(500n, recipientSigner.address);
-        const withinLimitTx = await getConfirmedTransaction(withinLimitSignature);
+        const withinLimitTx = await getConfirmedTransaction(client, withinLimitSignature);
         expect(withinLimitTx).toBeTruthy();
 
-        const recipientBalanceAfter = await getBalance(recipientSigner.address);
-        expect(recipientBalanceAfter - recipientBalanceBefore).toBeGreaterThanOrEqual(500);
+        const recipientBalanceAfter = await getBalance(client, recipientSigner.address);
+        expect(recipientBalanceAfter - recipientBalanceBefore).toBeGreaterThanOrEqual(500n);
 
         await expect(async () => {
             await swig.spendFromSwig(900n, recipientSigner.address);
-        }).rejects.toThrow(/Transaction simulation failed/);
+        }).rejects.toThrow(/Failed to send transaction|Transaction simulation failed/);
     } finally {
         await harness.close();
     }
@@ -1021,7 +858,7 @@ test('e2e: session swig_session mode uses on-chain setup and enforces spend limi
 
 test('e2e: session close can include on-chain settlement transaction', async () => {
     const swig = await createSwigHarness({
-        walletSigner: clientSigner,
+        client,
         spendLimitLamports: 2_000n,
         sessionTtlSeconds: 120,
     });
@@ -1043,7 +880,7 @@ test('e2e: session close can include on-chain settlement transaction', async () 
         transactionVerifier: {
             async verifyClose(_channelId, closeTx) {
                 verifiedCloseTx = closeTx;
-                const tx = await getConfirmedTransaction(closeTx);
+                const tx = await getConfirmedTransaction(client, closeTx);
                 expect(tx).toBeTruthy();
             },
         },
@@ -1093,7 +930,7 @@ test('e2e: session close can include on-chain settlement transaction', async () 
         const updateResponse = await mppx.fetch(endpoint);
         expect(updateResponse.status).toBe(200);
 
-        const recipientBalanceBeforeClose = await getBalance(recipientSigner.address);
+        const recipientBalanceBeforeClose = await getBalance(client, recipientSigner.address);
 
         const closeResponse = await mppx.fetch(endpoint, {
             context: { action: 'close' },
@@ -1101,8 +938,8 @@ test('e2e: session close can include on-chain settlement transaction', async () 
         expect(closeResponse.status).toBe(204);
         expect(verifiedCloseTx).toBeTruthy();
 
-        const recipientBalanceAfterClose = await getBalance(recipientSigner.address);
-        expect(recipientBalanceAfterClose - recipientBalanceBeforeClose).toBeGreaterThanOrEqual(10);
+        const recipientBalanceAfterClose = await getBalance(client, recipientSigner.address);
+        expect(recipientBalanceAfterClose - recipientBalanceBeforeClose).toBeGreaterThanOrEqual(10n);
     } finally {
         await harness.close();
     }
@@ -1111,7 +948,7 @@ test('e2e: session close can include on-chain settlement transaction', async () 
 test('e2e: session regular_budget mode enforces on-chain Swig role limits', async () => {
     const swigSpendLimitLamports = 700n;
     const swig = await createSwigHarness({
-        walletSigner: clientSigner,
+        client,
         spendLimitLamports: swigSpendLimitLamports,
         sessionTtlSeconds: 120,
     });
@@ -1133,7 +970,7 @@ test('e2e: session regular_budget mode enforces on-chain Swig role limits', asyn
         transactionVerifier: {
             async verifyOpen(_channelId, openTx) {
                 verifiedOpenTx = openTx;
-                const tx = await getConfirmedTransaction(openTx);
+                const tx = await getConfirmedTransaction(client, openTx);
                 expect(tx).toBeTruthy();
             },
         },
@@ -1150,12 +987,12 @@ test('e2e: session regular_budget mode enforces on-chain Swig role limits', asyn
             },
             buildOpenTx: async () =>
                 await sendMarkerTransfer({
-                    signer: clientSigner,
+                    client,
                     destination: recipientSigner.address,
                 }),
             buildTopupTx: async () =>
                 await sendMarkerTransfer({
-                    signer: clientSigner,
+                    client,
                     destination: recipientSigner.address,
                 }),
         });
@@ -1197,7 +1034,7 @@ test('e2e: session regular_budget mode enforces on-chain Swig role limits', asyn
 
 test('e2e: session swig_session mode rejects delegated signer not present on-chain', async () => {
     const swig = await createSwigHarness({
-        walletSigner: clientSigner,
+        client,
         spendLimitLamports: 500n,
         sessionTtlSeconds: 120,
     });
@@ -1258,7 +1095,7 @@ test('e2e: session swig_session mode rejects delegated signer not present on-cha
 
 test('e2e: session regular_budget mode rejects unknown configured Swig role', async () => {
     const swig = await createSwigHarness({
-        walletSigner: clientSigner,
+        client,
         spendLimitLamports: 500n,
         sessionTtlSeconds: 120,
     });
@@ -1289,12 +1126,12 @@ test('e2e: session regular_budget mode rejects unknown configured Swig role', as
             },
             buildOpenTx: async () =>
                 await sendMarkerTransfer({
-                    signer: clientSigner,
+                    client,
                     destination: recipientSigner.address,
                 }),
             buildTopupTx: async () =>
                 await sendMarkerTransfer({
-                    signer: clientSigner,
+                    client,
                     destination: recipientSigner.address,
                 }),
         });

--- a/sdk/src/__tests__/integration.test.ts
+++ b/sdk/src/__tests__/integration.test.ts
@@ -8,8 +8,7 @@
  *
  * Run: npm run test:integration
  */
-import { test, before, after } from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import http from 'node:http';
 import {
     appendTransactionMessageInstructions,
@@ -457,7 +456,7 @@ let recipientSigner: GeneratedSigner;
 let server: http.Server;
 let serverPort: number;
 
-before(async () => {
+beforeAll(async () => {
     const running = await isSurfpoolRunning();
     if (!running) {
         console.log('Surfpool not running on localhost:8899 — skipping integration tests.');
@@ -522,7 +521,7 @@ before(async () => {
     });
 });
 
-after(() => {
+afterAll(() => {
     server?.close();
 });
 
@@ -547,21 +546,18 @@ test('e2e: native SOL charge via pull mode (default)', async () => {
     const response = await mppx.fetch(`http://localhost:${serverPort}/test`);
     const data = await response.json();
 
-    assert.equal(response.status, 200);
-    assert.deepEqual(data, { paid: true });
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ paid: true });
 
     // Verify progress events
-    assert.ok(events.includes('challenge'), 'should emit challenge');
-    assert.ok(events.includes('signing'), 'should emit signing');
-    assert.ok(events.includes('signed'), 'should emit signed');
+    expect(events).toContain('challenge');
+    expect(events).toContain('signing');
+    expect(events).toContain('signed');
 
     // Verify recipient received payment
     const balanceAfter = await getBalance(recipientSigner.address);
-    assert.ok(balanceAfter > balanceBefore, 'recipient balance should increase');
-    assert.ok(
-        balanceAfter - balanceBefore >= 1_000_000,
-        `expected >= 1000000 lamports increase, got ${balanceAfter - balanceBefore}`,
-    );
+    expect(balanceAfter).toBeGreaterThan(balanceBefore);
+    expect(balanceAfter - balanceBefore).toBeGreaterThanOrEqual(1_000_000);
 });
 
 test('e2e: native SOL charge via push mode', async () => {
@@ -581,14 +577,14 @@ test('e2e: native SOL charge via push mode', async () => {
     const response = await mppx.fetch(`http://localhost:${serverPort}/test`);
     const data = await response.json();
 
-    assert.equal(response.status, 200);
-    assert.deepEqual(data, { paid: true });
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ paid: true });
 
     // Push mode should fire: challenge → signing → paying → confirming → paid
-    assert.ok(events.includes('challenge'), 'should emit challenge');
-    assert.ok(events.includes('signing'), 'should emit signing');
-    assert.ok(events.includes('paying'), 'should emit paying');
-    assert.ok(events.includes('paid'), 'should emit paid');
+    expect(events).toContain('challenge');
+    expect(events).toContain('signing');
+    expect(events).toContain('paying');
+    expect(events).toContain('paid');
 });
 
 test('e2e: multiple sequential charges succeed', async () => {
@@ -602,9 +598,9 @@ test('e2e: multiple sequential charges succeed', async () => {
     // Three sequential charges should all succeed (no replay issues)
     for (let i = 0; i < 3; i++) {
         const response = await mppx.fetch(`http://localhost:${serverPort}/test`);
-        assert.equal(response.status, 200, `request ${i + 1} should succeed`);
+        expect(response.status).toBe(200);
         const data = await response.json();
-        assert.deepEqual(data, { paid: true });
+        expect(data).toEqual({ paid: true });
     }
 });
 
@@ -617,11 +613,11 @@ test('e2e: receipt header is present on success', async () => {
     const mppx = ClientMppx.create({ methods: [clientMethod] });
 
     const response = await mppx.fetch(`http://localhost:${serverPort}/test`);
-    assert.equal(response.status, 200);
+    expect(response.status).toBe(200);
 
     // mppx attaches a receipt header
     const receiptHeader = response.headers.get('Payment-Receipt');
-    assert.ok(receiptHeader, 'response should have Payment-Receipt header');
+    expect(receiptHeader).toBeTruthy();
 });
 
 // ── Fee payer (server pays tx fees) ──
@@ -686,8 +682,8 @@ test('e2e: fee payer mode — server co-signs and pays fees', async () => {
         const response = await mppx.fetch(`http://localhost:${fpPort}/test`);
         const data = await response.json();
 
-        assert.equal(response.status, 200);
-        assert.deepEqual(data, { paid: true });
+        expect(response.status).toBe(200);
+        expect(data).toEqual({ paid: true });
 
         // Client should have paid exactly 1_000_000 lamports for the transfer,
         // but NOT the tx fee (the fee payer covered that).
@@ -696,11 +692,7 @@ test('e2e: fee payer mode — server co-signs and pays fees', async () => {
 
         // The client should have spent exactly the transfer amount (1_000_000 lamports).
         // Without fee payer, they'd also spend ~5000 lamports for the tx fee.
-        assert.equal(
-            clientSpent,
-            1_000_000,
-            `client should spend exactly 1000000 lamports (transfer only), got ${clientSpent}`,
-        );
+        expect(clientSpent).toBe(1_000_000);
     } finally {
         fpServer.close();
     }
@@ -736,31 +728,31 @@ test('e2e: session auto-open then update over repeated requests', async () => {
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const firstResponse = await mppx.fetch(endpoint);
-        assert.equal(firstResponse.status, 200);
-        assert.deepEqual(await firstResponse.json(), { paid: true });
+        expect(firstResponse.status).toBe(200);
+        expect(await firstResponse.json()).toEqual({ paid: true });
 
         const firstReceipt = receiptFromResponse(firstResponse);
         const channelId = firstReceipt.reference;
 
         const secondResponse = await mppx.fetch(endpoint);
-        assert.equal(secondResponse.status, 200);
-        assert.deepEqual(await secondResponse.json(), { paid: true });
+        expect(secondResponse.status).toBe(200);
+        expect(await secondResponse.json()).toEqual({ paid: true });
 
         const secondReceipt = receiptFromResponse(secondResponse);
-        assert.equal(secondReceipt.reference, channelId);
+        expect(secondReceipt.reference).toBe(channelId);
 
         const channel = await getSessionChannel(harness.store, channelId);
-        assert.ok(channel);
-        assert.equal(channel!.status, 'open');
-        assert.equal(channel!.escrowedAmount, '1000');
-        assert.equal(channel!.lastAuthorizedAmount, '10');
-        assert.equal(channel!.lastSequence, 1);
+        expect(channel).toBeTruthy();
+        expect(channel!.status).toBe('open');
+        expect(channel!.escrowedAmount).toBe('1000');
+        expect(channel!.lastAuthorizedAmount).toBe('10');
+        expect(channel!.lastSequence).toBe(1);
 
-        assert.ok(events.includes('challenge'), 'should emit challenge events');
-        assert.ok(events.includes('opening'), 'should emit opening event');
-        assert.ok(events.includes('opened'), 'should emit opened event');
-        assert.ok(events.includes('updating'), 'should emit updating event');
-        assert.ok(events.includes('updated'), 'should emit updated event');
+        expect(events).toContain('challenge');
+        expect(events).toContain('opening');
+        expect(events).toContain('opened');
+        expect(events).toContain('updating');
+        expect(events).toContain('updated');
     } finally {
         await harness.close();
     }
@@ -790,31 +782,31 @@ test('e2e: session autoTopup returns 204 management response, then resumes updat
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const openResponse = await mppx.fetch(endpoint);
-        assert.equal(openResponse.status, 200);
+        expect(openResponse.status).toBe(200);
         const channelId = receiptFromResponse(openResponse).reference;
 
         const updateResponse = await mppx.fetch(endpoint);
-        assert.equal(updateResponse.status, 200);
-        assert.equal(receiptFromResponse(updateResponse).reference, channelId);
+        expect(updateResponse.status).toBe(200);
+        expect(receiptFromResponse(updateResponse).reference).toBe(channelId);
 
         const topupResponse = await mppx.fetch(endpoint);
-        assert.equal(topupResponse.status, 204);
-        assert.equal(receiptFromResponse(topupResponse).reference, channelId);
+        expect(topupResponse.status).toBe(204);
+        expect(receiptFromResponse(topupResponse).reference).toBe(channelId);
 
         const channelAfterTopup = await getSessionChannel(harness.store, channelId);
-        assert.ok(channelAfterTopup);
-        assert.equal(channelAfterTopup!.escrowedAmount, '200');
-        assert.equal(channelAfterTopup!.lastAuthorizedAmount, '70');
-        assert.equal(channelAfterTopup!.lastSequence, 1);
+        expect(channelAfterTopup).toBeTruthy();
+        expect(channelAfterTopup!.escrowedAmount).toBe('200');
+        expect(channelAfterTopup!.lastAuthorizedAmount).toBe('70');
+        expect(channelAfterTopup!.lastSequence).toBe(1);
 
         const postTopupUpdateResponse = await mppx.fetch(endpoint);
-        assert.equal(postTopupUpdateResponse.status, 200);
-        assert.equal(receiptFromResponse(postTopupUpdateResponse).reference, channelId);
+        expect(postTopupUpdateResponse.status).toBe(200);
+        expect(receiptFromResponse(postTopupUpdateResponse).reference).toBe(channelId);
 
         const channelAfterUpdate = await getSessionChannel(harness.store, channelId);
-        assert.ok(channelAfterUpdate);
-        assert.equal(channelAfterUpdate!.lastAuthorizedAmount, '140');
-        assert.equal(channelAfterUpdate!.lastSequence, 2);
+        expect(channelAfterUpdate).toBeTruthy();
+        expect(channelAfterUpdate!.lastAuthorizedAmount).toBe('140');
+        expect(channelAfterUpdate!.lastSequence).toBe(2);
     } finally {
         await harness.close();
     }
@@ -845,24 +837,24 @@ test('e2e: session can auto-close when limit is hit and autoTopup is disabled', 
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const openResponse = await mppx.fetch(endpoint);
-        assert.equal(openResponse.status, 200);
+        expect(openResponse.status).toBe(200);
         const channelId = receiptFromResponse(openResponse).reference;
 
         const updateResponse = await mppx.fetch(endpoint);
-        assert.equal(updateResponse.status, 200);
-        assert.equal(receiptFromResponse(updateResponse).reference, channelId);
+        expect(updateResponse.status).toBe(200);
+        expect(receiptFromResponse(updateResponse).reference).toBe(channelId);
 
         const autoCloseResponse = await mppx.fetch(endpoint);
-        assert.equal(autoCloseResponse.status, 204);
-        assert.equal(receiptFromResponse(autoCloseResponse).reference, channelId);
+        expect(autoCloseResponse.status).toBe(204);
+        expect(receiptFromResponse(autoCloseResponse).reference).toBe(channelId);
 
         const closedChannel = await getSessionChannel(harness.store, channelId);
-        assert.ok(closedChannel);
-        assert.equal(closedChannel!.status, 'closed');
+        expect(closedChannel).toBeTruthy();
+        expect(closedChannel!.status).toBe('closed');
 
         const reopenedResponse = await mppx.fetch(endpoint);
-        assert.equal(reopenedResponse.status, 200);
-        assert.notEqual(receiptFromResponse(reopenedResponse).reference, channelId);
+        expect(reopenedResponse.status).toBe(200);
+        expect(receiptFromResponse(reopenedResponse).reference).not.toBe(channelId);
     } finally {
         await harness.close();
     }
@@ -891,32 +883,32 @@ test('e2e: session close action returns 204 and next request opens a new channel
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const openResponse = await mppx.fetch(endpoint);
-        assert.equal(openResponse.status, 200);
+        expect(openResponse.status).toBe(200);
         const initialChannelId = receiptFromResponse(openResponse).reference;
 
         const updateResponse = await mppx.fetch(endpoint);
-        assert.equal(updateResponse.status, 200);
+        expect(updateResponse.status).toBe(200);
 
         const closeResponse = await mppx.fetch(endpoint, {
             context: { action: 'close' },
         });
-        assert.equal(closeResponse.status, 204);
-        assert.equal(receiptFromResponse(closeResponse).reference, initialChannelId);
+        expect(closeResponse.status).toBe(204);
+        expect(receiptFromResponse(closeResponse).reference).toBe(initialChannelId);
 
         const closedChannel = await getSessionChannel(harness.store, initialChannelId);
-        assert.ok(closedChannel);
-        assert.equal(closedChannel!.status, 'closed');
+        expect(closedChannel).toBeTruthy();
+        expect(closedChannel!.status).toBe('closed');
 
         const reopenedResponse = await mppx.fetch(endpoint);
-        assert.equal(reopenedResponse.status, 200);
+        expect(reopenedResponse.status).toBe(200);
         const reopenedReceipt = receiptFromResponse(reopenedResponse);
 
-        assert.notEqual(reopenedReceipt.reference, initialChannelId);
+        expect(reopenedReceipt.reference).not.toBe(initialChannelId);
 
         const reopenedChannel = await getSessionChannel(harness.store, reopenedReceipt.reference);
-        assert.ok(reopenedChannel);
-        assert.equal(reopenedChannel!.status, 'open');
-        assert.equal(reopenedChannel!.lastSequence, 0);
+        expect(reopenedChannel).toBeTruthy();
+        expect(reopenedChannel!.status).toBe('open');
+        expect(reopenedChannel!.lastSequence).toBe(0);
     } finally {
         await harness.close();
     }
@@ -948,7 +940,7 @@ test('e2e: session swig_session mode uses on-chain setup and enforces spend limi
             async verifyOpen(_channelId, openTx) {
                 verifiedOpenTx = openTx;
                 const tx = await getConfirmedTransaction(openTx);
-                assert.ok(tx, 'openTx should resolve to a confirmed on-chain transaction');
+                expect(tx).toBeTruthy();
             },
         },
     });
@@ -990,45 +982,38 @@ test('e2e: session swig_session mode uses on-chain setup and enforces spend limi
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const openResponse = await mppx.fetch(endpoint);
-        assert.equal(openResponse.status, 200);
+        expect(openResponse.status).toBe(200);
         const channelId = receiptFromResponse(openResponse).reference;
 
         const updateResponse = await mppx.fetch(endpoint);
-        assert.equal(updateResponse.status, 200);
-        assert.equal(receiptFromResponse(updateResponse).reference, channelId);
+        expect(updateResponse.status).toBe(200);
+        expect(receiptFromResponse(updateResponse).reference).toBe(channelId);
 
-        assert.ok(verifiedOpenTx, 'transaction verifier should receive openTx signature');
+        expect(verifiedOpenTx).toBeTruthy();
 
         const delegatedSigner = swig.getCurrentSessionSigner();
-        assert.ok(delegatedSigner, 'swig session signer should be created on open');
+        expect(delegatedSigner).toBeTruthy();
 
         const channel = await getSessionChannel(harness.store, channelId);
-        assert.ok(channel);
-        assert.equal(channel!.authorizationMode, 'swig_session');
-        assert.equal(channel!.authority.wallet, clientSigner.address);
-        assert.equal(channel!.authority.delegatedSessionKey, delegatedSigner!.address);
-        assert.equal(channel!.lastAuthorizedAmount, '10');
-        assert.equal(channel!.lastSequence, 1);
+        expect(channel).toBeTruthy();
+        expect(channel!.authorizationMode).toBe('swig_session');
+        expect(channel!.authority.wallet).toBe(clientSigner.address);
+        expect(channel!.authority.delegatedSessionKey).toBe(delegatedSigner!.address);
+        expect(channel!.lastAuthorizedAmount).toBe('10');
+        expect(channel!.lastSequence).toBe(1);
 
         const recipientBalanceBefore = await getBalance(recipientSigner.address);
 
         const withinLimitSignature = await swig.spendFromSwig(500n, recipientSigner.address);
         const withinLimitTx = await getConfirmedTransaction(withinLimitSignature);
-        assert.ok(withinLimitTx, 'within-limit Swig spend should settle on-chain');
+        expect(withinLimitTx).toBeTruthy();
 
         const recipientBalanceAfter = await getBalance(recipientSigner.address);
-        assert.ok(
-            recipientBalanceAfter - recipientBalanceBefore >= 500,
-            'recipient should receive Swig spend transfer',
-        );
+        expect(recipientBalanceAfter - recipientBalanceBefore).toBeGreaterThanOrEqual(500);
 
-        await assert.rejects(
-            async () => {
-                await swig.spendFromSwig(900n, recipientSigner.address);
-            },
-            /Transaction simulation failed/,
-            'over-limit Swig spend should fail on-chain',
-        );
+        await expect(async () => {
+            await swig.spendFromSwig(900n, recipientSigner.address);
+        }).rejects.toThrow(/Transaction simulation failed/);
     } finally {
         await harness.close();
     }
@@ -1059,7 +1044,7 @@ test('e2e: session close can include on-chain settlement transaction', async () 
             async verifyClose(_channelId, closeTx) {
                 verifiedCloseTx = closeTx;
                 const tx = await getConfirmedTransaction(closeTx);
-                assert.ok(tx, 'closeTx should resolve to a confirmed on-chain transaction');
+                expect(tx).toBeTruthy();
             },
         },
     });
@@ -1103,24 +1088,21 @@ test('e2e: session close can include on-chain settlement transaction', async () 
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const openResponse = await mppx.fetch(endpoint);
-        assert.equal(openResponse.status, 200);
+        expect(openResponse.status).toBe(200);
 
         const updateResponse = await mppx.fetch(endpoint);
-        assert.equal(updateResponse.status, 200);
+        expect(updateResponse.status).toBe(200);
 
         const recipientBalanceBeforeClose = await getBalance(recipientSigner.address);
 
         const closeResponse = await mppx.fetch(endpoint, {
             context: { action: 'close' },
         });
-        assert.equal(closeResponse.status, 204);
-        assert.ok(verifiedCloseTx, 'transaction verifier should receive closeTx signature');
+        expect(closeResponse.status).toBe(204);
+        expect(verifiedCloseTx).toBeTruthy();
 
         const recipientBalanceAfterClose = await getBalance(recipientSigner.address);
-        assert.ok(
-            recipientBalanceAfterClose - recipientBalanceBeforeClose >= 10,
-            'recipient should receive settlement transfer on close',
-        );
+        expect(recipientBalanceAfterClose - recipientBalanceBeforeClose).toBeGreaterThanOrEqual(10);
     } finally {
         await harness.close();
     }
@@ -1152,7 +1134,7 @@ test('e2e: session regular_budget mode enforces on-chain Swig role limits', asyn
             async verifyOpen(_channelId, openTx) {
                 verifiedOpenTx = openTx;
                 const tx = await getConfirmedTransaction(openTx);
-                assert.ok(tx, 'budget openTx should resolve to a confirmed on-chain transaction');
+                expect(tx).toBeTruthy();
             },
         },
     });
@@ -1188,28 +1170,24 @@ test('e2e: session regular_budget mode enforces on-chain Swig role limits', asyn
         const endpoint = `http://localhost:${harness.port}/session`;
 
         const openResponse = await mppx.fetch(endpoint);
-        assert.equal(openResponse.status, 200);
+        expect(openResponse.status).toBe(200);
         const channelId = receiptFromResponse(openResponse).reference;
 
-        assert.ok(verifiedOpenTx, 'budget flow should verify openTx on-chain');
+        expect(verifiedOpenTx).toBeTruthy();
 
         const firstUpdateResponse = await mppx.fetch(endpoint);
-        assert.equal(firstUpdateResponse.status, 200);
-        assert.equal(receiptFromResponse(firstUpdateResponse).reference, channelId);
+        expect(firstUpdateResponse.status).toBe(200);
+        expect(receiptFromResponse(firstUpdateResponse).reference).toBe(channelId);
 
-        await assert.rejects(
-            async () => {
-                await mppx.fetch(endpoint);
-            },
-            /maxDepositAmount \(700\)/,
-            'budget authorizer should clamp topups to Swig on-chain spend limit',
-        );
+        await expect(async () => {
+            await mppx.fetch(endpoint);
+        }).rejects.toThrow(/maxDepositAmount \(700\)/);
 
         const channel = await getSessionChannel(harness.store, channelId);
-        assert.ok(channel);
-        assert.equal(channel!.authorizationMode, 'regular_budget');
-        assert.equal(channel!.lastAuthorizedAmount, '400');
-        assert.equal(channel!.lastSequence, 1);
+        expect(channel).toBeTruthy();
+        expect(channel!.authorizationMode).toBe('regular_budget');
+        expect(channel!.lastAuthorizedAmount).toBe('400');
+        expect(channel!.lastSequence).toBe(1);
     } finally {
         await harness.close();
     }
@@ -1270,13 +1248,9 @@ test('e2e: session swig_session mode rejects delegated signer not present on-cha
             polyfill: false,
         });
 
-        await assert.rejects(
-            async () => {
-                await mppx.fetch(`http://localhost:${harness.port}/session`);
-            },
-            /delegated session key|Swig role 0 does not match delegated session key role/,
-            'swig_session should reject delegated keys that are not created on-chain',
-        );
+        await expect(async () => {
+            await mppx.fetch(`http://localhost:${harness.port}/session`);
+        }).rejects.toThrow(/delegated session key|Swig role 0 does not match delegated session key role/);
     } finally {
         await harness.close();
     }
@@ -1335,13 +1309,9 @@ test('e2e: session regular_budget mode rejects unknown configured Swig role', as
             polyfill: false,
         });
 
-        await assert.rejects(
-            async () => {
-                await mppx.fetch(`http://localhost:${harness.port}/session`);
-            },
-            /Unable to locate Swig role 999/,
-            'regular_budget should reject non-existent configured Swig roles',
-        );
+        await expect(async () => {
+            await mppx.fetch(`http://localhost:${harness.port}/session`);
+        }).rejects.toThrow(/Unable to locate Swig role 999/);
     } finally {
         await harness.close();
     }

--- a/sdk/src/__tests__/session.test.ts
+++ b/sdk/src/__tests__/session.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { test, expect, beforeEach, afterEach } from 'vitest';
 import { generateKeyPairSigner } from '@solana/kit';
 import { Store } from 'mppx/server';
 import { session } from '../server/Session.js';

--- a/sdk/src/__tests__/session.test.ts
+++ b/sdk/src/__tests__/session.test.ts
@@ -1,5 +1,4 @@
-import { test, beforeEach, afterEach } from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { generateKeyPairSigner } from '@solana/kit';
 import { Store } from 'mppx/server';
 import { session } from '../server/Session.js';
@@ -83,17 +82,15 @@ afterEach(() => {
 });
 
 test('session() throws when asset is spl without mint', () => {
-    assert.throws(
-        () =>
-            session({
-                recipient: RECIPIENT,
-                network: NETWORK,
-                asset: { kind: 'spl', decimals: 6 },
-                channelProgram: CHANNEL_PROGRAM,
-                store,
-            }),
-        /asset\.mint is required/,
-    );
+    expect(() =>
+        session({
+            recipient: RECIPIENT,
+            network: NETWORK,
+            asset: { kind: 'spl', decimals: 6 },
+            channelProgram: CHANNEL_PROGRAM,
+            store,
+        }),
+    ).toThrow(/asset\.mint is required/);
 });
 
 test('request() populates recipient/network/asset/channel metadata', async () => {
@@ -129,21 +126,21 @@ test('request() populates recipient/network/asset/channel metadata', async () =>
         },
     });
 
-    assert.equal(request.recipient, RECIPIENT);
-    assert.equal(request.network, NETWORK);
-    assert.deepEqual(request.asset, { kind: 'sol', decimals: 9, symbol: 'SOL' });
-    assert.equal(request.channelProgram, CHANNEL_PROGRAM);
-    assert.deepEqual(request.pricing, {
+    expect(request.recipient).toBe(RECIPIENT);
+    expect(request.network).toBe(NETWORK);
+    expect(request.asset).toEqual({ kind: 'sol', decimals: 9, symbol: 'SOL' });
+    expect(request.channelProgram).toBe(CHANNEL_PROGRAM);
+    expect(request.pricing).toEqual({
         unit: 'request',
         amountPerUnit: '10',
         meter: 'api_calls',
         minDebit: '5',
     });
-    assert.deepEqual(request.sessionDefaults, {
+    expect(request.sessionDefaults).toEqual({
         suggestedDeposit: '1000',
         ttlSeconds: 60,
     });
-    assert.deepEqual(request.verifier, {
+    expect(request.verifier).toEqual({
         acceptAuthorizationModes: ['regular_unbounded'],
         maxClockSkewSeconds: 10,
     });
@@ -172,7 +169,7 @@ test('request() returns challenge request when credential is present', async () 
         },
     });
 
-    assert.deepEqual(request, challengeRequest);
+    expect(request).toEqual(challengeRequest);
 });
 
 test('open flow creates channel state and returns success receipt', async () => {
@@ -191,16 +188,16 @@ test('open flow creates channel state and returns success receipt', async () => 
         request: buildChallengeRequest(),
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, channelId);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(channelId);
 
     const channel = await getChannel(channelId);
-    assert.ok(channel);
-    assert.equal(channel!.status, 'open');
-    assert.equal(channel!.escrowedAmount, '1000');
-    assert.equal(channel!.lastAuthorizedAmount, '0');
-    assert.equal(channel!.lastSequence, 0);
-    assert.equal(channel!.recipient, RECIPIENT);
+    expect(channel).toBeTruthy();
+    expect(channel!.status).toBe('open');
+    expect(channel!.escrowedAmount).toBe('1000');
+    expect(channel!.lastAuthorizedAmount).toBe('0');
+    expect(channel!.lastSequence).toBe(0);
+    expect(channel!.recipient).toBe(RECIPIENT);
 
     const response = await method.respond!({
         credential,
@@ -208,7 +205,7 @@ test('open flow creates channel state and returns success receipt', async () => 
         receipt,
         input: new Request('http://localhost'),
     });
-    assert.equal(response, undefined);
+    expect(response).toBeUndefined();
 });
 
 test('update flow enforces monotonic cumulative amount and sequence', async () => {
@@ -238,13 +235,13 @@ test('update flow enforces monotonic cumulative amount and sequence', async () =
         request: buildChallengeRequest(),
     });
 
-    assert.equal(firstUpdate.status, 'success');
-    assert.equal(firstUpdate.reference, channelId);
+    expect(firstUpdate.status).toBe('success');
+    expect(firstUpdate.reference).toBe(channelId);
 
     const channelAfterFirst = await getChannel(channelId);
-    assert.ok(channelAfterFirst);
-    assert.equal(channelAfterFirst!.lastAuthorizedAmount, '300');
-    assert.equal(channelAfterFirst!.lastSequence, 1);
+    expect(channelAfterFirst).toBeTruthy();
+    expect(channelAfterFirst!.lastAuthorizedAmount).toBe('300');
+    expect(channelAfterFirst!.lastSequence).toBe(1);
 
     const replayCredential = await buildUpdateCredential({
         channelId,
@@ -253,14 +250,12 @@ test('update flow enforces monotonic cumulative amount and sequence', async () =
         sequence: 1,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: replayCredential,
-                request: buildChallengeRequest(),
-            }),
-        /replay detected/,
-    );
+    await expect(
+        method.verify({
+            credential: replayCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/replay detected/);
 
     const nonMonotonicCredential = await buildUpdateCredential({
         channelId,
@@ -269,14 +264,12 @@ test('update flow enforces monotonic cumulative amount and sequence', async () =
         sequence: 2,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: nonMonotonicCredential,
-                request: buildChallengeRequest(),
-            }),
-        /monotonically non-decreasing/,
-    );
+    await expect(
+        method.verify({
+            credential: nonMonotonicCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/monotonically non-decreasing/);
 });
 
 test('topup flow updates escrowed deposit and respond() returns 204', async () => {
@@ -305,12 +298,12 @@ test('topup flow updates escrowed deposit and respond() returns 204', async () =
         request: buildChallengeRequest(),
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, channelId);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(channelId);
 
     const channel = await getChannel(channelId);
-    assert.ok(channel);
-    assert.equal(channel!.escrowedAmount, '1250');
+    expect(channel).toBeTruthy();
+    expect(channel!.escrowedAmount).toBe('1250');
 
     const response = await method.respond!({
         credential: topupCredential,
@@ -318,7 +311,7 @@ test('topup flow updates escrowed deposit and respond() returns 204', async () =
         receipt,
         input: new Request('http://localhost'),
     });
-    assert.equal(response?.status, 204);
+    expect(response?.status).toBe(204);
 });
 
 test('close flow marks channel as closed and respond() returns 204', async () => {
@@ -360,14 +353,14 @@ test('close flow marks channel as closed and respond() returns 204', async () =>
         request: buildChallengeRequest(),
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, channelId);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(channelId);
 
     const channel = await getChannel(channelId);
-    assert.ok(channel);
-    assert.equal(channel!.status, 'closed');
-    assert.equal(channel!.lastAuthorizedAmount, '450');
-    assert.equal(channel!.lastSequence, 2);
+    expect(channel).toBeTruthy();
+    expect(channel!.status).toBe('closed');
+    expect(channel!.lastAuthorizedAmount).toBe('450');
+    expect(channel!.lastSequence).toBe(2);
 
     const response = await method.respond!({
         credential: closeCredential,
@@ -375,7 +368,7 @@ test('close flow marks channel as closed and respond() returns 204', async () =>
         receipt,
         input: new Request('http://localhost'),
     });
-    assert.equal(response?.status, 204);
+    expect(response?.status).toBe(204);
 });
 
 test('rejects invalid voucher signature', async () => {
@@ -400,14 +393,12 @@ test('rejects invalid voucher signature', async () => {
         voucher: invalidVoucher,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: invalidOpenCredential,
-                request: buildChallengeRequest(),
-            }),
-        /Invalid voucher signature/,
-    );
+    await expect(
+        method.verify({
+            credential: invalidOpenCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/Invalid voucher signature/);
 });
 
 test('accepts swig-session vouchers signed by delegated session key', async () => {
@@ -454,8 +445,8 @@ test('accepts swig-session vouchers signed by delegated session key', async () =
         request: buildChallengeRequest(),
     });
 
-    assert.equal(receipt.status, 'success');
-    assert.equal(receipt.reference, channelId);
+    expect(receipt.status).toBe('success');
+    expect(receipt.reference).toBe(channelId);
 });
 
 test('rejects swig-session voucher signed by wrong signer', async () => {
@@ -500,14 +491,12 @@ test('rejects swig-session voucher signed by wrong signer', async () => {
         }),
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: wrongSignerCredential,
-                request: buildChallengeRequest(),
-            }),
-        /delegated session key/,
-    );
+    await expect(
+        method.verify({
+            credential: wrongSignerCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/delegated session key/);
 });
 
 test('open flow supports configurable transactionVerifier callbacks', async () => {
@@ -527,14 +516,12 @@ test('open flow supports configurable transactionVerifier callbacks', async () =
         sequence: 0,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential,
-                request: buildChallengeRequest(),
-            }),
-        /open transaction rejected by verifier/,
-    );
+    await expect(
+        method.verify({
+            credential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/open transaction rejected by verifier/);
 });
 
 test('close flow supports configurable transactionVerifier callbacks', async () => {
@@ -585,9 +572,9 @@ test('close flow supports configurable transactionVerifier callbacks', async () 
         request: buildChallengeRequest(),
     });
 
-    assert.equal(receipt.reference, 'close-transaction-signature');
-    assert.equal(observedCloseTx, 'close-transaction-signature');
-    assert.equal(observedFinalCumulative, '450');
+    expect(receipt.reference).toBe('close-transaction-signature');
+    expect(observedCloseTx).toBe('close-transaction-signature');
+    expect(observedFinalCumulative).toBe('450');
 });
 
 test('close flow requires closeTx when verifyClose callback is configured', async () => {
@@ -621,19 +608,17 @@ test('close flow requires closeTx when verifyClose callback is configured', asyn
         request: buildChallengeRequest(),
     });
 
-    await assert.rejects(
-        async () =>
-            method.verify({
-                credential: await buildCloseCredential({
-                    channelId,
-                    serverNonce,
-                    cumulativeAmount: '450',
-                    sequence: 2,
-                }),
-                request: buildChallengeRequest(),
+    await expect(
+        method.verify({
+            credential: await buildCloseCredential({
+                channelId,
+                serverNonce,
+                cumulativeAmount: '450',
+                sequence: 2,
             }),
-        /closeTx is required/,
-    );
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/closeTx is required/);
 });
 
 test('rejects update when cumulative amount exceeds deposit', async () => {
@@ -659,14 +644,12 @@ test('rejects update when cumulative amount exceeds deposit', async () => {
         sequence: 1,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: exceedsDepositCredential,
-                request: buildChallengeRequest(),
-            }),
-        /exceeds channel deposit/,
-    );
+    await expect(
+        method.verify({
+            credential: exceedsDepositCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/exceeds channel deposit/);
 });
 
 test('rejects replay attempts using duplicate sequence', async () => {
@@ -702,14 +685,12 @@ test('rejects replay attempts using duplicate sequence', async () => {
         sequence: 1,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: replayUpdateCredential,
-                request: buildChallengeRequest(),
-            }),
-        /replay detected/,
-    );
+    await expect(
+        method.verify({
+            credential: replayUpdateCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/replay detected/);
 });
 
 test('rejects voucher signed by unauthorized signer', async () => {
@@ -750,14 +731,12 @@ test('rejects voucher signed by unauthorized signer', async () => {
         voucher: rogueVoucher,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: rogueCredential,
-                request: buildChallengeRequest(),
-            }),
-        /does not match channel payer/,
-    );
+    await expect(
+        method.verify({
+            credential: rogueCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/does not match channel payer/);
 });
 
 test('rejects actions after channel is closed', async () => {
@@ -793,14 +772,12 @@ test('rejects actions after channel is closed', async () => {
         sequence: 2,
     });
 
-    await assert.rejects(
-        () =>
-            method.verify({
-                credential: updateAfterCloseCredential,
-                request: buildChallengeRequest(),
-            }),
-        /closed/,
-    );
+    await expect(
+        method.verify({
+            credential: updateAfterCloseCredential,
+            request: buildChallengeRequest(),
+        }),
+    ).rejects.toThrow(/closed/);
 });
 
 function createMethod(overrides: Partial<session.Parameters> = {}) {

--- a/sdk/src/__tests__/transactions.test.ts
+++ b/sdk/src/__tests__/transactions.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { test, expect } from 'vitest';
 import {
     generateKeyPairSigner,
     pipe,

--- a/sdk/src/__tests__/transactions.test.ts
+++ b/sdk/src/__tests__/transactions.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, test, expect } from 'vitest';
 import {
     generateKeyPairSigner,
     pipe,
@@ -64,15 +63,15 @@ test('coSignBase64Transaction co-signs with a valid TransactionPartialSigner', a
 
     const result = await coSignBase64Transaction(feePayer, base64Tx);
 
-    assert.ok(typeof result === 'string' && result.length > 0);
-    assert.notEqual(result, base64Tx, 'co-signed tx should differ from input');
+    expect(typeof result === 'string' && result.length > 0).toBeTruthy();
+    expect(result).not.toBe(base64Tx);
 
     // Verify the fee payer signature is present in the decoded transaction
     const txBytes = getBase64Codec().encode(result);
     const decoded = getTransactionDecoder().decode(txBytes);
     const feePayerSig = decoded.signatures[feePayer.address];
-    assert.ok(feePayerSig, 'fee payer signature should be present');
-    assert.notEqual(feePayerSig, new Uint8Array(64), 'fee payer signature should not be empty bytes');
+    expect(feePayerSig).toBeTruthy();
+    expect(feePayerSig).not.toEqual(new Uint8Array(64));
 });
 
 test('coSignBase64Transaction preserves existing signatures', async () => {
@@ -82,12 +81,12 @@ test('coSignBase64Transaction preserves existing signatures', async () => {
 
     // Decode and verify both sender and fee payer signatures are present
     const decoded = getTransactionDecoder().decode(getBase64Codec().encode(result));
-    assert.ok(decoded.signatures[feePayer.address], 'fee payer sig should be present');
-    assert.ok(decoded.signatures[sender.address], 'sender sig should be preserved');
+    expect(decoded.signatures[feePayer.address]).toBeTruthy();
+    expect(decoded.signatures[sender.address]).toBeTruthy();
 });
 
 test('coSignBase64Transaction throws on invalid base64 input', async () => {
     const feePayer = await generateKeyPairSigner();
 
-    await assert.rejects(() => coSignBase64Transaction(feePayer, 'not-valid-base64!!!'));
+    await expect(coSignBase64Transaction(feePayer, 'not-valid-base64!!!')).rejects.toThrow();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['sdk/src/__tests__/integration.test.ts'],
+        testTimeout: 30_000,
+        fileParallelism: false,
+        maxWorkers: 1,
+        globals: true,
+    },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['sdk/src/__tests__/*.test.ts'],
+        exclude: ['**/integration.test.ts'],
+        testTimeout: 15_000,
+        globals: true,
+    },
+});


### PR DESCRIPTION
## Summary
- Migrate test runner from Jest to Vitest
- Replace ~150 lines of manual RPC helpers in integration tests with `createLocalClient` + `systemProgram` plugin from `@solana/kit-client-rpc`
- Bump `@solana-program/system` to `^0.12.0`, add `@solana/kit-client-rpc` as devDependency
- Clean up unused imports across all test files

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 42/42 unit tests pass
- [x] `pnpm lint` clean
- [x] `pnpm test:integration` — 14/14 integration tests pass against surfpool

Closes TOO-201