### PR TITLE
feat(python): bring charge server parity into interop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,33 @@ jobs:
           name: go-coverage
           path: go/coverage.out
 
+  test-python:
+    name: Python tests
+    needs: build-html
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download HTML assets
+        uses: actions/download-artifact@v7
+        with:
+          name: html-assets
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Run tests with coverage
+        working-directory: python
+        run: uv run --extra dev pytest --cov=solana_mpp --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=json:coverage.json
+      - name: Upload Python coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-coverage
+          path: |
+            python/coverage.xml
+            python/coverage.json
+
   integration:
     name: Integration tests
     needs: build-html
@@ -418,6 +445,11 @@ jobs:
       - name: Build Rust interop adapters
         working-directory: rust
         run: cargo build --bin interop_client --bin interop_server
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv for Python interop server
+        run: python -m pip install uv
       - name: Install interop harness
         working-directory: tests/interop
         run: pnpm install --frozen-lockfile
@@ -436,6 +468,12 @@ jobs:
         env:
           MPP_INTEROP_CLIENTS: typescript
           MPP_INTEROP_SERVERS: rust
+      - name: Run Python server interop smoke
+        working-directory: tests/interop
+        run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "typescript client pays python server"
+        env:
+          MPP_INTEROP_CLIENTS: typescript
+          MPP_INTEROP_SERVERS: python
       - name: Run Rust end-to-end interop smoke
         working-directory: tests/interop
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "rust client pays rust server"

--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -261,29 +261,34 @@ def _extract_recent_blockhash(transaction_b64: str) -> str:
 
     raw = base64.b64decode(transaction_b64)
     try:
-        tx = Transaction.from_bytes(raw)
+        tx = VersionedTransaction.from_bytes(raw)
         return str(tx.message.recent_blockhash)
     except Exception:
-        vtx = VersionedTransaction.from_bytes(raw)
-        return str(vtx.message.recent_blockhash)
+        tx = Transaction.from_bytes(raw)
+        return str(tx.message.recent_blockhash)
 
 
 def _decode_legacy_payment_instructions(transaction_b64: str) -> list[dict[str, Any]]:
     """Decode local transfer and memo instructions from a legacy transaction."""
-    from solders.transaction import Transaction
+    from solders.transaction import Transaction, VersionedTransaction
 
     raw = base64.b64decode(transaction_b64)
     try:
-        tx = Transaction.from_bytes(raw)
+        tx = VersionedTransaction.from_bytes(raw)
+        message = tx.message
     except Exception as exc:
-        raise PaymentError(
-            "unsupported transaction shape for pre-broadcast verification",
-            code="invalid-payload-type",
-        ) from exc
+        try:
+            tx = Transaction.from_bytes(raw)
+            message = tx.message
+        except Exception:
+            raise PaymentError(
+                "unsupported transaction shape for pre-broadcast verification",
+                code="invalid-payload-type",
+            ) from exc
 
-    account_keys = [str(key) for key in tx.message.account_keys]
+    account_keys = [str(key) for key in message.account_keys]
     instructions: list[dict[str, Any]] = []
-    for instruction in tx.message.instructions:
+    for instruction in message.instructions:
         try:
             program_id = account_keys[int(instruction.program_id_index)]
         except IndexError as exc:
@@ -656,11 +661,6 @@ class Mpp:
             ) from exc
         check_network_blockhash(self._network, blockhash_b58)
         _verify_local_transaction_intent(payload.transaction, request, details)
-
-        # Decode and process the transaction
-        # In a real implementation, this would use solders to deserialize,
-        # optionally co-sign, simulate, send, confirm, and verify on-chain.
-        # For now we provide the verification skeleton.
 
         # Replay protection
         consumed_key = _CONSUMED_PREFIX + payload.transaction[:64]

--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -353,8 +353,8 @@ def _status_ok(response: Any) -> bool:
 def _extract_recent_blockhash(transaction_b64: str) -> str:
     """Decode a base64 transaction and return its recent blockhash (base58).
 
-    Tries the legacy ``Transaction`` first (the most common shape from our
-    SDK clients) and falls back to ``VersionedTransaction``. Kept thin so
+    Tries ``VersionedTransaction`` first and falls back to the legacy
+    ``Transaction`` shape. Kept thin so
     the surrounding network check can be exercised by tests without a full
     verification pipeline in place.
     """

