### PR TITLE
fix(go): format payment link receipt header

### DIFF
--- a/go/cmd/payment-link-server/main.go
+++ b/go/cmd/payment-link-server/main.go
@@ -62,8 +62,13 @@ func main() {
 				if err != nil {
 					log.Printf("verify_credential: %v", err)
 				} else {
+					receiptHeader, err := mpp.FormatReceipt(receipt)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
 					w.Header().Set("Content-Type", "application/json")
-					w.Header().Set("Payment-Receipt", receipt.Reference)
+					w.Header().Set(mpp.PaymentReceiptHeader, receiptHeader)
 					json.NewEncoder(w).Encode(map[string]string{"fortune": "A smooth long journey!"})
 					return
 				}


### PR DESCRIPTION
## Summary

The Go payment link demo currently writes only `receipt.Reference` to the `Payment-Receipt` response header after a successful credential verification.

Other Go SDK surfaces format this header with `mpp.FormatReceipt(receipt)`, and clients parse it with `mpp.ParseReceipt`, so the demo response should use the same serialized receipt shape instead of a raw transaction/reference string.

This PR updates the demo server to:

- serialize the verified receipt with `mpp.FormatReceipt`
- set the exported `mpp.PaymentReceiptHeader` constant instead of a literal header name
- fail the response if a verified receipt cannot be formatted, rather than returning a paid payload with an invalid receipt header

## Verification

- `go test ./...`
- `git diff --check`
