### PR TITLE
test: clean up interop adapter processes on failure

### DIFF
--- a/tests/interop/src/process.ts
+++ b/tests/interop/src/process.ts
@@ -13,7 +13,14 @@ type RunningServer = {
   ready: ReadyMessage;
 };
 
-const ADAPTER_OUTPUT_TIMEOUT_MS = 120_000;
+const DEFAULT_ADAPTER_OUTPUT_TIMEOUT_MS = 120_000;
+
+function adapterOutputTimeoutMs(): number {
+  return Number(
+    process.env.MPP_INTEROP_ADAPTER_OUTPUT_TIMEOUT_MS ??
+      DEFAULT_ADAPTER_OUTPUT_TIMEOUT_MS,
+  );
+}
 
 async function waitForJsonMessage<T extends AdapterMessage>(
   child: ChildProcess,
@@ -53,7 +60,7 @@ async function waitForJsonMessage<T extends AdapterMessage>(
         });
       }),
       delay(timeoutMs).then(() => {
-        child.kill("SIGTERM");
+        terminateProcess(child, "SIGTERM");
         throw new Error(
           `Timed out waiting for adapter output after ${timeoutMs}ms`,
         );
@@ -89,7 +96,7 @@ export async function startServer(
   try {
     ready = await waitForJsonMessage<ReadyMessage>(
       child,
-      ADAPTER_OUTPUT_TIMEOUT_MS,
+      adapterOutputTimeoutMs(),
     );
   } catch (error) {
     await stopChildProcess(child);
@@ -120,7 +127,7 @@ export async function runClient(
   try {
     result = await waitForJsonMessage<ClientRunResult>(
       child,
-      ADAPTER_OUTPUT_TIMEOUT_MS,
+      adapterOutputTimeoutMs(),
     );
     await waitForExit(child, "Client adapter");
   } catch (error) {
@@ -170,12 +177,16 @@ async function stopChildProcess(child: ChildProcess): Promise<void> {
   });
 
   terminateProcess(child, "SIGTERM");
-  await Promise.race([
-    exited,
-    delay(5_000).then(() => {
-      terminateProcess(child, "SIGKILL");
-    }),
+  const exitedAfterTerm = await Promise.race([
+    exited.then(() => true),
+    delay(5_000).then(() => false),
   ]);
+  if (exitedAfterTerm) {
+    return;
+  }
+
+  terminateProcess(child, "SIGKILL");
+  await Promise.race([exited, delay(5_000)]);
 }
 
 function terminateProcess(

--- a/tests/interop/src/process.ts
+++ b/tests/interop/src/process.ts
@@ -71,6 +71,7 @@ function spawnAdapter(
   const [command, ...args] = implementation.command;
   return spawn(command, args, {
     cwd: process.cwd(),
+    detached: process.platform !== "win32",
     env: {
       ...process.env,
       ...extraEnv,
@@ -84,13 +85,19 @@ export async function startServer(
   extraEnv: Record<string, string> = {},
 ): Promise<RunningServer> {
   const child = spawnAdapter(implementation, extraEnv);
-  const ready = await waitForJsonMessage<ReadyMessage>(
-    child,
-    ADAPTER_OUTPUT_TIMEOUT_MS,
-  );
+  let ready: ReadyMessage;
+  try {
+    ready = await waitForJsonMessage<ReadyMessage>(
+      child,
+      ADAPTER_OUTPUT_TIMEOUT_MS,
+    );
+  } catch (error) {
+    await stopChildProcess(child);
+    throw error;
+  }
 
   if (ready.type !== "ready" || ready.role !== "server" || !ready.port) {
-    child.kill("SIGTERM");
+    await stopChildProcess(child);
     throw new Error(
       `Unexpected server readiness payload from ${implementation.id}`,
     );
@@ -109,11 +116,17 @@ export async function runClient(
     ...extraEnv,
   });
 
-  const result = await waitForJsonMessage<ClientRunResult>(
-    child,
-    ADAPTER_OUTPUT_TIMEOUT_MS,
-  );
-  await waitForExit(child, "Client adapter");
+  let result: ClientRunResult;
+  try {
+    result = await waitForJsonMessage<ClientRunResult>(
+      child,
+      ADAPTER_OUTPUT_TIMEOUT_MS,
+    );
+    await waitForExit(child, "Client adapter");
+  } catch (error) {
+    await stopChildProcess(child);
+    throw error;
+  }
 
   if (result.type !== "result" || result.role !== "client") {
     throw new Error(
@@ -144,13 +157,45 @@ async function waitForExit(child: ChildProcess, label: string): Promise<void> {
 }
 
 export async function stopServer(server: RunningServer): Promise<void> {
-  server.child.kill("SIGTERM");
+  await stopChildProcess(server.child);
+}
+
+async function stopChildProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) {
+    return;
+  }
+
+  const exited = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+
+  terminateProcess(child, "SIGTERM");
   await Promise.race([
-    new Promise<void>((resolve) => {
-      server.child.once("exit", () => resolve());
-    }),
+    exited,
     delay(5_000).then(() => {
-      server.child.kill("SIGKILL");
+      terminateProcess(child, "SIGKILL");
     }),
   ]);
+}
+
+function terminateProcess(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+): void {
+  if (child.exitCode !== null || child.pid === undefined) {
+    return;
+  }
+
+  try {
+    if (process.platform !== "win32") {
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+      return;
+    }
+  }
+
+  child.kill(signal);
 }

--- a/tests/interop/test/process.test.ts
+++ b/tests/interop/test/process.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { ImplementationDefinition } from "../src/implementations";
+import { runClient, startServer } from "../src/process";
+
+function adapter(command: string): ImplementationDefinition {
+  return {
+    id: "fixture",
+    label: "Fixture adapter",
+    role: "server",
+    command: [process.execPath, "-e", command],
+    enabled: true,
+  };
+}
+
+describe("adapter process lifecycle", () => {
+  it("cleans up server adapters that emit invalid readiness", async () => {
+    await expect(
+      startServer(
+        adapter(`
+          console.log(JSON.stringify({ type: "ready", implementation: "fixture", role: "server" }));
+          setInterval(() => {}, 1000);
+        `),
+      ),
+    ).rejects.toThrow("Unexpected server readiness payload");
+  });
+
+  it("cleans up client adapters that fail after emitting a result", async () => {
+    await expect(
+      runClient(
+        adapter(`
+          console.log(JSON.stringify({
+            type: "result",
+            implementation: "fixture",
+            role: "client",
+            ok: false,
+            status: 0,
+            responseHeaders: {},
+            responseBody: {}
+          }));
+          process.exit(2);
+        `),
+        "http://127.0.0.1:1/protected",
+      ),
+    ).rejects.toThrow("Client adapter exited with code 2");
+  });
+});

--- a/tests/interop/test/process.test.ts
+++ b/tests/interop/test/process.test.ts
@@ -13,6 +13,26 @@ function adapter(command: string): ImplementationDefinition {
 }
 
 describe("adapter process lifecycle", () => {
+  it("cleans up server adapters that never signal readiness", async () => {
+    const previousTimeout = process.env.MPP_INTEROP_ADAPTER_OUTPUT_TIMEOUT_MS;
+    process.env.MPP_INTEROP_ADAPTER_OUTPUT_TIMEOUT_MS = "50";
+    try {
+      await expect(
+        startServer(
+          adapter(`
+            setInterval(() => {}, 1000);
+          `),
+        ),
+      ).rejects.toThrow("Timed out waiting for adapter output");
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.MPP_INTEROP_ADAPTER_OUTPUT_TIMEOUT_MS;
+      } else {
+        process.env.MPP_INTEROP_ADAPTER_OUTPUT_TIMEOUT_MS = previousTimeout;
+      }
+    }
+  });
+
   it("cleans up server adapters that emit invalid readiness", async () => {
     await expect(
       startServer(


### PR DESCRIPTION
## What
- Track spawned adapter processes in the interop harness.
- Ensure server/client subprocesses are cleaned up when readiness or client execution fails.
- Add focused unit coverage for failure cleanup behavior.

## Why
The charge interop harness now runs more languages and more negative-path scenarios. Cleaning up subprocesses makes local runs and CI reruns more deterministic before adding more adapters.

## Verified
- pnpm typecheck
- pnpm test -- --runInBand
- MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=typescript MPP_INTEROP_SCENARIOS=charge-basic pnpm exec vitest run test/e2e.test.ts --testTimeout 180000