### PR TITLE
fix(python): pass splits through pay decorator

### DIFF
--- a/python/src/solana_mpp/server/middleware.py
+++ b/python/src/solana_mpp/server/middleware.py
@@ -32,6 +32,7 @@ def pay(mpp_handler: Mpp, amount: str, **options: Any) -> Callable:
         external_id=options.get("external_id", ""),
         expires=options.get("expires", ""),
         fee_payer=options.get("fee_payer", False),
+        splits=options.get("splits", []),
     )
 
     def decorator(handler: Callable) -> Callable:

--- a/python/tests/test_middleware.py
+++ b/python/tests/test_middleware.py
@@ -52,6 +52,29 @@ class TestPayDecorator:
         assert result is not None
 
     @pytest.mark.asyncio
+    async def test_splits_option_is_included_in_challenge(self, mpp_handler):
+        splits = [
+            {
+                "recipient": "VendorPayoutsWaLLetxxxxxxxxxxxxxxxxxxxxxx1111",
+                "amount": "1000",
+                "memo": "vendor payout",
+            }
+        ]
+
+        @pay(mpp_handler, "10000", splits=splits)
+        async def handler(request, credential, receipt):
+            return {"ok": True}
+
+        class FakeRequest:
+            headers = {}
+            url = "http://localhost/test"
+
+        result = await handler(FakeRequest())
+        request = result["challenge"].decode_request()
+
+        assert request["methodDetails"]["splits"] == splits
+
+    @pytest.mark.asyncio
     async def test_with_invalid_auth_returns_402(self, mpp_handler):
         @pay(mpp_handler, "10000")
         async def handler(request, credential, receipt):


### PR DESCRIPTION
## Summary

Passes the Python `pay(..., splits=[...])` option through to `ChargeOptions`.

The lower-level Python server API already supports split payments through `ChargeOptions.splits`, and the SDK README documents split payments as a supported capability. The ASGI-style `pay` decorator accepted arbitrary options but did not forward `splits`, so decorator users could not include split payment metadata in generated challenges.

## Changes

- Forward `splits` from `pay(..., splits=...)` into `ChargeOptions`
- Add a middleware test that verifies the generated challenge includes `methodDetails.splits`

## Verification

- `PYTHONPATH=python/src python3 -m pytest python/tests/test_middleware.py`
- `python3 -m ruff check python/src/solana_mpp/server/middleware.py python/tests/test_middleware.py`
- `git diff --check`
