### PR TITLE
feat(kotlin): add charge client credential core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,22 @@ jobs:
           name: go-coverage
           path: go/coverage.out
 
+  test-kotlin:
+    name: Kotlin tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: "9.5.1"
+      - name: Run tests
+        working-directory: kotlin
+        run: gradle test
+
   integration:
     name: Integration tests
     needs: build-html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,9 +223,18 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "9.5.1"
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: kotlin
-        run: gradle test
+        run: gradle test jacocoTestReport
+      - name: Upload Kotlin coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kotlin-coverage
+          path: |
+            kotlin/build/reports/jacoco/test/jacocoTestReport.xml
+            kotlin/build/reports/jacoco/test/html/
+          if-no-files-found: ignore
 
   integration:
     name: Integration tests

--- a/kotlin/.gitignore
+++ b/kotlin/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,31 @@
+# Solana MPP Kotlin SDK
+
+Kotlin support currently provides the MPP charge client protocol core:
+
+- parse `WWW-Authenticate: Payment ...` charge challenges
+- decode Solana charge request payloads
+- build pull-mode `Authorization: Payment ...` credentials
+- inject a transaction provider for wallet or application-specific signing
+
+The package does not pick an Android wallet dependency yet. Android integrations can connect this boundary to Solana Mobile Wallet Adapter or another signing stack while the SDK keeps the MPP challenge and credential contract aligned with TypeScript and Rust.
+
+## Build
+
+```sh
+gradle test
+```
+
+## Usage
+
+```kotlin
+import com.solana.mpp.ChargeCredentialBuilder
+import com.solana.mpp.MppHeaders
+import com.solana.mpp.StaticChargeTransactionProvider
+
+val challenge = MppHeaders.parseWWWAuthenticate(wwwAuthenticateHeader)
+val builder = ChargeCredentialBuilder(
+    StaticChargeTransactionProvider("signed-base64-transaction")
+)
+
+val authorization = builder.authorizationHeader(challenge)
+```

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -6,8 +6,11 @@ Kotlin support currently provides the MPP charge client protocol core:
 - decode Solana charge request payloads
 - build pull-mode `Authorization: Payment ...` credentials
 - inject a transaction provider for wallet or application-specific signing
+- model a small JVM `SolanaSigner` boundary for wallet-backed signing
 
-The package does not pick an Android wallet dependency yet. Android integrations can connect this boundary to Solana Mobile Wallet Adapter or another signing stack while the SDK keeps the MPP challenge and credential contract aligned with TypeScript and Rust.
+The package does not pick an Android wallet dependency yet. Android integrations can connect the signer boundary to Solana Mobile Wallet Adapter or another signing stack while the SDK keeps the MPP challenge and credential contract aligned with TypeScript and Rust.
+
+`MemorySigner` uses JDK Ed25519 and is intended for tests and local development only. It is not a wallet, key-management layer, or Solana transaction builder.
 
 ## Build
 
@@ -19,12 +22,20 @@ gradle test
 
 ```kotlin
 import com.solana.mpp.ChargeCredentialBuilder
+import com.solana.mpp.ChargeTransactionProvider
+import com.solana.mpp.Base64Url
+import com.solana.mpp.MemorySigner
 import com.solana.mpp.MppHeaders
-import com.solana.mpp.StaticChargeTransactionProvider
 
 val challenge = MppHeaders.parseWWWAuthenticate(wwwAuthenticateHeader)
+val signer = MemorySigner.generate()
 val builder = ChargeCredentialBuilder(
-    StaticChargeTransactionProvider("signed-base64-transaction")
+    ChargeTransactionProvider { request ->
+        // Build the Solana transaction with your wallet/application code, then
+        // sign the transaction message through the signer boundary.
+        val transactionMessage = "${request.externalId}:${request.recipient}:${signer.address}".encodeToByteArray()
+        Base64Url.encode(signer.sign(transactionMessage))
+    }
 )
 
 val authorization = builder.authorizationHeader(challenge)

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -12,10 +12,23 @@ The package does not pick an Android wallet dependency yet. Android integrations
 
 `MemorySigner` uses JDK Ed25519 and is intended for tests and local development only. It is not a wallet, key-management layer, or Solana transaction builder.
 
+## Solana Mobile integration
+
+For Android applications, keep this package as the MPP protocol layer and add the official Solana Mobile dependencies in the app or adapter module:
+
+```kotlin
+implementation("com.solanamobile:mobile-wallet-adapter-clientlib-ktx:2.0.3")
+implementation("com.solanamobile:web3-solana:0.2.5")
+implementation("com.solanamobile:rpc-core:0.2.7")
+implementation("io.github.funkatronics:multimult:0.2.3")
+```
+
+`mobile-wallet-adapter-clientlib-ktx` is the right boundary for connecting to MWA-compatible wallets. `web3-solana` and `rpc-core` are useful for transaction construction and RPC in an Android app. They are intentionally not runtime dependencies of the core MPP package yet so non-Android JVM users can parse challenges and build credentials without pulling in a wallet stack.
+
 ## Build
 
 ```sh
