### PR TITLE
fix(python): parse combined payment challenges

### DIFF
--- a/python/src/solana_mpp/_headers.py
+++ b/python/src/solana_mpp/_headers.py
@@ -7,6 +7,7 @@ Rust and Go implementations.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from typing import Any
 
 from solana_mpp._base64url import decode, decode_json, encode_json
@@ -71,6 +72,18 @@ def parse_www_authenticate(header: str) -> PaymentChallenge:
         digest=params.get("digest", ""),
         opaque=params.get("opaque"),
     )
+
+
+def parse_www_authenticate_all(headers: Iterable[str]) -> list[PaymentChallenge]:
+    """Parse all Payment challenges from one or more WWW-Authenticate values."""
+    challenges: list[PaymentChallenge] = []
+    for header in headers:
+        for challenge in _extract_challenges(header, PAYMENT_SCHEME):
+            try:
+                challenges.append(parse_www_authenticate(challenge))
+            except ParseError:
+                continue
+    return challenges
 
 
 def format_www_authenticate(challenge: PaymentChallenge) -> str:
@@ -227,11 +240,73 @@ def _strip_payment_scheme(header: str) -> str | None:
 
 def _extract_payment_scheme(header: str) -> str | None:
     """Extract the Payment scheme section from a comma-separated header."""
-    for part in header.split(","):
-        part = part.strip()
-        if len(part) >= 8 and part[:8].lower() == "payment ":
-            return part
+    for part in _extract_challenges(header, PAYMENT_SCHEME):
+        return part
     return None
+
+
+def _extract_challenges(header: str, scheme: str) -> list[str]:
+    """Extract scheme challenges from a WWW-Authenticate header value."""
+    all_starts = _find_challenge_starts(header)
+    selected_starts = [start for start in all_starts if _scheme_starts_at(header, start, scheme)]
+    challenges: list[str] = []
+    for start in selected_starts:
+        following_starts = [candidate for candidate in all_starts if candidate > start]
+        end = following_starts[0] if following_starts else len(header)
+        challenge = header[start:end].strip()
+        if challenge.endswith(","):
+            challenge = challenge[:-1].rstrip()
+        if challenge:
+            challenges.append(challenge)
+    return challenges
+
+
+def _find_challenge_starts(header: str) -> list[int]:
+    starts: list[int] = []
+    in_quote = False
+    escaped = False
+    i = 0
+    while i < len(header):
+        char = header[i]
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if char == "\\" and in_quote:
+            escaped = True
+            i += 1
+            continue
+        if char == '"':
+            in_quote = not in_quote
+            i += 1
+            continue
+        if not in_quote and _auth_scheme_starts_at(header, i):
+            starts.append(i)
+            while i < len(header) and header[i] not in (" ", "\t"):
+                i += 1
+            continue
+        i += 1
+    return starts
+
+
+def _scheme_starts_at(header: str, index: int, scheme: str) -> bool:
+    return header[index : index + len(scheme)].lower() == scheme.lower() and _auth_scheme_starts_at(header, index)
+
+
+def _auth_scheme_starts_at(header: str, index: int) -> bool:
+    if index >= len(header) or not header[index].isalpha():
+        return False
+    next_index = index
+    while next_index < len(header) and header[next_index].isalpha():
+        next_index += 1
+    if next_index == index or next_index >= len(header) or header[next_index] not in (" ", "\t"):
+        return False
+    if index == 0:
+        return True
+    previous = index - 1
+    while previous >= 0 and header[previous] in (" ", "\t"):
+        previous -= 1
+    return previous >= 0 and header[previous] == ","
 
 
 def _escape_quoted_value(s: str) -> str:

--- a/python/src/solana_mpp/client/transport.py
+++ b/python/src/solana_mpp/client/transport.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from solana_mpp._headers import ParseError, parse_www_authenticate
+from solana_mpp._headers import parse_www_authenticate_all
 from solana_mpp.client.charge import build_credential_header
 
 logger = logging.getLogger(__name__)
@@ -54,15 +54,8 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         # Look for WWW-Authenticate: Payment header
         www_auth_headers = response.headers.get_list("www-authenticate")
 
-        challenge = None
-        for header in www_auth_headers:
-            if not header.lower().startswith("payment "):
-                continue
-            try:
-                challenge = parse_www_authenticate(header)
-                break
-            except ParseError:
-                continue
+        challenges = parse_www_authenticate_all(www_auth_headers)
+        challenge = challenges[0] if challenges else None
 
         if challenge is None:
             return response

--- a/python/tests/test_client_transport.py
+++ b/python/tests/test_client_transport.py
@@ -18,8 +18,10 @@ class MockTransport(httpx.AsyncBaseTransport):
     def __init__(self, responses: list[httpx.Response]) -> None:
         self._responses = list(responses)
         self._call_count = 0
+        self.requests: list[httpx.Request] = []
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
         idx = min(self._call_count, len(self._responses) - 1)
         self._call_count += 1
         return self._responses[idx]
@@ -103,6 +105,36 @@ class TestPaymentTransport:
         )
         result = await transport.handle_async_request(httpx.Request("GET", "https://example.com"))
         assert result.status_code == 402
