### PR TITLE
docs: add mpp roadmap notes

### DIFF
--- a/docs/monorepo-plan.md
+++ b/docs/monorepo-plan.md
@@ -1,0 +1,144 @@
+# MPP and x402 Monorepo Plan
+
+This note sketches a practical path for eventually bringing `mpp-sdk` and
+`x402-sdk` into one repository without forcing the protocols into one shared
+abstraction too early.
+
+## Goal
+
+Keep MPP and x402 independently correct while making cross-language protocol
+work easier to test, review, and maintain.
+
+The monorepo should improve:
+
+- shared interop infrastructure
+- consistent language package layout
+- common CI matrix management
+- reusable Solana test fixtures
+- maintainer visibility into protocol gaps
+
+It should not imply that MPP and x402 are the same protocol or that their public
+SDK APIs must be unified immediately.
+
+## Proposed Shape
+
+```text
+payments-sdk/
+|-- protocols/
+|   |-- mpp/
+|   |   |-- typescript/
+|   |   |-- rust/
+|   |   |-- go/
+|   |   |-- python/
+|   |   |-- ruby/
+|   |   |-- lua/
+|   |   `-- php/
+|   `-- x402/
+|       |-- typescript/
+|       |-- rust/
+|       |-- go/
+|       |-- python/
+|       |-- ruby/
+|       |-- lua/
+|       `-- php/
+|-- tests/
+|   |-- interop/
+|   |   |-- harness/
+|   |   |-- mpp/
+|   |   `-- x402/
+|   `-- fixtures/
+|       `-- solana/
+|-- docs/
+`-- .github/workflows/
+```
+
+Language package names can remain protocol-specific, for example
+`@solana/mpp`, `@solana/x402`, `solana_mpp`, and `solana_x402`.
+
+## Shared Pieces
+
+Good candidates for shared infrastructure:
+
+- process adapter contract for interop tests
+- Surfpool startup and account funding fixtures
+- local Solana mint and token account helpers
+- matrix filtering, timeout handling, and diagnostic reporting
+- CI workflow templates
+- protocol fixture corpus for valid and invalid HTTP challenges/payments
+
+These should live below shared test or tooling directories, not inside either
+protocol's core SDK.
+
+## Separate Pieces
+
+Keep these protocol-specific:
+
+- MPP intent model: `charge`, `session`, `subscription`
+- MPP server challenge and credential verification
+- x402 payment requirement selection and exact-payment semantics
+- public SDK exports and package names
+- language-specific protocol core modules
+- docs and examples that explain protocol behavior
+
+Shared code should help test the protocols, not erase their boundaries.
+
+## Migration Sequence
+
+1. Stabilize local interop harnesses in both repos.
+2. Align adapter contracts where they are already naturally similar.
+3. Extract only test utilities that are duplicated and stable.
+4. Add a shared fixture corpus for Solana payment scenarios.
+5. Move repos into one tree with package paths preserved.
+6. Convert CI into a protocol-by-language matrix.
+7. Only then evaluate whether any SDK internals deserve shared packages.
+
+The first extraction target should be the harness runner and fixtures, not the
+protocol implementations.
+
+## CI Shape
+
+CI should support narrow and full runs:
+
+- protocol-only: MPP or x402
+- language-only: TypeScript, Rust, Go, Python, Ruby, Lua, PHP
+- intent/scheme-only: MPP charge/session/subscription or x402 exact
+- pair-only: one client implementation against one server implementation
+- full release gate: all stable matrix pairs
+
+Every failure should report:
+
+- protocol
+- intent or scheme
+- client implementation
+- server implementation
+- adapter command
+- selected fixture
+- final HTTP status
+- relevant response body and recent stderr
+
+## What Not To Do Yet
+
+Avoid these until both repos have stronger interop coverage:
+
+- merging public SDK APIs
+- introducing a generic "payment protocol" abstraction
+- moving MPP and x402 into one protocol core
+- sharing verification logic before fixtures prove identical behavior
+- broad package renames
+- large multi-language refactors in one PR
+
+The safe path is shared harness first, shared protocol code later only if it is
+proven by tests and review.
+
+## Near-Term PR Candidates
+
+Small PRs that move toward this shape:
+
+1. Document the shared adapter contract in both repos.
+2. Add per-protocol fixture IDs to interop result output.
+3. Standardize matrix filter naming and timeout behavior.
+4. Extract repeated Surfpool setup notes into harness docs.
+5. Add a compact matrix status document for MPP and x402.
+
+Each PR should be reviewable on its own and should avoid changing protocol
+behavior unless the interop harness exposes a concrete gap.

--- a/docs/session-subscription-source-of-truth.md
+++ b/docs/session-subscription-source-of-truth.md
@@ -1,0 +1,229 @@
+# Session and Subscription Source of Truth
+
+This note captures the current local source of truth before adding session or
+subscription support to additional language SDKs.
+
+It is intentionally descriptive. It does not propose a new protocol contract.
+
+## Related Pay Work
+
+The current `solana-foundation/pay` session reference is:
+
+- `solana-foundation/pay#364`: preliminary session support
+  <https://github.com/solana-foundation/pay/pull/364>
+- linked spec work: `tempoxyz/mpp-specs#201`
+  <https://github.com/tempoxyz/mpp-specs/pull/201>
+
+That work reinforces the core lifecycle: open a channel first, then pay through
+cumulative vouchers, then close/finalize the channel. It also highlights a
+field-name drift risk that should be resolved before copying schemas blindly
+between repos.
+
+`solana-foundation/pay#363` is not a session schema change, but it is relevant
+to server-side robustness because poisoned in-memory accounting state should not
+take down all later verification.
+
+The current subscription specification reference is:
+
+- `tempoxyz/mpp-specs#230`: subscription intent plus Stripe and Tempo method
+  profiles <https://github.com/tempoxyz/mpp-specs/pull/230>
+
+That PR defines subscription as a narrow recurring fixed-amount payment
+authorization. It does not model full billing-product behavior such as seats,
+trials, prorations, discounts, usage-based billing, or plan changes.
+
+## Current Code Shape
+
+### TypeScript
+
+TypeScript defines the shared `session` method schema in
+`typescript/packages/mpp/src/Methods.ts`.
+
+Client-side session support is implemented and exported from:
+
+- `typescript/packages/mpp/src/client/Session.ts`
+- `typescript/packages/mpp/src/client/SessionConsumer.ts`
+- `typescript/packages/mpp/src/client/SessionFetch.ts`
+- `typescript/packages/mpp/src/client/SessionUsageMeter.ts`
+- `typescript/packages/mpp/src/client/PaymentChannels.ts`
+
+The TypeScript client exposes `solana.session`. The TypeScript server export
+currently exposes `solana.charge`; server-side session integration is not
+exported through `typescript/packages/mpp/src/server/Methods.ts`.
+
+### Rust
+
+Rust defines session protocol types in
+`rust/src/protocol/intents/session.rs` and re-exports them from
+`rust/src/protocol/intents/mod.rs`.
+
+Rust also has client and server session logic:
+
+- `rust/src/client/session.rs`
+- `rust/src/client/session_consumer.rs`
+- `rust/src/client/payment_channels.rs`
+- `rust/src/server/session.rs`
+
+The Rust session server includes challenge construction, open processing,
+voucher verification, delivery reservation/commit behavior, top-up handling,
+and close/finalize helpers.
+
+### Python
+
+Python currently has charge intent types in
+`python/src/solana_mpp/protocol/intents.py`.
+
+No Python `SessionRequest`, `SessionAction`, voucher, metering directive, or
+subscription model is present yet.
+
+### Go
+
+Go currently has charge intent types in `go/protocol/intents/charge.go`.
+
+No Go `SessionRequest`, `SessionAction`, voucher, metering directive, or
+subscription model is present yet.
+
+### Lua
+
+Lua currently has charge intent helpers in
+`lua/mpp/protocol/intents/charge.lua` and generic intent-name helpers in
+`lua/mpp/protocol/core/types.lua`.
+
+Lua is server-side only for the near-term MPP roadmap. No Lua session or
+subscription server model is present yet.
+
+### Ruby and PHP
+
+Ruby and PHP package directories are not present in this checkout.
+
+PHP is expected to be server-side only when it is added. Ruby support remains
+unclear until a package layout exists.
+
+## Session Model Observed in TypeScript and Rust
+
+The common session vocabulary already visible in TypeScript and Rust is:
+
+- intent: `session`
+- method: `solana`
+- funding modes: `push`, `pull`
+- pull voucher strategies: `clientVoucher`, `operatedVoucher`
+- request cap: `cap`
+- currency and optional decimals: `currency`, `decimals`
+- server/operator identity: `operator`
+- primary recipient: `recipient`
+- optional splits: `splits`
+- optional minimum voucher increment: `minVoucherDelta`
+- optional payment-channel program: `programId`
+- optional server blockhash hint: `recentBlockhash`
+- actions: `open`, `voucher`, `commit`, `topUp`, `close`
+- voucher data: `channelId`, `cumulativeAmount`, `expiresAt`, optional `nonce`
+- metering directives: `sessionId`, `deliveryId`, `amount`, `currency`,
+  `sequence`, `expiresAt`, optional `commitUrl`, optional `proof`
+- commit receipts: `sessionId`, `deliveryId`, `amount`, `cumulative`, `status`
+
+Both implementations treat vouchers as cumulative authorization rather than
+per-call independent payments.
+
+The related Pay work points in the same direction: voucher amounts are
+cumulative watermarks, not deltas. An `open` action should not carry the first
+voucher; voucher and commit actions happen after the session is open.
+
+## Field Mapping To Resolve
+
+Before implementing another language, compare the current SDK field names with
+the active Pay/spec direction:
+
+| Concept | Current mpp-sdk names | Pay/spec names to verify |
+| --- | --- | --- |
+| Spend cap | `cap` | `amount` |
+| Suggested deposit | not distinct in the current request | `suggestedDeposit` |
+| Minimum deposit | not distinct in the current request | `minimumDeposit` |
+| Channel program | `programId` | `channelProgram` |
+| Distribution splits | `splits` | `distributionSplits` |
+| Grace period | `gracePeriod` | `gracePeriodSeconds` |
+
+This table is a review checklist, not a requested rename. Any rename should come
+from the spec or maintainer direction, not from an individual language port.
+
+## Subscription Status
+
+No `subscription` intent implementation or schema appears in this checkout.
+
+The active subscription spec work points to a distinct MPP intent rather than a
+thin alias for session:
+
+- intent: `subscription`
+- required shared request fields: `amount`, `currency`, `periodUnit`,
+  `periodCount`
+- optional shared request fields: `recipient`, `subscriptionExpires`,
+  `description`, `externalId`, `methodDetails`
+- period units: `day`, `week`, `month`, with methods required to reject periods
+  they cannot represent exactly
+- activation includes the first billing-period charge
+- renewal permits at most one charge per billing period
+- missed periods do not accumulate extra charge authority
+- activation and renewal require durable server accounting and idempotency
+- successful activation and renewal receipts include a `subscriptionId`
+- possession of a `subscriptionId` alone is not sufficient authorization
+
+Stripe and Tempo profiles are currently specified. No Solana-specific
+subscription profile appears in this checkout or in the inspected open spec PRs.
+
+That means Solana SDK work should start with shared subscription request and
+state modeling, not Solana transaction construction. A Solana-specific
+implementation needs maintainer/spec direction for the recurring authorization
+primitive before it can safely move beyond schema and server accounting tests.
+
+## Interop Harness Status
+
+The process interop harness currently models a single charge scenario:
+
+- `tests/interop/src/contracts.ts` has `intent: "charge"`
+- `tests/interop/README.md` describes charge-only protected resources
+- client adapters pay a protected URL and emit one result message
+- server adapters expose a charge-protected resource and emit one ready message
+
+The harness does not yet model session lifecycle, streamed/metered delivery,
+voucher commit, top-up, close, or subscription recurrence.
+
+The first session interop fixture should stay small and deterministic:
+
+1. parse a `session` challenge
+2. send an `open` action without a voucher
+3. send a `voucher` or `commit` action with a cumulative voucher
+4. reject non-monotonic cumulative amounts
+5. close or finalize the session
+
+Useful negative fixtures include wrong signer, missing or invalid `channelId`,
+cumulative decrease, cumulative amount above cap/deposit, and voucher after
+close.
+
+## Near-Term Implementation Order
+
+1. Keep charge interop stable before adding another intent.
+2. Add session protocol types to Python and Go from the shared TypeScript/Rust
+   vocabulary.
+3. Add focused unit tests for serialization, parsing, voucher bytes, and
+   request/action validation before wiring interop.
+4. Add server-side session models for Lua only after TypeScript/Rust behavior is
+   stable enough to compare against.
+5. Add shared subscription request/state types and validation tests separately
+   from session.
+6. Defer Solana subscription settlement behavior until a Solana method profile
+   exists or maintainers confirm which recurring authorization primitive to use.
+7. Defer PHP until its package layout and server-only boundary are present.
+
+## Open Questions
+
+- Should TypeScript server exports include a `solana.session` server method, or
+  is Rust currently the only server-side session source of truth?
+- Should omitted `modes` always mean push-only across all languages?
+- Is `clientVoucher` the first pull-mode strategy other SDKs should implement?
+- Should Solana subscription use a new Solana method profile, or should it be
+  implemented only for Stripe/Tempo-style methods in this SDK family?
+- Which recurring Solana authorization primitive, if any, should back
+  subscription renewal charges?
+- Should shared subscription schemas land before any language-specific
+  settlement behavior?
+- Which session flow should the first interop fixture cover: push payment
+  channel, pull client voucher, or operated voucher?


### PR DESCRIPTION
## Summary

Add two short roadmap notes:

- a practical mpp-sdk/x402-sdk monorepo path that keeps protocol cores separate while sharing harness and fixture infrastructure
- a session/subscription source-of-truth map before porting session behavior to more SDKs

## Why

Session work is starting to spread across repos and languages. This keeps the next implementation PRs anchored in the current TypeScript/Rust code, the active `solana-foundation/pay` session work, and the current interop harness limits.

## Verification

Docs-only change; reviewed the rendered markdown locally.
