### PR TITLE
test(interop): fail on empty adapter selection

### DIFF
--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -43,6 +43,12 @@ function createSplMintAccountData(decimals: number): Uint8Array {
 }
 
 const socketSupport = await canBindLocalSocket();
+const activeServers = serverImplementations.filter(implementation => implementation.enabled);
+const activeClients = clientImplementations.filter(implementation => implementation.enabled);
+
+function implementationIds(implementations: typeof serverImplementations): string {
+  return implementations.map(implementation => implementation.id).join(", ");
+}
 
 beforeAll(async () => {
   if (!socketSupport) {
@@ -80,9 +86,18 @@ afterEach(async () => {
 });
 
 describe("mpp interop", () => {
-  const activeServers = serverImplementations.filter(implementation => implementation.enabled);
-  const activeClients = clientImplementations.filter(implementation => implementation.enabled);
   const socketAwareIt = socketSupport ? it : it.skip;
+
+  it("has at least one enabled client and server implementation", () => {
+    expect(
+      activeClients.length,
+      `No MPP interop clients enabled. Set MPP_INTEROP_CLIENTS to one of: ${implementationIds(clientImplementations)}`,
+    ).toBeGreaterThan(0);
+    expect(
+      activeServers.length,
+      `No MPP interop servers enabled. Set MPP_INTEROP_SERVERS to one of: ${implementationIds(serverImplementations)}`,
+    ).toBeGreaterThan(0);
+  });
 
   for (const serverImplementation of activeServers) {
     for (const clientImplementation of activeClients) {


### PR DESCRIPTION
## Summary

- add an explicit interop configuration guard so `MPP_INTEROP_CLIENTS` / `MPP_INTEROP_SERVERS` typos do not silently produce an empty matrix
- include valid adapter ids in the failure message
- keep the default TypeScript/Rust matrix behavior unchanged

## Why

This is a small safety improvement for #57. As more process adapters are added, a misspelled adapter id should fail fast with a useful message instead of looking like a passing run with zero client/server combinations.

## Verification

- `pnpm install --frozen-lockfile && pnpm --filter @solana/mpp build` from `typescript/`
- `pnpm install --force --frozen-lockfile` from `tests/interop/` after building the local file dependency
- `pnpm exec tsc --noEmit` from `tests/interop/`
- `MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=typescript pnpm exec vitest run test/e2e.test.ts` from `tests/interop/`
- `MPP_INTEROP_CLIENTS=not-real MPP_INTEROP_SERVERS=typescript pnpm exec vitest run test/e2e.test.ts --testNamePattern "has at least one enabled"` fails with the intended guard message
- `git diff --check`

Refs #57
