### PR TITLE
fix(python): preserve split ata creation flag

### DIFF
--- a/python/src/solana_mpp/protocol/solana.py
+++ b/python/src/solana_mpp/protocol/solana.py
@@ -147,9 +147,12 @@ class Split:
     amount: str
     label: str = ""
     memo: str = ""
+    ata_creation_required: bool = False
 
     def to_dict(self) -> dict:
         d: dict = {"recipient": self.recipient, "amount": self.amount}
+        if self.ata_creation_required:
+            d["ataCreationRequired"] = self.ata_creation_required
         if self.label:
             d["label"] = self.label
         if self.memo:
@@ -163,6 +166,7 @@ class Split:
             amount=data["amount"],
             label=data.get("label", ""),
             memo=data.get("memo", ""),
+            ata_creation_required=data.get("ataCreationRequired", False),
         )
 
 

--- a/python/tests/test_solana_protocol.py
+++ b/python/tests/test_solana_protocol.py
@@ -11,8 +11,8 @@ from solana_mpp.protocol.solana import (
     CredentialPayload,
     MethodDetails,
     Split,
-    default_token_program_for_currency,
     default_rpc_url,
+    default_token_program_for_currency,
     is_native_sol,
     resolve_mint,
     stablecoin_symbol,
@@ -129,6 +129,27 @@ class TestMethodDetails:
         assert details.fee_payer is True
         assert len(details.splits) == 1
         assert details.splits[0].recipient == "addr"
+
+    def test_split_ata_creation_required_round_trips(self):
+        details = MethodDetails(
+            splits=[
+                Split(
+                    recipient="split-recipient",
+                    amount="100",
+                    ata_creation_required=True,
+                )
+            ]
+        )
+
+        encoded = details.to_dict()
+        assert encoded["splits"][0]["ataCreationRequired"] is True
+
+        decoded = MethodDetails.from_dict(encoded)
+        assert decoded.splits[0].ata_creation_required is True
+
+    def test_split_omits_false_ata_creation_required(self):
+        encoded = Split(recipient="split-recipient", amount="100").to_dict()
+        assert "ataCreationRequired" not in encoded
 
 
 class TestCredentialPayload:


### PR DESCRIPTION
## Summary

Adds Python protocol parity for split-level `ataCreationRequired`.

TypeScript/Rust can carry this split flag through Solana charge method details, but Python currently drops it when serializing/deserializing `Split` values. This adds the Python dataclass field and keeps the existing optional-field behavior by omitting it unless it is `true`.

## Verification

- `cd python && PYTHONPATH=src python3 -m pytest tests/test_solana_protocol.py`
- `cd python && PYTHONPATH=src python3 -m ruff check src/solana_mpp/protocol/solana.py tests/test_solana_protocol.py`
- `git diff --check`

`python3 -m pyright ...` was not run because `pyright` is not installed in this local Python environment.
