### PR TITLE
fix(go): select supported charge challenge

### DIFF
--- a/go/client/transport.go
+++ b/go/client/transport.go
@@ -96,11 +96,15 @@ func (t *PaymentTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 func selectChargeChallenge(challenges []mpp.PaymentChallenge) (mpp.PaymentChallenge, bool) {
 	for _, challenge := range challenges {
-		if string(challenge.Method) == "solana" && challenge.Intent.IsCharge() {
+		if isSupportedChargeChallenge(challenge) {
 			return challenge, true
 		}
 	}
 	return mpp.PaymentChallenge{}, false
+}
+
+func isSupportedChargeChallenge(challenge mpp.PaymentChallenge) bool {
+	return challenge.Method == mpp.NewMethodName("solana") && challenge.Intent.IsCharge()
 }
 
 // NewClient creates an *http.Client with automatic 402 payment handling.

--- a/go/client/transport.go
+++ b/go/client/transport.go
@@ -63,7 +63,10 @@ func (t *PaymentTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}
 
-	challenge := challenges[0]
+	challenge, ok := selectChargeChallenge(challenges)
+	if !ok {
+		return resp, nil
+	}
 
 	ctx := req.Context()
 	if ctx == nil {
@@ -89,6 +92,15 @@ func (t *PaymentTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	return t.base().RoundTrip(retry)
+}
+
+func selectChargeChallenge(challenges []mpp.PaymentChallenge) (mpp.PaymentChallenge, bool) {
+	for _, challenge := range challenges {
+		if string(challenge.Method) == "solana" && challenge.Intent.IsCharge() {
+			return challenge, true
+		}
+	}
+	return mpp.PaymentChallenge{}, false
 }
 
 // NewClient creates an *http.Client with automatic 402 payment handling.

--- a/go/client/transport_test.go
+++ b/go/client/transport_test.go
@@ -19,6 +19,10 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func newTestChallenge() mpp.PaymentChallenge {
+	return newTestChallengeFor("solana", "charge")
+}
+
+func newTestChallengeFor(method string, intent string) mpp.PaymentChallenge {
 	fakeRPC := testutil.NewFakeRPC()
 	request, _ := mpp.NewBase64URLJSONValue(map[string]any{
 		"amount":    "1000",
@@ -29,7 +33,13 @@ func newTestChallenge() mpp.PaymentChallenge {
 			"recentBlockhash": fakeRPC.Blockhash.String(),
 		},
 	})
-	return mpp.NewChallengeWithSecret("secret", "realm", "solana", "charge", request)
+	return mpp.NewChallengeWithSecret(
+		"secret",
+		"realm",
+		mpp.NewMethodName(method),
+		mpp.NewIntentName(intent),
+		request,
+	)
 }
 
 func TestTransportPassthroughNon402(t *testing.T) {
@@ -146,6 +156,100 @@ func TestTransport402RetryWithMergedWWWAuthenticate(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("expected 2 round trips, got %d", calls)
+	}
+}
+
+func TestTransport402SelectsSolanaChargeChallenge(t *testing.T) {
+	unsupportedChallenge := newTestChallengeFor("card", "charge")
+	unsupportedWWWAuth, err := mpp.FormatWWWAuthenticate(unsupportedChallenge)
+	if err != nil {
+		t.Fatalf("format unsupported challenge: %v", err)
+	}
+	challenge := newTestChallenge()
+	wwwAuth, err := mpp.FormatWWWAuthenticate(challenge)
+	if err != nil {
+		t.Fatalf("format challenge: %v", err)
+	}
+
+	calls := 0
+	transport := &PaymentTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusPaymentRequired,
+					Body:       io.NopCloser(strings.NewReader("payment required")),
+					Header:     http.Header{"Www-Authenticate": {unsupportedWWWAuth, wwwAuth}},
+				}, nil
+			}
+			auth := req.Header.Get(mpp.AuthorizationHeader)
+			if auth == "" {
+				t.Fatal("expected Authorization header on retry")
+			}
+			credential, err := mpp.ParseAuthorization(auth)
+			if err != nil {
+				t.Fatalf("parse retry authorization: %v", err)
+			}
+			if credential.Challenge.Method != "solana" {
+				t.Fatalf("expected solana challenge, got %q", credential.Challenge.Method)
+			}
+			if !credential.Challenge.Intent.IsCharge() {
+				t.Fatalf("expected charge intent, got %q", credential.Challenge.Intent)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("paid")),
+				Header:     http.Header{},
+			}, nil
+		}),
+		Signer: testutil.NewPrivateKey(),
+		RPC:    testutil.NewFakeRPC(),
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 round trips, got %d", calls)
+	}
+}
+
+func TestTransport402KeepsOriginalResponseWithoutSupportedChargeChallenge(t *testing.T) {
+	unsupportedChallenge := newTestChallengeFor("card", "charge")
+	unsupportedWWWAuth, err := mpp.FormatWWWAuthenticate(unsupportedChallenge)
+	if err != nil {
+		t.Fatalf("format unsupported challenge: %v", err)
+	}
+
+	calls := 0
+	transport := &PaymentTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{
+				StatusCode: http.StatusPaymentRequired,
+				Body:       io.NopCloser(strings.NewReader("payment required")),
+				Header:     http.Header{"Www-Authenticate": {unsupportedWWWAuth}},
+			}, nil
+		}),
+		Signer: testutil.NewPrivateKey(),
+		RPC:    testutil.NewFakeRPC(),
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("expected original 402, got %d", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 round trip, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Updates the Go `PaymentTransport` challenge selection so it does not blindly use the first parsed `WWW-Authenticate` Payment challenge.

The transport now selects the first supported `method=solana` + `intent=charge` challenge and leaves the original 402 response untouched when no supported challenge is present.

## Motivation

As MPP interop expands across languages and servers may advertise multiple payment methods/intents, the Go client should only build credentials for challenges it actually supports. This keeps Go aligned with the explicit challenge-selection behavior used elsewhere and avoids retrying with an unsupported challenge echo.

## Verification

- `gofmt -w go/client/transport.go go/client/transport_test.go`
- `git diff --check`
- `cd go && go test ./client ./protocol/core`
- `cd go && go test ./...`