+
+    async def test_402_with_combined_www_authenticate_payment_challenge(self, monkeypatch):
+        """Combined WWW-Authenticate values should still find Payment challenges."""
+        challenge = self._make_challenge()
+        www_auth = f'Bearer realm="test", {format_www_authenticate(challenge)}'
+
+        first_response = httpx.Response(402, headers={"www-authenticate": www_auth})
+        second_response = httpx.Response(200, text="Paid content")
+        inner = MockTransport([first_response, second_response])
+
+        async def fake_build_credential_header(**kwargs):
+            assert kwargs["challenge"].id == challenge.id
+            return "Payment credential"
+
+        monkeypatch.setattr(
+            "solana_mpp.client.transport.build_credential_header",
+            fake_build_credential_header,
+        )
+
+        transport = PaymentTransport(
+            signer=MagicMock(),
+            rpc_client=MagicMock(),
+            base_transport=inner,
+        )
+
+        result = await transport.handle_async_request(httpx.Request("GET", "https://example.com"))
+
+        assert result.status_code == 200
+        assert len(inner.requests) == 2
+        assert inner.requests[1].headers["authorization"] == "Payment credential"
 
     async def test_aclose(self):
         """aclose should close the inner transport."""

--- a/python/tests/test_headers.py
+++ b/python/tests/test_headers.py
@@ -13,6 +13,7 @@ from solana_mpp._headers import (
     parse_authorization,
     parse_receipt,
     parse_www_authenticate,
+    parse_www_authenticate_all,
 )
 from solana_mpp._types import ChallengeEcho, PaymentChallenge, PaymentCredential, Receipt
 
@@ -132,6 +133,58 @@ class TestWWWAuthenticate:
         parsed = parse_www_authenticate(header)
         assert parsed.id == r"id\with\backslash"
 
+    def test_parse_all_extracts_payment_from_combined_header(self):
+        challenge = PaymentChallenge(
+            id="payment-id",
+            realm="api",
+            method="solana",
+            intent="charge",
+            request=encode_json({"amount": "10000", "currency": "USDC"}),
+        )
+        header = f'Bearer realm="api", {format_www_authenticate(challenge)}'
+
+        parsed = parse_www_authenticate_all([header])
+
+        assert [c.id for c in parsed] == ["payment-id"]
+
+    def test_parse_all_handles_multiple_payment_challenges(self):
+        first = PaymentChallenge(
+            id="first",
+            realm="api",
+            method="solana",
+            intent="charge",
+            request=encode_json({"amount": "1", "description": "one, with comma"}),
+        )
+        second = PaymentChallenge(
+            id="second",
+            realm="api",
+            method="solana",
+            intent="charge",
+            request=encode_json({"amount": "2"}),
+        )
+        header = f"{format_www_authenticate(first)}, {format_www_authenticate(second)}"
+
+        parsed = parse_www_authenticate_all([header])
+
+        assert [c.id for c in parsed] == ["first", "second"]
+
+    def test_parse_all_skips_invalid_payment_challenges(self):
+        valid = PaymentChallenge(
+            id="valid",
+            realm="api",
+            method="solana",
+            intent="charge",
+            request=encode_json({"amount": "10000", "currency": "USDC"}),
+        )
+        header = (
+            'Payment id="", realm="api", method="solana", intent="charge", request="e30", '
+            f"{format_www_authenticate(valid)}"
+        )
+
+        parsed = parse_www_authenticate_all([header])
+
+        assert [c.id for c in parsed] == ["valid"]
+
 
 class TestAuthorization:
     def test_roundtrip(self):
@@ -181,6 +234,15 @@ class TestAuthorization:
         header = format_authorization(credential)
         # Prefix with another scheme
         multi = f"Bearer xyz123, {header}"
+        parsed = parse_authorization(multi)
+        assert parsed.challenge.id == "test"
+
+    def test_extract_from_multi_scheme_before_and_after_payment(self):
+        """Should not include later schemes in the Payment token."""
+        echo = ChallengeEcho(id="test", realm="api", method="solana", intent="charge", request="e30")
+        credential = PaymentCredential(challenge=echo, payload={"type": "transaction"})
+        header = format_authorization(credential)
+        multi = f'Bearer xyz123, {header}, Basic realm="fallback"'
         parsed = parse_authorization(multi)
         assert parsed.challenge.id == "test"
 


### PR DESCRIPTION
## Summary

Adds Python support for extracting Payment challenges from combined `WWW-Authenticate` header values.

This lets the Python payment transport handle responses such as:

```http
WWW-Authenticate: Bearer realm="api", Payment id="...", realm="...", ...
```

and multiple Payment challenges in the same header value. The parser is quote-aware so commas inside quoted auth-param values do not split the challenge.

## Why

Other implementations already have stronger multi-challenge handling, and servers/proxies can combine `WWW-Authenticate` values. The Python client previously only considered header values that started with `Payment `, so it could miss a valid challenge when another scheme appeared first.

## Verification

- `cd python && PYTHONPATH=src python3 -m pytest tests/test_headers.py tests/test_client_transport.py`
- `cd python && PYTHONPATH=src python3 -m ruff check src/solana_mpp/_headers.py src/solana_mpp/client/transport.py tests/test_headers.py tests/test_client_transport.py`
- `git diff --check`
