### PR TITLE
test(python): cover subscription renewal accounting

### DIFF
--- a/python/src/solana_mpp/protocol/subscriptions.py
+++ b/python/src/solana_mpp/protocol/subscriptions.py
@@ -1,0 +1,134 @@
+"""Subscription intent types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class SubscriptionPeriodUnit(StrEnum):
+    """Shared subscription billing period units."""
+
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+
+
+@dataclass
+class SubscriptionRequest:
+    """Shared subscription intent request body."""
+
+    amount: str
+    currency: str
+    period_unit: SubscriptionPeriodUnit | str
+    period_count: str
+    recipient: str = ""
+    subscription_expires: str = ""
+    description: str = ""
+    external_id: str = ""
+    method_details: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        self.period_unit = normalize_period_unit(self.period_unit)
+
+    def validate(self) -> None:
+        parse_positive_decimal(self.amount, "amount")
+        if not self.currency:
+            raise ValueError("currency is required")
+        parse_positive_decimal(self.period_count, "periodCount")
+        normalize_period_unit(self.period_unit)
+        if self.subscription_expires:
+            parse_subscription_expires(self.subscription_expires)
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        data: dict[str, Any] = {
+            "amount": self.amount,
+            "currency": self.currency,
+            "periodUnit": normalize_period_unit(self.period_unit).value,
+            "periodCount": self.period_count,
+        }
+        if self.recipient:
+            data["recipient"] = self.recipient
+        if self.subscription_expires:
+            data["subscriptionExpires"] = self.subscription_expires
+        if self.description:
+            data["description"] = self.description
+        if self.external_id:
+            data["externalId"] = self.external_id
+        if self.method_details:
+            data["methodDetails"] = self.method_details
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SubscriptionRequest:
+        return cls(
+            amount=str(data.get("amount", "")),
+            currency=str(data.get("currency", "")),
+            period_unit=str(data.get("periodUnit", "")),
+            period_count=str(data.get("periodCount", "")),
+            recipient=str(data.get("recipient", "")),
+            subscription_expires=str(data.get("subscriptionExpires", "")),
+            description=str(data.get("description", "")),
+            external_id=str(data.get("externalId", "")),
+            method_details=data.get("methodDetails"),
+        )
+
+
+@dataclass
+class SubscriptionReceipt:
+    """Receipt shape returned after activation or renewal."""
+
+    method: str
+    reference: str
+    status: str
+    subscription_id: str
+    timestamp: str
+    external_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "method": self.method,
+            "reference": self.reference,
+            "status": self.status,
+            "subscriptionId": self.subscription_id,
+            "timestamp": self.timestamp,
+        }
+        if self.external_id:
+            data["externalId"] = self.external_id
+        return data
+
+
+def normalize_period_unit(period_unit: SubscriptionPeriodUnit | str) -> SubscriptionPeriodUnit:
+    """Normalize a period unit from wire value."""
+    if isinstance(period_unit, SubscriptionPeriodUnit):
+        return period_unit
+    try:
+        return SubscriptionPeriodUnit(period_unit)
+    except ValueError as exc:
+        raise ValueError(f"unsupported periodUnit: {period_unit}") from exc
+
+
+def parse_positive_decimal(value: str, field: str) -> int:
+    """Parse a positive decimal integer with canonical string form."""
+    if not value:
+        raise ValueError(f"{field} is required")
+    if not value.isdecimal():
+        raise ValueError(f"invalid {field}: {value}")
+    parsed = int(value, 10)
+    if parsed <= 0 or str(parsed) != value:
+        raise ValueError(f"invalid {field}: {value}")
+    return parsed
+
+
+def parse_subscription_expires(value: str) -> datetime:
+    """Parse subscriptionExpires as RFC3339."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid subscriptionExpires: {value}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"invalid subscriptionExpires: {value}")
+    return parsed.astimezone(UTC)

--- a/python/src/solana_mpp/protocol/subscriptions.py
+++ b/python/src/solana_mpp/protocol/subscriptions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any
 
@@ -101,6 +101,51 @@ class SubscriptionReceipt:
         return data
 
 
