### PR TITLE
fix(go): align SPL ATA creation with interop policy

### DIFF
--- a/go/client/charge.go
+++ b/go/client/charge.go
@@ -125,23 +125,26 @@ func BuildChargeTransaction(
 				return protocol.CredentialPayload{}, err
 			}
 		}
-		addTransfer := func(owner solana.PublicKey, amount uint64) error {
+		addTransfer := func(owner solana.PublicKey, amount uint64, createTokenAccount bool) error {
 			destATA, err := solanautil.FindAssociatedTokenAddressWithProgram(owner, mint, tokenProgram)
 			if err != nil {
 				return err
 			}
-			createATA, err := solanautil.BuildCreateAssociatedTokenAccount(payer, owner, mint, tokenProgram)
-			if err != nil {
-				return err
+			if createTokenAccount {
+				createATA, err := solanautil.BuildCreateAssociatedTokenAccount(payer, owner, mint, tokenProgram)
+				if err != nil {
+					return err
+				}
+				instructions = append(instructions, createATA)
 			}
 			transfer, err := solanautil.BuildTransferChecked(amount, decimals, sourceATA, mint, destATA, signer.PublicKey(), tokenProgram)
 			if err != nil {
 				return err
 			}
-			instructions = append(instructions, createATA, transfer)
+			instructions = append(instructions, transfer)
 			return nil
 		}
-		if err := addTransfer(recipientKey, primaryAmount); err != nil {
+		if err := addTransfer(recipientKey, primaryAmount, false); err != nil {
 			return protocol.CredentialPayload{}, err
 		}
 		if options.ExternalID != "" {
@@ -160,7 +163,8 @@ func BuildChargeTransaction(
 			if err != nil {
 				return protocol.CredentialPayload{}, err
 			}
-			if err := addTransfer(splitKey, splitAmount); err != nil {
+			createTokenAccount := !useServerFeePayer || (split.AtaCreationRequired != nil && *split.AtaCreationRequired)
+			if err := addTransfer(splitKey, splitAmount, createTokenAccount); err != nil {
 				return protocol.CredentialPayload{}, err
 			}
 			if split.Memo != "" {

--- a/go/client/charge_test.go
+++ b/go/client/charge_test.go
@@ -145,8 +145,8 @@ func TestBuildChargeTransactionTokenPull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}
-	if len(tx.Message.Instructions) != 4 {
-		t.Fatalf("expected 4 instructions, got %d", len(tx.Message.Instructions))
+	if len(tx.Message.Instructions) != 3 {
+		t.Fatalf("expected 3 instructions, got %d", len(tx.Message.Instructions))
 	}
 }
 
@@ -292,9 +292,9 @@ func TestBuildChargeTransactionTokenWithSplits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}
-	// 2 compute budget + 2 (create ATA + transfer) for primary + 2 for split + 1 split memo = 7
-	if len(tx.Message.Instructions) != 7 {
-		t.Fatalf("expected 7 instructions, got %d", len(tx.Message.Instructions))
+	// 2 compute budget + 1 primary transfer + 2 split instructions + 1 split memo = 6
+	if len(tx.Message.Instructions) != 6 {
+		t.Fatalf("expected 6 instructions, got %d", len(tx.Message.Instructions))
 	}
 	if !hasMemoText(memoTexts(t, tx), "platform fee") {
 		t.Fatalf("expected split memo instruction")

--- a/go/protocol/solana.go
+++ b/go/protocol/solana.go
@@ -119,10 +119,11 @@ type MethodDetails struct {
 
 // Split is an additional transfer in the same asset.
 type Split struct {
-	Recipient string `json:"recipient"`
-	Amount    string `json:"amount"`
-	Label     string `json:"label,omitempty"`
-	Memo      string `json:"memo,omitempty"`
+	Recipient           string `json:"recipient"`
+	Amount              string `json:"amount"`
+	Label               string `json:"label,omitempty"`
+	Memo                string `json:"memo,omitempty"`
+	AtaCreationRequired *bool  `json:"ataCreationRequired,omitempty"`
 }
 
 // CredentialPayload is sent by clients in the payment credential payload.

--- a/tests/interop/src/implementations.ts
+++ b/tests/interop/src/implementations.ts
@@ -47,7 +47,7 @@ export const clientImplementations: ImplementationDefinition[] = [
     label: "Go HTTP client",
     role: "client",
     command: ["sh", "-c", "cd go-client && go run ."],
-    enabled: isEnabled("go", "MPP_INTEROP_CLIENTS", false),
+    enabled: isEnabled("go", "MPP_INTEROP_CLIENTS", true),
   },
 ];
 


### PR DESCRIPTION
## Summary
- stop the Go SPL client from creating the primary recipient ATA in charge transactions
- preserve split ATA creation behavior and honor ataCreationRequired in Go split metadata
- enable the Go process client in the default interop matrix after verifying it against TypeScript and Rust servers

## Why
TypeScript and Rust servers reject fee-sponsored primary-recipient ATA creation because that owner is not authorized by the challenge ATA policy. The Go client was creating that ATA unconditionally, so Go -> TypeScript and Go -> Rust interop failed even though Go -> Go passed.

## Verification
- cd go && GOCACHE=/private/tmp/mpp-sdk-go-cache go test ./client ./protocol/...
- cd tests/interop && pnpm typecheck
- cd tests/interop && pnpm test