### PR TITLE
feat(python): add solana charge challenge selection

### DIFF
--- a/python/src/solana_mpp/client/__init__.py
+++ b/python/src/solana_mpp/client/__init__.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from solana_mpp.client.challenge_selection import (
+    CurrencyPreference,
+    is_solana_charge_challenge,
+    select_solana_charge_challenge,
+)
 from solana_mpp.client.transport import PaymentTransport
 
 __all__ = [
+    "CurrencyPreference",
     "PaymentTransport",
+    "is_solana_charge_challenge",
+    "select_solana_charge_challenge",
 ]

--- a/python/src/solana_mpp/client/challenge_selection.py
+++ b/python/src/solana_mpp/client/challenge_selection.py
@@ -1,0 +1,99 @@
+"""Helpers for selecting client-compatible payment challenges."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from solana_mpp._types import PaymentChallenge
+from solana_mpp.protocol.intents import ChargeRequest
+from solana_mpp.protocol.solana import MethodDetails, resolve_mint
+
+CurrencyPreference = str | Sequence[str]
+
+
+def is_solana_charge_challenge(challenge: PaymentChallenge) -> bool:
+    """Return True when a challenge is a valid Solana charge challenge."""
+    if challenge.method != "solana" or challenge.intent != "charge":
+        return False
+
+    try:
+        _decode_charge_request(challenge)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def select_solana_charge_challenge(
+    challenges: Iterable[PaymentChallenge],
+    *,
+    currency: CurrencyPreference | None = None,
+    network: str | None = None,
+) -> PaymentChallenge | None:
+    """Select the first Solana charge challenge matching client preferences.
+
+    Server responses may include multiple challenges for the same resource,
+    commonly one per supported stablecoin. This helper preserves server order,
+    optionally filtering by Solana network and accepted currency.
+    """
+    candidates: list[tuple[PaymentChallenge, ChargeRequest, MethodDetails]] = []
+
+    for challenge in challenges:
+        if challenge.method != "solana" or challenge.intent != "charge":
+            continue
+
+        request = _decode_charge_request(challenge)
+        details = _decode_method_details(request)
+        if network is not None and details.network != network:
+            continue
+
+        candidates.append((challenge, request, details))
+
+    accepted_currencies = _normalize_currency_preference(currency)
+    if not accepted_currencies:
+        return candidates[0][0] if candidates else None
+
+    for accepted_currency in accepted_currencies:
+        for challenge, request, details in candidates:
+            if _currencies_match(request.currency, accepted_currency, details.network):
+                return challenge
+
+    return None
+
+
+def _decode_charge_request(challenge: PaymentChallenge) -> ChargeRequest:
+    try:
+        data = challenge.decode_request()
+    except Exception as exc:
+        raise ValueError("Invalid Solana charge challenge request") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("Invalid Solana charge challenge request")
+
+    request = ChargeRequest.from_dict(data)
+    if not request.amount or not request.currency or not request.recipient:
+        raise ValueError("Invalid Solana charge challenge request")
+    if not isinstance(request.method_details, dict):
+        raise ValueError("Invalid Solana charge challenge request")
+    return request
+
+
+def _decode_method_details(request: ChargeRequest) -> MethodDetails:
+    method_details: Any = request.method_details
+    if not isinstance(method_details, dict):
+        raise ValueError("Invalid Solana charge challenge methodDetails")
+    return MethodDetails.from_dict(method_details)
+
+
+def _normalize_currency_preference(currency: CurrencyPreference | None) -> tuple[str, ...]:
+    if currency is None:
+        return ()
+    if isinstance(currency, str):
+        return (currency,)
+    return tuple(currency)
+
+
+def _currencies_match(challenge_currency: str, accepted_currency: str, network: str) -> bool:
+    challenge_mint = resolve_mint(challenge_currency, network)
+    accepted_mint = resolve_mint(accepted_currency, network)
+    return challenge_mint == accepted_mint

--- a/python/tests/test_challenge_selection.py
+++ b/python/tests/test_challenge_selection.py
@@ -1,0 +1,121 @@
+"""Tests for client challenge selection helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from solana_mpp._base64url import encode_json
+from solana_mpp._types import PaymentChallenge
+from solana_mpp.client.challenge_selection import (
+    is_solana_charge_challenge,
+    select_solana_charge_challenge,
+)
+from solana_mpp.protocol.solana import resolve_mint
+
+
+def _challenge(
+    *,
+    id_: str,
+    currency: str = "USDC",
+    network: str = "mainnet-beta",
+    method: str = "solana",
+    intent: str = "charge",
+    request: dict | None = None,
+) -> PaymentChallenge:
+    request_obj = request or {
+        "amount": "1000000",
+        "currency": currency,
+        "methodDetails": {"network": network},
+        "recipient": "recipient",
+    }
+    return PaymentChallenge(
+        id=id_,
+        realm="api",
+        method=method,
+        intent=intent,
+        request=encode_json(request_obj),
+    )
+
+
+class TestIsSolanaChargeChallenge:
+    def test_accepts_valid_solana_charge_challenge(self):
+        assert is_solana_charge_challenge(_challenge(id_="usdc"))
+
+    def test_rejects_other_method_or_intent(self):
+        assert not is_solana_charge_challenge(_challenge(id_="card", method="card"))
+        assert not is_solana_charge_challenge(_challenge(id_="refund", intent="refund"))
+
+    def test_rejects_invalid_charge_request(self):
+        challenge = _challenge(id_="invalid", request={"currency": "USDC"})
+        assert not is_solana_charge_challenge(challenge)
+
+
+class TestSelectSolanaChargeChallenge:
+    def test_preserves_server_order_without_preferences(self):
+        first = _challenge(id_="first", currency="USDC")
+        second = _challenge(id_="second", currency="PYUSD")
+
+        selected = select_solana_charge_challenge([first, second])
+
+        assert selected is first
+
+    def test_filters_by_network(self):
+        mainnet = _challenge(id_="mainnet", currency="USDC", network="mainnet-beta")
+        devnet = _challenge(id_="devnet", currency="USDC", network="devnet")
+
+        selected = select_solana_charge_challenge([mainnet, devnet], network="devnet")
+
+        assert selected is devnet
+
+    def test_defaults_missing_network_to_mainnet_beta(self):
+        challenge = _challenge(
+            id_="default-network",
+            request={
+                "amount": "1000000",
+                "currency": "USDC",
+                "methodDetails": {},
+                "recipient": "recipient",
+            },
+        )
+
+        selected = select_solana_charge_challenge([challenge], network="mainnet-beta")
+
+        assert selected is challenge
+
+    def test_filters_by_currency_symbol_preference(self):
+        usdc = _challenge(id_="usdc", currency="USDC")
+        pyusd = _challenge(id_="pyusd", currency="PYUSD")
+
+        selected = select_solana_charge_challenge([usdc, pyusd], currency="PYUSD")
+
+        assert selected is pyusd
+
+    def test_filters_by_ordered_currency_preferences(self):
+        usdc = _challenge(id_="usdc", currency="USDC")
+        pyusd = _challenge(id_="pyusd", currency="PYUSD")
+
+        selected = select_solana_charge_challenge([usdc, pyusd], currency=["USDG", "PYUSD"])
+
+        assert selected is pyusd
+
+    def test_matches_symbol_against_mint_on_same_network(self):
+        devnet_usdc_mint = resolve_mint("USDC", "devnet")
+        challenge = _challenge(id_="devnet-usdc-mint", currency=devnet_usdc_mint, network="devnet")
+
+        selected = select_solana_charge_challenge([challenge], currency="USDC", network="devnet")
+
+        assert selected is challenge
+
+    def test_ignores_non_matching_challenges(self):
+        refund = _challenge(id_="refund", intent="refund")
+        card = _challenge(id_="card", method="card")
+
+        selected = select_solana_charge_challenge([refund, card])
+
+        assert selected is None
+
+    def test_raises_for_invalid_matching_charge_request(self):
+        invalid = _challenge(id_="invalid", request={"currency": "USDC"})
+
+        with pytest.raises(ValueError, match="Invalid Solana charge challenge request"):
+            select_solana_charge_challenge([invalid])


### PR DESCRIPTION
## Summary

Adds a small Python client helper for choosing the Solana charge challenge a client should satisfy when a response contains multiple Payment challenges.

This mirrors the TypeScript client helper shape without changing transport retry behavior yet:

- filters to valid `method=solana` / `intent=charge` challenges
- preserves server order when no preferences are provided
- filters by `methodDetails.network` with the same `mainnet-beta` default
- supports a single currency or ordered currency preferences
- matches currency symbols against known mint addresses for the selected network

## Why

This gives Python a small parity building block before wiring multi-challenge transport behavior or adding more interop adapters.

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_challenge_selection.py tests/test_headers.py tests/test_solana_protocol.py`
- `PYTHONPATH=src python3 -m ruff check src/solana_mpp/client/challenge_selection.py src/solana_mpp/client/__init__.py tests/test_challenge_selection.py`
- `git diff --check`

`pyright` was not run locally because it is not installed in this Python environment.

GitHub CI is also green for this branch, including typecheck, Python-related checks, and the current interop jobs.
