### PR TITLE
feat(go): add subscription intent types

### DIFF
--- a/go/protocol/intents/subscription.go
+++ b/go/protocol/intents/subscription.go
@@ -1,0 +1,158 @@
+package intents
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// SubscriptionPeriodUnit identifies the billing-period unit.
+type SubscriptionPeriodUnit string
+
+const (
+	SubscriptionPeriodDay   SubscriptionPeriodUnit = "day"
+	SubscriptionPeriodWeek  SubscriptionPeriodUnit = "week"
+	SubscriptionPeriodMonth SubscriptionPeriodUnit = "month"
+)
+
+// SubscriptionRequest is the shared subscription intent request body.
+type SubscriptionRequest struct {
+	Amount              string                 `json:"amount"`
+	Currency            string                 `json:"currency"`
+	PeriodUnit          SubscriptionPeriodUnit `json:"periodUnit"`
+	PeriodCount         string                 `json:"periodCount"`
+	Recipient           string                 `json:"recipient,omitempty"`
+	SubscriptionExpires string                 `json:"subscriptionExpires,omitempty"`
+	Description         string                 `json:"description,omitempty"`
+	ExternalID          string                 `json:"externalId,omitempty"`
+	MethodDetails       any                    `json:"methodDetails,omitempty"`
+}
+
+// Validate checks the shared subscription request shape.
+func (r SubscriptionRequest) Validate() error {
+	if _, err := parsePositiveDecimalString(r.Amount, "amount"); err != nil {
+		return err
+	}
+	if r.Currency == "" {
+		return fmt.Errorf("currency is required")
+	}
+	if _, err := r.ParsePeriodCount(); err != nil {
+		return err
+	}
+	switch r.PeriodUnit {
+	case SubscriptionPeriodDay, SubscriptionPeriodWeek, SubscriptionPeriodMonth:
+	default:
+		return fmt.Errorf("unsupported periodUnit: %s", r.PeriodUnit)
+	}
+	if r.SubscriptionExpires != "" {
+		if _, err := r.ParseSubscriptionExpires(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ParseAmount parses the fixed billing-period amount.
+func (r SubscriptionRequest) ParseAmount() (uint64, error) {
+	return parsePositiveDecimalString(r.Amount, "amount")
+}
+
+// ParsePeriodCount parses the billing period count.
+func (r SubscriptionRequest) ParsePeriodCount() (uint64, error) {
+	return parsePositiveDecimalString(r.PeriodCount, "periodCount")
+}
+
+// ParseSubscriptionExpires parses subscriptionExpires when present.
+func (r SubscriptionRequest) ParseSubscriptionExpires() (time.Time, error) {
+	if r.SubscriptionExpires == "" {
+		return time.Time{}, nil
+	}
+	value, err := time.Parse(time.RFC3339, r.SubscriptionExpires)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid subscriptionExpires: %w", err)
+	}
+	return value, nil
+}
+
+// SubscriptionReceipt is the shared receipt shape after activation or renewal.
+type SubscriptionReceipt struct {
+	Method         string `json:"method"`
+	Reference      string `json:"reference"`
+	Status         string `json:"status"`
+	SubscriptionID string `json:"subscriptionId"`
+	Timestamp      string `json:"timestamp"`
+	ExternalID     string `json:"externalId,omitempty"`
+}
+
+// SubscriptionState tracks durable server accounting for one subscription.
+type SubscriptionState struct {
+	SubscriptionID string
+	Anchor         time.Time
+	PeriodUnit     SubscriptionPeriodUnit
+	PeriodCount    uint64
+	LastPaidPeriod int64
+	CanceledAt     *time.Time
+	Revoked        bool
+}
+
+// CurrentPeriod returns the period index for now.
+func (s SubscriptionState) CurrentPeriod(now time.Time) (int64, error) {
+	if s.Anchor.IsZero() {
+		return 0, fmt.Errorf("subscription anchor is required")
+	}
+	if now.Before(s.Anchor) {
+		return 0, nil
+	}
+	switch s.PeriodUnit {
+	case SubscriptionPeriodDay:
+		return int64(now.Sub(s.Anchor) / (24 * time.Hour * time.Duration(s.PeriodCount))), nil
+	case SubscriptionPeriodWeek:
+		return int64(now.Sub(s.Anchor) / (7 * 24 * time.Hour * time.Duration(s.PeriodCount))), nil
+	case SubscriptionPeriodMonth:
+		return 0, fmt.Errorf("calendar-month subscription accounting requires method-specific handling")
+	default:
+		return 0, fmt.Errorf("unsupported periodUnit: %s", s.PeriodUnit)
+	}
+}
+
+// CanRenew returns whether a renewal may be charged for now's billing period.
+func (s SubscriptionState) CanRenew(now time.Time) (bool, int64, error) {
+	if s.Revoked {
+		return false, 0, nil
+	}
+	if s.CanceledAt != nil && !now.Before(*s.CanceledAt) {
+		return false, 0, nil
+	}
+	period, err := s.CurrentPeriod(now)
+	if err != nil {
+		return false, 0, err
+	}
+	return period > s.LastPaidPeriod, period, nil
+}
+
+// RecordRenewal marks now's billing period as paid.
+func (s *SubscriptionState) RecordRenewal(now time.Time) (int64, error) {
+	ok, period, err := s.CanRenew(now)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return period, fmt.Errorf("subscription period %d cannot renew", period)
+	}
+	s.LastPaidPeriod = period
+	return period, nil
+}
+
+func parsePositiveDecimalString(input string, field string) (uint64, error) {
+	if input == "" {
+		return 0, fmt.Errorf("%s is required", field)
+	}
+	value := new(big.Int)
+	if _, ok := value.SetString(input, 10); !ok || value.Sign() <= 0 || !value.IsUint64() {
+		return 0, fmt.Errorf("invalid %s: %s", field, input)
+	}
+	if input != value.String() {
+		return 0, fmt.Errorf("invalid %s: %s", field, input)
+	}
+	return value.Uint64(), nil
+}

--- a/go/protocol/intents/subscription_test.go
+++ b/go/protocol/intents/subscription_test.go
@@ -1,0 +1,138 @@
+package intents
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestSubscriptionRequestValidate(t *testing.T) {
+	request := SubscriptionRequest{
+		Amount:              "1000000",
+		Currency:            "usd",
+		PeriodUnit:          SubscriptionPeriodMonth,
+		PeriodCount:         "1",
+		SubscriptionExpires: "2026-07-14T12:00:00Z",
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("valid request failed: %v", err)
+	}
+}
+
+func TestSubscriptionRequestRejectsInvalidShapes(t *testing.T) {
+	tests := []SubscriptionRequest{
+		{Amount: "0", Currency: "usd", PeriodUnit: SubscriptionPeriodMonth, PeriodCount: "1"},
+		{Amount: "9.99", Currency: "usd", PeriodUnit: SubscriptionPeriodMonth, PeriodCount: "1"},
+		{Amount: "100", Currency: "", PeriodUnit: SubscriptionPeriodMonth, PeriodCount: "1"},
+		{Amount: "100", Currency: "usd", PeriodUnit: "year", PeriodCount: "1"},
+		{Amount: "100", Currency: "usd", PeriodUnit: SubscriptionPeriodMonth, PeriodCount: "0"},
+		{Amount: "100", Currency: "usd", PeriodUnit: SubscriptionPeriodMonth, PeriodCount: "01"},
+		{Amount: "100", Currency: "usd", PeriodUnit: SubscriptionPeriodMonth, PeriodCount: "1", SubscriptionExpires: "not-a-date"},
+	}
+	for _, request := range tests {
+		if err := request.Validate(); err == nil {
+			t.Fatalf("expected request to fail: %#v", request)
+		}
+	}
+}
+
+func TestSubscriptionRequestRoundTrip(t *testing.T) {
+	input := []byte(`{"amount":"1000000","currency":"usd","periodUnit":"month","periodCount":"1","description":"Monthly API plan","externalId":"plan_monthly_api"}`)
+	var request SubscriptionRequest
+	if err := json.Unmarshal(input, &request); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("validate failed: %v", err)
+	}
+	output, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(output, &decoded); err != nil {
+		t.Fatalf("roundtrip output invalid: %v", err)
+	}
+	if decoded["periodUnit"] != "month" {
+		t.Fatalf("unexpected period unit: %v", decoded["periodUnit"])
+	}
+}
+
+func TestSubscriptionStateRenewalAccounting(t *testing.T) {
+	anchor := mustTime(t, "2026-01-15T12:03:10Z")
+	state := SubscriptionState{
+		SubscriptionID: "sub_1",
+		Anchor:         anchor,
+		PeriodUnit:     SubscriptionPeriodDay,
+		PeriodCount:    30,
+		LastPaidPeriod: 0,
+	}
+	ok, period, err := state.CanRenew(mustTime(t, "2026-02-14T12:03:10Z"))
+	if err != nil {
+		t.Fatalf("can renew failed: %v", err)
+	}
+	if !ok || period != 1 {
+		t.Fatalf("expected period 1 renewal, got ok=%v period=%d", ok, period)
+	}
+	recorded, err := state.RecordRenewal(mustTime(t, "2026-02-14T12:03:10Z"))
+	if err != nil {
+		t.Fatalf("record failed: %v", err)
+	}
+	if recorded != 1 || state.LastPaidPeriod != 1 {
+		t.Fatalf("unexpected recorded period %d state %#v", recorded, state)
+	}
+	if _, err := state.RecordRenewal(mustTime(t, "2026-02-15T00:00:00Z")); err == nil {
+		t.Fatal("expected duplicate period renewal to fail")
+	}
+}
+
+func TestSubscriptionStateMissedPeriodsDoNotAccumulate(t *testing.T) {
+	state := SubscriptionState{
+		SubscriptionID: "sub_1",
+		Anchor:         mustTime(t, "2026-01-15T12:03:10Z"),
+		PeriodUnit:     SubscriptionPeriodDay,
+		PeriodCount:    30,
+		LastPaidPeriod: 0,
+	}
+	period, err := state.RecordRenewal(mustTime(t, "2026-04-15T12:03:10Z"))
+	if err != nil {
+		t.Fatalf("record failed: %v", err)
+	}
+	if period != 3 || state.LastPaidPeriod != 3 {
+		t.Fatalf("expected one renewal for current period 3, got %d", period)
+	}
+}
+
+func TestSubscriptionStateCancellationAndMonthHandling(t *testing.T) {
+	canceledAt := mustTime(t, "2026-02-01T00:00:00Z")
+	state := SubscriptionState{
+		SubscriptionID: "sub_1",
+		Anchor:         mustTime(t, "2026-01-15T12:03:10Z"),
+		PeriodUnit:     SubscriptionPeriodDay,
+		PeriodCount:    30,
+		LastPaidPeriod: 0,
+		CanceledAt:     &canceledAt,
+	}
+	ok, _, err := state.CanRenew(mustTime(t, "2026-02-14T12:03:10Z"))
+	if err != nil {
+		t.Fatalf("can renew failed: %v", err)
+	}
+	if ok {
+		t.Fatal("canceled subscription should not renew")
+	}
+
+	state.PeriodUnit = SubscriptionPeriodMonth
+	state.CanceledAt = nil
+	if _, err := state.CurrentPeriod(mustTime(t, "2026-02-14T12:03:10Z")); err == nil {
+		t.Fatal("month accounting should be deferred")
+	}
+}
+
+func mustTime(t *testing.T, input string) time.Time {
+	t.Helper()
+	value, err := time.Parse(time.RFC3339, input)
+	if err != nil {
+		t.Fatalf("invalid test time: %v", err)
+	}
+	return value
+}


### PR DESCRIPTION
## Summary

Add Go shared `subscription` intent request and receipt types with validation for:

- positive base-unit `amount`
- positive `periodCount`
- `day` / `week` / `month` period units
- RFC3339 `subscriptionExpires`
- JSON wire field names from the subscription intent draft

No Solana settlement behavior is added.

## Why

This gives Go a schema-level subscription surface that can be tested before a Solana-specific recurring authorization primitive is selected.

## Verification

- `cd go && go test ./protocol/intents`
