### PR TITLE
fix(python): precheck SPL transaction intent

### DIFF
--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -19,6 +19,8 @@ from solana_mpp._types import PaymentChallenge, PaymentCredential, Receipt
 from solana_mpp.protocol.intents import ChargeRequest, parse_units
 from solana_mpp.protocol.solana import (
     MEMO_PROGRAM,
+    TOKEN_2022_PROGRAM,
+    TOKEN_PROGRAM,
     CredentialPayload,
     MethodDetails,
     default_rpc_url,
@@ -37,6 +39,7 @@ _SECRET_KEY_ENV_VAR = "MPP_SECRET_KEY"
 _CONSUMED_PREFIX = "solana-charge:consumed:"
 _SYSTEM_PROGRAM = "11111111111111111111111111111111"
 _SYSTEM_TRANSFER_INSTRUCTION = 2
+_TOKEN_TRANSFER_CHECKED_INSTRUCTION = 12
 
 
 def _build_expected_transfers(request: ChargeRequest, details: MethodDetails) -> list[tuple[str, int]]:
@@ -265,8 +268,8 @@ def _extract_recent_blockhash(transaction_b64: str) -> str:
         return str(vtx.message.recent_blockhash)
 
 
-def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[str, Any]]:
-    """Decode local SOL transfer and memo instructions from a legacy transaction."""
+def _decode_legacy_payment_instructions(transaction_b64: str) -> list[dict[str, Any]]:
+    """Decode local transfer and memo instructions from a legacy transaction."""
     from solders.transaction import Transaction
 
     raw = base64.b64decode(transaction_b64)
@@ -274,7 +277,7 @@ def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[s
         tx = Transaction.from_bytes(raw)
     except Exception as exc:
         raise PaymentError(
-            "unsupported SOL transaction shape for pre-broadcast verification",
+            "unsupported transaction shape for pre-broadcast verification",
             code="invalid-payload-type",
         ) from exc
 
@@ -311,6 +314,33 @@ def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[s
                     },
                 }
             )
+        elif program_id in {TOKEN_PROGRAM, TOKEN_2022_PROGRAM}:
+            if len(data) < 10:
+                continue
+            kind = data[0]
+            if kind != _TOKEN_TRANSFER_CHECKED_INSTRUCTION or len(instruction.accounts) < 3:
+                continue
+            try:
+                mint = account_keys[int(instruction.accounts[1])]
+                destination = account_keys[int(instruction.accounts[2])]
+            except IndexError as exc:
+                raise PaymentError(
+                    "transaction token transfer references an unknown account", code="invalid-payload"
+                ) from exc
+            amount = int.from_bytes(data[1:9], "little")
+            instructions.append(
+                {
+                    "programId": program_id,
+                    "parsed": {
+                        "type": "transferChecked",
+                        "info": {
+                            "destination": destination,
+                            "mint": mint,
+                            "tokenAmount": {"amount": str(amount)},
+                        },
+                    },
+                }
+            )
         elif program_id == MEMO_PROGRAM:
             try:
                 memo = data.decode("utf-8")
@@ -327,11 +357,11 @@ def _verify_local_transaction_intent(
     details: MethodDetails,
 ) -> None:
     """Verify locally-decodable payment intent before broadcasting."""
-    if not is_native_sol(request.currency):
-        return
-
-    instructions = _decode_legacy_sol_payment_instructions(transaction_b64)
-    _verify_parsed_sol_transfers(instructions, request, details)
+    instructions = _decode_legacy_payment_instructions(transaction_b64)
+    if is_native_sol(request.currency):
+        _verify_parsed_sol_transfers(instructions, request, details)
+    else:
+        _verify_parsed_spl_transfers(instructions, request, details)
     _verify_parsed_memo_instructions(instructions, request, details)
 
 

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from solders.hash import Hash
-from solders.instruction import Instruction
+from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
 from solders.message import Message
 from solders.pubkey import Pubkey
@@ -51,6 +51,44 @@ def _build_sol_transaction(recipient: str, lamports: int, memo: str = "") -> str
                 to_pubkey=Pubkey.from_string(recipient),
                 lamports=lamports,
             )
