### PR TITLE
test(subscription): add canonical intent fixtures

### DIFF
--- a/tests/fixtures/subscription/README.md
+++ b/tests/fixtures/subscription/README.md
@@ -1,0 +1,15 @@
+# MPP Subscription Fixtures
+
+These fixtures capture the shared `subscription` intent shape from
+`tempoxyz/mpp-specs#230` without adding a Solana-specific settlement profile.
+
+The shared subscription intent is intentionally narrow:
+
+- fixed amount per billing period
+- activation includes the first billing-period charge
+- at most one successful renewal charge per billing period
+- missed periods do not accumulate extra charge authority
+- durable server accounting is required for idempotency
+
+These examples are safe to use for language-level schema and accounting tests.
+They should not be used to claim end-to-end Solana subscription settlement.

--- a/tests/fixtures/subscription/accounting-cases.json
+++ b/tests/fixtures/subscription/accounting-cases.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "activation records period zero",
+    "anchor": "2026-01-15T12:03:10Z",
+    "now": "2026-01-20T00:00:00Z",
+    "periodUnit": "day",
+    "periodCount": "30",
+    "lastPaidPeriod": 0,
+    "expectedCurrentPeriod": 0,
+    "renewalAllowed": false
+  },
+  {
+    "name": "next period can renew once",
+    "anchor": "2026-01-15T12:03:10Z",
+    "now": "2026-02-14T12:03:10Z",
+    "periodUnit": "day",
+    "periodCount": "30",
+    "lastPaidPeriod": 0,
+    "expectedCurrentPeriod": 1,
+    "renewalAllowed": true
+  },
+  {
+    "name": "missed period does not accumulate",
+    "anchor": "2026-01-15T12:03:10Z",
+    "now": "2026-04-15T12:03:10Z",
+    "periodUnit": "day",
+    "periodCount": "30",
+    "lastPaidPeriod": 0,
+    "expectedCurrentPeriod": 3,
+    "renewalAllowed": true,
+    "maximumNewCharges": 1
+  },
+  {
+    "name": "canceled subscription cannot renew",
+    "anchor": "2026-01-15T12:03:10Z",
+    "now": "2026-02-14T12:03:10Z",
+    "periodUnit": "day",
+    "periodCount": "30",
+    "lastPaidPeriod": 0,
+    "canceledAt": "2026-02-01T00:00:00Z",
+    "expectedCurrentPeriod": 1,
+    "renewalAllowed": false
+  }
+]

--- a/tests/fixtures/subscription/invalid-requests.json
+++ b/tests/fixtures/subscription/invalid-requests.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "zero amount",
+    "request": {
+      "amount": "0",
+      "currency": "usd",
+      "periodUnit": "month",
+      "periodCount": "1"
+    }
+  },
+  {
+    "name": "decimal amount",
+    "request": {
+      "amount": "9.99",
+      "currency": "usd",
+      "periodUnit": "month",
+      "periodCount": "1"
+    }
+  },
+  {
+    "name": "unsupported period unit",
+    "request": {
+      "amount": "1000000",
+      "currency": "usd",
+      "periodUnit": "year",
+      "periodCount": "1"
+    }
+  },
+  {
+    "name": "zero period count",
+    "request": {
+      "amount": "1000000",
+      "currency": "usd",
+      "periodUnit": "month",
+      "periodCount": "0"
+    }
+  },
+  {
+    "name": "invalid subscription expiry",
+    "request": {
+      "amount": "1000000",
+      "currency": "usd",
+      "periodUnit": "month",
+      "periodCount": "1",
+      "subscriptionExpires": "not-a-date"
+    }
+  }
+]

--- a/tests/fixtures/subscription/receipt.json
+++ b/tests/fixtures/subscription/receipt.json
@@ -1,0 +1,7 @@
+{
+  "method": "tempo",
+  "reference": "0x8d7c6c0d94d8488cb4cf6ab7b8a2f9c3f8e0eac7e5b6d1e8c3d86f733c2b7c01",
+  "status": "success",
+  "subscriptionId": "c3ViXzAxMjM0NTY",
+  "timestamp": "2026-01-15T12:03:10Z"
+}

--- a/tests/fixtures/subscription/tempo-request.json
+++ b/tests/fixtures/subscription/tempo-request.json
@@ -1,0 +1,15 @@
+{
+  "amount": "10000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "periodUnit": "day",
+  "periodCount": "30",
+  "subscriptionExpires": "2026-07-14T12:00:00Z",
+  "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
+  "methodDetails": {
+    "accessKey": {
+      "accessKeyAddress": "0x1111111111111111111111111111111111111111",
+      "keyType": "p256"
+    },
+    "chainId": 42431
+  }
+}

--- a/tests/fixtures/subscription/valid-request.json
+++ b/tests/fixtures/subscription/valid-request.json
@@ -1,0 +1,8 @@
+{
+  "amount": "1000000",
+  "currency": "usd",
+  "periodUnit": "month",
+  "periodCount": "1",
+  "description": "Monthly API plan",
+  "externalId": "plan_monthly_api"
+}


### PR DESCRIPTION
## Summary

Add canonical JSON fixtures for the shared MPP `subscription` intent:

- valid shared request
- Tempo-style request example
- invalid request cases
- receipt example
- accounting scenarios for duplicate and missed-period behavior

## Why

These fixtures give Python, Go, and future SDK ports a stable test target before any Solana-specific subscription settlement path exists.

## Verification

- Parsed every fixture with `node JSON.parse`
