### PR TITLE
fix(ci): checkout surfpool report action branch

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: solana-foundation/surfpool
-          ref: feat/sdk
+          ref: feat/sdk-report
           sparse-checkout: .github/actions
           path: _surfpool
 


### PR DESCRIPTION
## Summary
- update the report workflow to checkout Surfpool's existing `feat/sdk-report` branch
- keep the sparse checkout path for `.github/actions` unchanged

## Why
The Report workflow currently checks out `solana-foundation/surfpool` at `ref: feat/sdk`. That branch no longer exists, so recent Report runs fail before posting coverage/test reports. The failed run logs show `A branch or tag with the name 'feat/sdk' could not be found`, while Surfpool does have `feat/sdk-report` with `.github/actions/test-report/action.yml`.

## Verification
- `gh run view 25937923665 --repo solana-foundation/mpp-sdk --log-failed` shows the checkout failure for `feat/sdk`
- `gh api 'repos/solana-foundation/surfpool/contents/.github/actions/test-report/action.yml?ref=feat/sdk-report'` confirms the reusable action exists on `feat/sdk-report`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/report.yml"); puts "yaml ok"'`
- `git diff --check`