+        )
+    ]
+    if memo:
+        instructions.append(Instruction(Pubkey.from_string(MEMO_PROGRAM), memo.encode("utf-8"), []))
+
+    blockhash = Hash.from_string(TEST_BLOCKHASH)
+    message = Message.new_with_blockhash(instructions, signer.pubkey(), blockhash)
+    transaction = Transaction.new_unsigned(message)
+    transaction.sign([signer], blockhash)
+
+    import base64
+
+    return base64.b64encode(bytes(transaction)).decode("ascii")
+
+
+def _build_spl_transfer_checked_transaction(
+    recipient: str,
+    mint: str,
+    amount: int,
+    memo: str = "",
+    token_program: str = TOKEN_PROGRAM,
+    decimals: int = 6,
+) -> str:
+    signer = Keypair()
+    source = Pubkey.new_unique()
+    destination = Pubkey.from_string(_derive_ata(recipient, mint, token_program))
+    mint_key = Pubkey.from_string(mint)
+    data = bytes([12]) + amount.to_bytes(8, "little") + bytes([decimals])
+    instructions = [
+        Instruction(
+            Pubkey.from_string(token_program),
+            data,
+            [
+                AccountMeta(source, False, True),
+                AccountMeta(mint_key, False, False),
+                AccountMeta(destination, False, True),
+                AccountMeta(signer.pubkey(), True, False),
+            ],
         )
     ]
     if memo:
@@ -486,6 +524,130 @@ class TestVerifyCredential:
             payload={
                 "type": "transaction",
                 "transaction": _build_sol_transaction(TEST_RECIPIENT, 1000),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="No memo instruction found"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
+
+    async def test_token_transaction_verification_broadcasts_matching_transaction(self):
+        recipient_ata = _derive_ata(TEST_RECIPIENT, USDC_DEVNET)
+        tx = {
+            "meta": {"err": None},
+            "transaction": {
+                "message": {
+                    "instructions": [
+                        {
+                            "programId": TOKEN_PROGRAM,
+                            "parsed": {
+                                "type": "transferChecked",
+                                "info": {
+                                    "destination": recipient_ata,
+                                    "mint": USDC_DEVNET,
+                                    "tokenAmount": {"amount": "1000000"},
+                                },
+                            },
+                        }
+                    ]
+                }
+            },
+        }
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="USDC",
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("1.00", ChargeOptions())
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_spl_transfer_checked_transaction(TEST_RECIPIENT, USDC_DEVNET, 1000000),
+            },
+        )
+
+        receipt = await mpp.verify_credential(credential)
+        assert receipt.is_success()
+        assert rpc.sent
+
+    async def test_token_transaction_verification_rejects_wrong_recipient_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="USDC",
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("1.00", ChargeOptions())
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_spl_transfer_checked_transaction(str(Pubkey.new_unique()), USDC_DEVNET, 1000000),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="no matching token transfer"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
+
+    async def test_token_transaction_verification_rejects_wrong_amount_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="USDC",
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("1.00", ChargeOptions())
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_spl_transfer_checked_transaction(TEST_RECIPIENT, USDC_DEVNET, 999999),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="no matching token transfer"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
+
+    async def test_token_transaction_verification_rejects_missing_memo_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="USDC",
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge_with_options("1.00", ChargeOptions(external_id="order-123"))
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_spl_transfer_checked_transaction(TEST_RECIPIENT, USDC_DEVNET, 1000000),
             },
         )
 


### PR DESCRIPTION
## Summary

- Extend Python pull-mode pre-broadcast verification to SPL Token and Token-2022 `TransferChecked` instructions.
- Normalize locally decoded token transfers into the existing parsed instruction shape and reuse the current transfer/memo verifiers.
- Add regression coverage for matching SPL transactions plus wrong recipient, wrong amount, and missing externalId memo before `send_raw_transaction`.

## Why

#44 added pre-broadcast checks for native SOL transactions. Token payments should get the same fail-before-execution behavior so agent/payment servers do not broadcast a signed transaction that does not match the issued charge intent.

Fixes #43.

## Verification

- `cd python && uv run ruff format src/solana_mpp/server/mpp.py tests/test_server.py`
- `cd python && uv run ruff check --select I,F401 src/solana_mpp/server/mpp.py tests/test_server.py`
- `cd python && uv run --extra dev pytest tests/test_server.py`
- `cd python && uv run --extra dev pyright src/solana_mpp/server/mpp.py tests/test_server.py`
- `git diff --check`

GitHub CI is green for this branch, including the current interop jobs.

## Notes

- `cd python && uv run --extra dev pytest` currently reports 218 passed / 5 failed on existing HTML rendering expectations in `tests/test_server_html.py` (`<!DOCTYPE html>` vs `<!doctype html>` and embedded HTML data expectations). The new `tests/test_server.py` coverage passes.