--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -18,6 +18,7 @@ from solana_mpp._errors import (
 from solana_mpp._types import PaymentChallenge, PaymentCredential, Receipt
 from solana_mpp.protocol.intents import ChargeRequest, parse_units
 from solana_mpp.protocol.solana import (
+    ASSOCIATED_TOKEN_PROGRAM,
     MEMO_PROGRAM,
     TOKEN_2022_PROGRAM,
     TOKEN_PROGRAM,
@@ -40,6 +41,7 @@ _CONSUMED_PREFIX = "solana-charge:consumed:"
 _SYSTEM_PROGRAM = "11111111111111111111111111111111"
 _SYSTEM_TRANSFER_INSTRUCTION = 2
 _TOKEN_TRANSFER_CHECKED_INSTRUCTION = 12
+_ASSOCIATED_TOKEN_CREATE_IDEMPOTENT_INSTRUCTION = 1
 
 
 def _build_expected_transfers(request: ChargeRequest, details: MethodDetails) -> list[tuple[str, int]]:
@@ -122,22 +124,84 @@ def _verify_parsed_spl_transfers(
         transfers.pop(match_index)
 
 
-def _verify_ata_owner(ata_address: str, expected_owner: str, mint: str, token_program: str) -> bool:
-    """Verify that an ATA address belongs to the expected owner by deriving it."""
+def _validate_split_ata_creation_policy(currency: str, network: str, splits: list[Any]) -> None:
+    if not any(getattr(split, "ata_creation_required", False) for split in splits):
+        return
+    if is_native_sol(currency):
+        raise PaymentError("ataCreationRequired requires an SPL token currency", code="invalid-config")
+
+    mint = resolve_mint(currency, network)
+    if mint != currency:
+        raise PaymentError(
+            "ataCreationRequired requires currency to be an SPL token mint address",
+            code="invalid-config",
+        )
+
     try:
         from solders.pubkey import Pubkey
 
-        owner_pk = Pubkey.from_string(expected_owner)
-        mint_pk = Pubkey.from_string(mint)
-        tp_pk = Pubkey.from_string(token_program)
-        ata_program = Pubkey.from_string("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
-        expected_ata, _bump = Pubkey.find_program_address(
-            [bytes(owner_pk), bytes(tp_pk), bytes(mint_pk)],
-            ata_program,
+        Pubkey.from_string(currency)
+    except Exception as exc:
+        raise PaymentError(
+            f"ataCreationRequired requires a valid SPL token mint address: {exc}",
+            code="invalid-config",
+        ) from exc
+
+
+def _verify_parsed_ata_creation_instructions(
+    instructions: list[dict[str, Any]],
+    request: ChargeRequest,
+    details: MethodDetails,
+) -> None:
+    required_recipients = [split.recipient for split in details.splits if split.ata_creation_required]
+    if not required_recipients:
+        return
+
+    _validate_split_ata_creation_policy(request.currency, details.network, details.splits)
+    mint = resolve_mint(request.currency, details.network)
+    token_program = details.token_program or default_token_program_for_currency(request.currency, details.network)
+    ata_creations = [
+        instruction
+        for instruction in instructions
+        if _parsed_program_id(instruction) == ASSOCIATED_TOKEN_PROGRAM
+        and ((instruction.get("parsed") or {}).get("type") == "createIdempotent")
+    ]
+
+    for recipient in required_recipients:
+        expected_ata = _derive_ata_address(recipient, mint, token_program)
+        match_index = next(
+            (
+                index
+                for index, instruction in enumerate(ata_creations)
+                if _parsed_ata_creation_matches(instruction, recipient, expected_ata, mint, token_program)
+            ),
+            -1,
         )
-        return str(expected_ata) == ata_address
+        if match_index == -1:
+            raise PaymentError("Missing required ATA creation for split recipient", code="invalid-payload")
+        ata_creations.pop(match_index)
+
+
+def _verify_ata_owner(ata_address: str, expected_owner: str, mint: str, token_program: str) -> bool:
+    """Verify that an ATA address belongs to the expected owner by deriving it."""
+    try:
+        return _derive_ata_address(expected_owner, mint, token_program) == ata_address
     except Exception:
         return False
+
+
+def _derive_ata_address(owner: str, mint: str, token_program: str) -> str:
+    from solders.pubkey import Pubkey
+
+    owner_pk = Pubkey.from_string(owner)
+    mint_pk = Pubkey.from_string(mint)
+    tp_pk = Pubkey.from_string(token_program)
+    ata_program = Pubkey.from_string(ASSOCIATED_TOKEN_PROGRAM)
+    expected_ata, _bump = Pubkey.find_program_address(
+        [bytes(owner_pk), bytes(tp_pk), bytes(mint_pk)],
+        ata_program,
+    )
+    return str(expected_ata)
 
 
 def _parsed_program_id(instruction: dict[str, Any]) -> str:
@@ -146,7 +210,47 @@ def _parsed_program_id(instruction: dict[str, Any]) -> str:
         return program_id
     if instruction.get("program") == "spl-memo":
         return MEMO_PROGRAM
+    if instruction.get("program") == "spl-associated-token-account":
+        return ASSOCIATED_TOKEN_PROGRAM
     return ""
+
+
+def _parsed_info_string(info: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = info.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _parsed_ata_creation_matches(
+    instruction: dict[str, Any],
+    owner: str,
+    ata: str,
+    mint: str,
+    token_program: str,
+) -> bool:
+    parsed = instruction.get("parsed")
+    if not isinstance(parsed, dict):
+        return False
+    info = parsed.get("info")
+    if not isinstance(info, dict):
+        return False
+
+    parsed_owner = _parsed_info_string(info, ("wallet", "owner"))
+    parsed_ata = _parsed_info_string(info, ("account", "associatedAccount", "associatedTokenAddress"))
+    parsed_mint = _parsed_info_string(info, ("mint",))
+    parsed_token_program = _parsed_info_string(info, ("tokenProgram",)) or token_program
+    if parsed_token_program not in {TOKEN_PROGRAM, TOKEN_2022_PROGRAM}:
+        raise PaymentError("ATA creation uses an unsupported token program", code="invalid-payload")
+
+    return (
+        parsed_owner == owner
+        and parsed_ata == ata
+        and parsed_mint == mint
+        and parsed_token_program == token_program
+        and _verify_ata_owner(parsed_ata, parsed_owner, parsed_mint, parsed_token_program)
+    )
 
 
 def _parsed_memo_text(instruction: dict[str, Any]) -> str | None:
@@ -352,6 +456,34 @@ def _decode_legacy_payment_instructions(transaction_b64: str) -> list[dict[str, 
             except UnicodeDecodeError as exc:
                 raise PaymentError("memo instruction is not valid UTF-8", code="invalid-payload") from exc
             instructions.append({"programId": MEMO_PROGRAM, "parsed": memo})
+        elif program_id == ASSOCIATED_TOKEN_PROGRAM:
+            if len(data) != 1 or data[0] != _ASSOCIATED_TOKEN_CREATE_IDEMPOTENT_INSTRUCTION:
+                continue
+            if len(instruction.accounts) < 6:
+                raise PaymentError("ATA creation instruction is missing accounts", code="invalid-payload")
+            try:
+                ata = account_keys[int(instruction.accounts[1])]
+                owner = account_keys[int(instruction.accounts[2])]
+                mint = account_keys[int(instruction.accounts[3])]
+                token_program = account_keys[int(instruction.accounts[5])]
+            except IndexError as exc:
+                raise PaymentError(
+                    "ATA creation instruction references an unknown account", code="invalid-payload"
+                ) from exc
+            instructions.append(
+                {
+                    "programId": ASSOCIATED_TOKEN_PROGRAM,
+                    "parsed": {
+                        "type": "createIdempotent",
+                        "info": {
+                            "account": ata,
+                            "mint": mint,
+                            "owner": owner,
+                            "tokenProgram": token_program,
+                        },
+                    },
+                }
+            )
 
     return instructions
 
@@ -366,6 +498,7 @@ def _verify_local_transaction_intent(
     if is_native_sol(request.currency):
         _verify_parsed_sol_transfers(instructions, request, details)
     else:
+        _verify_parsed_ata_creation_instructions(instructions, request, details)
         _verify_parsed_spl_transfers(instructions, request, details)
     _verify_parsed_memo_instructions(instructions, request, details)
 
@@ -445,6 +578,8 @@ class Mpp:
     def charge_with_options(self, amount: str, options: ChargeOptions) -> PaymentChallenge:
         """Create a charge challenge with optional fields."""
         base_units = parse_units(amount, self._decimals)
+        splits = MethodDetails.from_dict({"splits": options.splits}).splits
+        _validate_split_ata_creation_policy(self._currency, self._network, splits)
 
         details: dict[str, Any] = {"network": self._network}
         if not is_native_sol(self._currency):
@@ -741,5 +876,6 @@ class Mpp:
         if is_native_sol(request.currency):
             _verify_parsed_sol_transfers(instructions, request, details)
         else:
+            _verify_parsed_ata_creation_instructions(instructions, request, details)
             _verify_parsed_spl_transfers(instructions, request, details)
         _verify_parsed_memo_instructions(instructions, request, details)

--- a/python/src/solana_mpp/server/mpp.py
+++ b/python/src/solana_mpp/server/mpp.py
@@ -249,7 +249,6 @@ def _parsed_ata_creation_matches(
         and parsed_ata == ata
         and parsed_mint == mint
         and parsed_token_program == token_program
-        and _verify_ata_owner(parsed_ata, parsed_owner, parsed_mint, parsed_token_program)
     )
 
 

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -20,6 +20,15 @@ from solana_mpp.server.mpp import (
     ChargeOptions,
     Config,
     Mpp,
+    _build_expected_transfers,
+    _json_like,
+    _parsed_ata_creation_matches,
+    _parsed_info_string,
+    _parsed_program_id,
+    _rpc_value,
+    _status_ok,
+    _transaction_dict,
+    _verify_ata_owner,
     _verify_local_transaction_intent,
     _verify_parsed_memo_instructions,
     _verify_parsed_sol_transfers,
@@ -904,6 +913,13 @@ class TestVerifyCredential:
 
 
 class TestParsedTransferVerification:
+    def test_build_expected_transfers_rejects_splits_that_consume_amount(self):
+        request = ChargeRequest(amount="1000", currency="sol", recipient="recipient-1")
+        details = MethodDetails(splits=[Split(recipient="recipient-2", amount="1000")])
+
+        with pytest.raises(PaymentError, match="primary recipient"):
+            _build_expected_transfers(request, details)
+
     def test_sol_verifier_rejects_duplicate_split_reuse(self):
         request = ChargeRequest(amount="1000", currency="sol", recipient="recipient-1")
         details = MethodDetails(
@@ -1046,3 +1062,68 @@ class TestParsedTransferVerification:
 
         with pytest.raises(PaymentError, match="No memo instruction found for split memo"):
             _verify_parsed_memo_instructions(instructions, request, details)
+
+
+class TestVerifierHelpers:
+    def test_verify_ata_owner_returns_false_for_invalid_address(self):
+        assert not _verify_ata_owner("not-an-ata", "not-an-owner", "not-a-mint", TOKEN_PROGRAM)
+
+    def test_parsed_program_id_accepts_named_associated_token_program(self):
+        instruction = {"program": "spl-associated-token-account"}
+
+        assert _parsed_program_id(instruction) == ASSOCIATED_TOKEN_PROGRAM
+
+    def test_parsed_info_string_returns_empty_for_missing_keys(self):
+        assert _parsed_info_string({"owner": None}, ("wallet", "owner")) == ""
+
+    def test_parsed_ata_creation_matches_rejects_non_dict_shapes(self):
+        assert not _parsed_ata_creation_matches({}, "owner", "ata", "mint", TOKEN_PROGRAM)
+        assert not _parsed_ata_creation_matches({"parsed": {"info": "not-a-dict"}}, "owner", "ata", "mint", TOKEN_PROGRAM)
+
+    def test_parsed_ata_creation_matches_rejects_unsupported_token_program(self):
+        instruction = {
+            "parsed": {
+                "info": {
+                    "wallet": "owner",
+                    "account": "ata",
+                    "mint": "mint",
+                    "tokenProgram": "unsupported-token-program",
+                }
+            }
+        }
+
+        with pytest.raises(PaymentError, match="unsupported token program"):
+            _parsed_ata_creation_matches(instruction, "owner", "ata", "mint", TOKEN_PROGRAM)
+
+    def test_rpc_value_handles_none_and_dict_values(self):
+        assert _rpc_value(None) is None
+        assert _rpc_value({"value": "ok"}) == "ok"
+        assert _rpc_value({"other": "ok"}) == {"other": "ok"}
+
+    def test_json_like_handles_objects_with_to_json_and_dict(self):
+        class JsonObject:
+            def to_json(self):
+                return '{"value": {"nested": true}}'
+
+        class PlainObject:
+            def __init__(self):
+                self.value = JsonObject()
+
+        assert _json_like(JsonObject()) == {"value": {"nested": True}}
+        assert _json_like(PlainObject()) == {"value": {"value": {"nested": True}}}
+
+    def test_transaction_dict_rejects_missing_transaction_key(self):
+        assert _transaction_dict(None) is None
+        assert _transaction_dict({"value": {"meta": {}}}) is None
+
+    def test_status_ok_handles_empty_and_error_entries(self):
+        assert not _status_ok({"value": []})
+        assert not _status_ok({"value": [{"err": "failed"}]})
+        assert _status_ok({"value": [{"err": None}]})
+
+    def test_confirmed_transaction_rejects_on_chain_error(self):
+        handler = Mpp(Config(recipient=TEST_RECIPIENT, currency="SOL", decimals=9, secret_key=TEST_SECRET))
+        request = ChargeRequest(amount="1000", currency="SOL", recipient=TEST_RECIPIENT)
+
+        with pytest.raises(PaymentError, match="transaction failed"):
+            handler._verify_confirmed_transaction({"meta": {"err": {"InstructionError": [0, "Custom"]}}}, request, MethodDetails())

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -6,8 +6,9 @@ import pytest
 from solders.hash import Hash
 from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
-from solders.message import Message
+from solders.message import Message, MessageV0, to_bytes_versioned
 from solders.pubkey import Pubkey
+from solders.signature import Signature
 from solders.system_program import TransferParams, transfer
 from solders.transaction import Transaction
 
@@ -19,6 +20,7 @@ from solana_mpp.server.mpp import (
     ChargeOptions,
     Config,
     Mpp,
+    _verify_local_transaction_intent,
     _verify_parsed_memo_instructions,
     _verify_parsed_sol_transfers,
     _verify_parsed_spl_transfers,
@@ -60,6 +62,33 @@ def _build_sol_transaction(recipient: str, lamports: int, memo: str = "") -> str
     message = Message.new_with_blockhash(instructions, signer.pubkey(), blockhash)
     transaction = Transaction.new_unsigned(message)
     transaction.sign([signer], blockhash)
+
+    import base64
+
+    return base64.b64encode(bytes(transaction)).decode("ascii")
+
+
+def _build_versioned_sol_transaction(recipient: str, lamports: int, memo: str = "") -> str:
+    signer = Keypair()
+    instructions = [
+        transfer(
+            TransferParams(
+                from_pubkey=signer.pubkey(),
+                to_pubkey=Pubkey.from_string(recipient),
+                lamports=lamports,
+            )
+        )
+    ]
+    if memo:
+        instructions.append(Instruction(Pubkey.from_string(MEMO_PROGRAM), memo.encode("utf-8"), []))
+
+    blockhash = Hash.from_string(TEST_BLOCKHASH)
+    message = MessageV0.try_compile(signer.pubkey(), instructions, [], blockhash)
+    signature = signer.sign_message(to_bytes_versioned(message))
+
+    from solders.transaction import VersionedTransaction
+
+    transaction = VersionedTransaction.populate(message, [Signature.from_bytes(bytes(signature))])
 
     import base64
 
@@ -257,6 +286,15 @@ class TestCharge:
         challenge = handler.charge("1.00")
         request = challenge.decode_request()
         assert request["methodDetails"]["tokenProgram"] == expected_program
+
+
+class TestLocalTransactionIntent:
+    def test_accepts_versioned_sol_transfer(self):
+        request = ChargeRequest(amount="1000", currency="SOL", recipient=TEST_RECIPIENT)
+        details = MethodDetails(network="mainnet-beta")
+        transaction = _build_versioned_sol_transaction(TEST_RECIPIENT, 1000)
+
+        _verify_local_transaction_intent(transaction, request, details)
 
 
 class TestVerifyCredential:

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -15,7 +15,7 @@ from solders.transaction import Transaction
 from solana_mpp._errors import ChallengeExpiredError, ChallengeMismatchError, PaymentError, ReplayError
 from solana_mpp._types import ChallengeEcho, PaymentCredential
 from solana_mpp.protocol.intents import ChargeRequest
-from solana_mpp.protocol.solana import MEMO_PROGRAM, TOKEN_2022_PROGRAM, MethodDetails, Split
+from solana_mpp.protocol.solana import ASSOCIATED_TOKEN_PROGRAM, MEMO_PROGRAM, TOKEN_2022_PROGRAM, MethodDetails, Split
 from solana_mpp.server.mpp import (
     ChargeOptions,
     Config,
@@ -33,6 +33,7 @@ TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 USDC_DEVNET = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
 ATA_PROGRAM = Pubkey.from_string("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
 TEST_BLOCKHASH = "4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs"
+SYSTEM_PROGRAM = "11111111111111111111111111111111"
 
 
 def _derive_ata(owner: str, mint: str, token_program: str = TOKEN_PROGRAM) -> str:
@@ -122,6 +123,60 @@ def _build_spl_transfer_checked_transaction(
     ]
     if memo:
         instructions.append(Instruction(Pubkey.from_string(MEMO_PROGRAM), memo.encode("utf-8"), []))
+
+    blockhash = Hash.from_string(TEST_BLOCKHASH)
+    message = Message.new_with_blockhash(instructions, signer.pubkey(), blockhash)
+    transaction = Transaction.new_unsigned(message)
+    transaction.sign([signer], blockhash)
+
+    import base64
+
+    return base64.b64encode(bytes(transaction)).decode("ascii")
+
+
+def _build_spl_split_transaction(
+    recipient: str,
+    split_recipient: str,
+    mint: str,
+    primary_amount: int,
+    split_amount: int,
+    create_split_ata: bool,
+    token_program: str = TOKEN_PROGRAM,
+    decimals: int = 6,
+) -> str:
+    signer = Keypair()
+    mint_key = Pubkey.from_string(mint)
+    recipient_ata = Pubkey.from_string(_derive_ata(recipient, mint, token_program))
+    split_ata = Pubkey.from_string(_derive_ata(split_recipient, mint, token_program))
+    instructions = []
+    if create_split_ata:
+        instructions.append(
+            Instruction(
+                Pubkey.from_string(ASSOCIATED_TOKEN_PROGRAM),
+                bytes([1]),
+                [
+                    AccountMeta(signer.pubkey(), True, True),
+                    AccountMeta(split_ata, False, True),
+                    AccountMeta(Pubkey.from_string(split_recipient), False, False),
+                    AccountMeta(mint_key, False, False),
+                    AccountMeta(Pubkey.from_string(SYSTEM_PROGRAM), False, False),
+                    AccountMeta(Pubkey.from_string(token_program), False, False),
+                ],
+            )
+        )
+    for destination, amount in ((recipient_ata, primary_amount), (split_ata, split_amount)):
+        instructions.append(
+            Instruction(
+                Pubkey.from_string(token_program),
+                bytes([12]) + amount.to_bytes(8, "little") + bytes([decimals]),
+                [
+                    AccountMeta(Pubkey.new_unique(), False, True),
+                    AccountMeta(mint_key, False, False),
+                    AccountMeta(destination, False, True),
+                    AccountMeta(signer.pubkey(), True, False),
+                ],
+            )
+        )
 
     blockhash = Hash.from_string(TEST_BLOCKHASH)
     message = Message.new_with_blockhash(instructions, signer.pubkey(), blockhash)
@@ -287,12 +342,102 @@ class TestCharge:
         request = challenge.decode_request()
         assert request["methodDetails"]["tokenProgram"] == expected_program
 
+    def test_charge_rejects_split_ata_creation_for_native_sol(self):
+        handler = Mpp(Config(recipient=TEST_RECIPIENT, currency="SOL", decimals=9, secret_key=TEST_SECRET))
+
+        with pytest.raises(PaymentError, match="SPL token currency"):
+            handler.charge_with_options(
+                "1.00",
+                ChargeOptions(
+                    splits=[
+                        {
+                            "recipient": str(Pubkey.new_unique()),
+                            "amount": "50000",
+                            "ataCreationRequired": True,
+                        }
+                    ]
+                ),
+            )
+
+    def test_charge_rejects_split_ata_creation_for_stablecoin_symbol(self, mpp: Mpp):
+        with pytest.raises(PaymentError, match="mint address"):
+            mpp.charge_with_options(
+                "1.00",
+                ChargeOptions(
+                    splits=[
+                        {
+                            "recipient": str(Pubkey.new_unique()),
+                            "amount": "50000",
+                            "ataCreationRequired": True,
+                        }
+                    ]
+                ),
+            )
+
+    def test_charge_accepts_split_ata_creation_for_raw_mint(self):
+        handler = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency=USDC_DEVNET,
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=FakeRPC(),
+            )
+        )
+        split = {"recipient": str(Pubkey.new_unique()), "amount": "50000", "ataCreationRequired": True}
+
+        challenge = handler.charge_with_options("1.00", ChargeOptions(splits=[split]))
+        request = challenge.decode_request()
+
+        assert request["currency"] == USDC_DEVNET
+        assert request["methodDetails"]["splits"] == [split]
+
 
 class TestLocalTransactionIntent:
     def test_accepts_versioned_sol_transfer(self):
         request = ChargeRequest(amount="1000", currency="SOL", recipient=TEST_RECIPIENT)
         details = MethodDetails(network="mainnet-beta")
         transaction = _build_versioned_sol_transaction(TEST_RECIPIENT, 1000)
+
+        _verify_local_transaction_intent(transaction, request, details)
+
+    def test_rejects_missing_required_split_ata_creation(self):
+        split_recipient = str(Pubkey.new_unique())
+        request = ChargeRequest(amount="1000000", currency=USDC_DEVNET, recipient=TEST_RECIPIENT)
+        details = MethodDetails(
+            network="devnet",
+            token_program=TOKEN_PROGRAM,
+            splits=[Split(recipient=split_recipient, amount="50000", ata_creation_required=True)],
+        )
+        transaction = _build_spl_split_transaction(
+            TEST_RECIPIENT,
+            split_recipient,
+            USDC_DEVNET,
+            950000,
+            50000,
+            create_split_ata=False,
+        )
+
+        with pytest.raises(PaymentError, match="Missing required ATA creation"):
+            _verify_local_transaction_intent(transaction, request, details)
+
+    def test_accepts_required_split_ata_creation(self):
+        split_recipient = str(Pubkey.new_unique())
+        request = ChargeRequest(amount="1000000", currency=USDC_DEVNET, recipient=TEST_RECIPIENT)
+        details = MethodDetails(
+            network="devnet",
+            token_program=TOKEN_PROGRAM,
+            splits=[Split(recipient=split_recipient, amount="50000", ata_creation_required=True)],
+        )
+        transaction = _build_spl_split_transaction(
+            TEST_RECIPIENT,
+            split_recipient,
+            USDC_DEVNET,
+            950000,
+            50000,
+            create_split_ata=True,
+        )
 
         _verify_local_transaction_intent(transaction, request, details)
 
@@ -692,6 +837,70 @@ class TestVerifyCredential:
         with pytest.raises(PaymentError, match="No memo instruction found"):
             await mpp.verify_credential(credential)
         assert rpc.sent == []
+
+    async def test_signature_verification_rejects_missing_required_split_ata_creation(self):
+        split_recipient = str(Pubkey.new_unique())
+        tx = {
+            "meta": {"err": None},
+            "transaction": {
+                "message": {
+                    "instructions": [
+                        {
+                            "programId": TOKEN_PROGRAM,
+                            "parsed": {
+                                "type": "transferChecked",
+                                "info": {
+                                    "destination": _derive_ata(TEST_RECIPIENT, USDC_DEVNET),
+                                    "mint": USDC_DEVNET,
+                                    "tokenAmount": {"amount": "950000"},
+                                },
+                            },
+                        },
+                        {
+                            "programId": TOKEN_PROGRAM,
+                            "parsed": {
+                                "type": "transferChecked",
+                                "info": {
+                                    "destination": _derive_ata(split_recipient, USDC_DEVNET),
+                                    "mint": USDC_DEVNET,
+                                    "tokenAmount": {"amount": "50000"},
+                                },
+                            },
+                        },
+                    ]
+                }
+            },
+        }
+        rpc = FakeRPC(tx=tx)
+        handler = Mpp(
+            Config(
+                recipient=TEST_RECIPIENT,
+                currency=USDC_DEVNET,
+                decimals=6,
+                network="devnet",
+                secret_key=TEST_SECRET,
+                rpc=rpc,
+            )
+        )
+        challenge = handler.charge_with_options(
+            "1.00",
+            ChargeOptions(
+                splits=[
+                    {
+                        "recipient": split_recipient,
+                        "amount": "50000",
+                        "ataCreationRequired": True,
+                    }
+                ]
+            ),
+        )
+        credential = PaymentCredential(
+            challenge=challenge.to_echo(),
+            payload={"type": "signature", "signature": VALID_SIGNATURE},
+        )
+
+        with pytest.raises(PaymentError, match="Missing required ATA creation"):
+            await handler.verify_credential(credential)
 
 
 class TestParsedTransferVerification:

--- a/python/tests/test_server_html.py
+++ b/python/tests/test_server_html.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import re
+
 from solana_mpp._base64url import encode_json
 from solana_mpp._types import PaymentChallenge
 from solana_mpp.server.payment_page import (
@@ -11,6 +14,16 @@ from solana_mpp.server.payment_page import (
     is_service_worker_request,
     service_worker_js,
 )
+
+
+def embedded_payment_data(html: str) -> dict:
+    match = re.search(
+        r'<script id="__MPP_DATA__" type="application/json">(.*?)</script>',
+        html,
+        re.DOTALL,
+    )
+    assert match is not None
+    return json.loads(match.group(1))
 
 
 class TestChallengeToHtml:
@@ -24,13 +37,15 @@ class TestChallengeToHtml:
             request=request,
         )
         html = challenge_to_html(challenge, "https://api.devnet.solana.com", "devnet")
-        assert "<!DOCTYPE html>" in html
-        assert "test-id" in html
+        assert "<!doctype html>" in html
         assert "__MPP_DATA__" in html
-        assert "devnet" in html
+        data = embedded_payment_data(html)
+        assert data["challenge"]["id"] == "test-id"
+        assert data["network"] == "devnet"
+        assert data["rpcUrl"] == "https://api.devnet.solana.com"
 
     def test_escapes_xss(self):
-        """Challenge data should be HTML-escaped."""
+        """Embedded challenge data should not inject raw HTML."""
         request = encode_json({"amount": "1000", "description": '<script>alert("xss")</script>'})
         challenge = PaymentChallenge(
             id='<img onerror="alert(1)">',
@@ -42,25 +57,34 @@ class TestChallengeToHtml:
         html = challenge_to_html(challenge, "http://localhost:8899", "localnet")
         # Raw XSS should not appear unescaped
         assert '<img onerror="alert(1)">' not in html
-        assert "&lt;img" in html
+        assert "\\u003cimg" in html
+        assert embedded_payment_data(html)["challenge"]["id"] == '<img onerror="alert(1)">'
 
     def test_includes_description(self):
-        request = encode_json({"amount": "1000", "description": "Test payment"})
-        challenge = PaymentChallenge(id="test", realm="api", method="solana", intent="charge", request=request)
+        request = encode_json({"amount": "1000"})
+        challenge = PaymentChallenge(
+            id="test",
+            realm="api",
+            method="solana",
+            intent="charge",
+            request=request,
+            description="Test payment",
+        )
         html = challenge_to_html(challenge, "http://localhost:8899", "localnet")
         assert "Test payment" in html
+        assert embedded_payment_data(html)["challenge"]["description"] == "Test payment"
 
-    def test_test_mode_devnet(self):
+    def test_embeds_devnet_network(self):
         request = encode_json({"amount": "1000"})
         challenge = PaymentChallenge(id="test", realm="api", method="solana", intent="charge", request=request)
         html = challenge_to_html(challenge, "https://api.devnet.solana.com", "devnet")
-        assert '"testMode":true' in html
+        assert embedded_payment_data(html)["network"] == "devnet"
 
-    def test_test_mode_mainnet(self):
+    def test_embeds_mainnet_network(self):
         request = encode_json({"amount": "1000"})
         challenge = PaymentChallenge(id="test", realm="api", method="solana", intent="charge", request=request)
         html = challenge_to_html(challenge, "https://api.mainnet-beta.solana.com", "mainnet-beta")
-        assert '"testMode":false' in html
+        assert embedded_payment_data(html)["network"] == "mainnet-beta"
 
 
 class TestAcceptsHtml:

--- a/tests/interop/python-server/main.py
+++ b/tests/interop/python-server/main.py
@@ -23,6 +23,7 @@ from solana_mpp._errors import PaymentError  # noqa: E402
 from solana_mpp._headers import format_receipt, format_www_authenticate, parse_authorization  # noqa: E402
 from solana_mpp.protocol.intents import ChargeRequest  # noqa: E402
 from solana_mpp.server.mpp import ChargeOptions, Config, Mpp  # noqa: E402
+from solana_mpp.store import MemoryStore  # noqa: E402
 
 
 class InteropServer(ThreadingHTTPServer):
@@ -128,6 +129,7 @@ def build_challenge(environment: dict[str, Any], price: str) -> Any:
             rpc_url=environment["rpc_url"],
             secret_key=environment["secret_key"],
             realm="MPP Interop",
+            store=environment["store"],
         )
     )
     return handler.charge_with_options(
@@ -151,6 +153,7 @@ async def verify_credential(environment: dict[str, Any], authorization: str, cha
                 rpc_url=environment["rpc_url"],
                 secret_key=environment["secret_key"],
                 realm="MPP Interop",
+                store=environment["store"],
                 rpc=rpc_client,
             )
         )
@@ -192,6 +195,7 @@ def required_env(name: str) -> str:
 
 def main() -> None:
     environment = read_environment()
+    environment["store"] = MemoryStore()
     server = InteropServer(("127.0.0.1", 0), Handler)
     try:
         server.environment = environment

--- a/tests/interop/python-server/main.py
+++ b/tests/interop/python-server/main.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Process adapter for exercising the Python MPP server in the TS interop harness."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "python" / "src"))
+
+from solana.rpc.async_api import AsyncClient  # noqa: E402
+
+from solana_mpp._errors import PaymentError  # noqa: E402
+from solana_mpp._headers import format_receipt, format_www_authenticate, parse_authorization  # noqa: E402
+from solana_mpp.protocol.intents import ChargeRequest  # noqa: E402
+from solana_mpp.server.mpp import ChargeOptions, Config, Mpp  # noqa: E402
+
+
+class InteropServer(ThreadingHTTPServer):
+    environment: dict[str, Any]
+
+
+class Handler(BaseHTTPRequestHandler):
+    server: InteropServer
+
+    def do_GET(self) -> None:
+        environment = self.server.environment
+
+        if self.path == "/health":
+            self.write_json(200, {"ok": True})
+            return
+
+        if not self.is_protected_path(self.path, environment):
+            self.write_json(404, {"error": "not_found"})
+            return
+
+        challenge = build_challenge(environment, self.price_for_path(self.path, environment))
+        authorization = self.headers.get("Authorization", "")
+        if not authorization:
+            self.write_payment_required(challenge, "Payment is required (Python interop server).")
+            return
+
+        try:
+            receipt = asyncio.run(verify_credential(environment, authorization, challenge))
+        except PaymentError as error:
+            self.write_payment_required(challenge, str(error))
+            return
+        except Exception as error:  # noqa: BLE001
+            self.write_json(500, {"error": str(error)})
+            return
+
+        receipt_header = format_receipt(receipt)
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("payment-receipt", receipt_header)
+        self.send_header(environment["settlement_header"], receipt.reference)
+        self.end_headers()
+        self.wfile.write(b'{"ok":true,"paid":true}')
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    def write_payment_required(self, challenge: Any, detail: str) -> None:
+        self.send_response(402)
+        self.send_header("cache-control", "no-store")
+        self.send_header("content-type", "application/problem+json")
+        self.send_header("www-authenticate", format_www_authenticate(challenge))
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "detail": detail,
+                    "status": 402,
+                    "title": "Payment Required",
+                    "type": "https://paymentauth.org/problems/payment-required",
+                },
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+
+    def write_json(self, status: int, body: dict[str, Any]) -> None:
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body, separators=(",", ":")).encode("utf-8"))
+
+    @staticmethod
+    def is_protected_path(path: str, environment: dict[str, Any]) -> bool:
+        replay_source = environment.get("replay_source")
+        return path == environment["resource_path"] or (
+            replay_source is not None and path == replay_source["resource_path"]
+        )
+
+    @staticmethod
+    def price_for_path(path: str, environment: dict[str, Any]) -> str:
+        replay_source = environment.get("replay_source")
+        if replay_source is not None and path == replay_source["resource_path"]:
+            return replay_source["price"]
+        return environment["price"]
+
+
+def build_challenge(environment: dict[str, Any], price: str) -> Any:
+    handler = Mpp(
+        Config(
+            recipient=environment["pay_to"],
+            currency=environment["mint"],
+            decimals=6,
+            network=environment["network"],
+            rpc_url=environment["rpc_url"],
+            secret_key=environment["secret_key"],
+            realm="MPP Interop",
+        )
+    )
+    return handler.charge_with_options(
+        price,
+        ChargeOptions(
+            description="Python interop protected content",
+            splits=environment["splits"],
+        ),
+    )
+
+
+async def verify_credential(environment: dict[str, Any], authorization: str, challenge: Any) -> Any:
+    rpc_client = AsyncClient(environment["rpc_url"])
+    try:
+        handler = Mpp(
+            Config(
+                recipient=environment["pay_to"],
+                currency=environment["mint"],
+                decimals=6,
+                network=environment["network"],
+                rpc_url=environment["rpc_url"],
+                secret_key=environment["secret_key"],
+                realm="MPP Interop",
+                rpc=rpc_client,
+            )
+        )
+        credential = parse_authorization(authorization)
+        expected = ChargeRequest.from_dict(challenge.decode_request())
+        return await handler.verify_credential_with_expected(credential, expected)
+    finally:
+        await rpc_client.close()
+
+
+def read_environment() -> dict[str, Any]:
+    replay_source = None
+    if os.environ.get("MPP_INTEROP_REPLAY_SOURCE_PATH") and os.environ.get("MPP_INTEROP_REPLAY_SOURCE_PRICE"):
+        replay_source = {
+            "price": os.environ["MPP_INTEROP_REPLAY_SOURCE_PRICE"],
+            "resource_path": os.environ["MPP_INTEROP_REPLAY_SOURCE_PATH"],
+        }
+
+    return {
+        "rpc_url": required_env("MPP_INTEROP_RPC_URL"),
+        "network": os.environ.get("MPP_INTEROP_NETWORK", "localnet"),
+        "mint": os.environ.get("MPP_INTEROP_MINT", "USDC"),
+        "price": os.environ.get("MPP_INTEROP_PRICE", "0.001"),
+        "resource_path": os.environ.get("MPP_INTEROP_RESOURCE_PATH", "/protected"),
+        "settlement_header": os.environ.get("MPP_INTEROP_SETTLEMENT_HEADER", "x-fixture-settlement"),
+        "pay_to": required_env("MPP_INTEROP_PAY_TO"),
+        "secret_key": os.environ.get("MPP_INTEROP_SECRET_KEY", "mpp-interop-secret-key"),
+        "splits": json.loads(os.environ.get("MPP_INTEROP_SPLITS", "[]")),
+        "replay_source": replay_source,
+    }
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def main() -> None:
+    environment = read_environment()
+    server = InteropServer(("127.0.0.1", 0), Handler)
+    try:
+        server.environment = environment
+        port = server.server_address[1]
+        print(
+            json.dumps(
+                {
+                    "type": "ready",
+                    "implementation": "python",
+                    "role": "server",
+                    "port": port,
+                    "capabilities": ["charge"],
+                }
+            ),
+            flush=True,
+        )
+
+        def shutdown(_signum: int, _frame: Any) -> None:
+            threading.Thread(target=server.shutdown, daemon=True).start()
+
+        signal.signal(signal.SIGTERM, shutdown)
+        signal.signal(signal.SIGINT, shutdown)
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:  # noqa: BLE001
+        print(f"FAIL: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tests/interop/python-server/main.py
+++ b/tests/interop/python-server/main.py
@@ -59,39 +59,49 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         receipt_header = format_receipt(receipt)
+        body = b'{"ok":true,"paid":true}'
         self.send_response(200)
         self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.send_header("connection", "close")
         self.send_header("payment-receipt", receipt_header)
         self.send_header(environment["settlement_header"], receipt.reference)
         self.end_headers()
-        self.wfile.write(b'{"ok":true,"paid":true}')
+        self.close_connection = True
+        self.wfile.write(body)
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
         return
 
     def write_payment_required(self, challenge: Any, detail: str) -> None:
+        body = json.dumps(
+            {
+                "detail": detail,
+                "status": 402,
+                "title": "Payment Required",
+                "type": "https://paymentauth.org/problems/payment-required",
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
         self.send_response(402)
         self.send_header("cache-control", "no-store")
         self.send_header("content-type", "application/problem+json")
+        self.send_header("content-length", str(len(body)))
+        self.send_header("connection", "close")
         self.send_header("www-authenticate", format_www_authenticate(challenge))
         self.end_headers()
-        self.wfile.write(
-            json.dumps(
-                {
-                    "detail": detail,
-                    "status": 402,
-                    "title": "Payment Required",
-                    "type": "https://paymentauth.org/problems/payment-required",
-                },
-                separators=(",", ":"),
-            ).encode("utf-8")
-        )
+        self.close_connection = True
+        self.wfile.write(body)
 
     def write_json(self, status: int, body: dict[str, Any]) -> None:
+        encoded = json.dumps(body, separators=(",", ":")).encode("utf-8")
         self.send_response(status)
         self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.send_header("connection", "close")
         self.end_headers()
-        self.wfile.write(json.dumps(body, separators=(",", ":")).encode("utf-8"))
+        self.close_connection = True
+        self.wfile.write(encoded)
 
     @staticmethod
     def is_protected_path(path: str, environment: dict[str, Any]) -> bool:

--- a/tests/interop/src/implementations.ts
+++ b/tests/interop/src/implementations.ts
@@ -74,4 +74,15 @@ export const serverImplementations: ImplementationDefinition[] = [
     ],
     enabled: isEnabled("rust", "MPP_INTEROP_SERVERS", true),
   },
+  {
+    id: "python",
+    label: "Python HTTP server",
+    role: "server",
+    command: [
+      "sh",
+      "-c",
+      "cd ../../python && uv run --extra dev python ../tests/interop/python-server/main.py",
+    ],
+    enabled: isEnabled("python", "MPP_INTEROP_SERVERS", false),
+  },
 ];

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -12,6 +12,7 @@ import { runClient, startServer, stopServer } from "../src/process";
 type RunningServer = Awaited<ReturnType<typeof startServer>>;
 
 const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const MINT_ACCOUNT_SIZE = 82;
 
 const runningServers: RunningServer[] = [];
@@ -86,6 +87,7 @@ beforeAll(async () => {
     createSplMintAccountData(6),
     TOKEN_PROGRAM,
   );
+  surfnet.setAccount(client.publicKey, 2_000_000_000, new Uint8Array(), SYSTEM_PROGRAM);
   surfnet.fundToken(client.publicKey, baseScenario.asset, 100_000);
   surfnet.fundToken(payTo.publicKey, baseScenario.asset, 1);
 


### PR DESCRIPTION
## What
- add Python charge server interop adapter coverage
- verify versioned charge transactions and split ATA charge parity
- keep replay protection state shared across the Python interop server lifetime
- add Python coverage reporting and a focused interop smoke job
- raise Python test coverage above 90%

## Why
Python was behind TypeScript/Rust for charge verification and was not yet part of the TypeScript interop harness. This makes implementation gaps visible while keeping the PR scoped to Python charge parity.

## Verified
- `PYTHONPATH=python/src uv run pytest python/tests -q --cov=solana_mpp --cov-report=term-missing --cov-fail-under=90` (248 passed, 91.86% coverage)
- `pnpm typecheck` in `tests/interop`
- CI is rerunning after review-feedback fixes