### PR TITLE
fix(rust): guard session voucher overflow

### DIFF
--- a/rust/src/client/session.rs
+++ b/rust/src/client/session.rs
@@ -110,7 +110,14 @@ impl ActiveSession {
 
     /// Sign a voucher adding `amount` to the current cumulative.
     pub async fn sign_increment(&mut self, amount: u64) -> Result<SignedVoucher> {
-        self.sign_voucher(self.cumulative + amount).await
+        let next_cumulative = self.cumulative.checked_add(amount).ok_or_else(|| {
+            Error::Other(format!(
+                "Voucher increment {amount} overflows current watermark {}",
+                self.cumulative
+            ))
+        })?;
+
+        self.sign_voucher(next_cumulative).await
     }
 
     /// Build a `SessionAction::Voucher` wrapping a freshly-signed increment.
@@ -236,6 +243,16 @@ mod tests {
     async fn sign_voucher_zero_rejected() {
         let mut s = make_session();
         assert!(s.sign_voucher(0).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn sign_increment_rejects_overflow() {
+        let mut s = make_session();
+        s.sign_voucher(u64::MAX - 1).await.unwrap();
+
+        let err = s.sign_increment(2).await.unwrap_err();
+        assert!(err.to_string().contains("overflows current watermark"));
+        assert_eq!(s.cumulative, u64::MAX - 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Summary
- Return an error from Rust session voucher increments when cumulative arithmetic would overflow.
- Keep the existing cumulative watermark unchanged on rejected overflow attempts.
- Add a focused unit test for the overflow path.

Why
- `sign_increment` previously added `self.cumulative + amount` directly before calling `sign_voucher`. In debug builds this can panic on overflow, and in release builds it can wrap before the monotonic voucher check sees the value.
- For payment sessions, overflow should be an explicit rejected state rather than arithmetic-dependent behavior.

Verification
- `cargo fmt --manifest-path rust/Cargo.toml --check`
- `cargo test client::session --manifest-path rust/Cargo.toml`
- `git diff --check`