### PR TITLE
fix(go): handle merged payment challenges

### DIFF
--- a/go/client/transport.go
+++ b/go/client/transport.go
@@ -58,15 +58,12 @@ func (t *PaymentTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}
 
-	wwwAuth := resp.Header.Get(mpp.WWWAuthenticateHeader)
-	if wwwAuth == "" {
+	challenges := mpp.ParseWWWAuthenticateAll(resp.Header.Values(mpp.WWWAuthenticateHeader))
+	if len(challenges) == 0 {
 		return resp, nil
 	}
 
-	challenge, err := mpp.ParseWWWAuthenticate(wwwAuth)
-	if err != nil {
-		return resp, nil
-	}
+	challenge := challenges[0]
 
 	ctx := req.Context()
 	if ctx == nil {

--- a/go/client/transport_test.go
+++ b/go/client/transport_test.go
@@ -103,6 +103,52 @@ func TestTransport402RetryWithAuthorization(t *testing.T) {
 	}
 }
 
+func TestTransport402RetryWithMergedWWWAuthenticate(t *testing.T) {
+	challenge := newTestChallenge()
+	wwwAuth, err := mpp.FormatWWWAuthenticate(challenge)
+	if err != nil {
+		t.Fatalf("format challenge: %v", err)
+	}
+
+	calls := 0
+	transport := &PaymentTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusPaymentRequired,
+					Body:       io.NopCloser(strings.NewReader("payment required")),
+					Header: http.Header{
+						"Www-Authenticate": {`Bearer realm="api"`, wwwAuth},
+					},
+				}, nil
+			}
+			if req.Header.Get(mpp.AuthorizationHeader) == "" {
+				t.Fatal("expected Authorization header on retry")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("paid")),
+				Header:     http.Header{},
+			}, nil
+		}),
+		Signer: testutil.NewPrivateKey(),
+		RPC:    testutil.NewFakeRPC(),
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 round trips, got %d", calls)
+	}
+}
+
 func TestTransportInvalidWWWAuthenticateReturnsOriginal402(t *testing.T) {
 	transport := &PaymentTransport{
 		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -210,10 +256,10 @@ func TestTransport402Debug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
-	
+
 	fakeRPC := testutil.NewFakeRPC()
 	signer := testutil.NewPrivateKey()
-	
+
 	header, err := BuildCredentialHeader(t.Context(), signer, fakeRPC, parsed)
 	if err != nil {
 		t.Fatalf("BuildCredentialHeader after roundtrip: %v", err)

--- a/go/mpp.go
+++ b/go/mpp.go
@@ -47,5 +47,6 @@ var (
 	ParseAuthorization         = core.ParseAuthorization
 	ParseReceipt               = core.ParseReceipt
 	ParseUnits                 = intents.ParseUnits
+	ParseWWWAuthenticateAll    = core.ParseWWWAuthenticateAll
 	ParseWWWAuthenticate       = core.ParseWWWAuthenticate
 )

--- a/go/protocol/core/headers.go
+++ b/go/protocol/core/headers.go
@@ -61,6 +61,22 @@ func ParseWWWAuthenticate(header string) (PaymentChallenge, error) {
 	return challenge, nil
 }
 
+// ParseWWWAuthenticateAll parses successfully decoded Payment challenges from
+// WWW-Authenticate header values, including merged values that also contain
+// non-Payment schemes.
+func ParseWWWAuthenticateAll(headers []string) []PaymentChallenge {
+	challenges := make([]PaymentChallenge, 0, len(headers))
+	for _, header := range headers {
+		for _, value := range splitPaymentChallengeValues(header) {
+			challenge, err := ParseWWWAuthenticate(value)
+			if err == nil {
+				challenges = append(challenges, challenge)
+			}
+		}
+	}
+	return challenges
+}
+
 // FormatWWWAuthenticate formats a challenge into a header value.
 func FormatWWWAuthenticate(challenge PaymentChallenge) (string, error) {
 	parts := []string{
@@ -149,6 +165,122 @@ func ExtractPaymentScheme(header string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func splitPaymentChallengeValues(header string) []string {
+	starts := []int{}
+	inQuote := false
+	escaped := false
+	for i := 0; i < len(header); i++ {
+		if inQuote {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch header[i] {
+			case '\\':
+				escaped = true
+			case '"':
+				inQuote = false
+			}
+			continue
+		}
+		if header[i] == '"' {
+			inQuote = true
+			continue
+		}
+		if isPaymentSchemeStart(header, i) {
+			starts = append(starts, i)
+			i += len(PaymentScheme) - 1
+		}
+	}
+
+	values := make([]string, 0, len(starts))
+	for i, start := range starts {
+		end := len(header)
+		if i+1 < len(starts) {
+			end = starts[i+1]
+		} else if next := nextAuthSchemeStart(header, start+len(PaymentScheme)); next != -1 {
+			end = next
+		}
+		value := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(header[start:end]), ","))
+		if value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func nextAuthSchemeStart(header string, index int) int {
+	inQuote := false
+	escaped := false
+	for i := index; i < len(header); i++ {
+		if inQuote {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch header[i] {
+			case '\\':
+				escaped = true
+			case '"':
+				inQuote = false
+			}
+			continue
+		}
+		if header[i] == '"' {
+			inQuote = true
+			continue
+		}
+		if header[i] != ',' {
+			continue
+		}
+		next := i + 1
+		for next < len(header) && (header[next] == ' ' || header[next] == '\t') {
+			next++
+		}
+		if isAuthSchemeStart(header, next) {
+			return next
+		}
+	}
+	return -1
+}
+
+func isAuthSchemeStart(header string, index int) bool {
+	if index >= len(header) {
+		return false
+	}
+	tokenEnd := index
+	for tokenEnd < len(header) {
+		ch := header[tokenEnd]
+		if ch == ' ' || ch == '\t' || ch == ',' || ch == '=' {
+			break
+		}
+		tokenEnd++
+	}
+	if tokenEnd == index || tokenEnd >= len(header) {
+		return false
+	}
+	return header[tokenEnd] == ' ' || header[tokenEnd] == '\t'
+}
+
+func isPaymentSchemeStart(header string, index int) bool {
+	end := index + len(PaymentScheme)
+	if end >= len(header) {
+		return false
+	}
+	if !strings.EqualFold(header[index:end], PaymentScheme) {
+		return false
+	}
+	if header[end] != ' ' && header[end] != '\t' {
+		return false
+	}
+
+	previous := index
+	for previous > 0 && (header[previous-1] == ' ' || header[previous-1] == '\t') {
+		previous--
+	}
+	return previous == 0 || header[previous-1] == ','
 }
 
 func stripPaymentScheme(header string) (string, bool) {

--- a/go/protocol/core/headers_test.go
+++ b/go/protocol/core/headers_test.go
@@ -213,6 +213,61 @@ func TestExtractPaymentSchemeMultipleSchemes(t *testing.T) {
 	}
 }
 
+func TestParseWWWAuthenticateAllFiltersNonPaymentChallenges(t *testing.T) {
+	header := `Payment id="abc", realm="api", method="solana", intent="charge", request="e30"`
+	challenges := ParseWWWAuthenticateAll([]string{
+		`Bearer realm="api"`,
+		header,
+		`Digest realm="api", qop="auth"`,
+	})
+
+	if len(challenges) != 1 {
+		t.Fatalf("expected 1 challenge, got %d", len(challenges))
+	}
+	if challenges[0].ID != "abc" {
+		t.Fatalf("unexpected challenge ID: %q", challenges[0].ID)
+	}
+}
+
+func TestParseWWWAuthenticateAllMergedPaymentChallenges(t *testing.T) {
+	header := `Payment id="abc", realm="api", method="solana", intent="charge", request="e30", Payment id="def", realm="api", method="solana", intent="charge", request="e30"`
+	challenges := ParseWWWAuthenticateAll([]string{header})
+
+	if len(challenges) != 2 {
+		t.Fatalf("expected 2 challenges, got %d", len(challenges))
+	}
+	if challenges[0].ID != "abc" || challenges[1].ID != "def" {
+		t.Fatalf("unexpected challenge IDs: %#v", challenges)
+	}
+}
+
+func TestParseWWWAuthenticateAllIgnoresPaymentInsideQuotes(t *testing.T) {
+	header := `Payment id="abc", realm="api, Payment realm", method="solana", intent="charge", request="e30", Payment id="def", realm="api", method="solana", intent="charge", request="e30"`
+	challenges := ParseWWWAuthenticateAll([]string{header})
+
+	if len(challenges) != 2 {
+		t.Fatalf("expected 2 challenges, got %d", len(challenges))
+	}
+	if challenges[0].Realm != "api, Payment realm" {
+		t.Fatalf("unexpected realm: %q", challenges[0].Realm)
+	}
+	if challenges[1].ID != "def" {
+		t.Fatalf("unexpected second challenge ID: %q", challenges[1].ID)
+	}
+}
+
+func TestParseWWWAuthenticateAllStopsBeforeTrailingScheme(t *testing.T) {
+	header := `Payment id="abc", realm="api", method="solana", intent="charge", request="e30", Bearer realm="fallback"`
+	challenges := ParseWWWAuthenticateAll([]string{header})
+
+	if len(challenges) != 1 {
+		t.Fatalf("expected 1 challenge, got %d", len(challenges))
+	}
+	if challenges[0].ID != "abc" {
+		t.Fatalf("unexpected challenge ID: %q", challenges[0].ID)
+	}
+}
+
 func TestExtractPaymentSchemeNotPresent(t *testing.T) {
 	if _, ok := ExtractPaymentScheme("Bearer token123"); ok {
 		t.Fatal("expected no Payment scheme")


### PR DESCRIPTION
## Summary
- parse Payment challenges out of multiple and merged `WWW-Authenticate` header values in Go
- let `PaymentTransport` retry when a non-Payment auth scheme appears before the Payment challenge
- add protocol and transport regression coverage for merged challenges

## Why
HTTP `WWW-Authenticate` can contain multiple challenges either as repeated header values or as one comma-separated value. The Go transport used `Header.Get` and parsed that single value directly, so a response such as `Bearer realm="api", Payment ...` returned the original 402 instead of building a payment credential.

## Verification
- `go test ./client -run TestTransport402RetryWithMergedWWWAuthenticate -count=1` failed before the fix
- `go test ./client -run TestTransport402RetryWithMergedWWWAuthenticate -count=1`
- `go test ./client ./protocol/core`
- `go test ./...`