### PR TITLE
fix(lua): reject malformed auth params

### DIFF
--- a/lua/mpp/protocol/core/headers.lua
+++ b/lua/mpp/protocol/core/headers.lua
@@ -28,24 +28,65 @@ end
 local function parse_auth_params(input)
   local params = {}
   local i = 1
+  local first = true
+
   while i <= #input do
-    while i <= #input and input:sub(i, i):match('[%s,]') do
+    while i <= #input and input:sub(i, i):match('%s') do
       i = i + 1
     end
     if i > #input then
       break
     end
-    local eq = input:find('=', i, true)
-    if not eq then
+
+    if not first then
+      if input:sub(i, i) ~= ',' then
+        error('invalid auth parameter separator')
+      end
+      i = i + 1
+      while i <= #input and input:sub(i, i):match('%s') do
+        i = i + 1
+      end
+      if i > #input then
+        error('invalid auth parameter')
+      end
+    elseif input:sub(i, i) == ',' then
       error('invalid auth parameter')
     end
-    local key = input:sub(i, eq - 1):gsub('%s+$', '')
-    i = eq + 1
+
+    local key_start = i
+    while i <= #input do
+      local ch = input:sub(i, i)
+      if ch == '=' or ch == ',' or ch:match('%s') then
+        break
+      end
+      i = i + 1
+    end
+    local key = input:sub(key_start, i - 1)
+    if key == '' then
+      error('invalid auth parameter')
+    end
+
+    while i <= #input and input:sub(i, i):match('%s') do
+      i = i + 1
+    end
+    if input:sub(i, i) ~= '=' then
+      error('invalid auth parameter')
+    end
+    i = i + 1
+
+    while i <= #input and input:sub(i, i):match('%s') do
+      i = i + 1
+    end
+    if i > #input then
+      error('invalid auth parameter')
+    end
+
     local value
     if input:sub(i, i) == '"' then
       i = i + 1
       local out = {}
       local escaped = false
+      local closed = false
       while i <= #input do
         local ch = input:sub(i, i)
         i = i + 1
@@ -55,26 +96,35 @@ local function parse_auth_params(input)
         elseif ch == '\\' then
           escaped = true
         elseif ch == '"' then
+          closed = true
           break
         else
           out[#out + 1] = ch
         end
       end
+      if not closed then
+        error('unterminated quoted value')
+      end
       value = table.concat(out)
     else
-      local next_comma = input:find(',', i, true)
-      if next_comma then
-        value = input:sub(i, next_comma - 1):gsub('%s+$', '')
-        i = next_comma + 1
-      else
-        value = input:sub(i):gsub('%s+$', '')
-        i = #input + 1
+      local value_start = i
+      while i <= #input do
+        local ch = input:sub(i, i)
+        if ch == ',' or ch:match('%s') then
+          break
+        end
+        i = i + 1
+      end
+      value = input:sub(value_start, i - 1)
+      if value == '' then
+        error('invalid auth parameter')
       end
     end
     if params[key] ~= nil then
       error('duplicate parameter: ' .. key)
     end
     params[key] = value
+    first = false
   end
   return params
 end

--- a/lua/tests/core_spec.lua
+++ b/lua/tests/core_spec.lua
@@ -21,6 +21,24 @@ t.test('www-authenticate round trip', function()
   t.assert_equal(parsed.request:raw(), challenge.request:raw())
 end)
 
+t.test('www-authenticate rejects malformed auth params', function()
+  local request = mpp.NewBase64URLJSONValue({ amount = '1000', currency = 'sol' })
+  local challenge = mpp.NewChallengeWithSecret('secret', 'realm', mpp.NewMethodName('solana'), mpp.NewIntentName('charge'), request)
+  local header = mpp.FormatWWWAuthenticate(challenge)
+
+  t.assert_error(function()
+    mpp.ParseWWWAuthenticate((header:gsub(', realm=', ' realm=', 1)))
+  end, 'separator')
+
+  t.assert_error(function()
+    mpp.ParseWWWAuthenticate(header .. ' trailing')
+  end, 'separator')
+
+  t.assert_error(function()
+    mpp.ParseWWWAuthenticate(header .. ', opaque="unterminated')
+  end, 'unterminated')
+end)
+
 t.test('authorization round trip', function()
   local request = mpp.NewBase64URLJSONValue({ amount = '1000' })
   local challenge = mpp.NewChallengeWithSecret('secret', 'realm', mpp.NewMethodName('solana'), mpp.NewIntentName('charge'), request)


### PR DESCRIPTION
## Summary

- make the Lua `WWW-Authenticate` auth-param parser reject missing comma separators
- reject trailing junk after a parsed parameter
- reject unterminated quoted auth-param values
- add a focused Lua core regression test for malformed MPP challenge headers

## Why

The Lua parser previously skipped commas and whitespace together before reading the next auth-param. That meant malformed challenge headers such as `id="..." realm="..."` could be accepted instead of failing early. It also accepted unterminated quoted values.

This brings Lua closer to the stricter behavior added for Python in the adjacent parser hardening work.

## Verification

- `mise x lua@5.4 -- bash -lc 'cd lua && lua -e "package.path = table.concat({\"./?.lua\",\"./?/init.lua\",\"./lua/?.lua\",\"./lua/?/init.lua\",package.path},\";\"); require(\"tests.core_spec\"); require(\"tests.test_helper\").run()"'`
- `mise x lua@5.4 -- bash -lc 'cd lua && luac -p mpp/protocol/core/headers.lua tests/core_spec.lua'`
- `git diff --check`

Note: full `cd lua && lua tests/run.lua` reaches the new core test successfully, then fails later in the existing HTML server spec because `mpp/server/html.lua` expects generated `payment_ui_js` assets that are absent in this local checkout.
