### PR TITLE
docs(ts): align split limit comment

### DIFF
--- a/typescript/packages/mpp/src/Methods.ts
+++ b/typescript/packages/mpp/src/Methods.ts
@@ -46,7 +46,7 @@ export const charge = Method.from({
                 network: z.optional(z.string()),
                 /** Server-provided base58-encoded recent blockhash. Saves the client an RPC round-trip. */
                 recentBlockhash: z.optional(z.string()),
-                /** Additional payment splits (max 32). Same asset as primary payment. */
+                /** Additional payment splits (max 8). Same asset as primary payment. */
                 splits: z.optional(
                     z.array(
                         z.object({


### PR DESCRIPTION
## Summary

Aligns the shared TypeScript Solana charge schema comment with the actual split limit enforced by the SDK.

`server/Charge.ts` rejects more than 8 split entries and the public server parameter docs also say max 8. The shared schema comment still said max 32, which can mislead client/server users looking at the request schema.

## Changes

- Update the `methodDetails.splits` comment from max 32 to max 8

## Verification

- `pnpm --dir typescript install`
- `pnpm --dir typescript --filter @solana/mpp typecheck`
- `pnpm --dir typescript --filter @solana/mpp exec tsc --noEmit --pretty false`
- `git diff --check`
