### PR TITLE
fix(python): precheck SOL transaction intent

### DIFF
--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 import base64
 import json
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -18,8 +18,8 @@ from solana_mpp._errors import (
 from solana_mpp._types import PaymentChallenge, PaymentCredential, Receipt
 from solana_mpp.protocol.intents import ChargeRequest, parse_units
 from solana_mpp.protocol.solana import (
-    CredentialPayload,
     MEMO_PROGRAM,
+    CredentialPayload,
     MethodDetails,
     default_rpc_url,
     default_token_program_for_currency,
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_REALM = "MPP Payment"
 _SECRET_KEY_ENV_VAR = "MPP_SECRET_KEY"
 _CONSUMED_PREFIX = "solana-charge:consumed:"
+_SYSTEM_PROGRAM = "11111111111111111111111111111111"
+_SYSTEM_TRANSFER_INSTRUCTION = 2
 
 
 def _build_expected_transfers(request: ChargeRequest, details: MethodDetails) -> list[tuple[str, int]]:
@@ -263,6 +265,76 @@ def _extract_recent_blockhash(transaction_b64: str) -> str:
         return str(vtx.message.recent_blockhash)
 
 
+def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[str, Any]]:
+    """Decode local SOL transfer and memo instructions from a legacy transaction."""
+    from solders.transaction import Transaction
+
+    raw = base64.b64decode(transaction_b64)
+    try:
+        tx = Transaction.from_bytes(raw)
+    except Exception as exc:
+        raise PaymentError(
+            "unsupported SOL transaction shape for pre-broadcast verification",
+            code="invalid-payload-type",
+        ) from exc
+
+    account_keys = [str(key) for key in tx.message.account_keys]
+    instructions: list[dict[str, Any]] = []
+    for instruction in tx.message.instructions:
+        try:
+            program_id = account_keys[int(instruction.program_id_index)]
+        except IndexError as exc:
+            raise PaymentError("transaction instruction references an unknown program", code="invalid-payload") from exc
+        data = bytes(instruction.data)
+        if program_id == _SYSTEM_PROGRAM:
+            if len(data) < 12:
+                continue
+            kind = int.from_bytes(data[:4], "little")
+            if kind != _SYSTEM_TRANSFER_INSTRUCTION or len(instruction.accounts) < 2:
+                continue
+            try:
+                destination = account_keys[int(instruction.accounts[1])]
+            except IndexError as exc:
+                raise PaymentError(
+                    "transaction transfer references an unknown account", code="invalid-payload"
+                ) from exc
+            lamports = int.from_bytes(data[4:12], "little")
+            instructions.append(
+                {
+                    "program": "system",
+                    "parsed": {
+                        "type": "transfer",
+                        "info": {
+                            "destination": destination,
+                            "lamports": str(lamports),
+                        },
+                    },
+                }
+            )
+        elif program_id == MEMO_PROGRAM:
+            try:
+                memo = data.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise PaymentError("memo instruction is not valid UTF-8", code="invalid-payload") from exc
+            instructions.append({"programId": MEMO_PROGRAM, "parsed": memo})
+
+    return instructions
+
+
+def _verify_local_transaction_intent(
+    transaction_b64: str,
+    request: ChargeRequest,
+    details: MethodDetails,
+) -> None:
+    """Verify locally-decodable payment intent before broadcasting."""
+    if not is_native_sol(request.currency):
+        return
+
+    instructions = _decode_legacy_sol_payment_instructions(transaction_b64)
+    _verify_parsed_sol_transfers(instructions, request, details)
+    _verify_parsed_memo_instructions(instructions, request, details)
+
+
 @dataclass
 class ChargeOptions:
     """Options for charge challenge generation."""
@@ -472,9 +544,7 @@ class Mpp:
         payload = CredentialPayload.from_dict(credential.payload)
         return request, details, payload
 
-    def _verify_pinned_fields(
-        self, credential: PaymentCredential, request: ChargeRequest
-    ) -> None:
+    def _verify_pinned_fields(self, credential: PaymentCredential, request: ChargeRequest) -> None:
         method_name = "solana"
         if credential.challenge.method != method_name:
             raise PaymentError(
@@ -555,6 +625,7 @@ class Mpp:
                 code="invalid-payload-type",
             ) from exc
         check_network_blockhash(self._network, blockhash_b58)
+        _verify_local_transaction_intent(payload.transaction, request, details)
 
         # Decode and process the transaction
         # In a real implementation, this would use solders to deserialize,

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import pytest
+from solders.hash import Hash
+from solders.instruction import Instruction
+from solders.keypair import Keypair
+from solders.message import Message
+from solders.pubkey import Pubkey
+from solders.system_program import TransferParams, transfer
+from solders.transaction import Transaction
 
-import solana_mpp.server.mpp as server_mpp
 from solana_mpp._errors import ChallengeExpiredError, ChallengeMismatchError, PaymentError, ReplayError
 from solana_mpp._types import ChallengeEcho, PaymentCredential
-from solders.pubkey import Pubkey
-
 from solana_mpp.protocol.intents import ChargeRequest
-from solana_mpp.protocol.solana import MEMO_PROGRAM, MethodDetails, Split, TOKEN_2022_PROGRAM
+from solana_mpp.protocol.solana import MEMO_PROGRAM, TOKEN_2022_PROGRAM, MethodDetails, Split
 from solana_mpp.server.mpp import (
     ChargeOptions,
     Config,
@@ -23,10 +27,10 @@ from solana_mpp.server.mpp import (
 TEST_SECRET = "test-secret-key-that-is-long-enough-for-hmac-sha256"
 TEST_RECIPIENT = "11111111111111111111111111111112"
 VALID_SIGNATURE = "1111111111111111111111111111111111111111111111111111111111111111"
-DUMMY_TRANSACTION = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
 TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 USDC_DEVNET = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
 ATA_PROGRAM = Pubkey.from_string("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
+TEST_BLOCKHASH = "4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs"
 
 
 def _derive_ata(owner: str, mint: str, token_program: str = TOKEN_PROGRAM) -> str:
@@ -36,6 +40,30 @@ def _derive_ata(owner: str, mint: str, token_program: str = TOKEN_PROGRAM) -> st
     tp_pk = Pubkey.from_string(token_program)
     ata, _ = Pubkey.find_program_address([bytes(owner_pk), bytes(tp_pk), bytes(mint_pk)], ATA_PROGRAM)
     return str(ata)
+
+
+def _build_sol_transaction(recipient: str, lamports: int, memo: str = "") -> str:
+    signer = Keypair()
+    instructions = [
+        transfer(
+            TransferParams(
+                from_pubkey=signer.pubkey(),
+                to_pubkey=Pubkey.from_string(recipient),
+                lamports=lamports,
+            )
+        )
+    ]
+    if memo:
+        instructions.append(Instruction(Pubkey.from_string(MEMO_PROGRAM), memo.encode("utf-8"), []))
+
+    blockhash = Hash.from_string(TEST_BLOCKHASH)
+    message = Message.new_with_blockhash(instructions, signer.pubkey(), blockhash)
+    transaction = Transaction.new_unsigned(message)
+    transaction.sign([signer], blockhash)
+
+    import base64
+
+    return base64.b64encode(bytes(transaction)).decode("ascii")
 
 
 class FakeResponse:
@@ -348,7 +376,7 @@ class TestVerifyCredential:
         assert receipt.is_success()
         assert receipt.external_id == "order-123"
 
-    async def test_transaction_verification_broadcasts_and_checks_transaction(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_transaction_verification_broadcasts_and_checks_transaction(self):
         tx = {
             "meta": {"err": None},
             "transaction": {
@@ -374,16 +402,11 @@ class TestVerifyCredential:
             )
         )
         challenge = mpp.charge_with_options("0.000001", ChargeOptions())
-        monkeypatch.setattr(
-            server_mpp,
-            "_extract_recent_blockhash",
-            lambda _tx: "4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs",
-        )
         credential = PaymentCredential(
             challenge=challenge.to_echo(),
             payload={
                 "type": "transaction",
-                "transaction": DUMMY_TRANSACTION,
+                "transaction": _build_sol_transaction(TEST_RECIPIENT, 1000),
             },
         )
 
@@ -391,6 +414,84 @@ class TestVerifyCredential:
         assert receipt.is_success()
         assert receipt.reference == "1111111111111111111111111111111111111111111111111111111111111111"
         assert rpc.sent
+
+    async def test_transaction_verification_rejects_wrong_recipient_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="SOL",
+                decimals=9,
+                network="mainnet-beta",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("0.000001", ChargeOptions())
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_sol_transaction(str(Pubkey.new_unique()), 1000),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="no matching SOL transfer"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
+
+    async def test_transaction_verification_rejects_wrong_amount_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="SOL",
+                decimals=9,
+                network="mainnet-beta",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("0.000001", ChargeOptions())
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_sol_transaction(TEST_RECIPIENT, 999),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="no matching SOL transfer"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
+
+    async def test_transaction_verification_rejects_missing_memo_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="SOL",
+                decimals=9,
+                network="mainnet-beta",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("0.000001", ChargeOptions(external_id="order-123"))
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_sol_transaction(TEST_RECIPIENT, 1000),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="No memo instruction found"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
 
 
 class TestParsedTransferVerification:


### PR DESCRIPTION
Summary
- Decode legacy native SOL transaction credentials before broadcast.
- Verify local System Program transfers and Memo Program instructions against the charge request before `send_raw_transaction`.
- Add regression coverage for wrong recipient, wrong amount, and missing external-id memo proving the fake RPC does not broadcast.

Context
- Addresses the native SOL subset of #43. SPL/token transaction parsing remains a separate follow-up because it needs local token/ATA instruction normalization.

Verification
- `cd python && uv run ruff format src/solana_mpp/server/mpp.py tests/test_server.py`
- `cd python && uv run ruff check --select I,F401 src/solana_mpp/server/mpp.py tests/test_server.py`
- `cd python && uv run --extra dev pytest tests/test_server.py`
- `cd python && uv run --extra dev pyright src/solana_mpp/server/mpp.py tests/test_server.py`
- `git diff --check`

Full suite note
- `cd python && uv run --extra dev pytest` currently reports 207 passed / 5 failed. The failures are existing HTML rendering expectations in `tests/test_server_html.py` (`<!DOCTYPE html>` vs generated `<!doctype html>`, embedded HTML data expectations) and are unrelated to this SOL transaction precheck change.