### PR TITLE
feat(interop): add go process client adapter

### DIFF
--- a/tests/interop/go-client/main.go
+++ b/tests/interop/go-client/main.go
@@ -2,11 +2,11 @@
 //
 // Tests the full payment cycle against any MPP server:
 //
-//	1. GET /health → 200
-//	2. GET /fortune → 402 + WWW-Authenticate
-//	3. Fund test keypair via surfpool
-//	4. Build credential using solana-mpp Go client
-//	5. GET /fortune with Authorization → 200 + fortune
+//  1. GET /health → 200
+//  2. GET /fortune → 402 + WWW-Authenticate
+//  3. Fund test keypair via surfpool
+//  4. Build credential using solana-mpp Go client
+//  5. GET /fortune with Authorization → 200 + fortune
 //
 // Usage: SERVER_URL=http://localhost:3001 RPC_URL=http://localhost:8899 go run .
 package main
@@ -29,7 +29,109 @@ import (
 	"github.com/solana-foundation/mpp-sdk/go/client"
 )
 
+const fixtureSettlementHeader = "x-fixture-settlement"
+
+type adapterResult struct {
+	Type            string            `json:"type"`
+	Implementation  string            `json:"implementation"`
+	Role            string            `json:"role"`
+	OK              bool              `json:"ok"`
+	Status          int               `json:"status"`
+	ResponseHeaders map[string]string `json:"responseHeaders"`
+	ResponseBody    any               `json:"responseBody"`
+	Settlement      string            `json:"settlement,omitempty"`
+}
+
 func main() {
+	if os.Getenv("MPP_INTEROP_TARGET_URL") != "" {
+		if err := runProcessAdapter(os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	runLegacyInterop()
+}
+
+func runProcessAdapter(stdout io.Writer) error {
+	targetURL := os.Getenv("MPP_INTEROP_TARGET_URL")
+	rpcURL := os.Getenv("MPP_INTEROP_RPC_URL")
+	if rpcURL == "" {
+		return fmt.Errorf("MPP_INTEROP_RPC_URL is required")
+	}
+
+	signer, err := readPrivateKeyEnv("MPP_INTEROP_CLIENT_SECRET_KEY")
+	if err != nil {
+		return err
+	}
+
+	httpClient := client.NewClient(signer, rpc.New(rpcURL))
+	resp, err := httpClient.Get(targetURL)
+	if err != nil {
+		return fmt.Errorf("paid request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	result := adapterResult{
+		Type:            "result",
+		Implementation:  "go",
+		Role:            "client",
+		OK:              resp.StatusCode >= 200 && resp.StatusCode < 300,
+		Status:          resp.StatusCode,
+		ResponseHeaders: responseHeaders(resp.Header),
+		ResponseBody:    parseResponseBody(rawBody),
+		Settlement:      resp.Header.Get(fixtureSettlementHeader),
+	}
+	return json.NewEncoder(stdout).Encode(result)
+}
+
+func readPrivateKeyEnv(name string) (solana.PrivateKey, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, fmt.Errorf("%s is required", name)
+	}
+	var values []int
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if len(values) != 64 {
+		return nil, fmt.Errorf("%s must contain 64 private key bytes, got %d", name, len(values))
+	}
+	key := make([]byte, len(values))
+	for i, value := range values {
+		if value < 0 || value > 255 {
+			return nil, fmt.Errorf("%s byte %d is outside uint8 range", name, i)
+		}
+		key[i] = byte(value)
+	}
+	return solana.PrivateKey(key), nil
+}
+
+func responseHeaders(headers http.Header) map[string]string {
+	out := make(map[string]string, len(headers))
+	for key, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		out[strings.ToLower(key)] = strings.Join(values, ", ")
+	}
+	return out
+}
+
+func parseResponseBody(raw []byte) any {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err == nil {
+		return decoded
+	}
+	return string(raw)
+}
+
+func runLegacyInterop() {
 	serverURL := envOrDefault("SERVER_URL", "http://localhost:3001")
 	fortunePath := envOrDefault("FORTUNE_PATH", "/fortune")
 	rpcURL := envOrDefault("RPC_URL", "http://localhost:8899")

--- a/tests/interop/go-client/main_test.go
+++ b/tests/interop/go-client/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	solana "github.com/gagliardetto/solana-go"
+)
+
+func TestReadPrivateKeyEnvParsesJSONByteArray(t *testing.T) {
+	privateKey, err := solana.NewRandomPrivateKey()
+	if err != nil {
+		t.Fatalf("new private key: %v", err)
+	}
+	values := make([]int, len(privateKey))
+	for i, value := range []byte(privateKey) {
+		values[i] = int(value)
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+
+	t.Setenv("MPP_INTEROP_CLIENT_SECRET_KEY", string(raw))
+
+	got, err := readPrivateKeyEnv("MPP_INTEROP_CLIENT_SECRET_KEY")
+	if err != nil {
+		t.Fatalf("read private key: %v", err)
+	}
+	if got.PublicKey() != privateKey.PublicKey() {
+		t.Fatalf("expected public key %s, got %s", privateKey.PublicKey(), got.PublicKey())
+	}
+}
+
+func TestReadPrivateKeyEnvRejectsInvalidLength(t *testing.T) {
+	t.Setenv("MPP_INTEROP_CLIENT_SECRET_KEY", "[1,2,3]")
+
+	_, err := readPrivateKeyEnv("MPP_INTEROP_CLIENT_SECRET_KEY")
+	if err == nil {
+		t.Fatal("expected invalid private key length to fail")
+	}
+}
+
+func TestResponseHeadersLowercaseAndJoinValues(t *testing.T) {
+	headers := http.Header{}
+	headers.Add("X-Fixture-Settlement", "abc")
+	headers.Add("Vary", "Authorization")
+	headers.Add("Vary", "Accept")
+
+	got := responseHeaders(headers)
+	if got[fixtureSettlementHeader] != "abc" {
+		t.Fatalf("expected settlement header, got %#v", got)
+	}
+	if got["vary"] != "Authorization, Accept" {
+		t.Fatalf("expected joined vary header, got %q", got["vary"])
+	}
+}
+
+func TestParseResponseBodyKeepsJSONObjects(t *testing.T) {
+	body := parseResponseBody([]byte(`{"ok":true,"paid":true}`))
+	object, ok := body.(map[string]any)
+	if !ok {
+		t.Fatalf("expected JSON object, got %T", body)
+	}
+	if object["ok"] != true || object["paid"] != true {
+		t.Fatalf("unexpected response body: %#v", object)
+	}
+}
+
+func TestParseResponseBodyKeepsPlainText(t *testing.T) {
+	body := parseResponseBody([]byte("paid"))
+	if body != "paid" {
+		t.Fatalf("expected plain body, got %#v", body)
+	}
+}
+
+func TestRunProcessAdapterRequiresRPCURL(t *testing.T) {
+	t.Setenv("MPP_INTEROP_TARGET_URL", "http://127.0.0.1/protected")
+
+	if err := runProcessAdapter(io.Discard); err == nil {
+		t.Fatal("expected missing RPC URL to fail")
+	}
+}

--- a/tests/interop/src/implementations.ts
+++ b/tests/interop/src/implementations.ts
@@ -42,6 +42,13 @@ export const clientImplementations: ImplementationDefinition[] = [
     ],
     enabled: isEnabled("rust", "MPP_INTEROP_CLIENTS", true),
   },
+  {
+    id: "go",
+    label: "Go HTTP client",
+    role: "client",
+    command: ["sh", "-c", "cd go-client && go run ."],
+    enabled: isEnabled("go", "MPP_INTEROP_CLIENTS", false),
+  },
 ];
 
 export const serverImplementations: ImplementationDefinition[] = [


### PR DESCRIPTION
## Summary

Adds an opt-in Go client adapter for the Surfpool-backed process interop harness.

This keeps the existing legacy `tests/interop/go-client` flow intact, but when `MPP_INTEROP_TARGET_URL` is set the same binary now behaves like a process adapter:

- reads `MPP_INTEROP_RPC_URL`
- reads `MPP_INTEROP_CLIENT_SECRET_KEY` as the harness-provided JSON byte array
- uses the Go SDK `client.NewClient` 402 transport to pay the target URL
- emits one JSON `result` message on stdout
- sends errors/diagnostics to stderr

The adapter is registered as `go`, but left opt-in for now via `MPP_INTEROP_CLIENTS=go` so this PR does not force CI to install Go for the process harness before the adapter shape is reviewed.

## Motivation

This is a small first step toward bringing Go into the same serious client/server interop matrix as TypeScript and Rust, without making the PR depend on a broader CI or server-adapter change.

## Verification

- `cd tests/interop/go-client && gofmt -w main.go main_test.go && go test ./...`
- `cd tests/interop && sh -c 'cd go-client && go test ./...'`
- `cd go && GOCACHE=/tmp/go-build-cache go test ./...`
- `git diff --check`
- GitHub CI: `Go tests` passed
- GitHub CI: `Interop: Python → go` passed

I did not run the full `tests/interop` Vitest matrix locally because this checkout did not have the interop Node dependencies installed and disk was constrained. The Go adapter is opt-in until the full process matrix/CI setup is reviewed.

Refs #57
