### PR TITLE
feat(python): add charge max amount helper

### DIFF
--- a/python/src/solana_mpp/protocol/intents.py
+++ b/python/src/solana_mpp/protocol/intents.py
@@ -78,3 +78,19 @@ def parse_units(amount: str, decimals: int) -> str:
         raise ValueError(f"invalid amount: {amount}") from exc
 
     return str(val)
+
+
+def validate_max_amount(request: ChargeRequest, max_amount: str) -> None:
+    """Validate that a charge request does not exceed a max base-unit amount."""
+    try:
+        actual = int(request.amount)
+    except ValueError as exc:
+        raise ValueError(f"invalid amount: {request.amount}") from exc
+
+    try:
+        maximum = int(max_amount)
+    except ValueError as exc:
+        raise ValueError(f"invalid max amount: {max_amount}") from exc
+
+    if actual > maximum:
+        raise ValueError(f"amount {actual} exceeds maximum {maximum}")

--- a/python/tests/test_intents.py
+++ b/python/tests/test_intents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from solana_mpp.protocol.intents import ChargeRequest, parse_units
+from solana_mpp.protocol.intents import ChargeRequest, parse_units, validate_max_amount
 
 
 class TestParseUnits:
@@ -76,3 +76,33 @@ class TestChargeRequest:
         assert "description" not in d
         assert "externalId" not in d
         assert "methodDetails" not in d
+
+
+class TestValidateMaxAmount:
+    def test_allows_amount_below_maximum(self):
+        req = ChargeRequest(amount="1000", currency="USDC")
+
+        validate_max_amount(req, "2000")
+
+    def test_allows_amount_equal_to_maximum(self):
+        req = ChargeRequest(amount="1000", currency="USDC")
+
+        validate_max_amount(req, "1000")
+
+    def test_rejects_amount_above_maximum(self):
+        req = ChargeRequest(amount="1001", currency="USDC")
+
+        with pytest.raises(ValueError, match="amount 1001 exceeds maximum 1000"):
+            validate_max_amount(req, "1000")
+
+    def test_rejects_invalid_amount(self):
+        req = ChargeRequest(amount="not-a-number", currency="USDC")
+
+        with pytest.raises(ValueError, match="invalid amount"):
+            validate_max_amount(req, "1000")
+
+    def test_rejects_invalid_max_amount(self):
+        req = ChargeRequest(amount="1000", currency="USDC")
+
+        with pytest.raises(ValueError, match="invalid max amount"):
+            validate_max_amount(req, "not-a-number")


### PR DESCRIPTION
## Summary

Adds a small Python helper for validating that a charge request stays under a caller-defined maximum base-unit amount.

Other SDK surfaces already expose amount parsing / max-amount validation patterns for client-side spend caps. This gives Python users a simple equivalent primitive for policy-before-payment flows, especially agent clients that need to reject unexpected or oversized payment requirements before signing.

## Changes

- Add `validate_max_amount(request, max_amount)` to `solana_mpp.protocol.intents`
- Cover below-max, equal-max, above-max, invalid amount, and invalid max cases

## Verification

- `PYTHONPATH=python/src python3 -m pytest python/tests/test_intents.py`
- `python3 -m ruff check python/src/solana_mpp/protocol/intents.py python/tests/test_intents.py`
- `git diff --check`
