### PR TITLE
fix(python): precheck SPL transaction intent

### DIFF
--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -19,6 +19,8 @@ from solana_mpp._types import PaymentChallenge, PaymentCredential, Receipt
 from solana_mpp.protocol.intents import ChargeRequest, parse_units
 from solana_mpp.protocol.solana import (
     MEMO_PROGRAM,
+    TOKEN_2022_PROGRAM,
+    TOKEN_PROGRAM,
     CredentialPayload,
     MethodDetails,
     default_rpc_url,
@@ -37,6 +39,7 @@ _SECRET_KEY_ENV_VAR = "MPP_SECRET_KEY"
 _CONSUMED_PREFIX = "solana-charge:consumed:"
 _SYSTEM_PROGRAM = "11111111111111111111111111111111"
 _SYSTEM_TRANSFER_INSTRUCTION = 2
+_TOKEN_TRANSFER_CHECKED_INSTRUCTION = 12
 
 
 def _build_expected_transfers(request: ChargeRequest, details: MethodDetails) -> list[tuple[str, int]]:
@@ -237,10 +240,7 @@ def _status_ok(response: Any) -> bool:
     value = _rpc_value(response)
     data = _json_like(value)
     if isinstance(data, list):
-        for entry in data:
-            if entry and entry.get("err") is None:
-                return True
-        return False
+        return any(entry and entry.get("err") is None for entry in data)
     return data is not None
 
 
@@ -265,8 +265,11 @@ def _extract_recent_blockhash(transaction_b64: str) -> str:
         return str(vtx.message.recent_blockhash)
 
 
-def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[str, Any]]:
-    """Decode local SOL transfer and memo instructions from a legacy transaction."""
+def _decode_legacy_payment_instructions(
+    transaction_b64: str,
+    token_programs: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Decode local transfer and memo instructions from a legacy transaction."""
     from solders.transaction import Transaction
 
     raw = base64.b64decode(transaction_b64)
@@ -280,6 +283,7 @@ def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[s
 
     account_keys = [str(key) for key in tx.message.account_keys]
     instructions: list[dict[str, Any]] = []
+    token_programs = token_programs or {TOKEN_PROGRAM, TOKEN_2022_PROGRAM}
     for instruction in tx.message.instructions:
         try:
             program_id = account_keys[int(instruction.program_id_index)]
@@ -311,6 +315,30 @@ def _decode_legacy_sol_payment_instructions(transaction_b64: str) -> list[dict[s
                     },
                 }
             )
+        elif program_id in token_programs:
+            if len(data) < 10 or data[0] != _TOKEN_TRANSFER_CHECKED_INSTRUCTION or len(instruction.accounts) < 3:
+                continue
+            try:
+                destination = account_keys[int(instruction.accounts[2])]
+                mint = account_keys[int(instruction.accounts[1])]
+            except IndexError as exc:
+                raise PaymentError(
+                    "transaction token transfer references an unknown account", code="invalid-payload"
+                ) from exc
+            amount = int.from_bytes(data[1:9], "little")
+            instructions.append(
+                {
+                    "programId": program_id,
+                    "parsed": {
+                        "type": "transferChecked",
+                        "info": {
+                            "destination": destination,
+                            "mint": mint,
+                            "tokenAmount": {"amount": str(amount)},
+                        },
+                    },
+                }
+            )
         elif program_id == MEMO_PROGRAM:
             try:
                 memo = data.decode("utf-8")
@@ -327,11 +355,14 @@ def _verify_local_transaction_intent(
     details: MethodDetails,
 ) -> None:
     """Verify locally-decodable payment intent before broadcasting."""
-    if not is_native_sol(request.currency):
-        return
-
-    instructions = _decode_legacy_sol_payment_instructions(transaction_b64)
-    _verify_parsed_sol_transfers(instructions, request, details)
+    token_programs = {TOKEN_PROGRAM, TOKEN_2022_PROGRAM}
+    if details.token_program:
+        token_programs.add(details.token_program)
+    instructions = _decode_legacy_payment_instructions(transaction_b64, token_programs)
+    if is_native_sol(request.currency):
+        _verify_parsed_sol_transfers(instructions, request, details)
+    else:
+        _verify_parsed_spl_transfers(instructions, request, details)
     _verify_parsed_memo_instructions(instructions, request, details)
 
 
@@ -548,7 +579,8 @@ class Mpp:
         method_name = "solana"
         if credential.challenge.method != method_name:
             raise PaymentError(
-                f"credential method '{credential.challenge.method}' does not match this server (expected '{method_name}')",
+                f"credential method '{credential.challenge.method}' does not match this server "
+                f"(expected '{method_name}')",
                 code="challenge-mismatch",
             )
         # IntentName equivalent: case-insensitive "charge" comparison.
@@ -561,7 +593,8 @@ class Mpp:
         # one), so a tampered echoed realm passes HMAC unless re-signed. Pin it.
         if credential.challenge.realm != self._realm:
             raise PaymentError(
-                f"credential realm '{credential.challenge.realm}' does not match this server (expected '{self._realm}')",
+                f"credential realm '{credential.challenge.realm}' does not match this server "
+                f"(expected '{self._realm}')",
                 code="challenge-mismatch",
             )
         if request.currency != self._currency:

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from solders.hash import Hash
-from solders.instruction import Instruction
+from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
 from solders.message import Message
 from solders.pubkey import Pubkey
@@ -51,6 +51,44 @@ def _build_sol_transaction(recipient: str, lamports: int, memo: str = "") -> str
                 to_pubkey=Pubkey.from_string(recipient),
                 lamports=lamports,
             )
+        )
+    ]
+    if memo:
+        instructions.append(Instruction(Pubkey.from_string(MEMO_PROGRAM), memo.encode("utf-8"), []))
+
+    blockhash = Hash.from_string(TEST_BLOCKHASH)
+    message = Message.new_with_blockhash(instructions, signer.pubkey(), blockhash)
+    transaction = Transaction.new_unsigned(message)
+    transaction.sign([signer], blockhash)
+
+    import base64
+
+    return base64.b64encode(bytes(transaction)).decode("ascii")
+
+
+def _build_spl_transfer_checked_transaction(
+    recipient: str,
+    mint: str,
+    amount: int,
+    token_program: str = TOKEN_PROGRAM,
+    memo: str = "",
+) -> str:
+    signer = Keypair()
+    source = Pubkey.new_unique()
+    destination = Pubkey.from_string(_derive_ata(recipient, mint, token_program))
+    mint_key = Pubkey.from_string(mint)
+    token_program_key = Pubkey.from_string(token_program)
+    data = bytes([12]) + amount.to_bytes(8, "little") + bytes([6])
+    instructions = [
+        Instruction(
+            token_program_key,
+            data,
+            [
+                AccountMeta(source, False, True),
+                AccountMeta(mint_key, False, False),
+                AccountMeta(destination, False, True),
+                AccountMeta(signer.pubkey(), True, False),
+            ],
         )
     ]
     if memo:
@@ -490,6 +528,32 @@ class TestVerifyCredential:
         )
 
         with pytest.raises(PaymentError, match="No memo instruction found"):
+            await mpp.verify_credential(credential)
+        assert rpc.sent == []
+
+    async def test_transaction_verification_rejects_wrong_spl_recipient_before_broadcast(self):
+        tx = {"meta": {"err": None}, "transaction": {"message": {"instructions": []}}}
+        rpc = FakeRPC(tx=tx, send_value="1111111111111111111111111111111111111111111111111111111111111111")
+        mpp = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency="USDC",
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = mpp.charge("1.00")
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={
+                "type": "transaction",
+                "transaction": _build_spl_transfer_checked_transaction(str(Pubkey.new_unique()), USDC_DEVNET, 1000000),
+            },
+        )
+
+        with pytest.raises(PaymentError, match="no matching token transfer"):
             await mpp.verify_credential(credential)
         assert rpc.sent == []
 


### PR DESCRIPTION
## Summary
- decode legacy Token/Token-2022 `TransferChecked` instructions before broadcasting pull-mode Python transactions
- run the existing SPL transfer and memo verifiers in the pre-broadcast path
- add a regression test proving a wrong SPL recipient is rejected before `send_raw_transaction`

## Why
Issue #43 was partially addressed for native SOL in #44, but SPL/token pull-mode credentials still skipped local intent checks before broadcast. For delegated payment flows, the server should reject locally-decodable token transactions whose recipient/amount/mint does not match the charge request before submitting them to the network.

## Verification
- `python/.venv/bin/pytest tests/test_server.py -k wrong_spl_recipient_before_broadcast -q`
- `python/.venv/bin/pytest tests/test_server.py -q`
- `python/.venv/bin/ruff check src/solana_mpp/server/mpp.py tests/test_server.py`
- `python/.venv/bin/pyright --pythonpath .venv/bin/python src/solana_mpp/server/mpp.py tests/test_server.py`

Note: full `python/.venv/bin/pytest -q` currently fails on existing `tests/test_server_html.py` HTML fixture expectations unrelated to this change.