### PR TITLE
feat(python): add subscription intent types

### DIFF
--- a/python/src/solana_mpp/protocol/subscriptions.py
+++ b/python/src/solana_mpp/protocol/subscriptions.py
@@ -1,0 +1,134 @@
+"""Subscription intent types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class SubscriptionPeriodUnit(StrEnum):
+    """Shared subscription billing period units."""
+
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+
+
+@dataclass
+class SubscriptionRequest:
+    """Shared subscription intent request body."""
+
+    amount: str
+    currency: str
+    period_unit: SubscriptionPeriodUnit | str
+    period_count: str
+    recipient: str = ""
+    subscription_expires: str = ""
+    description: str = ""
+    external_id: str = ""
+    method_details: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        self.period_unit = normalize_period_unit(self.period_unit)
+
+    def validate(self) -> None:
+        parse_positive_decimal(self.amount, "amount")
+        if not self.currency:
+            raise ValueError("currency is required")
+        parse_positive_decimal(self.period_count, "periodCount")
+        normalize_period_unit(self.period_unit)
+        if self.subscription_expires:
+            parse_subscription_expires(self.subscription_expires)
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        data: dict[str, Any] = {
+            "amount": self.amount,
+            "currency": self.currency,
+            "periodUnit": normalize_period_unit(self.period_unit).value,
+            "periodCount": self.period_count,
+        }
+        if self.recipient:
+            data["recipient"] = self.recipient
+        if self.subscription_expires:
+            data["subscriptionExpires"] = self.subscription_expires
+        if self.description:
+            data["description"] = self.description
+        if self.external_id:
+            data["externalId"] = self.external_id
+        if self.method_details:
+            data["methodDetails"] = self.method_details
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SubscriptionRequest:
+        return cls(
+            amount=str(data.get("amount", "")),
+            currency=str(data.get("currency", "")),
+            period_unit=str(data.get("periodUnit", "")),
+            period_count=str(data.get("periodCount", "")),
+            recipient=str(data.get("recipient", "")),
+            subscription_expires=str(data.get("subscriptionExpires", "")),
+            description=str(data.get("description", "")),
+            external_id=str(data.get("externalId", "")),
+            method_details=data.get("methodDetails"),
+        )
+
+
+@dataclass
+class SubscriptionReceipt:
+    """Receipt shape returned after activation or renewal."""
+
+    method: str
+    reference: str
+    status: str
+    subscription_id: str
+    timestamp: str
+    external_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "method": self.method,
+            "reference": self.reference,
+            "status": self.status,
+            "subscriptionId": self.subscription_id,
+            "timestamp": self.timestamp,
+        }
+        if self.external_id:
+            data["externalId"] = self.external_id
+        return data
+
+
+def normalize_period_unit(period_unit: SubscriptionPeriodUnit | str) -> SubscriptionPeriodUnit:
+    """Normalize a period unit from wire value."""
+    if isinstance(period_unit, SubscriptionPeriodUnit):
+        return period_unit
+    try:
+        return SubscriptionPeriodUnit(period_unit)
+    except ValueError as exc:
+        raise ValueError(f"unsupported periodUnit: {period_unit}") from exc
+
+
+def parse_positive_decimal(value: str, field: str) -> int:
+    """Parse a positive decimal integer with canonical string form."""
+    if not value:
+        raise ValueError(f"{field} is required")
+    if not value.isdecimal():
+        raise ValueError(f"invalid {field}: {value}")
+    parsed = int(value, 10)
+    if parsed <= 0 or str(parsed) != value:
+        raise ValueError(f"invalid {field}: {value}")
+    return parsed
+
+
+def parse_subscription_expires(value: str) -> datetime:
+    """Parse subscriptionExpires as RFC3339."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid subscriptionExpires: {value}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"invalid subscriptionExpires: {value}")
+    return parsed.astimezone(UTC)

