### PR TITLE
docs: add language package readmes

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,57 @@
+# Go MPP SDK
+
+Go implements Solana MPP helpers for server and client-side `charge` flows.
+
+This module provides:
+
+- protocol core helpers for MPP headers and credentials
+- Solana charge request and transaction helpers
+- HTTP client/server helpers
+- test coverage for charge verification behavior
+
+## Layout
+
+```text
+go/
+├── client/       HTTP client helpers
+├── protocol/     wire and Solana protocol helpers
+├── server/       server middleware and verification helpers
+└── go.mod
+```
+
+## Test
+
+```bash
+cd go
+go test ./...
+```
+
+If local sandboxing blocks the default Go cache, use temp caches:
+
+```bash
+GOCACHE=/tmp/mpp-go-cache GOMODCACHE=/tmp/mpp-go-mod go test ./...
+```
+
+## Local Payment Check
+
+Use `curl` to confirm the server returns a payment challenge, then use the
+`pay` CLI to complete the 402 challenge/credential flow.
+
+```bash
+brew install pay
+
+# payment required
+curl http://localhost:4567/paid
+
+# payment successful
+pay curl http://localhost:4567/paid
+```
+
+## Interop
+
+The cross-language interop harness lives in `../tests/interop`.
+
+```bash
+cd ../tests/interop
+MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=go pnpm test
+```

--- a/go/README.md
+++ b/go/README.md
@@ -49,9 +49,11 @@ pay curl http://localhost:4567/paid
 
 ## Interop
 
-The cross-language interop harness lives in `../tests/interop`.
+The cross-language interop harness lives in `../tests/interop`. On current
+`main`, Go is registered as an opt-in client adapter. Use Rust as the reference
+server when running the Go client through the harness.
 
 ```bash
 cd ../tests/interop
-MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=go pnpm test
+MPP_INTEROP_CLIENTS=go MPP_INTEROP_SERVERS=rust pnpm test
 ```

--- a/lua/README.md
+++ b/lua/README.md
@@ -34,3 +34,19 @@ For coverage, when `luacov` is available:
 ```bash
 just lua-test-cover
 ```
+
+## Local Payment Check
+
+Lua is server-side only in this repository. Use `curl` to confirm a Lua-backed
+server returns a payment challenge, then use the `pay` CLI to complete the 402
+challenge/credential flow.
+
+```bash
+brew install pay
+
+# payment required
+curl http://localhost:4567/paid
+
+# payment successful
+pay curl http://localhost:4567/paid
+```

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,56 @@
+# Python MPP SDK
+
+Python implements Solana MPP helpers for server and client-side `charge` flows.
+
+This package provides:
+
+- MPP header, challenge, credential, and receipt helpers
+- Solana charge client and server helpers
+- payment-page HTML helpers
+- pytest coverage for protocol and server behavior
+
+## Layout
+
+```text
+python/
+├── src/solana_mpp/     SDK source
+├── tests/              pytest suite
+└── pyproject.toml
+```
+
+## Install
+
+```bash
+cd python
+uv sync --extra dev
+```
+
+## Test
+
+```bash
+uv run --extra dev pytest
+```
+
+## Local Payment Check
+
+Use `curl` to confirm the server returns a payment challenge, then use the
+`pay` CLI to complete the 402 challenge/credential flow.
+
+```bash
+brew install pay
+
+# payment required
+curl http://localhost:4567/paid
+
+# payment successful
+pay curl http://localhost:4567/paid
+```
+
+## Interop
+
+The cross-language interop harness lives in `../tests/interop`.
+
+```bash
+cd ../tests/interop
+MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=python pnpm test
+```

--- a/python/README.md
+++ b/python/README.md
@@ -48,9 +48,7 @@ pay curl http://localhost:4567/paid
 
 ## Interop
 
-The cross-language interop harness lives in `../tests/interop`.
-
-```bash
-cd ../tests/interop
-MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=python pnpm test
-```
+The cross-language interop harness lives in `../tests/interop`. Python adapter
+coverage is being added separately; on current `main`, use the Python test suite
+above for Python changes and the TypeScript/Rust interop harness for
+cross-language regression checks.

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,53 @@
+# Rust MPP SDK
+
+Rust is the strongest native implementation for the Solana payment method in
+the Machine Payments Protocol.
+
+This crate provides:
+
+- Solana `charge` client and server helpers
+- transaction and verification primitives
+- optional server/client features
+- reference binaries used by the interop harness
+
+## Layout
+
+```text
+rust/
+├── src/                         SDK source
+├── tests/                       Rust test suite
+├── payment_channels_client/     local helper crate
+└── Cargo.toml
+```
+
+## Test
+
+```bash
+cd rust
+cargo test
+```
+
+## Local Payment Check
+
+Use `curl` to confirm the server returns a payment challenge, then use the
+`pay` CLI to complete the 402 challenge/credential flow.
+
+```bash
+brew install pay
+
+# payment required
+curl http://localhost:4567/paid
+
+# payment successful
+pay curl http://localhost:4567/paid
+```
+
+## Interop
+
+The TypeScript interop harness can run the Rust server and client adapters from
+`../tests/interop`.
+
+```bash
+cd ../tests/interop
+pnpm test
+```

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,60 @@
+# TypeScript MPP SDK
+
+TypeScript is the primary JavaScript implementation for the Solana payment
+method in the Machine Payments Protocol.
+
+This package provides:
+
+- Solana `charge` client and server helpers
+- session and subscription helpers where implemented
+- shared browser payment-link assets
+- the reference TypeScript interop harness used by CI
+
+## Layout
+
+```text
+typescript/
+├── packages/mpp/        SDK package
+├── vitest.config*.ts    test configurations
+└── package.json         workspace scripts
+```
+
+## Install
+
+```bash
+cd typescript
+pnpm install
+```
+
+## Test
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm test:integration
+```
+
+## Local Payment Check
+
+Use `curl` to confirm the server returns a payment challenge, then use the
+`pay` CLI to complete the 402 challenge/credential flow.
+
+```bash
+brew install pay
+
+# payment required
+curl http://localhost:4567/paid
+
+# payment successful
+pay curl http://localhost:4567/paid
+```
+
+## Interop
+
+The cross-language interop harness lives in `../tests/interop`.
+
+```bash
+cd ../tests/interop
+pnpm install
+pnpm test
+```


### PR DESCRIPTION
## What
- Add root README files for the TypeScript, Rust, Go, and Python packages.
- Expand the Lua README with the same package-level shape.
- Use the current pay CLI flow for local payment checks: brew install pay, plain curl for the 402 challenge, then pay curl for the successful request.

## Why
Ludo asked for a root README per language package and for the local payment example to use the pay CLI instead of the older mppx CLI example.

## Verified
- rg confirmed these package READMEs use brew install pay and pay curl.
- Docs-only change; no runtime tests required.