+@dataclass
+class SubscriptionAccountState:
+    """Minimum durable accounting state for a subscription."""
+
+    subscription_id: str
+    anchor: datetime
+    period_unit: SubscriptionPeriodUnit | str
+    period_count: int
+    last_paid_period: int
+    canceled_at: datetime | None = None
+    revoked: bool = False
+
+    def __post_init__(self) -> None:
+        self.period_unit = normalize_period_unit(self.period_unit)
+
+    def current_period(self, now: datetime) -> int:
+        now = ensure_utc(now)
+        anchor = ensure_utc(self.anchor)
+        if now < anchor:
+            return 0
+        if self.period_count <= 0:
+            raise ValueError("period_count must be positive")
+        if self.period_unit == SubscriptionPeriodUnit.DAY:
+            return int((now - anchor) // timedelta(days=self.period_count))
+        if self.period_unit == SubscriptionPeriodUnit.WEEK:
+            return int((now - anchor) // timedelta(weeks=self.period_count))
+        raise ValueError("calendar-month subscription accounting requires method-specific handling")
+
+    def can_renew(self, now: datetime) -> tuple[bool, int]:
+        if self.revoked:
+            return False, 0
+        now = ensure_utc(now)
+        if self.canceled_at is not None and now >= ensure_utc(self.canceled_at):
+            return False, 0
+        period = self.current_period(now)
+        return period > self.last_paid_period, period
+
+    def record_renewal(self, now: datetime) -> int:
+        allowed, period = self.can_renew(now)
+        if not allowed:
+            raise ValueError(f"subscription period {period} cannot renew")
+        self.last_paid_period = period
+        return period
+
+
 def normalize_period_unit(period_unit: SubscriptionPeriodUnit | str) -> SubscriptionPeriodUnit:
     """Normalize a period unit from wire value."""
     if isinstance(period_unit, SubscriptionPeriodUnit):
@@ -132,3 +177,10 @@ def parse_subscription_expires(value: str) -> datetime:
     if parsed.tzinfo is None:
         raise ValueError(f"invalid subscriptionExpires: {value}")
     return parsed.astimezone(UTC)
+
+
+def ensure_utc(value: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/python/tests/test_subscriptions.py
+++ b/python/tests/test_subscriptions.py
@@ -1,0 +1,101 @@
+"""Tests for subscription intent types."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from solana_mpp.protocol.subscriptions import (
+    SubscriptionPeriodUnit,
+    SubscriptionReceipt,
+    SubscriptionRequest,
+    parse_subscription_expires,
+)
+
+
+def test_subscription_request_to_dict_uses_wire_field_names() -> None:
+    request = SubscriptionRequest(
+        amount="1000000",
+        currency="usd",
+        period_unit=SubscriptionPeriodUnit.MONTH,
+        period_count="1",
+        description="Monthly API plan",
+        external_id="plan_monthly_api",
+    )
+
+    assert request.to_dict() == {
+        "amount": "1000000",
+        "currency": "usd",
+        "periodUnit": "month",
+        "periodCount": "1",
+        "description": "Monthly API plan",
+        "externalId": "plan_monthly_api",
+    }
+
+
+def test_subscription_request_roundtrip_and_validate() -> None:
+    request = SubscriptionRequest.from_dict(
+        {
+            "amount": "10000000",
+            "currency": "0x20c0000000000000000000000000000000000001",
+            "periodUnit": "day",
+            "periodCount": "30",
+            "subscriptionExpires": "2026-07-14T12:00:00Z",
+            "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
+            "methodDetails": {"chainId": 42431},
+        }
+    )
+
+    request.validate()
+
+    assert request.period_unit == SubscriptionPeriodUnit.DAY
+    assert request.to_dict()["periodCount"] == "30"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"amount": "0", "currency": "usd", "periodUnit": "month", "periodCount": "1"},
+        {"amount": "9.99", "currency": "usd", "periodUnit": "month", "periodCount": "1"},
+        {"amount": "100", "currency": "", "periodUnit": "month", "periodCount": "1"},
+        {"amount": "100", "currency": "usd", "periodUnit": "year", "periodCount": "1"},
+        {"amount": "100", "currency": "usd", "periodUnit": "month", "periodCount": "0"},
+        {"amount": "100", "currency": "usd", "periodUnit": "month", "periodCount": "01"},
+        {
+            "amount": "100",
+            "currency": "usd",
+            "periodUnit": "month",
+            "periodCount": "1",
+            "subscriptionExpires": "not-a-date",
+        },
+    ],
+)
+def test_subscription_request_rejects_invalid_shapes(payload: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        SubscriptionRequest.from_dict(payload).validate()
+
+
+def test_parse_subscription_expires_requires_rfc3339_timezone() -> None:
+    assert parse_subscription_expires("2026-07-14T12:00:00Z") == datetime(2026, 7, 14, 12, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match="invalid subscriptionExpires"):
+        parse_subscription_expires("2026-07-14T12:00:00")
+
+
+def test_subscription_receipt_to_dict_uses_wire_field_names() -> None:
+    receipt = SubscriptionReceipt(
+        method="tempo",
+        reference="0xabc",
+        status="success",
+        subscription_id="c3ViXzAxMjM0NTY",
+        timestamp="2026-01-15T12:03:10Z",
+    )
+
+    assert receipt.to_dict() == {
+        "method": "tempo",
+        "reference": "0xabc",
+        "status": "success",
+        "subscriptionId": "c3ViXzAxMjM0NTY",
+        "timestamp": "2026-01-15T12:03:10Z",
+    }

--- a/python/tests/test_subscriptions.py
+++ b/python/tests/test_subscriptions.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 
 from solana_mpp.protocol.subscriptions import (
+    SubscriptionAccountState,
     SubscriptionPeriodUnit,
     SubscriptionReceipt,
     SubscriptionRequest,
@@ -99,3 +100,55 @@ def test_subscription_receipt_to_dict_uses_wire_field_names() -> None:
         "subscriptionId": "c3ViXzAxMjM0NTY",
         "timestamp": "2026-01-15T12:03:10Z",
     }
+
+
+def test_subscription_account_state_records_one_renewal_per_period() -> None:
+    state = SubscriptionAccountState(
+        subscription_id="sub_1",
+        anchor=datetime(2026, 1, 15, 12, 3, 10, tzinfo=UTC),
+        period_unit=SubscriptionPeriodUnit.DAY,
+        period_count=30,
+        last_paid_period=0,
+    )
+
+    assert state.record_renewal(datetime(2026, 2, 14, 12, 3, 10, tzinfo=UTC)) == 1
+
+    with pytest.raises(ValueError, match="cannot renew"):
+        state.record_renewal(datetime(2026, 2, 15, tzinfo=UTC))
+
+
+def test_subscription_account_state_missed_periods_do_not_accumulate() -> None:
+    state = SubscriptionAccountState(
+        subscription_id="sub_1",
+        anchor=datetime(2026, 1, 15, 12, 3, 10, tzinfo=UTC),
+        period_unit=SubscriptionPeriodUnit.DAY,
+        period_count=30,
+        last_paid_period=0,
+    )
+
+    assert state.record_renewal(datetime(2026, 4, 15, 12, 3, 10, tzinfo=UTC)) == 3
+    assert state.last_paid_period == 3
+
+
+def test_subscription_account_state_rejects_canceled_revoked_and_month_accounting() -> None:
+    state = SubscriptionAccountState(
+        subscription_id="sub_1",
+        anchor=datetime(2026, 1, 15, 12, 3, 10, tzinfo=UTC),
+        period_unit=SubscriptionPeriodUnit.DAY,
+        period_count=30,
+        last_paid_period=0,
+        canceled_at=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+
+    allowed, _ = state.can_renew(datetime(2026, 2, 14, 12, 3, 10, tzinfo=UTC))
+    assert not allowed
+
+    state.canceled_at = None
+    state.revoked = True
+    allowed, _ = state.can_renew(datetime(2026, 2, 14, 12, 3, 10, tzinfo=UTC))
+    assert not allowed
+
+    state.revoked = False
+    state.period_unit = SubscriptionPeriodUnit.MONTH
+    with pytest.raises(ValueError, match="calendar-month"):
+        state.current_period(datetime(2026, 2, 14, 12, 3, 10, tzinfo=UTC))


### PR DESCRIPTION
## Summary

Add Python subscription accounting helpers and tests for:

- current day/week billing period calculation
- one renewal per billing period
- missed periods not accumulating extra charge authority
- cancellation and revocation checks
- explicit deferral of calendar-month accounting

This branch is stacked on the Python subscription schema commit. No Solana settlement behavior is added.

## Why

The subscription draft requires durable accounting/idempotency before renewal behavior is safe. This locks down those shared semantics independently from any payment rail.

## Verification

- `PYTHONPATH=src pytest tests/test_subscriptions.py tests/test_intents.py tests/test_store.py`
- `PYTHONPATH=src ruff check src/solana_mpp/protocol/subscriptions.py tests/test_subscriptions.py`
