### PR TITLE
feat(go): bring charge parity into coverage and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,22 @@ jobs:
         env:
           GOCACHE: /tmp/go-build-cache
         run: |
-          go test ./... -coverprofile=coverage.out -covermode=atomic
-          ./scripts/check_coverage.sh coverage.out 70
+          go test \
+            github.com/solana-foundation/mpp-sdk/go \
+            github.com/solana-foundation/mpp-sdk/go/client \
+            github.com/solana-foundation/mpp-sdk/go/internal/solanautil \
+            github.com/solana-foundation/mpp-sdk/go/protocol \
+            github.com/solana-foundation/mpp-sdk/go/protocol/core \
+            github.com/solana-foundation/mpp-sdk/go/protocol/intents \
+            github.com/solana-foundation/mpp-sdk/go/server \
+            -coverprofile=coverage.out \
+            -covermode=atomic
+          ./scripts/check_coverage.sh coverage.out 90
+      - name: Run all Go packages
+        working-directory: go
+        env:
+          GOCACHE: /tmp/go-build-cache
+        run: go test ./...
       - name: Upload Go coverage
         if: always()
         uses: actions/upload-artifact@v7

--- a/go/client/charge_test.go
+++ b/go/client/charge_test.go
@@ -329,6 +329,21 @@ func TestBuildChargeTransactionTokenWithFeePayer(t *testing.T) {
 	}
 }
 
+func TestBuildChargeTransactionRejectsUnsupportedTokenProgramHint(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	signer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey().String()
+	mint := testutil.NewPrivateKey().PublicKey()
+	decimals := uint8(6)
+
+	if _, err := BuildChargeTransaction(context.Background(), signer, rpcClient, "1000", mint.String(), recipient, protocol.MethodDetails{
+		Decimals:     &decimals,
+		TokenProgram: protocol.SystemProgram,
+	}, BuildOptions{}); err == nil {
+		t.Fatal("expected unsupported token program hint to fail")
+	}
+}
+
 func TestBuildChargeTransactionSOLBroadcast(t *testing.T) {
 	rpcClient := testutil.NewFakeRPC()
 	signer := testutil.NewPrivateKey()

--- a/go/client/charge_test.go
+++ b/go/client/charge_test.go
@@ -329,6 +329,25 @@ func TestBuildChargeTransactionTokenWithFeePayer(t *testing.T) {
 	}
 }
 
+func TestBuildChargeTransactionTokenRejectsInvalidFeePayerKey(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	signer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey().String()
+	mint := testutil.NewPrivateKey().PublicKey()
+	rpcClient.MintOwners[mint.String()] = solana.TokenProgramID
+	decimals := uint8(6)
+	enabled := true
+
+	_, err := BuildChargeTransaction(context.Background(), signer, rpcClient, "1000", mint.String(), recipient, protocol.MethodDetails{
+		Decimals:    &decimals,
+		FeePayer:    &enabled,
+		FeePayerKey: "not-a-pubkey",
+	}, BuildOptions{})
+	if err == nil {
+		t.Fatal("expected invalid fee payer key to fail")
+	}
+}
+
 func TestBuildChargeTransactionRejectsUnsupportedTokenProgramHint(t *testing.T) {
 	rpcClient := testutil.NewFakeRPC()
 	signer := testutil.NewPrivateKey()
@@ -421,6 +440,22 @@ func TestBuildCredentialHeaderInvalidRequest(t *testing.T) {
 	}
 	if _, err := BuildCredentialHeader(context.Background(), signer, rpcClient, challenge); err == nil {
 		t.Fatal("expected error for invalid request")
+	}
+}
+
+func TestBuildCredentialHeaderRejectsInvalidMethodDetails(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	signer := testutil.NewPrivateKey()
+	challengeRequest, _ := mpp.NewBase64URLJSONValue(map[string]any{
+		"amount":        "1000",
+		"currency":      "sol",
+		"recipient":     testutil.NewPrivateKey().PublicKey().String(),
+		"methodDetails": map[string]any{"decimals": "not-a-number"},
+	})
+	challenge := mpp.NewChallengeWithSecret("secret", "realm", "solana", "charge", challengeRequest)
+
+	if _, err := BuildCredentialHeader(context.Background(), signer, rpcClient, challenge); err == nil {
+		t.Fatal("expected invalid methodDetails to fail")
 	}
 }
 

