### PR TITLE
fix(python): reject malformed auth params

### DIFF
--- a/python/src/solana_mpp/_headers.py
+++ b/python/src/solana_mpp/_headers.py
@@ -253,29 +253,46 @@ def _parse_auth_params(params_str: str) -> dict[str, str]:
     params: dict[str, str] = {}
     chars = list(params_str)
     i = 0
+    first = True
 
     while i < len(chars):
-        # Skip whitespace and commas
-        while i < len(chars) and (chars[i] in (" ", "\t", ",")):
+        while i < len(chars) and chars[i] in (" ", "\t"):
             i += 1
         if i >= len(chars):
             break
+
+        if first:
+            if chars[i] == ",":
+                raise ParseError("Malformed authentication parameters")
+        else:
+            if chars[i] != ",":
+                raise ParseError("Malformed authentication parameters")
+            i += 1
+            while i < len(chars) and chars[i] in (" ", "\t"):
+                i += 1
+            if i >= len(chars):
+                raise ParseError("Malformed authentication parameters")
 
         # Read key
         key_start = i
-        while i < len(chars) and chars[i] != "=" and chars[i] not in (" ", "\t"):
+        while i < len(chars) and chars[i] not in ("=", " ", "\t", ","):
             i += 1
-        if i >= len(chars) or chars[i] != "=":
-            # Skip to next comma or whitespace
-            while i < len(chars) and chars[i] not in (" ", "\t", ","):
-                i += 1
-            continue
+        if i == key_start:
+            raise ParseError("Malformed authentication parameters")
 
         key = "".join(chars[key_start:i])
+
+        while i < len(chars) and chars[i] in (" ", "\t"):
+            i += 1
+        if i >= len(chars) or chars[i] != "=":
+            raise ParseError("Malformed authentication parameters")
+
         i += 1  # skip '='
 
+        while i < len(chars) and chars[i] in (" ", "\t"):
+            i += 1
         if i >= len(chars):
-            break
+            raise ParseError("Malformed authentication parameters")
 
         # Read value
         if chars[i] == '"':
@@ -288,17 +305,21 @@ def _parse_auth_params(params_str: str) -> dict[str, str]:
                 else:
                     value_parts.append(chars[i])
                 i += 1
-            if i < len(chars):
-                i += 1  # skip closing quote
+            if i >= len(chars):
+                raise ParseError("Malformed authentication parameters")
+            i += 1  # skip closing quote
             value = "".join(value_parts)
         else:
             value_start = i
             while i < len(chars) and chars[i] not in (" ", "\t", ","):
                 i += 1
+            if i == value_start:
+                raise ParseError("Malformed authentication parameters")
             value = "".join(chars[value_start:i])
 
         if key in params:
             raise ParseError(f"Duplicate parameter: {key}")
         params[key] = value
+        first = False
 
     return params

--- a/python/tests/test_headers.py
+++ b/python/tests/test_headers.py
@@ -74,6 +74,16 @@ class TestWWWAuthenticate:
         with pytest.raises(ParseError, match="Duplicate"):
             parse_www_authenticate(header)
 
+    def test_rejects_malformed_auth_params(self):
+        valid = 'Payment id="x", realm="api", method="solana", intent="charge", request="e30"'
+        missing_separator = valid.replace(', realm="api"', ' realm="api"')
+        trailing_junk = f"{valid} not-a-param"
+        unterminated_quote = valid.replace('realm="api"', 'realm="api')
+
+        for header in (missing_separator, trailing_junk, unterminated_quote):
+            with pytest.raises(ParseError, match="Malformed authentication parameters"):
+                parse_www_authenticate(header)
+
     def test_tab_after_scheme(self):
         header = 'Payment\tid="x", realm="api", method="solana", intent="charge", request="e30"'
         parsed = parse_www_authenticate(header)


### PR DESCRIPTION
## Summary

Tighten Python `WWW-Authenticate: Payment` auth-param parsing so malformed parameter lists fail closed instead of being partially accepted.

This catches cases such as:

- missing comma separators between auth params
- trailing non-param text after an otherwise valid challenge
- unterminated quoted values

## Why

The parser is used on the protocol boundary. Accepting a partial parse can hide producer bugs and make interop failures harder to diagnose across SDK implementations.

## Verification

- `PYTHONPATH=src uv run pytest tests/test_headers.py`
- `uv run ruff check src/solana_mpp/_headers.py tests/test_headers.py`
- `uv run ruff format --check src/solana_mpp/_headers.py tests/test_headers.py`
- `git diff --check`

Additional note: I also tried `PYTHONPATH=src uv run pytest tests`; it collected 220 tests and passed 215, but 5 existing `tests/test_server_html.py` expectations failed against the generated HTML output. Those failures appear unrelated to this header parser change.