--- a/python/tests/test_subscriptions.py
+++ b/python/tests/test_subscriptions.py
@@ -1,0 +1,101 @@
+"""Tests for subscription intent types."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from solana_mpp.protocol.subscriptions import (
+    SubscriptionPeriodUnit,
+    SubscriptionReceipt,
+    SubscriptionRequest,
+    parse_subscription_expires,
+)
+
+
+def test_subscription_request_to_dict_uses_wire_field_names() -> None:
+    request = SubscriptionRequest(
+        amount="1000000",
+        currency="usd",
+        period_unit=SubscriptionPeriodUnit.MONTH,
+        period_count="1",
+        description="Monthly API plan",
+        external_id="plan_monthly_api",
+    )
+
+    assert request.to_dict() == {
+        "amount": "1000000",
+        "currency": "usd",
+        "periodUnit": "month",
+        "periodCount": "1",
+        "description": "Monthly API plan",
+        "externalId": "plan_monthly_api",
+    }
+
+
+def test_subscription_request_roundtrip_and_validate() -> None:
+    request = SubscriptionRequest.from_dict(
+        {
+            "amount": "10000000",
+            "currency": "0x20c0000000000000000000000000000000000001",
+            "periodUnit": "day",
+            "periodCount": "30",
+            "subscriptionExpires": "2026-07-14T12:00:00Z",
+            "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
+            "methodDetails": {"chainId": 42431},
+        }
+    )
+
+    request.validate()
+
+    assert request.period_unit == SubscriptionPeriodUnit.DAY
+    assert request.to_dict()["periodCount"] == "30"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"amount": "0", "currency": "usd", "periodUnit": "month", "periodCount": "1"},
+        {"amount": "9.99", "currency": "usd", "periodUnit": "month", "periodCount": "1"},
+        {"amount": "100", "currency": "", "periodUnit": "month", "periodCount": "1"},
+        {"amount": "100", "currency": "usd", "periodUnit": "year", "periodCount": "1"},
+        {"amount": "100", "currency": "usd", "periodUnit": "month", "periodCount": "0"},
+        {"amount": "100", "currency": "usd", "periodUnit": "month", "periodCount": "01"},
+        {
+            "amount": "100",
+            "currency": "usd",
+            "periodUnit": "month",
+            "periodCount": "1",
+            "subscriptionExpires": "not-a-date",
+        },
+    ],
+)
+def test_subscription_request_rejects_invalid_shapes(payload: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        SubscriptionRequest.from_dict(payload).validate()
+
+
+def test_parse_subscription_expires_requires_rfc3339_timezone() -> None:
+    assert parse_subscription_expires("2026-07-14T12:00:00Z") == datetime(2026, 7, 14, 12, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match="invalid subscriptionExpires"):
+        parse_subscription_expires("2026-07-14T12:00:00")
+
+
+def test_subscription_receipt_to_dict_uses_wire_field_names() -> None:
+    receipt = SubscriptionReceipt(
+        method="tempo",
+        reference="0xabc",
+        status="success",
+        subscription_id="c3ViXzAxMjM0NTY",
+        timestamp="2026-01-15T12:03:10Z",
+    )
+
+    assert receipt.to_dict() == {
+        "method": "tempo",
+        "reference": "0xabc",
+        "status": "success",
+        "subscriptionId": "c3ViXzAxMjM0NTY",
+        "timestamp": "2026-01-15T12:03:10Z",
+    }


### PR DESCRIPTION
## Summary

Add Python shared `subscription` intent request and receipt types with validation for:

- positive base-unit `amount`
- positive `periodCount`
- `day` / `week` / `month` period units
- RFC3339 `subscriptionExpires`
- wire field names from the subscription intent draft

No Solana settlement behavior is added.

## Why

This gives Python a schema-level subscription surface that matches the active MPP subscription draft before we decide on any Solana-specific recurring authorization primitive.

## Verification

- `PYTHONPATH=src pytest tests/test_subscriptions.py tests/test_intents.py tests/test_store.py`
- `PYTHONPATH=src ruff check src/solana_mpp/protocol/subscriptions.py tests/test_subscriptions.py`