--- a/go/client/transport_test.go
+++ b/go/client/transport_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -18,6 +19,16 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (errReadCloser) Close() error {
+	return nil
+}
+
 func newTestChallenge() mpp.PaymentChallenge {
 	fakeRPC := testutil.NewFakeRPC()
 	request, _ := mpp.NewBase64URLJSONValue(map[string]any{
@@ -30,6 +41,52 @@ func newTestChallenge() mpp.PaymentChallenge {
 		},
 	})
 	return mpp.NewChallengeWithSecret("secret", "realm", "solana", "charge", request)
+}
+
+func TestTransportDefaults(t *testing.T) {
+	transport := &PaymentTransport{}
+	if transport.base() != http.DefaultTransport {
+		t.Fatal("expected default transport")
+	}
+	if got := transport.buildOptions(); got != (BuildOptions{}) {
+		t.Fatalf("expected empty build options, got %#v", got)
+	}
+
+	opts := &BuildOptions{ComputeUnitLimit: 400_000, ComputeUnitPrice: 10}
+	transport.Options = opts
+	if got := transport.buildOptions(); got != *opts {
+		t.Fatalf("expected configured build options, got %#v", got)
+	}
+}
+
+func TestTransportReturnsBodyReadError(t *testing.T) {
+	transport := &PaymentTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatal("base transport should not be called when request body cannot be buffered")
+			return nil, nil
+		}),
+	}
+
+	req, _ := http.NewRequest("POST", "http://example.com", nil)
+	req.Body = errReadCloser{}
+	_, err := transport.RoundTrip(req)
+	if err == nil || !strings.Contains(err.Error(), "read failed") {
+		t.Fatalf("expected body read error, got %v", err)
+	}
+}
+
+func TestTransportReturnsBaseError(t *testing.T) {
+	transport := &PaymentTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("network failed")
+		}),
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, err := transport.RoundTrip(req)
+	if err == nil || !strings.Contains(err.Error(), "network failed") {
+		t.Fatalf("expected base transport error, got %v", err)
+	}
 }
 
 func TestTransportPassthroughNon402(t *testing.T) {
@@ -52,6 +109,48 @@ func TestTransportPassthroughNon402(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestTransportBuildCredentialFailureReturnsOriginal402(t *testing.T) {
+	request, err := mpp.NewBase64URLJSONValue(map[string]any{
+		"amount":    "not-a-number",
+		"currency":  "sol",
+		"recipient": testutil.NewPrivateKey().PublicKey().String(),
+	})
+	if err != nil {
+		t.Fatalf("request encode failed: %v", err)
+	}
+	challenge := mpp.NewChallengeWithSecret("secret", "realm", "solana", "charge", request)
+	wwwAuth, err := mpp.FormatWWWAuthenticate(challenge)
+	if err != nil {
+		t.Fatalf("format challenge: %v", err)
+	}
+
+	calls := 0
+	transport := &PaymentTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{
+				StatusCode: http.StatusPaymentRequired,
+				Body:       io.NopCloser(strings.NewReader("payment required")),
+				Header:     http.Header{"Www-Authenticate": {wwwAuth}},
+			}, nil
+		}),
+		Signer: testutil.NewPrivateKey(),
+		RPC:    testutil.NewFakeRPC(),
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("expected original 402, got %d", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Fatalf("expected no retry when credential build fails, got %d calls", calls)
 	}
 }
 
@@ -225,7 +324,16 @@ func TestTransportPOSTBodyReplay(t *testing.T) {
 func TestNewClient(t *testing.T) {
 	signer := testutil.NewPrivateKey()
 	rpc := testutil.NewFakeRPC()
-	c := NewClient(signer, rpc)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     http.Header{},
+		}, nil
+	})
+	c := NewClient(signer, rpc, func(t *PaymentTransport) {
+		t.Base = base
+	})
 	if c == nil {
 		t.Fatal("expected non-nil client")
 	}
@@ -235,6 +343,9 @@ func TestNewClient(t *testing.T) {
 	}
 	if pt.Signer == nil || pt.RPC == nil {
 		t.Fatal("expected signer and rpc to be set")
+	}
+	if pt.Base == nil {
+		t.Fatal("expected option to configure base transport")
 	}
 }
 

--- a/go/error_test.go
+++ b/go/error_test.go
@@ -12,10 +12,30 @@ func TestNewError(t *testing.T) {
 	}
 }
 
+func TestNilErrorMethods(t *testing.T) {
+	var err *Error
+	if err.Error() != "<nil>" {
+		t.Fatalf("unexpected nil error string %q", err.Error())
+	}
+	if err.Unwrap() != nil {
+		t.Fatal("expected nil unwrap")
+	}
+}
+
 func TestWrapError(t *testing.T) {
 	cause := errors.New("boom")
 	err := WrapError(ErrCodeRPC, "rpc failed", cause)
 	if err.Unwrap() != cause {
 		t.Fatal("expected wrapped cause")
+	}
+}
+
+func TestWrapErrorWithoutCause(t *testing.T) {
+	err := WrapError(ErrCodeRPC, "rpc failed", nil)
+	if err.Unwrap() != nil {
+		t.Fatal("expected nil wrapped cause")
+	}
+	if err.Message != "rpc failed" {
+		t.Fatalf("unexpected message %q", err.Message)
 	}
 }

--- a/go/internal/solanautil/solanautil.go
+++ b/go/internal/solanautil/solanautil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"time"
 
 	bin "github.com/gagliardetto/binary"