-gradle test
+gradle check
 ```
 
 ## Usage

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm") version "2.3.21"
     kotlin("plugin.serialization") version "2.3.21"
+    jacoco
 }
 
 group = "com.solana.mpp"
@@ -17,4 +18,13 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -28,3 +28,19 @@ tasks.jacocoTestReport {
         html.required = true
     }
 }
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                minimum = "0.90".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.serialization") version "2.3.21"
+}
+
+group = "com.solana.mpp"
+version = "0.1.0"
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/kotlin/settings.gradle.kts
+++ b/kotlin/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "solana-mpp-kotlin"

--- a/kotlin/src/main/kotlin/com/solana/mpp/Base64Url.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Base64Url.kt
@@ -1,0 +1,15 @@
+package com.solana.mpp
+
+import java.util.Base64
+
+internal object Base64Url {
+    fun encode(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    fun decode(value: String): ByteArray =
+        try {
+            Base64.getUrlDecoder().decode(value)
+        } catch (error: IllegalArgumentException) {
+            throw MppException.InvalidBase64Url(error)
+        }
+}

--- a/kotlin/src/main/kotlin/com/solana/mpp/Charge.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Charge.kt
@@ -4,10 +4,6 @@ fun interface ChargeTransactionProvider {
     fun buildTransaction(request: ChargeRequest): String
 }
 
-class StaticChargeTransactionProvider(private val transaction: String) : ChargeTransactionProvider {
-    override fun buildTransaction(request: ChargeRequest): String = transaction
-}
-
 class ChargeCredentialBuilder(private val transactionProvider: ChargeTransactionProvider) {
     fun authorizationHeader(challenge: PaymentChallenge): String {
         challenge.requireSolanaCharge()

--- a/kotlin/src/main/kotlin/com/solana/mpp/Charge.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Charge.kt
@@ -1,10 +1,14 @@
 package com.solana.mpp
 
+/** Builds a signed Solana transaction for a decoded MPP charge request. */
 fun interface ChargeTransactionProvider {
+    /** Returns the signed base64 transaction for the provided charge request. */
     fun buildTransaction(request: ChargeRequest): String
 }
 
+/** Creates MPP Authorization credentials from Solana charge challenges. */
 class ChargeCredentialBuilder(private val transactionProvider: ChargeTransactionProvider) {
+    /** Builds an `Authorization: Payment ...` header for a Solana charge challenge. */
     fun authorizationHeader(challenge: PaymentChallenge): String {
         challenge.requireSolanaCharge()
 

--- a/kotlin/src/main/kotlin/com/solana/mpp/Charge.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Charge.kt
@@ -1,0 +1,23 @@
+package com.solana.mpp
+
+fun interface ChargeTransactionProvider {
+    fun buildTransaction(request: ChargeRequest): String
+}
+
+class StaticChargeTransactionProvider(private val transaction: String) : ChargeTransactionProvider {
+    override fun buildTransaction(request: ChargeRequest): String = transaction
+}
+
+class ChargeCredentialBuilder(private val transactionProvider: ChargeTransactionProvider) {
+    fun authorizationHeader(challenge: PaymentChallenge): String {
+        challenge.requireSolanaCharge()
+
+        val transaction = transactionProvider.buildTransaction(challenge.chargeRequest())
+        return MppHeaders.formatAuthorization(
+            PaymentCredential(
+                challenge = challenge.echo(),
+                payload = CredentialPayload.transaction(transaction),
+            )
+        )
+    }
+}

--- a/kotlin/src/main/kotlin/com/solana/mpp/Headers.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Headers.kt
@@ -3,7 +3,9 @@ package com.solana.mpp
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
+/** Parses and formats MPP HTTP Payment headers. */
 object MppHeaders {
+    /** HTTP authentication scheme used by MPP. */
     const val PAYMENT_SCHEME = "Payment"
 
     private val json = Json {
@@ -11,6 +13,7 @@ object MppHeaders {
         explicitNulls = false
     }
 
+    /** Parses a `WWW-Authenticate: Payment ...` challenge header. */
     fun parseWWWAuthenticate(header: String): PaymentChallenge {
         val rest = paymentSchemePayload(header)
         val params = parseAuthParams(rest)
@@ -30,6 +33,7 @@ object MppHeaders {
         }
     }
 
+    /** Formats an `Authorization: Payment ...` credential header. */
     fun formatAuthorization(credential: PaymentCredential): String {
         val encoded = Base64Url.encode(json.encodeToString(credential).encodeToByteArray())
         return "$PAYMENT_SCHEME $encoded"

--- a/kotlin/src/main/kotlin/com/solana/mpp/Headers.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Headers.kt
@@ -75,6 +75,7 @@ object MppHeaders {
 
             val decoded = StringBuilder()
             var escaped = false
+            var closed = false
             while (index < value.length) {
                 val char = value[index]
                 index += 1
@@ -84,10 +85,14 @@ object MppHeaders {
                         escaped = false
                     }
                     char == '\\' -> escaped = true
-                    char == '"' -> break
+                    char == '"' -> {
+                        closed = true
+                        break
+                    }
                     else -> decoded.append(char)
                 }
             }
+            if (!closed || escaped) throw MppException.InvalidHeader
             params[key] = decoded.toString()
         }
 

--- a/kotlin/src/main/kotlin/com/solana/mpp/Headers.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Headers.kt
@@ -1,0 +1,96 @@
+package com.solana.mpp
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+object MppHeaders {
+    const val PAYMENT_SCHEME = "Payment"
+
+    private val json = Json {
+        encodeDefaults = false
+        explicitNulls = false
+    }
+
+    fun parseWWWAuthenticate(header: String): PaymentChallenge {
+        val rest = paymentSchemePayload(header)
+        val params = parseAuthParams(rest)
+        val request = params["request"] ?: throw MppException.MissingField("request")
+
+        return PaymentChallenge(
+            id = params["id"] ?: throw MppException.MissingField("id"),
+            realm = params["realm"] ?: throw MppException.MissingField("realm"),
+            method = params["method"] ?: throw MppException.MissingField("method"),
+            intent = params["intent"] ?: throw MppException.MissingField("intent"),
+            request = request,
+            expires = params["expires"],
+            digest = params["digest"],
+            opaque = params["opaque"],
+        ).also {
+            Base64Url.decode(request)
+        }
+    }
+
+    fun formatAuthorization(credential: PaymentCredential): String {
+        val encoded = Base64Url.encode(json.encodeToString(credential).encodeToByteArray())
+        return "$PAYMENT_SCHEME $encoded"
+    }
+
+    internal fun decodeChargeRequest(request: String): ChargeRequest =
+        try {
+            json.decodeFromString<ChargeRequest>(Base64Url.decode(request).decodeToString())
+        } catch (error: IllegalArgumentException) {
+            throw MppException.InvalidJson(error)
+        }
+
+    private fun paymentSchemePayload(header: String): String {
+        val trimmed = header.trim()
+        if (!trimmed.startsWith(PAYMENT_SCHEME, ignoreCase = true)) {
+            throw MppException.InvalidPaymentScheme
+        }
+        return trimmed.drop(PAYMENT_SCHEME.length).trim()
+    }
+
+    private fun parseAuthParams(value: String): Map<String, String> {
+        val params = mutableMapOf<String, String>()
+        var index = 0
+
+        while (index < value.length) {
+            while (index < value.length && (value[index].isWhitespace() || value[index] == ',')) {
+                index += 1
+            }
+            if (index >= value.length) break
+
+            val keyStart = index
+            while (index < value.length && value[index] != '=') {
+                index += 1
+            }
+            if (index >= value.length) throw MppException.InvalidHeader
+            val key = value.substring(keyStart, index).trim()
+            index += 1
+
+            if (index >= value.length || value[index] != '"') {
+                throw MppException.InvalidHeader
+            }
+            index += 1
+
+            val decoded = StringBuilder()
+            var escaped = false
+            while (index < value.length) {
+                val char = value[index]
+                index += 1
+                when {
+                    escaped -> {
+                        decoded.append(char)
+                        escaped = false
+                    }
+                    char == '\\' -> escaped = true
+                    char == '"' -> break
+                    else -> decoded.append(char)
+                }
+            }
+            params[key] = decoded.toString()
+        }
+
+        return params
+    }
+}

--- a/kotlin/src/main/kotlin/com/solana/mpp/Models.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Models.kt
@@ -1,0 +1,107 @@
+package com.solana.mpp
+
+import kotlinx.serialization.Serializable
+
+sealed class MppException(message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause) {
+    class InvalidBase64Url(cause: Throwable? = null) : MppException("invalid base64url value", cause)
+    object InvalidHeader : MppException("invalid Payment header")
+    class InvalidJson(cause: Throwable? = null) : MppException("invalid JSON payload", cause)
+    object InvalidPaymentScheme : MppException("expected Payment scheme")
+    class MissingField(field: String) : MppException("missing required field: $field")
+    class UnsupportedChallenge(method: String, intent: String) :
+        MppException("unsupported challenge: method=$method intent=$intent")
+}
+
+@Serializable
+data class PaymentChallenge(
+    val id: String,
+    val realm: String,
+    val method: String,
+    val intent: String,
+    val request: String,
+    val expires: String? = null,
+    val digest: String? = null,
+    val opaque: String? = null,
+) {
+    fun chargeRequest(): ChargeRequest = MppHeaders.decodeChargeRequest(request)
+
+    fun requireSolanaCharge() {
+        if (method != "solana" || intent != "charge") {
+            throw MppException.UnsupportedChallenge(method, intent)
+        }
+    }
+
+    fun echo(): ChallengeEcho =
+        ChallengeEcho(
+            id = id,
+            realm = realm,
+            method = method,
+            intent = intent,
+            request = request,
+            expires = expires,
+            digest = digest,
+            opaque = opaque,
+        )
+}
+
+@Serializable
+data class ChallengeEcho(
+    val id: String,
+    val realm: String,
+    val method: String,
+    val intent: String,
+    val request: String,
+    val expires: String? = null,
+    val digest: String? = null,
+    val opaque: String? = null,
+)
+
+@Serializable
+data class ChargeRequest(
+    val amount: String,
+    val currency: String,
+    val recipient: String,
+    val externalId: String? = null,
+    val methodDetails: SolanaChargeMethodDetails,
+)
+
+@Serializable
+data class SolanaChargeMethodDetails(
+    val network: String? = null,
+    val decimals: Int? = null,
+    val feePayer: Boolean? = null,
+    val feePayerKey: String? = null,
+    val recentBlockhash: String? = null,
+    val splits: List<SolanaChargeSplit>? = null,
+    val tokenProgram: String? = null,
+)
+
+@Serializable
+data class SolanaChargeSplit(
+    val recipient: String,
+    val amount: String,
+    val ataCreationRequired: Boolean? = null,
+    val memo: String? = null,
+)
+
+@Serializable
+data class PaymentCredential(
+    val challenge: ChallengeEcho,
+    val payload: CredentialPayload,
+    val source: String? = null,
+)
+
+@Serializable
+data class CredentialPayload(
+    val type: String,
+    val transaction: String? = null,
+    val signature: String? = null,
+) {
+    companion object {
+        fun transaction(transaction: String): CredentialPayload =
+            CredentialPayload(type = "transaction", transaction = transaction)
+
+        fun signature(signature: String): CredentialPayload =
+            CredentialPayload(type = "signature", signature = signature)
+    }
+}

--- a/kotlin/src/main/kotlin/com/solana/mpp/Models.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/Models.kt
@@ -2,6 +2,7 @@ package com.solana.mpp
 
 import kotlinx.serialization.Serializable
 
+/** Base exception hierarchy for Kotlin MPP SDK failures. */
 sealed class MppException(message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause) {
     class InvalidBase64Url(cause: Throwable? = null) : MppException("invalid base64url value", cause)
     object InvalidHeader : MppException("invalid Payment header")
@@ -12,6 +13,7 @@ sealed class MppException(message: String? = null, cause: Throwable? = null) : R
         MppException("unsupported challenge: method=$method intent=$intent")
 }
 
+/** Parsed MPP `WWW-Authenticate` challenge. */
 @Serializable
 data class PaymentChallenge(
     val id: String,
@@ -23,14 +25,17 @@ data class PaymentChallenge(
     val digest: String? = null,
     val opaque: String? = null,
 ) {
+    /** Decodes this challenge's request as a Solana charge request. */
     fun chargeRequest(): ChargeRequest = MppHeaders.decodeChargeRequest(request)
 
+    /** Fails unless this challenge targets the Solana charge intent. */
     fun requireSolanaCharge() {
         if (method != "solana" || intent != "charge") {
             throw MppException.UnsupportedChallenge(method, intent)
         }
     }
 
+    /** Creates the challenge echo included in an MPP credential. */
     fun echo(): ChallengeEcho =
         ChallengeEcho(
             id = id,
@@ -44,6 +49,7 @@ data class PaymentChallenge(
         )
 }
 
+/** Challenge fields echoed inside a client credential. */
 @Serializable
 data class ChallengeEcho(
     val id: String,
@@ -56,6 +62,7 @@ data class ChallengeEcho(
     val opaque: String? = null,
 )
 
+/** Solana charge request payload encoded in the challenge `request` field. */
 @Serializable
 data class ChargeRequest(
     val amount: String,
@@ -65,6 +72,7 @@ data class ChargeRequest(
     val methodDetails: SolanaChargeMethodDetails,
 )
 
+/** Solana-specific method details for a charge request. */
 @Serializable
 data class SolanaChargeMethodDetails(
     val network: String? = null,
@@ -76,6 +84,7 @@ data class SolanaChargeMethodDetails(
     val tokenProgram: String? = null,
 )
 
+/** Split transfer target for a Solana charge request. */
 @Serializable
 data class SolanaChargeSplit(
     val recipient: String,
@@ -84,6 +93,7 @@ data class SolanaChargeSplit(
     val memo: String? = null,
 )
 
+/** MPP credential submitted in the `Authorization` header. */
 @Serializable
 data class PaymentCredential(
     val challenge: ChallengeEcho,
@@ -91,6 +101,7 @@ data class PaymentCredential(
     val source: String? = null,
 )
 
+/** Credential payload carrying either a signed transaction or signature. */
 @Serializable
 data class CredentialPayload(
     val type: String,
@@ -98,9 +109,11 @@ data class CredentialPayload(
     val signature: String? = null,
 ) {
     companion object {
+        /** Creates a transaction credential payload. */
         fun transaction(transaction: String): CredentialPayload =
             CredentialPayload(type = "transaction", transaction = transaction)
 
+        /** Creates a signature credential payload. */
         fun signature(signature: String): CredentialPayload =
             CredentialPayload(type = "signature", signature = signature)
     }

--- a/kotlin/src/main/kotlin/com/solana/mpp/SolanaSigner.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/SolanaSigner.kt
@@ -6,11 +6,16 @@ import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.Signature
 
+/** Signs Solana messages or transaction messages for MPP credential builders. */
 interface SolanaSigner {
+    /** Base64url-encoded raw 32-byte Ed25519 public key. */
     val publicKey: String
+
+    /** Address alias used by wallet adapters that expose a Solana account string. */
     val address: String
         get() = publicKey
 
+    /** Returns an Ed25519 signature for the provided message bytes. */
     fun sign(message: ByteArray): ByteArray
 }
 
@@ -24,6 +29,7 @@ class MemorySigner private constructor(
     private val privateKey: PrivateKey,
     override val publicKey: String,
 ) : SolanaSigner {
+    /** Signs the provided message with this in-memory Ed25519 key pair. */
     override fun sign(message: ByteArray): ByteArray {
         val signature = Signature.getInstance(ED25519)
         signature.initSign(privateKey)
@@ -37,18 +43,20 @@ class MemorySigner private constructor(
             0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
         )
 
+        /** Generates a new in-memory Ed25519 signer for tests or local examples. */
         fun generate(): MemorySigner {
             val keyPair = KeyPairGenerator.getInstance(ED25519).generateKeyPair()
             return fromKeyPair(keyPair)
         }
 
+        /** Creates a memory signer from a JDK Ed25519 key pair. */
         fun fromKeyPair(keyPair: KeyPair): MemorySigner =
             MemorySigner(
                 privateKey = keyPair.private,
                 publicKey = Base64Url.encode(rawEd25519PublicKey(keyPair.public)),
             )
 
-        private fun rawEd25519PublicKey(publicKey: PublicKey): ByteArray {
+        internal fun rawEd25519PublicKey(publicKey: PublicKey): ByteArray {
             val encoded = publicKey.encoded
             require(encoded.size == ED25519_X509_PREFIX.size + 32) { "expected Ed25519 X.509 public key" }
             require(encoded.copyOfRange(0, ED25519_X509_PREFIX.size).contentEquals(ED25519_X509_PREFIX)) {

--- a/kotlin/src/main/kotlin/com/solana/mpp/SolanaSigner.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/SolanaSigner.kt
@@ -3,6 +3,7 @@ package com.solana.mpp
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.PrivateKey
+import java.security.PublicKey
 import java.security.Signature
 
 interface SolanaSigner {
@@ -32,6 +33,9 @@ class MemorySigner private constructor(
 
     companion object {
         private const val ED25519 = "Ed25519"
+        private val ED25519_X509_PREFIX = byteArrayOf(
+            0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+        )
 
         fun generate(): MemorySigner {
             val keyPair = KeyPairGenerator.getInstance(ED25519).generateKeyPair()
@@ -41,7 +45,16 @@ class MemorySigner private constructor(
         fun fromKeyPair(keyPair: KeyPair): MemorySigner =
             MemorySigner(
                 privateKey = keyPair.private,
-                publicKey = Base64Url.encode(keyPair.public.encoded),
+                publicKey = Base64Url.encode(rawEd25519PublicKey(keyPair.public)),
             )
+
+        private fun rawEd25519PublicKey(publicKey: PublicKey): ByteArray {
+            val encoded = publicKey.encoded
+            require(encoded.size == ED25519_X509_PREFIX.size + 32) { "expected Ed25519 X.509 public key" }
+            require(encoded.copyOfRange(0, ED25519_X509_PREFIX.size).contentEquals(ED25519_X509_PREFIX)) {
+                "expected Ed25519 X.509 public key"
+            }
+            return encoded.copyOfRange(ED25519_X509_PREFIX.size, encoded.size)
+        }
     }
 }

--- a/kotlin/src/main/kotlin/com/solana/mpp/SolanaSigner.kt
+++ b/kotlin/src/main/kotlin/com/solana/mpp/SolanaSigner.kt
@@ -1,0 +1,47 @@
+package com.solana.mpp
+
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Signature
+
+interface SolanaSigner {
+    val publicKey: String
+    val address: String
+        get() = publicKey
+
+    fun sign(message: ByteArray): ByteArray
+}
+
+/**
+ * In-memory Ed25519 signer for tests and local development.
+ *
+ * Production Solana wallet integrations should provide their own SolanaSigner
+ * backed by a wallet, keychain, HSM, or mobile signing adapter.
+ */
+class MemorySigner private constructor(
+    private val privateKey: PrivateKey,
+    override val publicKey: String,
+) : SolanaSigner {
+    override fun sign(message: ByteArray): ByteArray {
+        val signature = Signature.getInstance(ED25519)
+        signature.initSign(privateKey)
+        signature.update(message)
+        return signature.sign()
+    }
+
+    companion object {
+        private const val ED25519 = "Ed25519"
+
+        fun generate(): MemorySigner {
+            val keyPair = KeyPairGenerator.getInstance(ED25519).generateKeyPair()
+            return fromKeyPair(keyPair)
+        }
+
+        fun fromKeyPair(keyPair: KeyPair): MemorySigner =
+            MemorySigner(
+                privateKey = keyPair.private,
+                publicKey = Base64Url.encode(keyPair.public.encoded),
+            )
+    }
+}

--- a/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
@@ -41,6 +41,26 @@ class ChargeCredentialTest {
     }
 
     @Test
+    fun transactionProviderCanUseSolanaSigner() {
+        val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader())
+        val signer = MemorySigner.generate()
+        val builder = ChargeCredentialBuilder(
+            ChargeTransactionProvider { request ->
+                val message = "${request.externalId}:${request.recipient}:${signer.address}".encodeToByteArray()
+                Base64Url.encode(signer.sign(message))
+            }
+        )
+
+        val encoded = builder.authorizationHeader(challenge).removePrefix("Payment ")
+        val credential = Json.decodeFromString<PaymentCredential>(
+            Base64Url.decode(encoded).decodeToString(),
+        )
+
+        assertEquals("transaction", credential.payload.type)
+        assertTrue(credential.payload.transaction?.isNotBlank() == true)
+    }
+
+    @Test
     fun rejectsUnsupportedIntent() {
         val challenge = PaymentChallenge(
             id = "challenge-2",

--- a/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import java.security.KeyPairGenerator
+import java.security.PublicKey
 
 class ChargeCredentialTest {
     @Test
@@ -102,11 +103,101 @@ class ChargeCredentialTest {
     }
 
     @Test
+    fun rejectsInvalidPaymentScheme() {
+        assertFailsWith<MppException.InvalidPaymentScheme> {
+            MppHeaders.parseWWWAuthenticate("""Bearer id="challenge-5"""")
+        }
+    }
+
+    @Test
+    fun rejectsMissingRequiredChallengeFields() {
+        assertFailsWith<MppException.MissingField> {
+            MppHeaders.parseWWWAuthenticate(
+                """Payment id="challenge-6", realm="MPP Payment", method="solana", request="${encodedRequest()}"""",
+            )
+        }
+    }
+
+    @Test
+    fun rejectsInvalidChargeRequestJson() {
+        val encoded = Base64Url.encode("not json".encodeToByteArray())
+
+        assertFailsWith<MppException.InvalidJson> {
+            MppHeaders.parseWWWAuthenticate(
+                """Payment id="challenge-7", realm="MPP Payment", method="solana", intent="charge", request="$encoded"""",
+            ).chargeRequest()
+        }
+    }
+
+    @Test
+    fun parsesOptionalChallengeFieldsAndSignaturePayload() {
+        val header = """Payment id="challenge-8", realm="MPP \"Payment\"", method="solana", intent="charge", request="${encodedRequest()}", digest="sha-256=:abc:", opaque="route-1""""
+        val challenge = MppHeaders.parseWWWAuthenticate(header)
+        val credential = PaymentCredential(
+            challenge = challenge.echo(),
+            payload = CredentialPayload.signature("sig"),
+            source = "did:pkh:solana:test",
+        )
+        val decoded = Json.decodeFromString<PaymentCredential>(
+            Base64Url.decode(MppHeaders.formatAuthorization(credential).removePrefix("Payment ")).decodeToString(),
+        )
+
+        assertEquals("""MPP "Payment"""", challenge.realm)
+        assertEquals("sha-256=:abc:", challenge.digest)
+        assertEquals("route-1", challenge.opaque)
+        assertEquals("sig", decoded.payload.signature)
+        assertEquals("did:pkh:solana:test", decoded.source)
+    }
+
+    @Test
     fun rejectsUnterminatedQuotedAuthParam() {
         assertFailsWith<MppException.InvalidHeader> {
             MppHeaders.parseWWWAuthenticate(
                 """Payment id="challenge-4", realm="MPP Payment", method="solana", intent="charge", request="${encodedRequest()}""",
             )
+        }
+    }
+
+    @Test
+    fun rejectsUnquotedAuthParam() {
+        assertFailsWith<MppException.InvalidHeader> {
+            MppHeaders.parseWWWAuthenticate(
+                """Payment id="challenge-9", realm="MPP Payment", method="solana", intent="charge", request=${encodedRequest()}""",
+            )
+        }
+    }
+
+    @Test
+    fun rejectsTrailingEscapeInQuotedAuthParam() {
+        assertFailsWith<MppException.InvalidHeader> {
+            MppHeaders.parseWWWAuthenticate(
+                """Payment id="challenge-10", realm="MPP Payment", method="solana", intent="charge", request="${encodedRequest()}\""",
+            )
+        }
+    }
+
+    @Test
+    fun rejectsNonEd25519MemorySignerPublicKey() {
+        val keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair()
+
+        assertFailsWith<IllegalArgumentException> {
+            MemorySigner.rawEd25519PublicKey(keyPair.public)
+        }
+    }
+
+    @Test
+    fun rejectsMalformedEd25519PublicKeyPrefix() {
+        val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+        val encoded = keyPair.public.encoded.clone()
+        encoded[0] = 0x31
+        val publicKey = object : PublicKey {
+            override fun getAlgorithm(): String = "Ed25519"
+            override fun getFormat(): String = "X.509"
+            override fun getEncoded(): ByteArray = encoded
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            MemorySigner.rawEd25519PublicKey(publicKey)
         }
     }
 

--- a/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
@@ -1,10 +1,13 @@
 package com.solana.mpp
 
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import java.security.KeyPairGenerator
 
 class ChargeCredentialTest {
     @Test
@@ -61,6 +64,19 @@ class ChargeCredentialTest {
     }
 
     @Test
+    fun memorySignerUsesRawEd25519PublicKeyBytes() {
+        val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+        val signer = MemorySigner.fromKeyPair(keyPair)
+        val publicKey = Base64Url.decode(signer.publicKey)
+        val derPublicKey = keyPair.public.encoded
+
+        assertEquals(32, publicKey.size)
+        assertNotEquals(Base64Url.encode(derPublicKey), signer.publicKey)
+        assertContentEquals(derPublicKey.copyOfRange(derPublicKey.size - 32, derPublicKey.size), publicKey)
+        assertEquals(signer.publicKey, signer.address)
+    }
+
+    @Test
     fun rejectsUnsupportedIntent() {
         val challenge = PaymentChallenge(
             id = "challenge-2",
@@ -83,6 +99,21 @@ class ChargeCredentialTest {
                 """Payment id="challenge-3", realm="MPP Payment", method="solana", intent="charge", request="@@@"""",
             )
         }
+    }
+
+    @Test
+    fun rejectsUnterminatedQuotedAuthParam() {
+        assertFailsWith<MppException.InvalidHeader> {
+            MppHeaders.parseWWWAuthenticate(
+                """Payment id="challenge-4", realm="MPP Payment", method="solana", intent="charge", request="${encodedRequest()}""",
+            )
+        }
+    }
+
+    private class StaticChargeTransactionProvider(
+        private val transaction: String,
+    ) : ChargeTransactionProvider {
+        override fun buildTransaction(request: ChargeRequest): String = transaction
     }
 
     private fun challengeHeader(): String =

--- a/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/mpp/ChargeCredentialTest.kt
@@ -1,0 +1,98 @@
+package com.solana.mpp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+class ChargeCredentialTest {
+    @Test
+    fun parsesChargeChallengeWithSplits() {
+        val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader())
+        val request = challenge.chargeRequest()
+
+        assertEquals("challenge-1", challenge.id)
+        assertEquals("solana", challenge.method)
+        assertEquals("charge", challenge.intent)
+        assertEquals("1000", request.amount)
+        assertEquals("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", request.currency)
+        assertEquals("localnet", request.methodDetails.network)
+        assertEquals("250", request.methodDetails.splits?.first()?.amount)
+        assertEquals(true, request.methodDetails.splits?.first()?.ataCreationRequired)
+    }
+
+    @Test
+    fun serializesPullModeAuthorizationCredential() {
+        val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader())
+        val builder = ChargeCredentialBuilder(StaticChargeTransactionProvider("base64-transaction"))
+
+        val header = builder.authorizationHeader(challenge)
+        assertTrue(header.startsWith("Payment "))
+
+        val encoded = header.removePrefix("Payment ")
+        val credential = Json.decodeFromString<PaymentCredential>(
+            Base64Url.decode(encoded).decodeToString(),
+        )
+
+        assertEquals(challenge.id, credential.challenge.id)
+        assertEquals(challenge.request, credential.challenge.request)
+        assertEquals(CredentialPayload.transaction("base64-transaction"), credential.payload)
+    }
+
+    @Test
+    fun rejectsUnsupportedIntent() {
+        val challenge = PaymentChallenge(
+            id = "challenge-2",
+            realm = "MPP Payment",
+            method = "solana",
+            intent = "session",
+            request = encodedRequest(),
+        )
+        val builder = ChargeCredentialBuilder(StaticChargeTransactionProvider("tx"))
+
+        assertFailsWith<MppException.UnsupportedChallenge> {
+            builder.authorizationHeader(challenge)
+        }
+    }
+
+    @Test
+    fun rejectsMalformedRequestBase64() {
+        assertFailsWith<MppException.InvalidBase64Url> {
+            MppHeaders.parseWWWAuthenticate(
+                """Payment id="challenge-3", realm="MPP Payment", method="solana", intent="charge", request="@@@"""",
+            )
+        }
+    }
+
+    private fun challengeHeader(): String =
+        """Payment id="challenge-1", realm="MPP Payment", method="solana", intent="charge", request="${encodedRequest()}", expires="2026-05-20T00:00:00Z""""
+
+    private fun encodedRequest(): String =
+        Base64Url.encode(
+            """
+            {
+              "amount": "1000",
+              "currency": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+              "recipient": "recipient11111111111111111111111111111111",
+              "externalId": "order-123",
+              "methodDetails": {
+                "network": "localnet",
+                "decimals": 6,
+                "feePayer": true,
+                "feePayerKey": "feePayer1111111111111111111111111111111",
+                "recentBlockhash": "blockhash11111111111111111111111111111111",
+                "splits": [
+                  {
+                    "recipient": "platform111111111111111111111111111111",
+                    "amount": "250",
+                    "ataCreationRequired": true,
+                    "memo": "interop split"
+                  }
+                ],
+                "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+              }
+            }
+            """.trimIndent().encodeToByteArray(),
+        )
+}


### PR DESCRIPTION
## What
- add a Kotlin/JVM package for MPP charge client credential construction
- parse Payment charge challenges and serialize pull-mode Authorization credentials
- add an injected Solana signer abstraction with a raw Ed25519 memory signer for tests
- harden header parsing and keep test-only transaction helpers out of the main API
- run Kotlin tests and upload Jacoco coverage artifacts in CI

## Why
M1 includes Kotlin client-side support for MPP charge. This keeps the first Kotlin surface narrow: challenge parsing, credential construction, and signer abstraction boundaries without choosing an Android wallet implementation. There is no Kotlin server or interop adapter in this PR; that is intentional for the client-only M1 scope.

## Verified
- `gradle test`
- local Jacoco report generation via Gradle
- CI is rerunning after review-feedback fixes