### PR TITLE
fix(go): mark paid middleware responses uncacheable

### DIFF
--- a/go/server/middleware.go
+++ b/go/server/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	mpp "github.com/solana-foundation/mpp-sdk/go"
 )
@@ -11,6 +12,19 @@ import (
 type contextKey string
 
 const receiptContextKey contextKey = "mpp-receipt"
+
+func markAuthorizationBoundResponse(header http.Header) {
+	header.Set("Cache-Control", "no-store")
+
+	for _, value := range header.Values("Vary") {
+		for _, field := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), "Authorization") || strings.TrimSpace(field) == "*" {
+				return
+			}
+		}
+	}
+	header.Add("Vary", "Authorization")
+}
 
 // ReceiptFromContext extracts the payment receipt from the request context.
 func ReceiptFromContext(ctx context.Context) (mpp.Receipt, bool) {
@@ -63,6 +77,7 @@ func PaymentMiddleware(m *Mpp, chargeFn ChargeFunc) func(http.Handler) http.Hand
 							if fmtErr == nil {
 								w.Header().Set(mpp.PaymentReceiptHeader, receiptHeader)
 							}
+							markAuthorizationBoundResponse(w.Header())
 							ctx := context.WithValue(r.Context(), receiptContextKey, receipt)
 							next.ServeHTTP(w, r.WithContext(ctx))
 							return
@@ -79,6 +94,7 @@ func PaymentMiddleware(m *Mpp, chargeFn ChargeFunc) func(http.Handler) http.Hand
 			}
 
 			w.Header().Set(mpp.WWWAuthenticateHeader, wwwAuth)
+			markAuthorizationBoundResponse(w.Header())
 
 			if m.HTMLEnabled() && AcceptsHTML(r) {
 				html, err := m.ChallengeToHTML(challenge)

--- a/go/server/middleware_test.go
+++ b/go/server/middleware_test.go
@@ -37,6 +37,17 @@ func constantCharge(amount string) ChargeFunc {
 	}
 }
 
+func hasVaryAuthorization(header http.Header) bool {
+	for _, value := range header.Values("Vary") {
+		for _, field := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), "Authorization") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestMiddlewareNoAuth402(t *testing.T) {
 	m := newMiddlewareTestMpp(t)
 	handler := PaymentMiddleware(m, constantCharge("0.001"))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +71,12 @@ func TestMiddlewareNoAuth402(t *testing.T) {
 	contentType := rr.Header().Get("Content-Type")
 	if !strings.Contains(contentType, "application/json") {
 		t.Fatalf("expected JSON content type, got %q", contentType)
+	}
+	if rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("expected no-store cache control, got %q", rr.Header().Get("Cache-Control"))
+	}
+	if !hasVaryAuthorization(rr.Header()) {
+		t.Fatalf("expected Vary: Authorization, got %q", rr.Header().Values("Vary"))
 	}
 }
 
@@ -113,6 +130,12 @@ func TestMiddlewareValidAuth(t *testing.T) {
 	if rr.Header().Get(mpp.PaymentReceiptHeader) == "" {
 		t.Fatal("expected Payment-Receipt response header")
 	}
+	if rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("expected no-store cache control, got %q", rr.Header().Get("Cache-Control"))
+	}
+	if !hasVaryAuthorization(rr.Header()) {
+		t.Fatalf("expected Vary: Authorization, got %q", rr.Header().Values("Vary"))
+	}
 }
 
 func TestMiddlewareInvalidCredential402(t *testing.T) {
@@ -131,6 +154,12 @@ func TestMiddlewareInvalidCredential402(t *testing.T) {
 	}
 	if rr.Header().Get(mpp.WWWAuthenticateHeader) == "" {
 		t.Fatal("expected WWW-Authenticate header on re-challenge")
+	}
+	if rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("expected no-store cache control, got %q", rr.Header().Get("Cache-Control"))
+	}
+	if !hasVaryAuthorization(rr.Header()) {
+		t.Fatalf("expected Vary: Authorization, got %q", rr.Header().Values("Vary"))
 	}
 }
 


### PR DESCRIPTION
## Summary
- set `Cache-Control: no-store` on Go middleware 402 challenges and paid responses
- add `Vary: Authorization` so shared caches do not mix paid and unpaid variants
- cover no-auth, invalid-auth, and valid paid middleware paths

## Why
`Payment-Receipt` and authorization-bound paid responses should not be reusable from a shared cache without considering the `Authorization` header.

## Verification
- `cd go && GOCACHE=/tmp/go-build-cache go test ./server`
- `cd go && GOCACHE=/tmp/go-build-cache go test ./...`