@@ -269,8 +270,8 @@ func SplitAmounts(total uint64, splits []protocol.Split) (uint64, error) {
 	}
 	var splitTotal uint64
 	for _, split := range splits {
-		var amount uint64
-		if _, err := fmt.Sscanf(split.Amount, "%d", &amount); err != nil {
+		amount, err := strconv.ParseUint(split.Amount, 10, 64)
+		if err != nil {
 			return 0, fmt.Errorf("invalid split amount %q", split.Amount)
 		}
 		splitTotal += amount

--- a/go/internal/solanautil/solanautil_test.go
+++ b/go/internal/solanautil/solanautil_test.go
@@ -2,6 +2,7 @@ package solanautil
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,6 +12,19 @@ import (
 	"github.com/solana-foundation/mpp-sdk/go/internal/testutil"
 	"github.com/solana-foundation/mpp-sdk/go/protocol"
 )
+
+type failingSigner struct {
+	key solana.PublicKey
+	err error
+}
+
+func (s failingSigner) PublicKey() solana.PublicKey {
+	return s.key
+}
+
+func (s failingSigner) Sign([]byte) (solana.Signature, error) {
+	return solana.Signature{}, s.err
+}
 
 func TestSplitAmounts(t *testing.T) {
 	primary, err := SplitAmounts(1000, []protocol.Split{{Recipient: testutil.NewPrivateKey().PublicKey().String(), Amount: "100"}})
@@ -71,6 +85,39 @@ func TestSignEncodeDecodeTransaction(t *testing.T) {
 	}
 	if len(decoded.Signatures) != 1 || decoded.Signatures[0].IsZero() {
 		t.Fatal("expected decoded signature")
+	}
+}
+
+func TestSignTransactionRejectsSignerFailure(t *testing.T) {
+	payer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey()
+	transfer, err := BuildSOLTransfer(payer.PublicKey(), recipient, 1000)
+	if err != nil {
+		t.Fatalf("transfer failed: %v", err)
+	}
+	tx, err := solana.NewTransaction([]solana.Instruction{transfer}, testutil.NewFakeRPC().Blockhash, solana.TransactionPayer(payer.PublicKey()))
+	if err != nil {
+		t.Fatalf("tx failed: %v", err)
+	}
+	if err := SignTransaction(tx, failingSigner{key: payer.PublicKey(), err: errors.New("sign failed")}); err == nil {
+		t.Fatal("expected signer failure")
+	}
+}
+
+func TestSignTransactionRejectsUnexpectedSigner(t *testing.T) {
+	payer := testutil.NewPrivateKey()
+	other := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey()
+	transfer, err := BuildSOLTransfer(payer.PublicKey(), recipient, 1000)
+	if err != nil {
+		t.Fatalf("transfer failed: %v", err)
+	}
+	tx, err := solana.NewTransaction([]solana.Instruction{transfer}, testutil.NewFakeRPC().Blockhash, solana.TransactionPayer(payer.PublicKey()))
+	if err != nil {
+		t.Fatalf("tx failed: %v", err)
+	}
+	if err := SignTransaction(tx, other); err == nil {
+		t.Fatal("expected non-required signer to fail")
 	}
 }
 
@@ -334,5 +381,33 @@ func TestWaitForConfirmationReturnsFailure(t *testing.T) {
 	}
 	if err := WaitForConfirmation(context.Background(), rpcClient, signature); err == nil {
 		t.Fatal("expected confirmation failure")
+	}
+}
+
+func TestWaitForConfirmationReturnsContextError(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	signature := solana.MustSignatureFromBase58("5jKh25biPsnrmLWXXuqKNH2Q67Q4UmVVx8Gf2wrS6VoCeyfGE9wKikjY7Q1GQQgmpQ3xy7wJX5U1rcz82q4R8Nkv")
+	rpcClient.Statuses[signature.String()] = nil
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := WaitForConfirmation(ctx, rpcClient, signature); err == nil {
+		t.Fatal("expected context cancellation")
+	}
+}
+
+func TestSimulateTransactionReturnsSimulationError(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	rpcClient.SimulateErr = errors.New("simulate failed")
+	if err := SimulateTransaction(context.Background(), rpcClient, &solana.Transaction{}); err == nil {
+		t.Fatal("expected simulate error")
+	}
+}
+
+func TestFetchTransactionReturnsRPCError(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	rpcClient.GetTxErr = errors.New("get transaction failed")
+	signature := solana.MustSignatureFromBase58("5jKh25biPsnrmLWXXuqKNH2Q67Q4UmVVx8Gf2wrS6VoCeyfGE9wKikjY7Q1GQQgmpQ3xy7wJX5U1rcz82q4R8Nkv")
+	if _, _, err := FetchTransaction(context.Background(), rpcClient, signature); err == nil {
+		t.Fatal("expected get transaction error")
 	}
 }

--- a/go/internal/solanautil/solanautil_test.go
+++ b/go/internal/solanautil/solanautil_test.go
@@ -2,6 +2,7 @@ package solanautil
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -129,6 +130,29 @@ func TestAssociatedTokenHelpers(t *testing.T) {
 	_, err = BuildComputeUnitPrice(1)
 	if err != nil {
 		t.Fatalf("compute unit price failed: %v", err)
+	}
+}
+
+func TestBuildMemoInstruction(t *testing.T) {
+	ix, err := BuildMemoInstruction("order-123")
+	if err != nil {
+		t.Fatalf("memo failed: %v", err)
+	}
+	if ix == nil {
+		t.Fatal("expected memo instruction")
+	}
+	data, err := ix.Data()
+	if err != nil {
+		t.Fatalf("memo data failed: %v", err)
+	}
+	if string(data) != "order-123" {
+		t.Fatalf("unexpected memo data %q", string(data))
+	}
+}
+
+func TestBuildMemoInstructionRejectsLongMemo(t *testing.T) {
+	if _, err := BuildMemoInstruction(strings.Repeat("x", 567)); err == nil {
+		t.Fatal("expected long memo to fail")
 	}
 }
 
@@ -274,6 +298,31 @@ func TestResolveTokenProgramMintNotFound(t *testing.T) {
 	// Not in MintOwners map
 	if _, err := ResolveTokenProgram(context.Background(), rpcClient, mint, ""); err == nil {
 		t.Fatal("expected error for mint not found")
+	}
+}
+
+func TestResolveTokenProgramUnsupportedOwner(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	mint := testutil.NewPrivateKey().PublicKey()
+	rpcClient.MintOwners[mint.String()] = solana.SystemProgramID
+	if _, err := ResolveTokenProgram(context.Background(), rpcClient, mint, ""); err == nil {
+		t.Fatal("expected unsupported mint owner error")
+	}
+}
+
+func TestResolveRecentBlockhashRejectsInvalidProvided(t *testing.T) {
+	rpcClient := testutil.NewFakeRPC()
+	if _, err := ResolveRecentBlockhash(context.Background(), rpcClient, "not-a-blockhash"); err == nil {
+		t.Fatal("expected invalid provided blockhash to fail")
+	}
+}
+
+func TestSplitAmountsRejectsPartiallyNumericAmount(t *testing.T) {
+	splits := []protocol.Split{
+		{Recipient: testutil.NewPrivateKey().PublicKey().String(), Amount: "100abc"},
+	}
+	if _, err := SplitAmounts(1000, splits); err == nil {
+		t.Fatal("expected error for partially numeric split amount")
 	}
 }
 

--- a/go/protocol/core/challenge_test.go
+++ b/go/protocol/core/challenge_test.go
@@ -43,6 +43,14 @@ func TestPaymentCredentialPayloadAs(t *testing.T) {
 	}
 }
 
+func TestNewPaymentCredentialRejectsUnmarshalablePayload(t *testing.T) {
+	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1000"})
+	challenge := NewChallengeWithSecret("secret", "realm", NewMethodName("solana"), NewIntentName("charge"), request)
+	if _, err := NewPaymentCredential(challenge.ToEcho(), map[string]any{"bad": make(chan int)}); err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
 func TestIsExpiredEmptyString(t *testing.T) {
 	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1"})
 	challenge := NewChallengeWithSecretFull("s", "r", NewMethodName("solana"), NewIntentName("charge"), request, "", "", "", nil)

--- a/go/protocol/core/headers_test.go
+++ b/go/protocol/core/headers_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -84,6 +85,26 @@ func TestParseWWWAuthenticateMissingRequiredFields(t *testing.T) {
 	}
 }
 
+func TestParseWWWAuthenticateRejectsMalformedParams(t *testing.T) {
+	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1000"})
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{"unterminated quote", `Payment id="abc, realm="r", method="solana", intent="charge", request="` + request.Raw() + `"`},
+		{"duplicate parameter", `Payment id="abc", id="def", realm="r", method="solana", intent="charge", request="` + request.Raw() + `"`},
+		{"invalid parameter", `Payment id, realm="r", method="solana", intent="charge", request="` + request.Raw() + `"`},
+		{"invalid request json", `Payment id="abc", realm="r", method="solana", intent="charge", request="bm90LWpzb24"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseWWWAuthenticate(tc.header); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestParseWWWAuthenticateWithOpaqueAndDigest(t *testing.T) {
 	opaque, _ := NewBase64URLJSONValue(map[string]string{"session": "xyz"})
 	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1000"})
@@ -156,6 +177,25 @@ func TestParseAuthorizationInvalidBase64(t *testing.T) {
 	}
 }
 
+func TestParseAuthorizationInvalidJSON(t *testing.T) {
+	header := PaymentScheme + " " + Base64URLEncode([]byte("not-json"))
+	if _, err := ParseAuthorization(header); err == nil {
+		t.Fatal("expected invalid credential JSON error")
+	}
+}
+
+func TestParseReceiptRejectsMalformedValues(t *testing.T) {
+	if _, err := ParseReceipt("not-base64"); err == nil {
+		t.Fatal("expected invalid base64 receipt error")
+	}
+	if _, err := ParseReceipt(Base64URLEncode([]byte("not-json"))); err == nil {
+		t.Fatal("expected invalid JSON receipt error")
+	}
+	if _, err := ParseReceipt(string(make([]byte, 17*1024))); err == nil {
+		t.Fatal("expected oversized receipt error")
+	}
+}
+
 func TestFormatAuthorizationRoundTrip(t *testing.T) {
 	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "500"})
 	challenge := NewChallengeWithSecret("secret", "realm", NewMethodName("solana"), NewIntentName("charge"), request)
@@ -177,6 +217,14 @@ func TestFormatAuthorizationRoundTrip(t *testing.T) {
 	}
 	if payload["type"] != "transaction" {
 		t.Fatalf("unexpected payload type: %q", payload["type"])
+	}
+}
+
+func TestFormatAuthorizationRejectsInvalidRawPayload(t *testing.T) {
+	raw := json.RawMessage(`{"unterminated"`)
+	_, err := FormatAuthorization(PaymentCredential{Payload: &raw})
+	if err == nil {
+		t.Fatal("expected invalid raw payload to fail")
 	}
 }
 

--- a/go/protocol/core/types.go
+++ b/go/protocol/core/types.go
@@ -48,7 +48,15 @@ func NewBase64URLJSONValue(value any) (Base64URLJSON, error) {
 	if err != nil {
 		return Base64URLJSON{}, err
 	}
-	return Base64URLJSON{raw: Base64URLEncode(raw)}, nil
+	var canonicalValue any
+	if err := json.Unmarshal(raw, &canonicalValue); err != nil {
+		return Base64URLJSON{}, err
+	}
+	canonicalRaw, err := json.Marshal(canonicalValue)
+	if err != nil {
+		return Base64URLJSON{}, err
+	}
+	return Base64URLJSON{raw: Base64URLEncode(canonicalRaw)}, nil
 }
 
 // Raw returns the raw base64url value.

--- a/go/protocol/core/types.go
+++ b/go/protocol/core/types.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
@@ -48,8 +49,10 @@ func NewBase64URLJSONValue(value any) (Base64URLJSON, error) {
 	if err != nil {
 		return Base64URLJSON{}, err
 	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
 	var canonicalValue any
-	if err := json.Unmarshal(raw, &canonicalValue); err != nil {
+	if err := decoder.Decode(&canonicalValue); err != nil {
 		return Base64URLJSON{}, err
 	}
 	canonicalRaw, err := json.Marshal(canonicalValue)

--- a/go/protocol/core/types_test.go
+++ b/go/protocol/core/types_test.go
@@ -47,6 +47,23 @@ func TestBase64URLJSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestBase64URLJSONValueRejectsUnmarshalableValue(t *testing.T) {
+	if _, err := NewBase64URLJSONValue(map[string]any{"bad": make(chan int)}); err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
+func TestBase64URLJSONDecodeRejectsInvalidRawValue(t *testing.T) {
+	value := NewBase64URLJSONRaw("not-base64")
+	var out map[string]any
+	if err := value.Decode(&out); err == nil {
+		t.Fatal("expected invalid base64 decode error")
+	}
+	if _, err := value.DecodeValue(); err == nil {
+		t.Fatal("expected invalid base64 decode value error")
+	}
+}
+
 func TestBase64URLJSONValueCanonicalizesStructFields(t *testing.T) {
 	type request struct {
 		Currency      string         `json:"currency"`

--- a/go/protocol/core/types_test.go
+++ b/go/protocol/core/types_test.go
@@ -47,6 +47,33 @@ func TestBase64URLJSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestBase64URLJSONValueCanonicalizesStructFields(t *testing.T) {
+	type request struct {
+		Currency      string         `json:"currency"`
+		Amount        string         `json:"amount"`
+		MethodDetails map[string]any `json:"methodDetails"`
+	}
+	value, err := NewBase64URLJSONValue(request{
+		Currency: "USDC",
+		Amount:   "1000",
+		MethodDetails: map[string]any{
+			"network":  "localnet",
+			"feePayer": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	decoded, err := Base64URLDecode(value.Raw())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	want := `{"amount":"1000","currency":"USDC","methodDetails":{"feePayer":true,"network":"localnet"}}`
+	if string(decoded) != want {
+		t.Fatalf("unexpected canonical JSON:\n got %s\nwant %s", decoded, want)
+	}
+}
+
 func TestIntentNameIsCharge(t *testing.T) {
 	if !NewIntentName("Charge").IsCharge() {
 		t.Fatal("expected charge intent")

--- a/go/protocol/core/types_test.go
+++ b/go/protocol/core/types_test.go
@@ -91,6 +91,21 @@ func TestBase64URLJSONValueCanonicalizesStructFields(t *testing.T) {
 	}
 }
 
+func TestBase64URLJSONValuePreservesLargeJSONNumbers(t *testing.T) {
+	value, err := NewBase64URLJSONValue(map[string]any{"amount": uint64(18446744073709551615)})
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	decoded, err := Base64URLDecode(value.Raw())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	want := `{"amount":18446744073709551615}`
+	if string(decoded) != want {
+		t.Fatalf("unexpected canonical JSON:\n got %s\nwant %s", decoded, want)
+	}
+}
+
 func TestIntentNameIsCharge(t *testing.T) {
 	if !NewIntentName("Charge").IsCharge() {
 		t.Fatal("expected charge intent")

--- a/go/protocol/solana.go
+++ b/go/protocol/solana.go
@@ -119,10 +119,11 @@ type MethodDetails struct {
 
 // Split is an additional transfer in the same asset.
 type Split struct {
-	Recipient string `json:"recipient"`
-	Amount    string `json:"amount"`
-	Label     string `json:"label,omitempty"`
-	Memo      string `json:"memo,omitempty"`
+	Recipient           string `json:"recipient"`
+	Amount              string `json:"amount"`
+	Label               string `json:"label,omitempty"`
+	Memo                string `json:"memo,omitempty"`
+	AtaCreationRequired *bool  `json:"ataCreationRequired,omitempty"`
 }
 
 // CredentialPayload is sent by clients in the payment credential payload.

--- a/go/protocol/solana_test.go
+++ b/go/protocol/solana_test.go
@@ -1,6 +1,9 @@
 package protocol
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestDefaultRPCURL(t *testing.T) {
 	if DefaultRPCURL("devnet") != "https://api.devnet.solana.com" {
@@ -63,5 +66,21 @@ func TestDefaultTokenProgramForCurrency(t *testing.T) {
 		if DefaultTokenProgramForCurrency(currency, "mainnet-beta") != TokenProgram {
 			t.Fatalf("expected %s to default to SPL Token", currency)
 		}
+	}
+}
+
+func TestSplitJSONIncludesAtaCreationRequired(t *testing.T) {
+	ataCreationRequired := true
+	raw, err := json.Marshal(Split{
+		Recipient:           "recipient",
+		Amount:              "250",
+		AtaCreationRequired: &ataCreationRequired,
+	})
+	if err != nil {
+		t.Fatalf("marshal split: %v", err)
+	}
+	want := `{"recipient":"recipient","amount":"250","ataCreationRequired":true}`
+	if string(raw) != want {
+		t.Fatalf("unexpected split json:\n got %s\nwant %s", raw, want)
 	}
 }

--- a/go/server/html.go
+++ b/go/server/html.go
@@ -99,6 +99,7 @@ func (m *Mpp) ChallengeToHTML(challenge mpp.PaymentChallenge) (string, error) {
 func formatAmountDisplay(amountRaw, currency string, decimals uint8) string {
 	d := int(decimals)
 	if strings.EqualFold(currency, "sol") {
+		// Native SOL amounts are always lamports, regardless of the server default.
 		d = 9
 	}
 

--- a/go/server/html_test.go
+++ b/go/server/html_test.go
@@ -184,7 +184,7 @@ func TestFormatAmountDisplay(t *testing.T) {
 	}{
 		{"usdc whole", "1000000", "USDC", 6, "$1"},
 		{"usdc fractional", "1230000", "USDC", 6, "$1.23"},
-		{"sol", "500000000", "sol", 6, "0.50 SOL"},
+		{"sol uses lamports", "500000000", "sol", 6, "0.50 SOL"},
 		{"invalid amount", "not-a-number", "USDC", 6, "$0"},
 		{"custom currency truncated", "123456", "LONGTOKENMINT", 6, "0.12 LONGTO"},
 	}

--- a/go/server/html_test.go
+++ b/go/server/html_test.go
@@ -51,9 +51,9 @@ func TestAcceptsHTML(t *testing.T) {
 
 func TestIsServiceWorkerRequest(t *testing.T) {
 	tests := []struct {
-		name    string
-		rawURL  string
-		want    bool
+		name   string
+		rawURL string
+		want   bool
 	}{
 		{"with param", "http://example.com/?__mpp_worker", true},
 		{"with param and value", "http://example.com/?__mpp_worker=1", true},
@@ -171,5 +171,29 @@ func TestChallengeToHTMLEscapesDescription(t *testing.T) {
 	}
 	if !strings.Contains(html, `&lt;script&gt;alert(1)&lt;/script&gt;`) {
 		t.Fatal("expected HTML-escaped description in output")
+	}
+}
+
+func TestFormatAmountDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		amount   string
+		currency string
+		decimals uint8
+		want     string
+	}{
+		{"usdc whole", "1000000", "USDC", 6, "$1"},
+		{"usdc fractional", "1230000", "USDC", 6, "$1.23"},
+		{"sol", "500000000", "sol", 6, "0.50 SOL"},
+		{"invalid amount", "not-a-number", "USDC", 6, "$0"},
+		{"custom currency truncated", "123456", "LONGTOKENMINT", 6, "0.12 LONGTO"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatAmountDisplay(tt.amount, tt.currency, tt.decimals); got != tt.want {
+				t.Fatalf("formatAmountDisplay() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/go/server/middleware_test.go
+++ b/go/server/middleware_test.go
@@ -48,6 +48,23 @@ func hasVaryAuthorization(header http.Header) bool {
 	return false
 }
 
+func TestMarkAuthorizationBoundResponsePreservesExistingVary(t *testing.T) {
+	withAuthorization := http.Header{"Vary": {"Accept-Encoding, Authorization"}}
+	markAuthorizationBoundResponse(withAuthorization)
+	if got := withAuthorization.Values("Vary"); len(got) != 1 {
+		t.Fatalf("expected existing authorization vary to be preserved, got %#v", got)
+	}
+	if withAuthorization.Get("Cache-Control") != "no-store" {
+		t.Fatal("expected no-store cache control")
+	}
+
+	wildcard := http.Header{"Vary": {"*"}}
+	markAuthorizationBoundResponse(wildcard)
+	if got := wildcard.Values("Vary"); len(got) != 1 || got[0] != "*" {
+		t.Fatalf("expected wildcard vary to be preserved, got %#v", got)
+	}
+}
+
 func TestMiddlewareNoAuth402(t *testing.T) {
 	m := newMiddlewareTestMpp(t)
 	handler := PaymentMiddleware(m, constantCharge("0.001"))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/server/server_cross_route_test.go
+++ b/go/server/server_cross_route_test.go
@@ -195,6 +195,54 @@ func TestVerifyCredentialWithExpectedRejectsAmountMismatch(t *testing.T) {
 	}
 }
 
+func TestVerifyCredentialWithExpectedRejectsCurrencyMismatch(t *testing.T) {
+	handler, _, _ := newTestMpp(t)
+	challenge, err := handler.Charge(context.Background(), "0.001")
+	if err != nil {
+		t.Fatalf("charge: %v", err)
+	}
+	cred := signatureCredentialFromEcho(t, challenge.ToEcho())
+
+	var expected intents.ChargeRequest
+	if decErr := challenge.Request.Decode(&expected); decErr != nil {
+		t.Fatalf("decode: %v", decErr)
+	}
+	expected.Currency = "USDC"
+
+	_, err = handler.VerifyCredentialWithExpected(context.Background(), cred, expected)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "currency") {
+		t.Fatalf("expected currency mismatch, got: %v", err)
+	}
+	var paymentErr *mpp.Error
+	if !mppErrAs(err, &paymentErr) || paymentErr.Code != mpp.ErrCodeChallengeMismatch {
+		t.Fatalf("expected challenge-mismatch mpp error, got %T: %v", err, err)
+	}
+}
+
+func TestVerifyCredentialWithExpectedRejectsRecipientMismatch(t *testing.T) {
+	handler, _, _ := newTestMpp(t)
+	challenge, err := handler.Charge(context.Background(), "0.001")
+	if err != nil {
+		t.Fatalf("charge: %v", err)
+	}
+	cred := signatureCredentialFromEcho(t, challenge.ToEcho())
+
+	var expected intents.ChargeRequest
+	if decErr := challenge.Request.Decode(&expected); decErr != nil {
+		t.Fatalf("decode: %v", decErr)
+	}
+	expected.Recipient = testutil.NewPrivateKey().PublicKey().String()
+
+	_, err = handler.VerifyCredentialWithExpected(context.Background(), cred, expected)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "recipient") {
+		t.Fatalf("expected recipient mismatch, got: %v", err)
+	}
+	var paymentErr *mpp.Error
+	if !mppErrAs(err, &paymentErr) || paymentErr.Code != mpp.ErrCodeRecipientMismatch {
+		t.Fatalf("expected recipient-mismatch mpp error, got %T: %v", err, err)
+	}
+}
+
 // Sanity check: a credential that matches the route's expected request must
 // reach settlement (it'll fail downstream because the payload is bogus, but
 // the failure must NOT be a binding/Tier-2 mismatch).

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -8,12 +8,14 @@ import (
 
 	solana "github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/token"
+	token2022 "github.com/gagliardetto/solana-go/programs/token-2022"
 
 	"github.com/solana-foundation/mpp-sdk/go"
 	"github.com/solana-foundation/mpp-sdk/go/client"
 	"github.com/solana-foundation/mpp-sdk/go/internal/solanautil"
 	"github.com/solana-foundation/mpp-sdk/go/internal/testutil"
 	"github.com/solana-foundation/mpp-sdk/go/protocol"
+	"github.com/solana-foundation/mpp-sdk/go/protocol/intents"
 )
 
 func newTestMpp(t *testing.T) (*Mpp, *testutil.FakeRPC, testutilConfig) {
@@ -584,6 +586,55 @@ func TestVerifyTransfersAgainstChallengeRejectsWrongSPLMint(t *testing.T) {
 	}
 }
 
+func TestVerifyTransfersAgainstChallengeAcceptsToken2022Transfer(t *testing.T) {
+	payer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey()
+	mint := testutil.NewPrivateKey().PublicKey()
+	tokenProgram := solana.MustPublicKeyFromBase58(protocol.Token2022Program)
+
+	sourceATA, err := solanautil.FindAssociatedTokenAddressWithProgram(payer.PublicKey(), mint, tokenProgram)
+	if err != nil {
+		t.Fatalf("find source ata failed: %v", err)
+	}
+	recipientATA, err := solanautil.FindAssociatedTokenAddressWithProgram(recipient, mint, tokenProgram)
+	if err != nil {
+		t.Fatalf("find recipient ata failed: %v", err)
+	}
+	ix, err := token2022.NewTransferCheckedInstruction(
+		1000,
+		6,
+		sourceATA,
+		mint,
+		recipientATA,
+		payer.PublicKey(),
+		nil,
+	).ValidateAndBuild()
+	if err != nil {
+		t.Fatalf("build transfer failed: %v", err)
+	}
+
+	tx := newTestTransaction(t, payer, ix)
+	if err := verifyTransfersAgainstChallenge(tx, 1000, mint.String(), recipient, "", protocol.MethodDetails{
+		TokenProgram: protocol.Token2022Program,
+	}); err != nil {
+		t.Fatalf("expected token2022 transfer to pass: %v", err)
+	}
+}
+
+func TestBuildExpectedTransfersRejectsInvalidSplitFields(t *testing.T) {
+	recipient := testutil.NewPrivateKey().PublicKey()
+	if _, err := buildExpectedTransfers(1000, recipient, protocol.MethodDetails{
+		Splits: []protocol.Split{{Recipient: testutil.NewPrivateKey().PublicKey().String(), Amount: "not-a-number"}},
+	}); err == nil {
+		t.Fatal("expected invalid split amount to fail")
+	}
+	if _, err := buildExpectedTransfers(1000, recipient, protocol.MethodDetails{
+		Splits: []protocol.Split{{Recipient: "not-a-pubkey", Amount: "100"}},
+	}); err == nil {
+		t.Fatal("expected invalid split recipient to fail")
+	}
+}
+
 func TestVerifyCredentialExpiredChallengeRejected(t *testing.T) {
 	handler, _, _ := newTestMpp(t)
 	challenge, err := handler.ChargeWithOptions(context.Background(), "0.001", ChargeOptions{
@@ -601,6 +652,48 @@ func TestVerifyCredentialExpiredChallengeRejected(t *testing.T) {
 	}
 	if _, err := handler.VerifyCredential(context.Background(), credential); err == nil {
 		t.Fatal("expected expired challenge to fail")
+	}
+}
+
+func TestVerifyCredentialRejectsInvalidPayloadType(t *testing.T) {
+	handler, _, _ := newTestMpp(t)
+	challenge, err := handler.Charge(context.Background(), "0.001")
+	if err != nil {
+		t.Fatalf("charge failed: %v", err)
+	}
+	credential, err := mpp.NewPaymentCredential(challenge.ToEcho(), map[string]string{
+		"type": "voucher",
+	})
+	if err != nil {
+		t.Fatalf("credential failed: %v", err)
+	}
+	if _, err := handler.VerifyCredential(context.Background(), credential); err == nil {
+		t.Fatal("expected invalid payload type to fail")
+	}
+}
+
+func TestVerifyCredentialWithExpectedRejectsInvalidExpectedMethodDetails(t *testing.T) {
+	handler, _, _ := newTestMpp(t)
+	challenge, err := handler.Charge(context.Background(), "0.001")
+	if err != nil {
+		t.Fatalf("charge failed: %v", err)
+	}
+	credential, err := mpp.NewPaymentCredential(challenge.ToEcho(), map[string]string{
+		"type":      "signature",
+		"signature": testutil.NewPrivateKey().PublicKey().String(),
+	})
+	if err != nil {
+		t.Fatalf("credential failed: %v", err)
+	}
+
+	var expected intents.ChargeRequest
+	if err := challenge.Request.Decode(&expected); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	expected.MethodDetails = map[string]any{"decimals": "not-a-number"}
+
+	if _, err := handler.VerifyCredentialWithExpected(context.Background(), credential, expected); err == nil {
+		t.Fatal("expected invalid expected methodDetails to fail")
 	}
 }
 

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -461,6 +461,95 @@ func TestVerifyTransfersAgainstChallengeAcceptsSPLExternalIDMemo(t *testing.T) {
 	}
 }
 
+func TestVerifyTransfersAgainstChallengeRejectsMissingSPLSplitMemo(t *testing.T) {
+	payer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey()
+	splitRecipient := testutil.NewPrivateKey().PublicKey()
+	mint := testutil.NewPrivateKey().PublicKey()
+
+	sourceATA, err := solanautil.FindAssociatedTokenAddressWithProgram(payer.PublicKey(), mint, solana.TokenProgramID)
+	if err != nil {
+		t.Fatalf("find source ata failed: %v", err)
+	}
+	recipientATA, err := solanautil.FindAssociatedTokenAddressWithProgram(recipient, mint, solana.TokenProgramID)
+	if err != nil {
+		t.Fatalf("find recipient ata failed: %v", err)
+	}
+	splitATA, err := solanautil.FindAssociatedTokenAddressWithProgram(splitRecipient, mint, solana.TokenProgramID)
+	if err != nil {
+		t.Fatalf("find split ata failed: %v", err)
+	}
+
+	primaryIx, err := token.NewTransferCheckedInstruction(
+		800,
+		6,
+		sourceATA,
+		mint,
+		recipientATA,
+		payer.PublicKey(),
+		nil,
+	).ValidateAndBuild()
+	if err != nil {
+		t.Fatalf("build primary transfer failed: %v", err)
+	}
+	splitIx, err := token.NewTransferCheckedInstruction(
+		200,
+		6,
+		sourceATA,
+		mint,
+		splitATA,
+		payer.PublicKey(),
+		nil,
+	).ValidateAndBuild()
+	if err != nil {
+		t.Fatalf("build split transfer failed: %v", err)
+	}
+
+	tx := newTestTransaction(t, payer, primaryIx, splitIx)
+	if err := verifyTransfersAgainstChallenge(tx, 1000, mint.String(), recipient, "", protocol.MethodDetails{
+		Splits: []protocol.Split{{Recipient: splitRecipient.String(), Amount: "200", Memo: "platform fee"}},
+	}); err == nil {
+		t.Fatal("expected missing SPL split memo to fail")
+	}
+}
+
+func TestVerifyTransfersAgainstChallengeRejectsUnexpectedSPLMemo(t *testing.T) {
+	payer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey()
+	mint := testutil.NewPrivateKey().PublicKey()
+
+	sourceATA, err := solanautil.FindAssociatedTokenAddressWithProgram(payer.PublicKey(), mint, solana.TokenProgramID)
+	if err != nil {
+		t.Fatalf("find source ata failed: %v", err)
+	}
+	recipientATA, err := solanautil.FindAssociatedTokenAddressWithProgram(recipient, mint, solana.TokenProgramID)
+	if err != nil {
+		t.Fatalf("find recipient ata failed: %v", err)
+	}
+
+	primaryIx, err := token.NewTransferCheckedInstruction(
+		1000,
+		6,
+		sourceATA,
+		mint,
+		recipientATA,
+		payer.PublicKey(),
+		nil,
+	).ValidateAndBuild()
+	if err != nil {
+		t.Fatalf("build primary transfer failed: %v", err)
+	}
+	memoIx, err := solanautil.BuildMemoInstruction("unexpected")
+	if err != nil {
+		t.Fatalf("build memo failed: %v", err)
+	}
+
+	tx := newTestTransaction(t, payer, primaryIx, memoIx)
+	if err := verifyTransfersAgainstChallenge(tx, 1000, mint.String(), recipient, "", protocol.MethodDetails{}); err == nil {
+		t.Fatal("expected unexpected SPL memo to fail")
+	}
+}
+
 func TestVerifyTransfersAgainstChallengeRejectsWrongSPLMint(t *testing.T) {
 	payer := testutil.NewPrivateKey()
 	recipient := testutil.NewPrivateKey().PublicKey()
@@ -676,6 +765,21 @@ func TestVerifyCredentialMissingTransactionData(t *testing.T) {
 	}
 	if _, err := handler.VerifyCredential(context.Background(), credential); err == nil {
 		t.Fatal("expected error for missing transaction data")
+	}
+}
+
+func TestVerifyCredentialMalformedTransactionData(t *testing.T) {
+	handler, _, _ := newTestMpp(t)
+	challenge, _ := handler.Charge(context.Background(), "0.001")
+	credential, err := mpp.NewPaymentCredential(challenge.ToEcho(), map[string]string{
+		"type":        "transaction",
+		"transaction": "not-base64",
+	})
+	if err != nil {
+		t.Fatalf("credential failed: %v", err)
+	}
+	if _, err := handler.VerifyCredential(context.Background(), credential); err == nil {
+		t.Fatal("expected error for malformed transaction data")
 	}
 }
 


### PR DESCRIPTION
## What
- align Go charge request encoding with the TypeScript/Rust interop shape
- expose split ATA creation policy in Go charge metadata
- add Go charge parity tests for splits, cross-route replay, token program handling, transport fallback, and server verification edge cases
- preserve large JSON numbers during canonical challenge-request encoding
- enforce Go SDK/library coverage in CI at 90% and still run all Go packages

## Why
This follows the M1 language checklist: implementation first, then Rust/TypeScript-aligned tests, then CI coverage signal. The Go interop server adapter is already split into #80, so this PR keeps the SDK behavior and coverage changes reviewable without duplicating that adapter PR.

## Verified
- `GOTOOLCHAIN=go1.26.1 go test ./...`
- `GOTOOLCHAIN=go1.26.1 go test github.com/solana-foundation/mpp-sdk/go github.com/solana-foundation/mpp-sdk/go/client github.com/solana-foundation/mpp-sdk/go/internal/solanautil github.com/solana-foundation/mpp-sdk/go/protocol github.com/solana-foundation/mpp-sdk/go/protocol/core github.com/solana-foundation/mpp-sdk/go/protocol/intents github.com/solana-foundation/mpp-sdk/go/server -coverprofile=coverage.out -covermode=atomic`
- `./scripts/check_coverage.sh coverage.out 90` (90.2%)
- CI is rerunning after review-feedback fixes