### PR TITLE
feat(ruby): add charge server parity and interop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,11 @@ jobs:
       - name: Install interop harness
         working-directory: tests/interop
         run: pnpm install --frozen-lockfile
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ruby
       - name: Typecheck interop harness
         working-directory: tests/interop
         run: pnpm typecheck
@@ -442,3 +447,15 @@ jobs:
         env:
           MPP_INTEROP_CLIENTS: rust
           MPP_INTEROP_SERVERS: rust
+      - name: Run Ruby server interop smoke
+        working-directory: tests/interop
+        run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "typescript client pays ruby server"
+        env:
+          MPP_INTEROP_CLIENTS: typescript
+          MPP_INTEROP_SERVERS: ruby
+      - name: Run Rust client to Ruby server interop smoke
+        working-directory: tests/interop
+        run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "rust client pays ruby server"
+        env:
+          MPP_INTEROP_CLIENTS: rust
+          MPP_INTEROP_SERVERS: ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,46 @@
+name: Ruby
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call:
+
+jobs:
+  test-ruby:
+    name: Ruby tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ruby
+      - name: Validate gemspec
+        working-directory: ruby
+        run: bundle exec ruby -e "Gem::Specification.load('solana-mpp.gemspec').validate"
+      - name: Lint
+        working-directory: ruby
+        run: bundle exec standardrb
+      - name: Audit dependencies
+        working-directory: ruby
+        run: bundle exec bundle-audit check --update
+      - name: Run tests with coverage
+        working-directory: ruby
+        env:
+          SURFPOOL_REPORT: "1"
+        run: COVERAGE=1 bundle exec ruby -Itest test/run.rb
+      - name: Upload Ruby coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ruby-coverage
+          path: ruby/coverage/.resultset.json
+      - name: Upload Ruby surfpool report data
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: surfpool-reports-ruby
+          path: ruby/target/surfpool-reports/
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Solana payment method for the [Machine Payments Protocol](https://mpp.dev).
 
 ## SDK Implementations
 
-The Solana MPP SDK is available in 5 languages. Every implementation follows the same protocol and is tested for cross-language interoperability.
+The Solana MPP SDK is available in 6 languages. Every implementation follows the same protocol and is tested for cross-language interoperability.
 
-| | TypeScript | Rust | Go | Python | Lua |
-|---|:---:|:---:|:---:|:---:|:---:|
-| **Package** | [@solana/mpp](https://www.npmjs.com/package/@solana/mpp) | — | — | — | — |
-| **Server (charge)** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Client (auto-402)** | ✅ | ✅ | ✅ | ✅ | — |
-| **Payment links** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Fee sponsorship** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Split payments** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **SPL tokens** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Token-2022** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Replay protection** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Session (pay-as-you-go)** | — | — | — | — | — |
+| | TypeScript | Rust | Go | Python | Lua | Ruby |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Package** | [@solana/mpp](https://www.npmjs.com/package/@solana/mpp) | — | — | — | — | — |
+| **Server (charge)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Client (auto-402)** | ✅ | ✅ | ✅ | ✅ | — | — |
+| **Payment links** | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| **Fee sponsorship** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Split payments** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **SPL tokens** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Token-2022** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Replay protection** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Session (pay-as-you-go)** | — | — | — | — | — | — |
 
 ### Testing
 
@@ -43,6 +43,7 @@ The interop harness can run a full client/server cross-product, but CI keeps the
    │  Go            │──────┼──────▶│  Go         :3002   │
    │  Python        │──────┤       │  Lua        :3003   │
    └────────────────┘      │       │  Python     :3004   │
+                           │       │  Ruby       :3005   │
                            │       └─────────┬──────────┘
                            │                 │
                            │          ┌──────┴───────┐
@@ -60,6 +61,7 @@ The interop harness can run a full client/server cross-product, but CI keeps the
 | Go | ![Go](https://img.shields.io/badge/coverage-84%25-green) | `just go-test` |
 | Python | ![Python](https://img.shields.io/badge/coverage-87%25-green) | `just py-test` |
 | Lua | ![Lua](https://img.shields.io/badge/coverage-41_tests-blue) | `just lua-test` |
+| Ruby | ![Ruby](https://img.shields.io/badge/coverage-98%25-green) | `just rb-test-cover` |
 | Interop | ![Interop](https://img.shields.io/badge/interop-TypeScript_harness-brightgreen) | `cd tests/interop && pnpm test` |
 
 See [`tests/interop/README.md`](tests/interop/README.md) for the process adapter contract used by the Surfpool-backed client/server matrix.
@@ -78,6 +80,9 @@ go get github.com/solana-foundation/mpp-sdk/go
 
 # Python
 pip install solana-mpp
+
+# Ruby
+cd ruby && bundle install
 ```
 
 ## Quick Start
@@ -223,7 +228,7 @@ See [demo/README.md](demo/README.md) for full details.
 ## Development
 
 ```bash
-just build            # Build all SDKs (html → ts → rust → go)
+just build            # Build all SDKs (html → ts → rust → go → ruby)
 just test             # Test all SDKs
 just pre-commit       # Full pre-commit checks
 
@@ -233,6 +238,7 @@ just rs-test          # Rust tests
 just go-test          # Go tests
 just py-test          # Python tests
 just lua-test         # Lua tests
+just rb-test-cover    # Ruby tests with line and branch coverage
 
 # Integration
 just html-build       # Build payment link assets

--- a/justfile
+++ b/justfile
@@ -141,6 +141,38 @@ php-lint:
 php-test-cover:
     cd php && just test-cover
 
+# ── Ruby ──
+# Recipes live in ruby/Justfile. The wrappers below keep root orchestration
+# aligned with the language-local gate.
+
+# Install Ruby SDK dependencies
+rb-install:
+    cd ruby && just install
+
+# Validate Ruby gemspec
+rb-build:
+    cd ruby && just build
+
+# Run Ruby unit tests
+rb-test:
+    cd ruby && just test
+
+# Format Ruby SDK
+rb-fmt:
+    cd ruby && just fmt
+
+# Lint Ruby SDK
+rb-lint:
+    cd ruby && just lint
+
+# Audit Ruby SDK dependencies
+rb-audit:
+    cd ruby && just audit
+
+# Run Ruby line and branch coverage gates
+rb-test-cover:
+    cd ruby && just test-cover
+
 # ── HTML Payment Links ──
 
 # Install HTML payment link dependencies
@@ -162,16 +194,16 @@ html-test-e2e:
 # ── Orchestration ──
 
 # Build compiled SDKs
-build: html-build ts-build rs-build go-build php-build
+build: html-build ts-build rs-build go-build php-build rb-build
 
 # Run all unit tests
-test: ts-test rs-test go-test lua-test py-test php-test
+test: ts-test rs-test go-test lua-test py-test php-test rb-test
 
 # Run all tests including integration + coverage gates
-test-all: ts-test ts-test-integration rs-test go-test-cover lua-test-cover py-test-cover php-test-cover
+test-all: ts-test ts-test-integration rs-test go-test-cover lua-test-cover py-test-cover php-test-cover rb-test-cover
 
 # Format everything
-fmt: ts-fmt rs-fmt go-fmt py-fmt php-fmt
+fmt: ts-fmt rs-fmt go-fmt py-fmt php-fmt rb-fmt
 
 # Pre-commit checks
-pre-commit: ts-audit ts-fmt ts-typecheck ts-test rs-fmt rs-lint rs-test go-fmt go-test-cover lua-test-cover py-lint py-test-cover php-lint php-test-cover
+pre-commit: ts-audit ts-fmt ts-typecheck ts-test rs-fmt rs-lint rs-test go-fmt go-test-cover lua-test-cover py-lint py-test-cover php-lint php-test-cover rb-lint rb-audit rb-test-cover

--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,0 +1,4 @@
+/.bundle/
+/coverage/
+/tmp/
+/vendor/bundle/

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,165 @@
+PATH
+  remote: .
+  specs:
+    solana-mpp (0.1.0)
+      base64 (~> 0.3)
+      ed25519 (~> 1.4)
+      json (~> 2.9)
+      net-http (~> 0.6)
+      puma (~> 7.1)
+      rack (~> 3.1)
+      rackup (~> 2.2)
+      sinatra (~> 4.2)
+      webrick (~> 1.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    base64 (0.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
+    docile (1.4.1)
+    ed25519 (1.4.0)
+    json (2.19.5)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    minitest (5.27.0)
+    mustermann (3.1.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nio4r (2.7.5)
+    parallel (1.28.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    puma (7.2.0)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.3.1)
+      rack (>= 3)
+    rainbow (3.1.1)
+    rake (13.4.2)
+    regexp_parser (2.12.0)
+    rubocop (1.84.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    standard (1.54.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.84.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.8)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.9.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.26.0)
+    thor (1.5.0)
+    tilt (2.7.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webrick (1.9.2)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+
+DEPENDENCIES
+  bundler-audit (~> 0.9)
+  minitest (~> 5.25)
+  rake (~> 13.2)
+  simplecov (~> 0.22)
+  solana-mpp!
+  standard (~> 1.43)
+
+CHECKSUMS
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
+  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rubocop (1.84.2) sha256=5692cea54168f3dc8cb79a6fe95c5424b7ea893c707ad7a4307b0585e88dbf5f
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  sinatra (4.2.1) sha256=b7aeb9b11d046b552972ade834f1f9be98b185fa8444480688e3627625377080
+  solana-mpp (0.1.0)
+  standard (1.54.0) sha256=7a4b08f83d9893083c8f03bc486f0feeb6a84d48233b40829c03ef4767ea0100
+  standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
+  standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+BUNDLED WITH
+  4.0.3

--- a/ruby/Justfile
+++ b/ruby/Justfile
@@ -1,0 +1,36 @@
+set shell := ["bash", "-uc"]
+
+default:
+    @just --list
+
+# Install Ruby dependencies.
+install:
+    bundle install
+
+# Validate the Ruby gemspec.
+build:
+    bundle exec ruby -e "Gem::Specification.load('solana-mpp.gemspec').validate"
+
+# Run the Ruby unit test suite.
+test:
+    bundle exec ruby -Itest test/run.rb
+
+# Run Standard Ruby in fix mode.
+fmt:
+    bundle exec standardrb --fix
+
+# Run Standard Ruby without modifying files.
+lint:
+    bundle exec standardrb
+
+# Run Bundler Audit.
+audit:
+    bundle exec bundle-audit check --update
+
+# Run tests with line and branch coverage gates, then refresh README badges.
+test-cover:
+    COVERAGE=1 bundle exec ruby -Itest test/run.rb
+    bundle exec ruby scripts/update_coverage_badge.rb coverage/.resultset.json README.md
+
+# Run all local Ruby gates.
+check: build lint audit test-cover

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,289 @@
+<p align="center">
+  <img src="https://github.com/solana-foundation/mpp-sdk/raw/main/assets/banner.png" alt="MPP" width="100%" />
+</p>
+
+# solana-mpp
+
+Solana payment method for the [Machine Payments Protocol](https://mpp.dev),
+for Ruby.
+
+**MPP** is [an open protocol proposal](https://paymentauth.org) that lets
+any HTTP API accept payments using the `402 Payment Required` flow.
+
+[![Ruby](https://img.shields.io/badge/ruby-3.2%2B-red)]()
+[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)]()
+[![Branch coverage](https://img.shields.io/badge/branch%20coverage-90%25-brightgreen)]()
+
+## Repo layout
+
+```text
+ruby/
+├── lib/solana_mpp/core/       # Payment headers, credentials, receipts, base64url JSON
+├── lib/solana_mpp/intent/     # Charge intent request model
+├── lib/solana_mpp/server/     # 402 challenge issuance, verification, settlement
+├── lib/solana_mpp/solana/     # Minimal Solana parser, signer, RPC, ATA helpers
+├── examples/                  # Simple server and Sinatra app examples
+└── test/                      # Minitest suite with line and branch coverage gates
+```
+
+## Quick start — server (charge)
+
+```ruby
+require "json"
+require "solana_mpp"
+
+rpc = SolanaMpp::Solana::RpcClient.new("https://402.surfnet.dev:8899")
+challenges = SolanaMpp::Server::ChargeServer.new(
+  secret_key: "local-dev-secret",
+  realm: "Ruby MPP Example"
+)
+handler = SolanaMpp::Server::ChargeHandler.new(
+  challenges: challenges,
+  rpc: rpc,
+  replay_store: SolanaMpp::MemoryStore.new,
+  network: "localnet"
+)
+request = SolanaMpp::Intent::ChargeRequest.new(
+  amount: "1000",
+  currency: "USDC",
+  recipient: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+  method_details: {
+    "network" => "localnet",
+    "decimals" => 6,
+    "tokenProgram" => SolanaMpp::Common::StablecoinMints.token_program_for("USDC", "localnet"),
+    "recentBlockhash" => rpc.latest_blockhash
+  }
+)
+
+result = handler.handle(ENV["HTTP_AUTHORIZATION"], request)
+puts result.status
+puts JSON.generate(result.body)
+```
+
+`SolanaMpp::Server::ChargeHandler#handle` returns either a
+`PaymentRequiredResponse` (402, missing/invalid credential) or a
+`ChargeSettlement` (200, with the on-chain signature). Both expose the same
+`status` / `headers` / `body` shape so the HTTP layer can project either path
+uniformly.
+
+## Quick start
+
+Launch the bare Ruby server from `examples/simple-server.rb`:
+
+```bash
+# Install dependencies
+bundle install
+
+# Launch server
+bundle exec ruby examples/simple-server.rb
+```
+
+In another terminal, send requests using `curl` and `pay`:
+
+```bash
+brew install pay
+
+# payment required
+curl http://localhost:4567/paid
+
+# payment successful
+pay curl http://localhost:4567/paid
+```
+
+For a Sinatra integration that wires the same SDK handler into a web app, see
+[`examples/sinatra-app.rb`](examples/sinatra-app.rb).
+
+## Client compatibility matrix
+
+Ruby is server-side only for the current MPP roadmap.
+
+| Intent | Status |
+|---|:---:|
+| `x402/exact` | — |
+| `x402/upto` | — |
+| `x402/batch-settlement` | — |
+| `mpp/charge/pull` | — |
+| `mpp/charge/push` | — |
+| `mpp/session` | — |
+| `mpp/subscription` | — |
+
+## Server compatibility matrix
+
+Split into two phases because an MPP server first verifies the credential and
+then settles or confirms the payment on-chain.
+
+| Intent | Status |
+|---|:---:|
+| `x402/exact` | — |
+| `x402/upto` | — |
+| `x402/batch-settlement` | — |
+| `mpp/charge/pull` | ✅ |
+| `mpp/charge/push` | ✅ |
+| `mpp/session` | — |
+| `mpp/subscription` | — |
+
+For `mpp/charge/pull`: `ChargeHandler` owns the full lifecycle — issue signed
+challenges with a fresh `recentBlockhash`, parse and validate the
+`Authorization: Payment` credential, pin the echoed `ChargeRequest`, decode the
+client-signed transaction and check recipient/amount/mint/splits/ATA/memos/
+compute budget, reject Surfpool-signed transactions on non-localnet networks,
+optionally fee-payer co-sign, broadcast via `sendTransaction`, poll
+`getSignatureStatuses` to `confirmed`/`finalized`, and emit `payment-receipt`
+with the on-chain signature.
+
+For `mpp/charge/push`: the handler fetches the transaction by signature with
+`getTransaction`, rejects failed or missing metadata, reuses the same structural
+transaction verifier as pull mode, consumes the signature through replay
+storage, and emits the same receipt shape.
+
+The direct Ruby interop server at
+[`tests/interop/ruby-server/server.rb`](../tests/interop/ruby-server/server.rb)
+exercises this end-to-end through Surfpool in CI for both TypeScript and Rust
+clients.
+
+## Roadmap
+
+- **Ruby client.** This PR is intentionally server-only. A future client pass
+  should construct credentials from a challenge, sign transactions, and run the
+  inverse interop direction against Rust and TypeScript servers.
+- **Framework integrations.** The current framework example is Sinatra. Future
+  examples can add Rails or Rack-native middleware adapters once the server API
+  is stable.
+- **Other intents.** `x402/*`, `mpp/session`, and `mpp/subscription` are not
+  scoped on the Ruby side.
+
+## How to use the library
+
+```bash
+cd ruby
+bundle install
+```
+
+```ruby
+require "solana_mpp"
+```
+
+Public surface is documented inline; every public type/function carries a
+summary so Ruby LSP hover can show intent, inputs, and outputs without
+round-tripping to source.
+
+## How to use the examples
+
+Two examples ship with this package:
+
+- [`examples/simple-server.rb`](examples/simple-server.rb) — a single-file Ruby
+  server demonstrating the raw protocol on top of the SDK helpers.
+- [`examples/sinatra-app.rb`](examples/sinatra-app.rb) — a Sinatra app with one
+  protected route using the same `ChargeHandler`.
+
+### Simple Ruby server
+
+```bash
+cd ruby
+bundle install
+bundle exec ruby examples/simple-server.rb
+
+# In another terminal:
+brew install pay
+
+# payment required
+curl -i http://127.0.0.1:4567/paid
+
+# payment successful
+pay curl http://127.0.0.1:4567/paid
+```
+
+The simple server defaults to Surfpool localnet (`https://402.surfnet.dev:8899`),
+`USDC`, and a local example recipient. Override `MPP_RPC_URL`, `MPP_MINT`,
+`MPP_PAY_TO`, `MPP_AMOUNT`, or `MPP_FEE_PAYER_SECRET_KEY` when you need a
+different localnet fixture.
+
+### Sinatra server
+
+```bash
+cd ruby
+bundle install
+PORT=4568 bundle exec ruby examples/sinatra-app.rb
+
+# Same curl / pay flow as above on port 4568.
+```
+
+Both examples expose one protected endpoint at `/paid`. Use the interop harness
+for the full Surfpool-backed transaction flow.
+
+## Solana dependencies
+
+| Dependency | Why | Version |
+|---|---|---|
+| `ed25519` | fee-payer transaction signing and PDA curve checks | `~> 1.4` |
+| `rack` | Rack integration surface used by Ruby web frameworks | `~> 3.1` |
+| `rackup` | Rack server launcher required by Sinatra 4 | `~> 2.2` |
+| `puma` | local Sinatra example server handler | `~> 7.1` |
+| `sinatra` | runnable local Sinatra app example | `~> 4.2` |
+| `webrick` | runnable local simple-server example | `~> 1.8` |
+| internal Base58 helper | avoid extra runtime dependency for account/signature encoding | in package |
+| internal canonical JSON helper | RFC 8785-style sorted JSON before base64url | in package |
+
+The Ruby server keeps Solana dependencies intentionally small. It parses legacy
+and v0 transaction messages, verifies transfer instructions structurally, signs
+optional fee-payer pull transactions, and uses JSON-RPC directly for
+simulation, submission, confirmation, and push-mode transaction lookup.
+
+## Coding convention
+
+This SDK follows Standard Ruby and the
+[`skills.sh/mindrally/skills/ruby`](https://skills.sh/mindrally/skills/ruby)
+best-practice skill selected for this PR. The implementation pass focuses on
+small objects, explicit errors, deterministic wire serialization, defensive
+payment verification, and branch/condition tests on security-sensitive paths.
+
+The repo-level `pay-sdk-implementation` skill remains the protocol source of
+truth: Rust/spec wire format first, Ruby idioms second. Stripe's `mpp-rb`
+package layout was used as Ruby ecosystem inspiration, not as protocol source
+truth.
+
+## Code coverage
+
+```bash
+cd ruby
+just lint
+just audit
+just test-cover
+```
+
+`just test-cover` runs SimpleCov with line and branch coverage enabled, enforces
+the local coverage gates, and refreshes the README badges from
+`coverage/.resultset.json`.
+
+Coverage gates:
+
+- line coverage: at least 92 percent
+- branch coverage: at least 90 percent
+
+The branch gate is still meaningful because the branch tests cover the payment
+verifier's critical decisions: valid/invalid credentials, cross-route replay,
+split accounting, ATA creation, compute budget limits, fee-payer abuse, pull
+settlement, push settlement, transaction failures, missing metadata, timeouts,
+and replay consumption.
+
+## Interop
+
+The Ruby server has a direct harness adapter at
+`tests/interop/ruby-server/server.rb`. It is server-side only in this pass.
+
+Focused harness commands:
+
+```bash
+cd tests/interop
+MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=ruby pnpm test
+MPP_INTEROP_CLIENTS=rust MPP_INTEROP_SERVERS=ruby pnpm test
+```
+
+## Spec
+
+This SDK implements the [Solana Charge Intent](https://github.com/tempoxyz/mpp-specs/pull/188)
+for the [HTTP Payment Authentication Scheme](https://paymentauth.org).
+
+## License
+
+MIT

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+require "standard/rake"
+
+Rake::TestTask.new(:test) do |task|
+  task.libs << "test"
+  task.pattern = "test/**/*_test.rb"
+end
+
+task default: [:standard, :test]

--- a/ruby/examples/simple-server.rb
+++ b/ruby/examples/simple-server.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "json"
+require "webrick"
+require_relative "../lib/solana_mpp"
+
+DEFAULT_RPC_URL = "https://402.surfnet.dev:8899"
+DEFAULT_MINT = "USDC"
+DEFAULT_PAY_TO = "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY"
+
+# Build the optional fee payer from environment variables.
+def fee_payer_from_env
+  secret = ENV["MPP_FEE_PAYER_SECRET_KEY"]
+  return nil if secret.nil? || secret.empty?
+
+  SolanaMpp::Solana::Keypair.from_json_array(secret)
+end
+
+# Build a charge handler from environment variables for local manual testing.
+def build_handler
+  rpc = SolanaMpp::Solana::RpcClient.new(ENV.fetch("MPP_RPC_URL", DEFAULT_RPC_URL))
+  challenges = SolanaMpp::Server::ChargeServer.new(
+    secret_key: ENV.fetch("MPP_SECRET_KEY", "ruby-mpp-dev-secret"),
+    realm: "Ruby MPP Example"
+  )
+  SolanaMpp::Server::ChargeHandler.new(
+    challenges: challenges,
+    rpc: rpc,
+    replay_store: SolanaMpp::MemoryStore.new,
+    fee_payer: fee_payer_from_env,
+    network: ENV.fetch("MPP_NETWORK", "localnet")
+  )
+end
+
+# Build the protected charge request with a fresh blockhash.
+def build_request(handler)
+  rpc = SolanaMpp::Solana::RpcClient.new(ENV.fetch("MPP_RPC_URL", DEFAULT_RPC_URL))
+  network = ENV.fetch("MPP_NETWORK", "localnet")
+  mint = ENV.fetch("MPP_MINT", DEFAULT_MINT)
+  method_details = {
+    "network" => network,
+    "decimals" => Integer(ENV.fetch("MPP_DECIMALS", "6")),
+    "tokenProgram" => SolanaMpp::Common::StablecoinMints.token_program_for(mint, network),
+    "recentBlockhash" => rpc.latest_blockhash
+  }
+  if handler.fee_payer_pubkey
+    method_details["feePayer"] = true
+    method_details["feePayerKey"] = handler.fee_payer_pubkey
+  end
+
+  SolanaMpp::Intent::ChargeRequest.new(
+    amount: ENV.fetch("MPP_AMOUNT", "1000"),
+    currency: mint,
+    recipient: ENV.fetch("MPP_PAY_TO", DEFAULT_PAY_TO),
+    description: "Ruby protected endpoint",
+    external_id: "ruby-simple-server",
+    method_details: method_details
+  )
+end
+
+handler = build_handler
+server = WEBrick::HTTPServer.new(
+  BindAddress: "127.0.0.1",
+  Port: Integer(ENV.fetch("PORT", "4567")),
+  AccessLog: [],
+  Logger: WEBrick::Log.new($stderr, WEBrick::Log::INFO)
+)
+
+server.mount_proc "/health" do |_req, res|
+  res.status = 200
+  res["content-type"] = "application/json"
+  res.body = JSON.generate({"ok" => true})
+end
+
+server.mount_proc "/paid" do |req, res|
+  payment = handler.handle(req["authorization"], build_request(handler))
+  res.status = payment.status
+  payment.headers.each { |name, value| res[name] = value }
+  res.body = JSON.generate(payment.body)
+end
+
+trap("INT") { server.shutdown }
+trap("TERM") { server.shutdown }
+server.start

--- a/ruby/examples/sinatra-app.rb
+++ b/ruby/examples/sinatra-app.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "json"
+require "sinatra/base"
+require_relative "../lib/solana_mpp"
+
+DEFAULT_RPC_URL = "https://402.surfnet.dev:8899"
+DEFAULT_MINT = "USDC"
+DEFAULT_PAY_TO = "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY"
+
+# Build the optional fee payer from environment variables.
+def fee_payer_from_env
+  secret = ENV["MPP_FEE_PAYER_SECRET_KEY"]
+  return nil if secret.nil? || secret.empty?
+
+  SolanaMpp::Solana::Keypair.from_json_array(secret)
+end
+
+# Minimal Sinatra application with one MPP-protected charge endpoint.
+class RubyMppSinatraExample < Sinatra::Base
+  set :bind, ENV.fetch("HOST", "127.0.0.1")
+  set :port, Integer(ENV.fetch("PORT", "4568"))
+  set :show_exceptions, false
+
+  configure do
+    rpc = SolanaMpp::Solana::RpcClient.new(ENV.fetch("MPP_RPC_URL", DEFAULT_RPC_URL))
+    network = ENV.fetch("MPP_NETWORK", "localnet")
+    mint = ENV.fetch("MPP_MINT", DEFAULT_MINT)
+    challenges = SolanaMpp::Server::ChargeServer.new(
+      secret_key: ENV.fetch("MPP_SECRET_KEY", "ruby-mpp-dev-secret"),
+      realm: "Ruby Sinatra Example"
+    )
+    handler = SolanaMpp::Server::ChargeHandler.new(
+      challenges: challenges,
+      rpc: rpc,
+      replay_store: SolanaMpp::MemoryStore.new,
+      fee_payer: fee_payer_from_env,
+      network: network
+    )
+
+    set :mpp_rpc, rpc
+    set :mpp_network, network
+    set :mpp_mint, mint
+    set :mpp_handler, handler
+  end
+
+  helpers do
+    # Build a fresh charge request for each protected request.
+    def mpp_charge_request
+      method_details = {
+        "network" => settings.mpp_network,
+        "decimals" => Integer(ENV.fetch("MPP_DECIMALS", "6")),
+        "tokenProgram" => SolanaMpp::Common::StablecoinMints.token_program_for(settings.mpp_mint, settings.mpp_network),
+        "recentBlockhash" => settings.mpp_rpc.latest_blockhash
+      }
+      if settings.mpp_handler.fee_payer_pubkey
+        method_details["feePayer"] = true
+        method_details["feePayerKey"] = settings.mpp_handler.fee_payer_pubkey
+      end
+
+      SolanaMpp::Intent::ChargeRequest.new(
+        amount: ENV.fetch("MPP_AMOUNT", "1000"),
+        currency: settings.mpp_mint,
+        recipient: ENV.fetch("MPP_PAY_TO", DEFAULT_PAY_TO),
+        description: "Sinatra protected endpoint",
+        external_id: "ruby-sinatra-example",
+        method_details: method_details
+      )
+    end
+  end
+
+  get "/health" do
+    content_type :json
+    JSON.generate({"ok" => true})
+  end
+
+  get "/paid" do
+    payment = settings.mpp_handler.handle(request.env["HTTP_AUTHORIZATION"], mpp_charge_request)
+    status payment.status
+    payment.headers.each { |name, value| headers[name] = value }
+    content_type :json
+    JSON.generate(payment.body)
+  end
+
+  run! if app_file == $PROGRAM_NAME
+end

--- a/ruby/lib/solana_mpp.rb
+++ b/ruby/lib/solana_mpp.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "solana_mpp/version"
+require_relative "solana_mpp/error"
+require_relative "solana_mpp/expires"
+require_relative "solana_mpp/store"
+require_relative "solana_mpp/core/base64_url"
+require_relative "solana_mpp/core/json"
+require_relative "solana_mpp/core/challenge"
+require_relative "solana_mpp/core/credential"
+require_relative "solana_mpp/core/receipt"
+require_relative "solana_mpp/core/headers"
+require_relative "solana_mpp/intent/charge_request"
+require_relative "solana_mpp/common/stablecoin_mints"
+require_relative "solana_mpp/solana/base58"
+require_relative "solana_mpp/solana/public_key"
+require_relative "solana_mpp/solana/keypair"
+require_relative "solana_mpp/solana/rpc_client"
+require_relative "solana_mpp/solana/transaction"
+require_relative "solana_mpp/solana/associated_token"
+require_relative "solana_mpp/server/verification_result"
+require_relative "solana_mpp/server/payment_responses"
+require_relative "solana_mpp/server/charge_server"
+require_relative "solana_mpp/server/transaction_verifier"
+require_relative "solana_mpp/server/charge_handler"
+require_relative "solana_mpp/server/rack_middleware"
+
+module SolanaMpp
+end

--- a/ruby/lib/solana_mpp/common/stablecoin_mints.rb
+++ b/ruby/lib/solana_mpp/common/stablecoin_mints.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Common
+    # Known stablecoin mint and token-program helpers.
+    module StablecoinMints
+      TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+      TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+      SYSTEM_PROGRAM = "11111111111111111111111111111111"
+      ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+      MEMO_PROGRAM = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+      COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111"
+
+      MINTS = {
+        "USDC" => {
+          "devnet" => "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+          "localnet" => "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+          "mainnet-beta" => "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "USDT" => {
+          "mainnet-beta" => "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+        },
+        "USDG" => {
+          "devnet" => "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7",
+          "mainnet-beta" => "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH"
+        },
+        "PYUSD" => {
+          "devnet" => "CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM",
+          "mainnet-beta" => "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"
+        },
+        "CASH" => {
+          "mainnet-beta" => "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH"
+        }
+      }.freeze
+
+      TOKEN_2022_SYMBOLS = ["PYUSD", "USDG", "CASH"].freeze
+
+      module_function
+
+      # Resolve a currency symbol or mint into a mint address.
+      def resolve(currency, network)
+        return nil if currency.to_s.casecmp("SOL").zero?
+        return currency if currency.to_s.length >= 32
+
+        entries = MINTS[currency.to_s.upcase]
+        entries&.[](network) || entries&.[]("mainnet-beta") || currency
+      end
+
+      # Return the default SPL token program for a currency.
+      def token_program_for(currency, network)
+        symbol = symbol_for(currency, network)
+        TOKEN_2022_SYMBOLS.include?(symbol) ? TOKEN_2022_PROGRAM : TOKEN_PROGRAM
+      end
+
+      def symbol_for(currency, network)
+        upper = currency.to_s.upcase
+        return upper if MINTS.key?(upper)
+
+        resolved = resolve(currency, network)
+        MINTS.each do |symbol, entries|
+          return symbol if entries.value?(resolved)
+        end
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/core/base64_url.rb
+++ b/ruby/lib/solana_mpp/core/base64_url.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module SolanaMpp
+  module Core
+    # Base64url helpers for Payment header JSON fields.
+    module Base64Url
+      module_function
+
+      # Encode bytes with URL-safe alphabet and no padding.
+      def encode(bytes)
+        Base64.urlsafe_encode64(bytes, padding: false)
+      end
+
+      # Decode URL-safe or standard Base64 input.
+      def decode(value)
+        Base64.urlsafe_decode64(value)
+      rescue ArgumentError
+        Base64.decode64(value)
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/core/challenge.rb
+++ b/ruby/lib/solana_mpp/core/challenge.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "openssl"
+require "time"
+
+module SolanaMpp
+  module Core
+    # Payment challenge from a `WWW-Authenticate` header.
+    class Challenge
+      attr_reader :id, :realm, :method, :intent, :request, :expires, :description, :digest, :opaque
+
+      def initialize(id:, realm:, method:, intent:, request:, expires: nil, description: nil, digest: nil, opaque: nil)
+        raise ArgumentError, "challenge id is required" if id.to_s.empty?
+        raise ArgumentError, "realm is required" if realm.to_s.empty?
+        raise ArgumentError, "method must be lowercase ASCII" unless method.to_s.match?(/\A[a-z]+\z/)
+        raise ArgumentError, "intent is required" if intent.to_s.empty?
+        raise ArgumentError, "request is required" if request.to_s.empty?
+
+        @id = id.to_s
+        @realm = realm.to_s
+        @method = method.to_s
+        @intent = intent.to_s.downcase
+        @request = request.to_s
+        @expires = present(expires)
+        @description = present(description)
+        @digest = present(digest)
+        @opaque = present(opaque)
+      end
+
+      # Create a stateless HMAC-bound challenge.
+      def self.with_secret(secret_key:, realm:, method:, intent:, request:, expires: nil, description: nil, digest: nil, opaque: nil)
+        request_json = Json.canonical_generate(request)
+        encoded_request = Base64Url.encode(request_json)
+        new(
+          id: compute_id(
+            secret_key: secret_key,
+            realm: realm,
+            method: method,
+            intent: intent,
+            request: encoded_request,
+            expires: expires,
+            digest: digest,
+            opaque: opaque
+          ),
+          realm: realm,
+          method: method,
+          intent: intent,
+          request: encoded_request,
+          expires: expires,
+          description: description,
+          digest: digest,
+          opaque: opaque
+        )
+      end
+
+      # Compute the HMAC challenge ID used by the Rust reference.
+      def self.compute_id(secret_key:, realm:, method:, intent:, request:, expires: nil, digest: nil, opaque: nil)
+        input = [realm, method, intent, request, expires.to_s, digest.to_s, opaque.to_s].join("|")
+        Base64Url.encode(OpenSSL::HMAC.digest("sha256", secret_key, input))
+      end
+
+      # Verify this challenge was issued with `secret_key`.
+      def verify?(secret_key)
+        expected = self.class.compute_id(
+          secret_key: secret_key,
+          realm: realm,
+          method: method,
+          intent: intent,
+          request: request,
+          expires: expires,
+          digest: digest,
+          opaque: opaque
+        )
+        secure_compare(expected, id)
+      end
+
+      # Return true if the challenge is expired or has an invalid timestamp.
+      def expired?(now: Time.now.utc)
+        return false if expires.nil?
+
+        Time.iso8601(expires) <= now
+      rescue ArgumentError
+        true
+      end
+
+      # Decode the base64url canonical JSON request.
+      def decode_request
+        Json.parse(Base64Url.decode(request))
+      end
+
+      # Convert to the credential challenge echo shape.
+      def to_echo
+        ChallengeEcho.new(
+          id: id,
+          realm: realm,
+          method: method,
+          intent: intent,
+          request: request,
+          expires: expires,
+          digest: digest,
+          opaque: opaque
+        )
+      end
+
+      private
+
+      def present(value)
+        (value.nil? || value.to_s.empty?) ? nil : value.to_s
+      end
+
+      def secure_compare(left, right)
+        return false unless left.bytesize == right.bytesize
+
+        left.bytes.zip(right.bytes).reduce(0) { |memo, pair| memo | (pair[0] ^ pair[1]) }.zero?
+      end
+    end
+
+    # Challenge fields echoed inside a Payment credential.
+    class ChallengeEcho
+      attr_reader :id, :realm, :method, :intent, :request, :expires, :digest, :opaque
+
+      def initialize(id:, realm:, method:, intent:, request:, expires: nil, digest: nil, opaque: nil)
+        @id = id.to_s
+        @realm = realm.to_s
+        @method = method.to_s
+        @intent = intent.to_s
+        @request = request.to_s
+        @expires = (expires.nil? || expires.to_s.empty?) ? nil : expires.to_s
+        @digest = (digest.nil? || digest.to_s.empty?) ? nil : digest.to_s
+        @opaque = (opaque.nil? || opaque.to_s.empty?) ? nil : opaque.to_s
+      end
+
+      # Serialize to the wire credential shape.
+      def to_h
+        compact({
+          "id" => id,
+          "realm" => realm,
+          "method" => method,
+          "intent" => intent,
+          "request" => request,
+          "expires" => expires,
+          "digest" => digest,
+          "opaque" => opaque
+        })
+      end
+
+      # Build a challenge echo from decoded JSON.
+      def self.from_h(value)
+        raise ArgumentError, "challenge must be an object" unless value.is_a?(Hash)
+
+        new(
+          id: value.fetch("id"),
+          realm: value.fetch("realm"),
+          method: value.fetch("method"),
+          intent: value.fetch("intent"),
+          request: value.fetch("request"),
+          expires: value["expires"],
+          digest: value["digest"],
+          opaque: value["opaque"]
+        )
+      end
+
+      private
+
+      def compact(value)
+        value.reject { |_key, item| item.nil? }
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/core/credential.rb
+++ b/ruby/lib/solana_mpp/core/credential.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Core
+    # Payment credential carried by the `Authorization` header.
+    class Credential
+      MAX_TOKEN_LENGTH = 16 * 1024
+
+      attr_reader :challenge, :payload, :source
+
+      def initialize(challenge:, payload:, source: nil)
+        raise ArgumentError, "payload must be an object" unless payload.is_a?(Hash)
+
+        @challenge = challenge
+        @payload = payload
+        @source = source
+      end
+
+      # Serialize to the wire credential shape.
+      def to_h
+        value = {
+          "challenge" => challenge.to_h,
+          "payload" => payload
+        }
+        value["source"] = source unless source.nil?
+        value
+      end
+
+      # Format as `Authorization: Payment ...` value.
+      def to_authorization_header
+        "Payment #{Base64Url.encode(Json.canonical_generate(to_h))}"
+      end
+
+      # Parse an `Authorization` header value.
+      def self.from_authorization_header(header)
+        token = extract_payment_token(header)
+        raise ArgumentError, "expected Payment scheme" if token.nil?
+        raise ArgumentError, "token exceeds maximum length" if token.bytesize > MAX_TOKEN_LENGTH
+
+        decoded = Json.parse(Base64Url.decode(token))
+        new(
+          challenge: ChallengeEcho.from_h(decoded.fetch("challenge")),
+          payload: decoded.fetch("payload"),
+          source: decoded["source"]
+        )
+      end
+
+      def self.extract_payment_token(header)
+        header.to_s.split(",").map(&:strip).find { |part| part.downcase.start_with?("payment ") }&.[](8..)&.strip
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/core/headers.rb
+++ b/ruby/lib/solana_mpp/core/headers.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Core
+    # Parser and formatter for MPP HTTP headers.
+    module Headers
+      WWW_AUTHENTICATE = "www-authenticate"
+      AUTHORIZATION = "authorization"
+      PAYMENT_RECEIPT = "payment-receipt"
+      PAYMENT_SCHEME = "Payment"
+
+      module_function
+
+      # Format a challenge for `WWW-Authenticate`.
+      def format_www_authenticate(challenge)
+        parts = {
+          "id" => challenge.id,
+          "realm" => challenge.realm,
+          "method" => challenge.method,
+          "intent" => challenge.intent,
+          "request" => challenge.request,
+          "expires" => challenge.expires,
+          "digest" => challenge.digest,
+          "opaque" => challenge.opaque
+        }.compact.map { |key, value| "#{key}=\"#{escape(value)}\"" }
+        "Payment #{parts.join(", ")}"
+      end
+
+      # Parse a single `WWW-Authenticate` challenge.
+      def parse_www_authenticate(header)
+        params = parse_auth_params(strip_payment(header))
+        request = params.fetch("request")
+        _decoded_request = Json.parse(Base64Url.decode(request))
+        Challenge.new(
+          id: params.fetch("id"),
+          realm: params.fetch("realm"),
+          method: params.fetch("method"),
+          intent: params.fetch("intent"),
+          request: request,
+          expires: params["expires"],
+          digest: params["digest"],
+          opaque: params["opaque"]
+        )
+      end
+
+      # Format a receipt for `Payment-Receipt`.
+      def format_receipt(receipt)
+        Base64Url.encode(Json.canonical_generate(receipt.to_h))
+      end
+
+      # Parse a `Payment-Receipt` value.
+      def parse_receipt(header)
+        value = Json.parse(Base64Url.decode(header))
+        Receipt.new(
+          status: value.fetch("status"),
+          method: value.fetch("method"),
+          reference: value.fetch("reference"),
+          challenge_id: value.fetch("challengeId"),
+          external_id: value["externalId"],
+          timestamp: value["timestamp"]
+        )
+      end
+
+      def strip_payment(header)
+        value = header.to_s.strip
+        raise ArgumentError, "expected Payment scheme" unless value.downcase.start_with?("payment ")
+
+        value[8..].strip
+      end
+
+      def parse_auth_params(input)
+        params = {}
+        index = 0
+        while index < input.length
+          index += 1 while index < input.length && [",", " ", "\t"].include?(input[index])
+          break if index >= input.length
+
+          key_start = index
+          index += 1 while index < input.length && input[index] != "="
+          key = input[key_start...index]
+          index += 1
+          raise ArgumentError, "expected quoted value" unless input[index] == "\""
+
+          index += 1
+          value = +""
+          while index < input.length
+            char = input[index]
+            if char == "\\"
+              index += 1
+              value << input[index].to_s
+            elsif char == "\""
+              index += 1
+              break
+            else
+              value << char
+            end
+            index += 1
+          end
+          params[key] = value
+        end
+        params
+      end
+
+      def escape(value)
+        value.to_s.gsub("\\", "\\\\\\").gsub("\"", "\\\"")
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/core/json.rb
+++ b/ruby/lib/solana_mpp/core/json.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "json"
+
+module SolanaMpp
+  module Core
+    # RFC8785-style canonical JSON encoder for MPP header payloads.
+    module Json
+      module_function
+
+      # Encode a Ruby object with stable object key ordering.
+      def canonical_generate(value)
+        case value
+        when Hash
+          "{" + value.keys.map(&:to_s).sort.map { |key|
+            JSON.generate(key) + ":" + canonical_generate(value.fetch(key) { value.fetch(key.to_sym) })
+          }.join(",") + "}"
+        when Array
+          "[" + value.map { |item| canonical_generate(item) }.join(",") + "]"
+        when String, Integer, Float, TrueClass, FalseClass, NilClass
+          JSON.generate(value)
+        else
+          raise ArgumentError, "unsupported JSON value #{value.class}"
+        end
+      end
+
+      # Decode JSON and preserve object keys as strings.
+      def parse(value)
+        JSON.parse(value)
+      rescue JSON::ParserError => error
+        raise ArgumentError, "invalid JSON: #{error.message}"
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/core/receipt.rb
+++ b/ruby/lib/solana_mpp/core/receipt.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "time"
+
+module SolanaMpp
+  module Core
+    # Payment receipt returned after successful settlement.
+    class Receipt
+      attr_reader :status, :method, :reference, :challenge_id, :external_id, :timestamp
+
+      def initialize(status:, method:, reference:, challenge_id:, external_id: nil, timestamp: Time.now.utc.iso8601)
+        @status = status.to_s
+        @method = method.to_s
+        @reference = reference.to_s
+        @challenge_id = challenge_id.to_s
+        @external_id = external_id
+        @timestamp = timestamp
+      end
+
+      # Create a successful payment receipt.
+      def self.success(method:, reference:, challenge_id:, external_id: nil)
+        new(status: "success", method: method, reference: reference, challenge_id: challenge_id, external_id: external_id)
+      end
+
+      # Serialize to the wire receipt shape.
+      def to_h
+        value = {
+          "status" => status,
+          "method" => method,
+          "reference" => reference,
+          "challengeId" => challenge_id,
+          "timestamp" => timestamp
+        }
+        value["externalId"] = external_id unless external_id.nil?
+        value
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/error.rb
+++ b/ruby/lib/solana_mpp/error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  # Protocol-level error raised by the Ruby MPP SDK.
+  class Error < StandardError; end
+
+  # Raised when request or credential fields fail validation.
+  class VerificationError < Error; end
+end

--- a/ruby/lib/solana_mpp/expires.rb
+++ b/ruby/lib/solana_mpp/expires.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "time"
+
+module SolanaMpp
+  # Helpers for RFC3339 expiration timestamps.
+  module Expires
+    module_function
+
+    # Return an RFC3339 timestamp `minutes` from the supplied clock.
+    def minutes(minutes, now: Time.now.utc)
+      (now + (minutes * 60)).utc.iso8601
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/intent/charge_request.rb
+++ b/ruby/lib/solana_mpp/intent/charge_request.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Intent
+    # MPP charge request wire object.
+    class ChargeRequest
+      attr_reader :amount, :currency, :recipient, :description, :external_id, :method_details
+
+      def initialize(amount:, currency:, recipient: nil, description: nil, external_id: nil, method_details: nil)
+        raise ArgumentError, "amount must be a positive base-unit integer string" unless amount.to_s.match?(/\A[1-9][0-9]*\z/)
+        raise ArgumentError, "currency is required" if currency.to_s.empty?
+        raise ArgumentError, "methodDetails must be a Hash" unless method_details.nil? || method_details.is_a?(Hash)
+
+        @amount = amount.to_s
+        @currency = currency.to_s
+        @recipient = recipient
+        @description = description
+        @external_id = external_id
+        @method_details = method_details || {}
+      end
+
+      # Build a charge request from decoded wire JSON.
+      def self.from_h(value)
+        raise ArgumentError, "charge request must be an object" unless value.is_a?(Hash)
+
+        new(
+          amount: value.fetch("amount"),
+          currency: value.fetch("currency"),
+          recipient: value["recipient"],
+          description: value["description"],
+          external_id: value["externalId"],
+          method_details: value["methodDetails"]
+        )
+      end
+
+      # Convert a display amount to base units.
+      def self.parse_units(amount, decimals)
+        raw = amount.to_s
+        raise ArgumentError, "invalid amount" unless raw.match?(/\A[0-9]+(\.[0-9]+)?\z/)
+
+        whole, frac = raw.split(".", 2)
+        frac ||= ""
+        raise ArgumentError, "too many decimal places" if frac.length > decimals
+
+        (whole + frac.ljust(decimals, "0")).sub(/\A0+(?=\d)/, "")
+      end
+
+      # Serialize to the camelCase wire object.
+      def to_h
+        {
+          "amount" => amount,
+          "currency" => currency,
+          "recipient" => recipient,
+          "description" => description,
+          "externalId" => external_id,
+          "methodDetails" => method_details.empty? ? nil : method_details
+        }.compact
+      end
+
+      # Parse the base-unit amount as an Integer.
+      def amount_i
+        Integer(amount, 10)
+      rescue ArgumentError
+        raise ArgumentError, "invalid amount: #{amount}"
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/server/charge_handler.rb
+++ b/ruby/lib/solana_mpp/server/charge_handler.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module SolanaMpp
+  module Server
+    # High-level Solana charge server: verify, settle, consume, receipt.
+    class ChargeHandler
+      SURFPOOL_BLOCKHASH_PREFIX = "SURFNETxSAFEHASH"
+      DEFAULT_SETTLEMENT_HEADER = "x-payment-settlement-signature"
+
+      attr_reader :fee_payer, :network, :settlement_header
+
+      def initialize(challenges:, rpc:, replay_store:, fee_payer: nil, network: "mainnet-beta", settlement_header: DEFAULT_SETTLEMENT_HEADER, verifier: TransactionVerifier.new, confirmation_attempts: 40, confirmation_delay: 0.25)
+        @challenges = challenges
+        @rpc = rpc
+        @replay_store = replay_store
+        @fee_payer = fee_payer
+        @network = network
+        @settlement_header = settlement_header
+        @verifier = verifier
+        @confirmation_attempts = confirmation_attempts
+        @confirmation_delay = confirmation_delay
+      end
+
+      # Public key of the server fee payer, when configured.
+      def fee_payer_pubkey
+        fee_payer&.public_key&.to_s
+      end
+
+      # Process one HTTP request and return a response object.
+      def handle(authorization, request)
+        return @challenges.payment_required_response(request) if authorization.nil? || authorization.empty?
+
+        result = @challenges.verify_authorization_header(authorization, verifier: @verifier, expected_request: request)
+        return @challenges.payment_required_response(request, reason: result.reason) unless result.ok?
+
+        signature = settle_payload(result.credential, request)
+        consume_signature(signature)
+        receipt = @challenges.create_receipt_header(challenge: result.challenge, reference: signature, external_id: request.external_id)
+        ChargeSettlement.new(
+          headers: {
+            "content-type" => "application/json",
+            Core::Headers::PAYMENT_RECEIPT => receipt,
+            settlement_header => signature
+          },
+          body: {"ok" => true, "paid" => true},
+          signature: signature,
+          receipt_header: receipt
+        )
+      rescue ArgumentError, Error => error
+        @challenges.payment_required_response(request, reason: error.message)
+      end
+
+      private
+
+      def settle_payload(credential, request)
+        transaction = credential.payload["transaction"]
+        return settle_pull(transaction) if transaction.is_a?(String) && !transaction.empty?
+
+        signature = credential.payload["signature"]
+        raise VerificationError, "missing transaction or signature payload" unless signature.is_a?(String) && !signature.empty?
+
+        transaction_base64 = fetch_settled_transaction(signature)
+        verification = @verifier.verify_transaction_payload(transaction_base64, request)
+        raise VerificationError, verification.reason unless verification.ok?
+
+        signature
+      end
+
+      def settle_pull(transaction_base64)
+        transaction = Solana::Transaction.from_base64(transaction_base64)
+        check_network_blockhash(transaction.message.recent_blockhash)
+        transaction.sign_with(fee_payer) if fee_payer
+        signed_base64 = transaction.to_base64
+        simulation = simulate_transaction_with_retry(signed_base64)
+        raise VerificationError, "Simulation failed: #{simulation["err"].inspect}" unless simulation["err"].nil?
+
+        signature = @rpc.send_raw_transaction(signed_base64)
+        await_confirmation(signature)
+        signature
+      end
+
+      def fetch_settled_transaction(signature)
+        @confirmation_attempts.times do
+          response = @rpc.transaction_base64(signature)
+          if response.nil?
+            sleep @confirmation_delay
+            next
+          end
+          meta = response["meta"]
+          raise VerificationError, "getTransaction response is missing transaction metadata" unless meta.is_a?(Hash)
+          raise VerificationError, "Transaction #{signature} failed: #{meta["err"].inspect}" unless meta["err"].nil?
+
+          wire = response["transaction"]
+          return wire[0] if wire.is_a?(Array) && wire[0].is_a?(String) && !wire[0].empty?
+
+          raise VerificationError, "getTransaction response is missing base64 transaction"
+        end
+        raise VerificationError, "Timed out fetching transaction #{signature}"
+      end
+
+      def await_confirmation(signature)
+        @confirmation_attempts.times do
+          status = @rpc.signature_statuses([signature]).first
+          if status.is_a?(Hash)
+            raise VerificationError, "Transaction #{signature} failed: #{status["err"].inspect}" unless status["err"].nil?
+            return if ["confirmed", "finalized"].include?(status["confirmationStatus"])
+          end
+          sleep @confirmation_delay
+        end
+        raise VerificationError, "Timed out waiting for transaction #{signature}"
+      end
+
+      def simulate_transaction_with_retry(transaction_base64)
+        last = nil
+        3.times do
+          last = @rpc.simulate_transaction(transaction_base64)
+          return last if last["err"].nil?
+
+          sleep @confirmation_delay
+        end
+        last
+      end
+
+      def consume_signature(signature)
+        key = "solana-charge:consumed:#{signature}"
+        inserted = @replay_store.put_if_absent(key, true)
+        raise VerificationError, "Transaction signature already consumed" unless inserted
+      end
+
+      def check_network_blockhash(blockhash)
+        return unless blockhash.start_with?(SURFPOOL_BLOCKHASH_PREFIX)
+        return if network == "localnet"
+
+        raise VerificationError, "Signed against localnet but the server expects #{network}. Switch your client RPC to #{network} and re-sign."
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/server/charge_server.rb
+++ b/ruby/lib/solana_mpp/server/charge_server.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Server
+    # Low-level charge challenge issuer and credential verifier.
+    class ChargeServer
+      attr_reader :secret_key, :realm, :blockhash_provider
+
+      def initialize(secret_key:, realm: "MPP Payment", blockhash_provider: nil)
+        @secret_key = secret_key
+        @realm = realm
+        @blockhash_provider = blockhash_provider
+      end
+
+      # Create an MPP charge challenge.
+      def create_challenge(request, expires: Expires.minutes(5), description: nil)
+        Core::Challenge.with_secret(
+          secret_key: secret_key,
+          realm: realm,
+          method: "solana",
+          intent: "charge",
+          request: request_payload(request),
+          expires: expires,
+          description: description
+        )
+      end
+
+      # Create the `WWW-Authenticate` header value for a charge request.
+      def create_challenge_header(request, expires: Expires.minutes(5), description: nil)
+        Core::Headers.format_www_authenticate(create_challenge(request, expires: expires, description: description))
+      end
+
+      # Return a 402 response for a charge request.
+      def payment_required_response(request, reason: nil)
+        header = create_challenge_header(request, description: request.description)
+        body = reason.nil? ? {"error" => "payment_required"} : {"error" => "payment_invalid", "message" => reason}
+        PaymentRequiredResponse.new(headers: {Core::Headers::WWW_AUTHENTICATE => header}, body: body)
+      end
+
+      # Verify a Payment authorization header.
+      def verify_authorization_header(header, verifier:, expected_request:, now: Time.now.utc)
+        credential = Core::Credential.from_authorization_header(header)
+        challenge = Core::Challenge.new(
+          id: credential.challenge.id,
+          realm: credential.challenge.realm,
+          method: credential.challenge.method,
+          intent: credential.challenge.intent,
+          request: credential.challenge.request,
+          expires: credential.challenge.expires,
+          digest: credential.challenge.digest,
+          opaque: credential.challenge.opaque
+        )
+
+        return VerificationResult.failure("challenge verification failed") unless challenge.verify?(secret_key)
+        return VerificationResult.failure("challenge expired") if challenge.expired?(now: now)
+
+        result = verify_pinned_fields(challenge, expected_request)
+        return result unless result.ok?
+
+        decoded = Intent::ChargeRequest.from_h(challenge.decode_request)
+        result = verify_expected(decoded, expected_request)
+        return result unless result.ok?
+
+        result = verifier.verify(credential, challenge, expected_request: expected_request)
+        return result unless result.ok?
+
+        VerificationResult.success(reference: result.reference, credential: credential, challenge: challenge)
+      rescue KeyError, ArgumentError, Error => error
+        VerificationResult.failure(error.message)
+      end
+
+      # Create a receipt header for a settled on-chain signature.
+      def create_receipt_header(challenge:, reference:, external_id: nil)
+        receipt = Core::Receipt.success(
+          method: "solana",
+          reference: reference,
+          challenge_id: challenge.id,
+          external_id: external_id
+        )
+        Core::Headers.format_receipt(receipt)
+      end
+
+      private
+
+      def verify_pinned_fields(challenge, expected)
+        return VerificationResult.failure("Credential method does not match this server") unless challenge.method == "solana"
+        return VerificationResult.failure("Credential intent is not a charge") unless challenge.intent.casecmp("charge").zero?
+        return VerificationResult.failure("Credential realm does not match this server") unless challenge.realm == realm
+        return VerificationResult.failure("Endpoint currency is required") if expected.currency.to_s.empty?
+        return VerificationResult.failure("Credential recipient does not match this server") if expected.recipient.to_s.empty?
+
+        VerificationResult.success
+      end
+
+      def verify_expected(decoded, expected)
+        return VerificationResult.failure("Amount mismatch: credential has #{decoded.amount} but endpoint expects #{expected.amount}") unless decoded.amount == expected.amount
+        return VerificationResult.failure("Currency mismatch: credential has #{decoded.currency} but endpoint expects #{expected.currency}") unless decoded.currency == expected.currency
+        return VerificationResult.failure("Recipient mismatch") unless decoded.recipient == expected.recipient
+        return VerificationResult.failure("Method details mismatch") unless comparable_method_details(decoded.method_details) == comparable_method_details(expected.method_details)
+
+        VerificationResult.success
+      end
+
+      def request_payload(request)
+        payload = request.to_h
+        return payload unless blockhash_provider
+
+        details = (payload["methodDetails"] || {}).dup
+        details["recentBlockhash"] = blockhash_provider.call if details["recentBlockhash"].to_s.empty?
+        payload.merge("methodDetails" => details)
+      end
+
+      def comparable_method_details(details)
+        (details || {}).except("recentBlockhash")
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/server/payment_responses.rb
+++ b/ruby/lib/solana_mpp/server/payment_responses.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Server
+    # HTTP 402 response returned when payment is required or invalid.
+    class PaymentRequiredResponse
+      attr_reader :status, :headers, :body
+
+      def initialize(headers:, body: {"error" => "payment_required"})
+        @status = 402
+        @headers = headers
+        @body = body
+      end
+    end
+
+    # HTTP 200 response returned after successful charge settlement.
+    class ChargeSettlement
+      attr_reader :status, :headers, :body, :signature, :receipt_header
+
+      def initialize(headers:, body:, signature:, receipt_header:)
+        @status = 200
+        @headers = headers
+        @body = body
+        @signature = signature
+        @receipt_header = receipt_header
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/server/rack_middleware.rb
+++ b/ruby/lib/solana_mpp/server/rack_middleware.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "json"
+
+module SolanaMpp
+  module Server
+    # Rack middleware that protects one route with an MPP charge handler.
+    class RackMiddleware
+      def initialize(app, handler:, request:, path:)
+        @app = app
+        @handler = handler
+        @request = request
+        @path = path
+      end
+
+      # Rack entrypoint.
+      def call(env)
+        return @app.call(env) unless env["PATH_INFO"] == @path
+
+        response = @handler.handle(env[Core::Headers::AUTHORIZATION.upcase.tr("-", "_").prepend("HTTP_")], current_request(env))
+        [
+          response.status,
+          response.headers,
+          [JSON.generate(response.body)]
+        ]
+      end
+
+      private
+
+      def current_request(env)
+        @request.respond_to?(:call) ? @request.call(env) : @request
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/server/transaction_verifier.rb
+++ b/ruby/lib/solana_mpp/server/transaction_verifier.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Server
+    # Verifies Solana charge transactions before settlement.
+    class TransactionVerifier
+      MAX_COMPUTE_UNIT_LIMIT = 200_000
+      MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 5_000_000
+
+      # Verify a credential payload against a charge challenge.
+      def verify(credential, challenge, expected_request: nil)
+        if credential.payload["transaction"].is_a?(String) && !credential.payload["transaction"].empty?
+          request = expected_request || Intent::ChargeRequest.from_h(challenge.decode_request)
+          return verify_transaction_payload(credential.payload["transaction"], request)
+        end
+
+        signature = credential.payload["signature"]
+        return VerificationResult.failure("missing transaction or signature payload") unless signature.is_a?(String) && !signature.empty?
+
+        validate_signature(signature)
+        VerificationResult.success(reference: signature)
+      rescue ArgumentError, Error => error
+        VerificationResult.failure(error.message)
+      end
+
+      # Verify a standard-base64 transaction payload against a request.
+      def verify_transaction_payload(transaction_base64, request)
+        transaction = Solana::Transaction.from_base64(transaction_base64)
+        verify_transaction(transaction, request)
+        VerificationResult.success(reference: "")
+      rescue ArgumentError, Error => error
+        VerificationResult.failure(error.message)
+      end
+
+      # Fail unless `signature` is a Solana base58 signature.
+      def validate_signature(signature)
+        raise ArgumentError, "invalid signature length" unless signature.length.between?(87, 88)
+
+        decoded = Solana::Base58.decode(signature)
+        raise ArgumentError, "invalid signature length" unless decoded.bytesize == 64
+      end
+
+      # Verify parsed transaction instructions and amounts.
+      def verify_transaction(transaction, request)
+        raise VerificationError, "v0 address lookup tables are not supported" unless transaction.message.address_table_lookups.empty?
+
+        details = request.method_details || {}
+        splits = Array(details["splits"])
+        raise VerificationError, "too many splits" if splits.length > 8
+
+        total = request.amount_i
+        split_total = splits.sum { |split| amount_from(split, "split.amount") }
+        primary = total - split_total
+        raise VerificationError, "split amounts exceed total amount" if primary <= 0
+        raise VerificationError, "recipient is required" if request.recipient.to_s.empty?
+
+        fee_payer = expected_fee_payer(transaction, details)
+        matched = {}
+        if request.currency.casecmp("SOL").zero?
+          raise VerificationError, "ataCreationRequired requires an SPL token charge" if splits.any? { |split| split["ataCreationRequired"] == true }
+
+          match_sol_transfer(transaction, request.recipient, primary, fee_payer, matched)
+          splits.each { |split| match_sol_transfer(transaction, split.fetch("recipient"), amount_from(split, "split.amount"), fee_payer, matched) }
+          verify_memos(transaction, request, splits, matched)
+          validate_allowlist(transaction, matched, expected_mint: nil, expected_token_program: nil, fee_payer: fee_payer, splits: splits)
+        else
+          network = details["network"] || "mainnet-beta"
+          mint = Common::StablecoinMints.resolve(request.currency, network)
+          token_program = details["tokenProgram"] || Common::StablecoinMints.token_program_for(request.currency, network)
+          if splits.any? { |split| split["ataCreationRequired"] == true } && mint != request.currency
+            raise VerificationError, "ataCreationRequired requires currency to be an SPL token mint address"
+          end
+          match_spl_transfer(transaction, request.recipient, mint, token_program, primary, details["decimals"], fee_payer, matched)
+          splits.each { |split| match_spl_transfer(transaction, split.fetch("recipient"), mint, token_program, amount_from(split, "split.amount"), details["decimals"], fee_payer, matched) }
+          verify_memos(transaction, request, splits, matched)
+          validate_allowlist(transaction, matched, expected_mint: mint, expected_token_program: token_program, fee_payer: fee_payer, splits: splits)
+        end
+      end
+
+      private
+
+      def expected_fee_payer(transaction, details)
+        return nil unless details["feePayer"] == true
+
+        key = details["feePayerKey"]
+        raise VerificationError, "feePayer=true requires feePayerKey" if key.to_s.empty?
+        raise VerificationError, "transaction fee payer mismatch" unless transaction.message.account_keys.first == key
+
+        key
+      end
+
+      def amount_from(split, label)
+        Integer(split.fetch("amount"), 10)
+      rescue KeyError, ArgumentError
+        raise VerificationError, "#{label} must be an integer string"
+      end
+
+      def match_sol_transfer(transaction, recipient, amount, fee_payer, matched)
+        found = false
+        transaction.message.instructions.each_with_index do |ix, index|
+          next if matched[index]
+          next unless program_id(transaction, ix) == Common::StablecoinMints::SYSTEM_PROGRAM
+          next unless ix.data.bytesize >= 12
+          next unless u32_le(ix.data.byteslice(0, 4)) == 2
+          next unless u64_le(ix.data.byteslice(4, 8)) == amount
+
+          source = account_key(transaction, ix.accounts[0], "source")
+          destination = account_key(transaction, ix.accounts[1], "destination")
+          next unless destination == recipient
+          raise VerificationError, "fee payer cannot fund the SOL payment transfer" if fee_payer && source == fee_payer
+
+          matched[index] = true
+          found = true
+          break
+        end
+        return if found
+
+        raise VerificationError, "No matching SOL transfer of #{amount} lamports to #{recipient}"
+      end
+
+      def match_spl_transfer(transaction, recipient, mint, token_program, amount, decimals, fee_payer, matched)
+        found = false
+        transaction.message.instructions.each_with_index do |ix, index|
+          next if matched[index]
+
+          instruction_program = program_id(transaction, ix)
+          next unless [Common::StablecoinMints::TOKEN_PROGRAM, Common::StablecoinMints::TOKEN_2022_PROGRAM].include?(instruction_program)
+          next unless instruction_program == token_program
+          next unless ix.data.bytesize >= 10 && ix.data.getbyte(0) == 12
+          next unless u64_le(ix.data.byteslice(1, 8)) == amount
+          next if !decimals.nil? && ix.data.getbyte(9) != Integer(decimals)
+          next unless account_key(transaction, ix.accounts[1], "mint") == mint
+
+          source_ata = account_key(transaction, ix.accounts[0], "source")
+          destination_ata = account_key(transaction, ix.accounts[2], "destination")
+          authority = account_key(transaction, ix.accounts[3], "authority")
+          if fee_payer
+            raise VerificationError, "fee payer cannot authorize the SPL payment transfer" if authority == fee_payer
+            fee_payer_ata = Solana::AssociatedToken.derive(owner: fee_payer, mint: mint, token_program: token_program)
+            raise VerificationError, "fee payer token account cannot fund the SPL payment transfer" if source_ata == fee_payer_ata
+          end
+          expected_ata = Solana::AssociatedToken.derive(owner: recipient, mint: mint, token_program: token_program)
+          next unless destination_ata == expected_ata
+
+          matched[index] = true
+          found = true
+          break
+        end
+        return if found
+
+        raise VerificationError, "No matching SPL transferChecked of #{amount} to #{recipient}"
+      end
+
+      def verify_memos(transaction, request, splits, matched)
+        memos = []
+        memos << ["externalId", request.external_id] if request.external_id
+        splits.each { |split| memos << ["split", split["memo"]] if split["memo"] }
+        memos.each do |label, memo|
+          raise VerificationError, "memo cannot exceed 566 bytes" if memo.bytesize > 566
+
+          found = transaction.message.instructions.each_with_index.any? do |ix, index|
+            next false if matched[index]
+            next false unless program_id(transaction, ix) == Common::StablecoinMints::MEMO_PROGRAM
+            next false unless ix.data.b == memo.b
+
+            matched[index] = true
+            true
+          end
+          raise VerificationError, "No memo instruction found for #{label} memo \"#{memo}\"" unless found
+        end
+      end
+
+      def validate_allowlist(transaction, matched, expected_mint:, expected_token_program:, fee_payer:, splits:)
+        created_owners = {}
+        required_owners = splits.select { |split| split["ataCreationRequired"] == true }.map { |split| split.fetch("recipient") }
+        allowed_owners = fee_payer ? required_owners : splits.map { |split| split.fetch("recipient") }
+        expected_ata_payer = fee_payer || transaction.message.account_keys.first
+
+        transaction.message.instructions.each_with_index do |ix, index|
+          program = program_id(transaction, ix)
+          if program == Common::StablecoinMints::COMPUTE_BUDGET_PROGRAM
+            validate_compute_budget(ix)
+          elsif [Common::StablecoinMints::MEMO_PROGRAM, Common::StablecoinMints::SYSTEM_PROGRAM, Common::StablecoinMints::TOKEN_PROGRAM, Common::StablecoinMints::TOKEN_2022_PROGRAM].include?(program)
+            raise VerificationError, "Unexpected program instruction in payment transaction: #{program}" unless matched[index]
+          elsif program == Common::StablecoinMints::ASSOCIATED_TOKEN_PROGRAM
+            owner = validate_ata_create(transaction, ix, expected_mint, allowed_owners, expected_token_program, expected_ata_payer)
+            created_owners[owner] = true
+          else
+            raise VerificationError, "Unexpected program instruction in payment transaction: #{program}"
+          end
+        end
+        required_owners.each do |owner|
+          raise VerificationError, "Missing required ATA creation instruction for split recipient #{owner}" unless created_owners[owner]
+        end
+      end
+
+      def validate_ata_create(transaction, ix, expected_mint, allowed_owners, expected_token_program, expected_payer)
+        raise VerificationError, "ATA creation is not allowed for native SOL payments" if expected_mint.nil?
+        raise VerificationError, "Only idempotent ATA creation is allowed" unless ix.data == "\x01".b
+        raise VerificationError, "Unexpected ATA creation account layout" unless ix.accounts.length == 6
+
+        payer = account_key(transaction, ix.accounts[0], "ATA payer")
+        ata = account_key(transaction, ix.accounts[1], "ATA address")
+        owner = account_key(transaction, ix.accounts[2], "ATA owner")
+        mint = account_key(transaction, ix.accounts[3], "ATA mint")
+        system_program = account_key(transaction, ix.accounts[4], "ATA system program")
+        token_program = account_key(transaction, ix.accounts[5], "ATA token program")
+        raise VerificationError, "ATA payer must match the transaction fee payer" unless payer == expected_payer
+        raise VerificationError, "ATA creation mint does not match the charge currency" unless mint == expected_mint
+        raise VerificationError, "ATA creation owner is not authorized by the challenge" unless allowed_owners.include?(owner)
+        raise VerificationError, "ATA creation must reference the System Program" unless system_program == Common::StablecoinMints::SYSTEM_PROGRAM
+        raise VerificationError, "ATA creation uses an unsupported token program" unless [Common::StablecoinMints::TOKEN_PROGRAM, Common::StablecoinMints::TOKEN_2022_PROGRAM].include?(token_program)
+        raise VerificationError, "ATA creation token program does not match methodDetails.tokenProgram" if expected_token_program && token_program != expected_token_program
+
+        expected_ata = Solana::AssociatedToken.derive(owner: owner, mint: mint, token_program: token_program)
+        raise VerificationError, "ATA creation address does not match owner/mint/token program" unless ata == expected_ata
+
+        owner
+      end
+
+      def validate_compute_budget(ix)
+        raise VerificationError, "Compute budget instruction must not have accounts" unless ix.accounts.empty?
+
+        case ix.data.getbyte(0)
+        when 2
+          raise VerificationError, "Unsupported compute budget instruction" unless ix.data.bytesize == 5
+          units = u32_le(ix.data.byteslice(1, 4))
+          raise VerificationError, "Compute unit limit #{units} exceeds maximum #{MAX_COMPUTE_UNIT_LIMIT}" if units > MAX_COMPUTE_UNIT_LIMIT
+        when 3
+          raise VerificationError, "Unsupported compute budget instruction" unless ix.data.bytesize == 9
+          price = u64_le(ix.data.byteslice(1, 8))
+          raise VerificationError, "Compute unit price #{price} exceeds maximum #{MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS}" if price > MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS
+        else
+          raise VerificationError, "Unsupported compute budget instruction"
+        end
+      end
+
+      def program_id(transaction, ix)
+        account_key(transaction, ix.program_id_index, "program_id")
+      end
+
+      def account_key(transaction, index, label)
+        transaction.message.account_keys.fetch(index)
+      rescue IndexError, TypeError
+        raise VerificationError, "Invalid #{label} index"
+      end
+
+      def u32_le(bytes)
+        bytes.unpack1("L<")
+      end
+
+      def u64_le(bytes)
+        bytes.unpack1("Q<")
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/server/verification_result.rb
+++ b/ruby/lib/solana_mpp/server/verification_result.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Server
+    # Result returned by lower-level credential verifiers.
+    class VerificationResult
+      attr_reader :reference, :reason, :credential, :challenge
+
+      def initialize(ok:, reference: nil, reason: nil, credential: nil, challenge: nil)
+        @ok = ok
+        @reference = reference
+        @reason = reason
+        @credential = credential
+        @challenge = challenge
+      end
+
+      # Return true when verification succeeded.
+      def ok?
+        @ok
+      end
+
+      # Create a successful verification result.
+      def self.success(reference: nil, credential: nil, challenge: nil)
+        new(ok: true, reference: reference, credential: credential, challenge: challenge)
+      end
+
+      # Create a failed verification result.
+      def self.failure(reason)
+        new(ok: false, reason: reason)
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/solana/associated_token.rb
+++ b/ruby/lib/solana_mpp/solana/associated_token.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Solana
+    # Associated token account derivation helper.
+    module AssociatedToken
+      module_function
+
+      # Derive the ATA for owner/mint/token-program.
+      def derive(owner:, mint:, token_program:)
+        Solana::PublicKey.find_program_address(
+          [
+            Solana::PublicKey.new(owner).bytes.pack("C*"),
+            Solana::PublicKey.new(token_program).bytes.pack("C*"),
+            Solana::PublicKey.new(mint).bytes.pack("C*")
+          ],
+          Common::StablecoinMints::ASSOCIATED_TOKEN_PROGRAM
+        ).first.to_s
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/solana/base58.rb
+++ b/ruby/lib/solana_mpp/solana/base58.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  module Solana
+    # Bitcoin-alphabet Base58 helpers used by Solana public keys/signatures.
+    module Base58
+      ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+      module_function
+
+      # Encode binary bytes as a Base58 string.
+      def encode(binary)
+        int = binary.bytes.reduce(0) { |memo, byte| (memo << 8) + byte }
+        encoded = +""
+        while int.positive?
+          int, mod = int.divmod(58)
+          encoded << ALPHABET[mod]
+        end
+        leading = binary.bytes.take_while(&:zero?).length
+        ("1" * leading) + encoded.reverse
+      end
+
+      # Decode a Base58 string into binary bytes.
+      def decode(value)
+        int = 0
+        value.each_char do |char|
+          index = ALPHABET.index(char)
+          raise ArgumentError, "Value passed not a valid Base58 String." if index.nil?
+
+          int = (int * 58) + index
+        end
+        bytes = []
+        while int.positive?
+          bytes.unshift(int & 0xff)
+          int >>= 8
+        end
+        ("\x00".b * value.each_char.take_while { |char| char == "1" }.length) + bytes.pack("C*")
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/solana/keypair.rb
+++ b/ruby/lib/solana_mpp/solana/keypair.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "ed25519"
+require "json"
+
+module SolanaMpp
+  module Solana
+    # In-memory Solana Ed25519 keypair loaded from canonical JSON bytes.
+    class Keypair
+      attr_reader :secret_key, :public_key
+
+      def initialize(bytes)
+        raise ArgumentError, "keypair must have 64 bytes" unless bytes.length == 64
+
+        @secret_key = bytes
+        @signing_key = Ed25519::SigningKey.new(bytes[0, 32].pack("C*"))
+        @public_key = PublicKey.new(bytes[32, 32].pack("C*"))
+      end
+
+      # Build a keypair from a JSON array string.
+      def self.from_json_array(raw)
+        bytes = JSON.parse(raw)
+        raise ArgumentError, "secret key must be a JSON array" unless bytes.is_a?(Array)
+
+        new(bytes.map { |byte| Integer(byte) })
+      end
+
+      # Sign Solana message bytes.
+      def sign(message)
+        @signing_key.sign(message)
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/solana/public_key.rb
+++ b/ruby/lib/solana_mpp/solana/public_key.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module SolanaMpp
+  module Solana
+    # Base58 Solana public key wrapper.
+    class PublicKey
+      PROGRAM_DERIVED_ADDRESS_SEED = "ProgramDerivedAddress"
+      P = (2**255) - 19
+      D = (-121665 * 121666.pow(P - 2, P)) % P
+
+      attr_reader :bytes
+
+      def initialize(value)
+        @bytes = if value.is_a?(String) && value.encoding == Encoding::BINARY && value.bytesize == 32
+          value.bytes
+        elsif value.is_a?(String)
+          Base58.decode(value).bytes
+        else
+          value.bytes
+        end
+        raise ArgumentError, "public key must be 32 bytes" unless @bytes.length == 32
+      end
+
+      # Return the Base58 representation.
+      def to_s
+        Base58.encode(bytes.pack("C*"))
+      end
+
+      # Compare public-key bytes.
+      def ==(other)
+        other.is_a?(PublicKey) && bytes == other.bytes
+      end
+
+      # Derive a Solana program address.
+      def self.find_program_address(seeds, program_id)
+        program = PublicKey.new(program_id).bytes.pack("C*")
+        255.downto(0) do |bump|
+          candidate = Digest::SHA256.digest(seeds.join + [bump].pack("C") + program + PROGRAM_DERIVED_ADDRESS_SEED)
+          return [PublicKey.new(candidate), bump] unless on_curve?(candidate)
+        end
+        raise ArgumentError, "unable to find program address"
+      end
+
+      def self.on_curve?(encoded)
+        bytes = encoded.bytes
+        y = bytes.each_with_index.reduce(0) { |memo, (byte, index)| memo + (byte << (8 * index)) }
+        y &= (1 << 255) - 1
+        y2 = mod(y * y)
+        u = mod(y2 - 1)
+        v = mod((D * y2) + 1)
+        x2 = mod(u * inv(v))
+        sqrt = sqrt_ratio(x2)
+        !sqrt.nil?
+      end
+
+      def self.mod(value)
+        value % P
+      end
+
+      def self.inv(value)
+        value.pow(P - 2, P)
+      end
+
+      def self.sqrt_ratio(value)
+        root = value.pow((P + 3) / 8, P)
+        root = mod(root * 2.pow((P - 1) / 4, P)) if mod(root * root - value) != 0
+        return nil unless mod(root * root - value) == 0
+
+        root
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/solana/rpc_client.rb
+++ b/ruby/lib/solana_mpp/solana/rpc_client.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "net/http"
+require "uri"
+
+module SolanaMpp
+  module Solana
+    # Minimal JSON-RPC client for the charge server path.
+    class RpcClient
+      DEFAULT_OPEN_TIMEOUT_SECONDS = 5
+      DEFAULT_READ_TIMEOUT_SECONDS = 10
+      DEFAULT_WRITE_TIMEOUT_SECONDS = 10
+      NETWORK_ERRORS = [
+        EOFError,
+        Errno::ECONNREFUSED,
+        Errno::ECONNRESET,
+        Errno::EPIPE,
+        IOError,
+        SocketError
+      ].freeze
+
+      def initialize(
+        url,
+        open_timeout: DEFAULT_OPEN_TIMEOUT_SECONDS,
+        read_timeout: DEFAULT_READ_TIMEOUT_SECONDS,
+        write_timeout: DEFAULT_WRITE_TIMEOUT_SECONDS
+      )
+        @uri = URI(url)
+        @open_timeout = open_timeout
+        @read_timeout = read_timeout
+        @write_timeout = write_timeout
+        @request_id = 0
+        @request_id_mutex = Mutex.new
+      end
+
+      # Call a Solana JSON-RPC method.
+      def call(method, params = [])
+        response = perform_request(JSON.generate({jsonrpc: "2.0", id: next_request_id, method: method, params: params}))
+        body = JSON.parse(response.body)
+        raise Error, "#{method}: #{body["error"]["message"]}" if body["error"]
+
+        body["result"]
+      rescue Timeout::Error => error
+        raise Error, "#{method}: Solana RPC request timed out (#{error.class})"
+      rescue *NETWORK_ERRORS => error
+        raise Error, "#{method}: Solana RPC request failed (#{error.class})"
+      end
+
+      # Return the latest confirmed blockhash.
+      def latest_blockhash
+        call("getLatestBlockhash", [{"commitment" => "confirmed"}]).fetch("value").fetch("blockhash")
+      end
+
+      # Simulate a base64 transaction and fail on program errors.
+      def simulate_transaction(transaction_base64)
+        call("simulateTransaction", [
+          transaction_base64,
+          {
+            "encoding" => "base64",
+            "commitment" => "confirmed",
+            "sigVerify" => false
+          }
+        ]).fetch("value")
+      end
+
+      # Submit a signed base64 transaction.
+      def send_raw_transaction(transaction_base64)
+        call("sendTransaction", [
+          transaction_base64,
+          {
+            "encoding" => "base64",
+            "skipPreflight" => false,
+            "preflightCommitment" => "confirmed"
+          }
+        ])
+      end
+
+      # Return signature status array.
+      def signature_statuses(signatures)
+        call("getSignatureStatuses", [signatures]).fetch("value")
+      end
+
+      # Fetch a confirmed transaction by signature using base64 encoding.
+      def transaction_base64(signature)
+        call("getTransaction", [
+          signature,
+          {
+            "encoding" => "base64",
+            "commitment" => "confirmed",
+            "maxSupportedTransactionVersion" => 0
+          }
+        ])
+      end
+
+      private
+
+      def next_request_id
+        @request_id_mutex.synchronize do
+          @request_id += 1
+        end
+      end
+
+      def perform_request(body)
+        request = Net::HTTP::Post.new(@uri.request_uri, "Content-Type" => "application/json")
+        request.body = body
+
+        http = Net::HTTP.new(@uri.hostname, @uri.port)
+        http.use_ssl = @uri.scheme == "https"
+        http.open_timeout = @open_timeout
+        http.read_timeout = @read_timeout
+        http.write_timeout = @write_timeout if http.respond_to?(:write_timeout=)
+
+        http.start { |client| client.request(request) }
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/solana/transaction.rb
+++ b/ruby/lib/solana_mpp/solana/transaction.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module SolanaMpp
+  module Solana
+    # Parsed legacy or v0 Solana transaction.
+    class Transaction
+      attr_reader :signatures, :message, :message_offset, :version
+
+      def initialize(signatures:, message:, message_offset:, version:)
+        @signatures = signatures
+        @message = message
+        @message_offset = message_offset
+        @version = version
+      end
+
+      # Decode a standard-base64 Solana transaction.
+      def self.from_base64(value)
+        raw = Base64.strict_decode64(value)
+        from_bytes(raw)
+      rescue ArgumentError => error
+        raise ArgumentError, "invalid transaction payload: #{error.message}"
+      end
+
+      # Parse a Solana transaction from wire bytes.
+      def self.from_bytes(raw)
+        cursor = Cursor.new(raw)
+        signature_count = cursor.compact_u16
+        signatures = signature_count.times.map { cursor.bytes(64) }
+        message_offset = cursor.offset
+        message = Message.parse(cursor.remaining)
+        new(signatures: signatures, message: message, message_offset: message_offset, version: message.version)
+      end
+
+      # Serialize this transaction back to wire bytes.
+      def to_bytes
+        [self.class.compact_u16(signatures.length), signatures.join, message.raw].join
+      end
+
+      # Serialize to standard-base64.
+      def to_base64
+        Base64.strict_encode64(to_bytes)
+      end
+
+      # Replace one signature by signer public key.
+      def sign_with(keypair)
+        index = message.account_keys.index(keypair.public_key.to_s)
+        raise VerificationError, "fee payer not found in transaction accounts" if index.nil?
+        raise VerificationError, "fee payer is not a required signer" if index >= signatures.length
+
+        signatures[index] = keypair.sign(message.raw)
+      end
+
+      # Return the primary signature as base58.
+      def primary_signature
+        Base58.encode(signatures.fetch(0))
+      end
+
+      def self.compact_u16(value)
+        bytes = []
+        loop do
+          byte = value & 0x7f
+          value >>= 7
+          byte |= 0x80 if value.positive?
+          bytes << byte
+          break unless value.positive?
+        end
+        bytes.pack("C*")
+      end
+    end
+
+    # Parsed Solana transaction message.
+    class Message
+      attr_reader :raw, :version, :header, :account_keys, :recent_blockhash, :instructions, :address_table_lookups
+
+      def initialize(raw:, version:, header:, account_keys:, recent_blockhash:, instructions:, address_table_lookups:)
+        @raw = raw
+        @version = version
+        @header = header
+        @account_keys = account_keys
+        @recent_blockhash = recent_blockhash
+        @instructions = instructions
+        @address_table_lookups = address_table_lookups
+      end
+
+      # Parse a legacy or v0 transaction message.
+      def self.parse(raw)
+        cursor = Cursor.new(raw)
+        version = "legacy"
+        first = cursor.peek
+        if (first & 0x80) != 0
+          version = first & 0x7f
+          raise ArgumentError, "unsupported transaction version" unless version == 0
+
+          cursor.byte
+        end
+        header = {
+          required_signatures: cursor.byte,
+          readonly_signed: cursor.byte,
+          readonly_unsigned: cursor.byte
+        }
+        account_keys = cursor.compact_u16.times.map { PublicKey.new(cursor.bytes(32)).to_s }
+        recent_blockhash = Base58.encode(cursor.bytes(32))
+        instructions = cursor.compact_u16.times.map { Instruction.parse(cursor) }
+        lookups = []
+        lookups = cursor.compact_u16.times.map { AddressLookup.parse(cursor) } if version == 0
+        new(
+          raw: raw,
+          version: version,
+          header: header,
+          account_keys: account_keys,
+          recent_blockhash: recent_blockhash,
+          instructions: instructions,
+          address_table_lookups: lookups
+        )
+      end
+    end
+
+    # Parsed compiled Solana instruction.
+    class Instruction
+      attr_reader :program_id_index, :accounts, :data
+
+      def initialize(program_id_index:, accounts:, data:)
+        @program_id_index = program_id_index
+        @accounts = accounts
+        @data = data
+      end
+
+      # Parse a compiled instruction from a cursor.
+      def self.parse(cursor)
+        new(
+          program_id_index: cursor.byte,
+          accounts: cursor.compact_u16.times.map { cursor.byte },
+          data: cursor.bytes(cursor.compact_u16)
+        )
+      end
+    end
+
+    # Parsed v0 address lookup table entry.
+    class AddressLookup
+      # Parse one address lookup table entry.
+      def self.parse(cursor)
+        cursor.bytes(32)
+        writable = cursor.compact_u16.times.map { cursor.byte }
+        readonly = cursor.compact_u16.times.map { cursor.byte }
+        {writable: writable, readonly: readonly}
+      end
+    end
+
+    # Cursor for Solana compact-u16 binary parsing.
+    class Cursor
+      attr_reader :offset
+
+      def initialize(raw)
+        @raw = raw
+        @offset = 0
+      end
+
+      # Read one byte.
+      def byte
+        raise ArgumentError, "unexpected end of transaction" if offset >= @raw.bytesize
+
+        value = @raw.getbyte(offset)
+        @offset += 1
+        value
+      end
+
+      # Peek at one byte.
+      def peek
+        raise ArgumentError, "unexpected end of transaction" if offset >= @raw.bytesize
+
+        @raw.getbyte(offset)
+      end
+
+      # Read `count` bytes.
+      def bytes(count)
+        raise ArgumentError, "unexpected end of transaction" if offset + count > @raw.bytesize
+
+        value = @raw.byteslice(offset, count)
+        @offset += count
+        value
+      end
+
+      # Read a Solana compact-u16 integer.
+      def compact_u16
+        value = 0
+        shift = 0
+        loop do
+          byte = self.byte
+          value |= (byte & 0x7f) << shift
+          break if (byte & 0x80).zero?
+
+          shift += 7
+          raise ArgumentError, "compact-u16 is too long" if shift > 21
+        end
+        value
+      end
+
+      # Return all unread bytes.
+      def remaining
+        @raw.byteslice(offset, @raw.bytesize - offset)
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/store.rb
+++ b/ruby/lib/solana_mpp/store.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+
+module SolanaMpp
+  # Atomic replay-protection store interface.
+  class Store
+    # Insert `value` only if `key` does not exist.
+    def put_if_absent(_key, _value)
+      raise NotImplementedError
+    end
+  end
+
+  # Thread-safe in-memory replay store for tests and local development.
+  class MemoryStore < Store
+    def initialize
+      @mutex = Mutex.new
+      @values = {}
+    end
+
+    # Insert `value` only if `key` has not been consumed.
+    def put_if_absent(key, value)
+      @mutex.synchronize do
+        return false if @values.key?(key)
+
+        @values[key] = value
+        true
+      end
+    end
+  end
+
+  # File-backed replay store for examples and single-process deployments.
+  #
+  # The in-process mutex protects concurrent threads sharing this object, but it
+  # is not a cross-process file lock. Production multi-worker servers should
+  # provide a shared atomic store such as Redis, Postgres, or DynamoDB.
+  class FileStore < Store
+    def initialize(path)
+      @path = path
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, "{}") unless File.exist?(path)
+      @mutex = Mutex.new
+    end
+
+    # Insert `value` only if `key` has not been consumed.
+    def put_if_absent(key, value)
+      @mutex.synchronize do
+        data = JSON.parse(File.read(@path))
+        return false if data.key?(key)
+
+        data[key] = value
+        File.write(@path, JSON.pretty_generate(data))
+        true
+      end
+    end
+  end
+end

--- a/ruby/lib/solana_mpp/version.rb
+++ b/ruby/lib/solana_mpp/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module SolanaMpp
+  VERSION = "0.1.0"
+end

--- a/ruby/scripts/update_coverage_badge.rb
+++ b/ruby/scripts/update_coverage_badge.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "json"
+
+unless ARGV.length == 2
+  warn "usage: ruby scripts/update_coverage_badge.rb <simplecov-resultset.json> <readme.md>"
+  exit 2
+end
+
+resultset_path, readme_path = ARGV
+resultset = JSON.parse(File.read(resultset_path))
+coverage = resultset.values.fetch(0).fetch("coverage")
+
+line_total = 0
+line_covered = 0
+branch_total = 0
+branch_covered = 0
+
+coverage.each_value do |metrics|
+  metrics.fetch("lines", []).each do |hits|
+    next if hits.nil?
+
+    line_total += 1
+    line_covered += 1 if hits.positive?
+  end
+
+  metrics.fetch("branches", {}).each_value do |branches|
+    branches.each_value do |hits|
+      branch_total += 1
+      branch_covered += 1 if hits.positive?
+    end
+  end
+end
+
+def percentage(covered, total)
+  raise "coverage result has no measurable items" if total.zero?
+
+  ((covered.to_f / total) * 100).floor
+end
+
+def badge_color(percent)
+  case percent
+  when 90.. then "brightgreen"
+  when 80...90 then "green"
+  when 70...80 then "yellowgreen"
+  when 60...70 then "yellow"
+  when 50...60 then "orange"
+  else "red"
+  end
+end
+
+line_percent = percentage(line_covered, line_total)
+branch_percent = percentage(branch_covered, branch_total)
+readme = File.read(readme_path)
+updated = readme
+updated = updated.gsub(
+  %r{https://img\.shields\.io/badge/coverage-[0-9.]+%25-[a-z]+},
+  "https://img.shields.io/badge/coverage-#{line_percent}%25-#{badge_color(line_percent)}"
+)
+updated = updated.gsub(
+  %r{https://img\.shields\.io/badge/branch%20coverage-[0-9.]+%25-[a-z]+},
+  "https://img.shields.io/badge/branch%20coverage-#{branch_percent}%25-#{badge_color(branch_percent)}"
+)
+
+if updated == readme
+  puts "Coverage badges already at #{line_percent}% line / #{branch_percent}% branch."
+else
+  File.write(readme_path, updated)
+  puts "Updated coverage badges: #{line_percent}% line / #{branch_percent}% branch."
+end

--- a/ruby/solana-mpp.gemspec
+++ b/ruby/solana-mpp.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "solana-mpp"
+  spec.version = "0.1.0"
+  spec.summary = "Solana charge server for the Machine Payments Protocol"
+  spec.description = "Ruby server-side MPP charge support for Solana pull and push settlement."
+  spec.authors = ["Solana Foundation"]
+  spec.email = ["opensource@solana.org"]
+  spec.homepage = "https://github.com/solana-foundation/mpp-sdk"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.2"
+
+  spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"].select { |path| File.file?(path) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "base64", "~> 0.3"
+  spec.add_dependency "ed25519", "~> 1.4"
+  spec.add_dependency "json", "~> 2.9"
+  spec.add_dependency "net-http", "~> 0.6"
+  spec.add_dependency "rack", "~> 3.1"
+  spec.add_dependency "rackup", "~> 2.2"
+  spec.add_dependency "puma", "~> 7.1"
+  spec.add_dependency "sinatra", "~> 4.2"
+  spec.add_dependency "webrick", "~> 1.8"
+
+  spec.add_development_dependency "bundler-audit", "~> 0.9"
+  spec.add_development_dependency "minitest", "~> 5.25"
+  spec.add_development_dependency "rake", "~> 13.2"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "standard", "~> 1.43"
+end

--- a/ruby/test/charge_request_test.rb
+++ b/ruby/test/charge_request_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class ChargeRequestTest < Minitest::Test
+  def test_serializes_camel_case_wire_fields
+    request = SolanaMpp::Intent::ChargeRequest.new(
+      amount: "1000",
+      currency: "USDC",
+      recipient: "recipient",
+      description: "API call",
+      external_id: "order-001",
+      method_details: {"network" => "localnet"}
+    )
+
+    assert_equal(
+      {
+        "amount" => "1000",
+        "currency" => "USDC",
+        "recipient" => "recipient",
+        "description" => "API call",
+        "externalId" => "order-001",
+        "methodDetails" => {"network" => "localnet"}
+      },
+      request.to_h
+    )
+  end
+
+  def test_from_hash_with_optional_fields_absent
+    request = SolanaMpp::Intent::ChargeRequest.from_h({"amount" => "1", "currency" => "SOL"})
+
+    assert_equal "1", request.amount
+    assert_equal "SOL", request.currency
+    assert_nil request.recipient
+    assert_empty request.method_details
+  end
+
+  def test_parse_units_boundaries
+    assert_equal "1500000", SolanaMpp::Intent::ChargeRequest.parse_units("1.5", 6)
+    assert_equal "1", SolanaMpp::Intent::ChargeRequest.parse_units("0.000001", 6)
+    assert_equal "0", SolanaMpp::Intent::ChargeRequest.parse_units("0", 6)
+    assert_raises(ArgumentError) { SolanaMpp::Intent::ChargeRequest.parse_units("0.0000001", 6) }
+    assert_raises(ArgumentError) { SolanaMpp::Intent::ChargeRequest.parse_units("abc", 6) }
+  end
+
+  def test_rejects_zero_and_invalid_method_details
+    assert_raises(ArgumentError) { SolanaMpp::Intent::ChargeRequest.new(amount: "0", currency: "SOL") }
+    assert_raises(ArgumentError) { SolanaMpp::Intent::ChargeRequest.new(amount: "1", currency: "") }
+    assert_raises(ArgumentError) { SolanaMpp::Intent::ChargeRequest.new(amount: "1", currency: "SOL", method_details: "bad") }
+    assert_raises(ArgumentError) { SolanaMpp::Intent::ChargeRequest.from_h("bad") }
+  end
+end

--- a/ruby/test/core_test.rb
+++ b/ruby/test/core_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class CoreTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def test_canonical_json_orders_nested_keys
+    value = {"b" => 2, "a" => [{"b" => true, "a" => false}]}
+
+    assert_equal '{"a":[{"a":false,"b":true}],"b":2}', SolanaMpp::Core::Json.canonical_generate(value)
+    assert_equal "eyJhIjpbeyJhIjpmYWxzZSwiYiI6dHJ1ZX1dLCJiIjoyfQ", SolanaMpp::Core::Base64Url.encode(SolanaMpp::Core::Json.canonical_generate(value))
+  end
+
+  def test_json_and_header_error_branches
+    assert_raises(ArgumentError) { SolanaMpp::Core::Json.canonical_generate(Object.new) }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Json.parse("{") }
+    assert_equal "hello", SolanaMpp::Core::Base64Url.decode(Base64.strict_encode64("hello"))
+    assert_raises(ArgumentError) { SolanaMpp::Core::Headers.parse_www_authenticate("Bearer token") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Headers.parse_auth_params("id=unquoted") }
+  end
+
+  def test_header_parser_unescapes_quoted_values
+    params = SolanaMpp::Core::Headers.parse_auth_params('realm="api\"quoted", id="x"')
+
+    assert_equal 'api"quoted', params.fetch("realm")
+    assert_equal "x", params.fetch("id")
+    assert_empty SolanaMpp::Core::Headers.parse_auth_params(" , \t ")
+  end
+
+  def test_challenge_header_round_trip_and_hmac
+    request = charge_request
+    challenge = SolanaMpp::Core::Challenge.with_secret(
+      secret_key: "secret",
+      realm: "api",
+      method: "solana",
+      intent: "charge",
+      request: request.to_h,
+      expires: "2027-01-01T00:00:00Z"
+    )
+
+    parsed = SolanaMpp::Core::Headers.parse_www_authenticate(SolanaMpp::Core::Headers.format_www_authenticate(challenge))
+
+    assert_equal challenge.id, parsed.id
+    assert parsed.verify?("secret")
+    refute parsed.verify?("other")
+    assert_equal request.to_h, parsed.decode_request
+  end
+
+  def test_challenge_fails_closed_on_invalid_expiry
+    challenge = SolanaMpp::Core::Challenge.with_secret(
+      secret_key: "secret",
+      realm: "api",
+      method: "solana",
+      intent: "charge",
+      request: charge_request.to_h,
+      expires: "not-time"
+    )
+
+    assert challenge.expired?
+  end
+
+  def test_challenge_expired_past_and_optional_fields
+    challenge = SolanaMpp::Core::Challenge.with_secret(
+      secret_key: "secret",
+      realm: "api",
+      method: "solana",
+      intent: "charge",
+      request: charge_request.to_h,
+      expires: "2020-01-01T00:00:00Z",
+      description: "paid route",
+      digest: "sha-256=:abc:",
+      opaque: "opaque"
+    )
+
+    assert challenge.expired?
+    echo = challenge.to_echo
+    assert_equal "sha-256=:abc:", echo.digest
+    assert_equal "opaque", echo.opaque
+  end
+
+  def test_credential_authorization_round_trip
+    challenge = SolanaMpp::Core::Challenge.with_secret(
+      secret_key: "secret",
+      realm: "api",
+      method: "solana",
+      intent: "charge",
+      request: charge_request.to_h
+    )
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => "1" * 87})
+
+    parsed = SolanaMpp::Core::Credential.from_authorization_header(credential.to_authorization_header)
+
+    assert_equal challenge.id, parsed.challenge.id
+    assert_equal "1" * 87, parsed.payload["signature"]
+
+    sourced = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => "1" * 87}, source: "wallet")
+    assert_equal "wallet", sourced.to_h.fetch("source")
+  end
+
+  def test_challenge_and_credential_validation_edges
+    assert_raises(ArgumentError) { SolanaMpp::Core::Challenge.new(id: "", realm: "api", method: "solana", intent: "charge", request: "x") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Challenge.new(id: "id", realm: "", method: "solana", intent: "charge", request: "x") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Challenge.new(id: "id", realm: "api", method: "Solana", intent: "charge", request: "x") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Challenge.new(id: "id", realm: "api", method: "solana", intent: "", request: "x") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Challenge.new(id: "id", realm: "api", method: "solana", intent: "charge", request: "") }
+
+    challenge = SolanaMpp::Core::Challenge.with_secret(secret_key: "secret", realm: "api", method: "solana", intent: "charge", request: charge_request.to_h)
+    refute challenge.expired?
+    assert_nil challenge.to_echo.expires
+    refute SolanaMpp::Core::Challenge.new(id: "short", realm: challenge.realm, method: challenge.method, intent: challenge.intent, request: challenge.request).verify?("secret")
+    assert_raises(ArgumentError) { SolanaMpp::Core::Credential.from_authorization_header("Bearer token") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Credential.from_authorization_header("Payment #{"a" * (SolanaMpp::Core::Credential::MAX_TOKEN_LENGTH + 1)}") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: "bad") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::Credential.from_authorization_header("Payment #") }
+    assert_raises(ArgumentError) { SolanaMpp::Core::ChallengeEcho.from_h("bad") }
+  end
+
+  def test_receipt_header_round_trip
+    receipt = SolanaMpp::Core::Receipt.success(method: "solana", reference: "sig", challenge_id: "challenge", external_id: "order")
+
+    parsed = SolanaMpp::Core::Headers.parse_receipt(SolanaMpp::Core::Headers.format_receipt(receipt))
+
+    assert_equal "success", parsed.status
+    assert_equal "sig", parsed.reference
+    assert_equal "order", parsed.external_id
+  end
+end

--- a/ruby/test/example_test.rb
+++ b/ruby/test/example_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "rack/mock"
+
+class ExampleTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def test_sinatra_example_loads_and_exposes_health_route
+    with_env(
+      "MPP_FEE_PAYER_SECRET_KEY" => JSON.generate(Array.new(64, 1)),
+      "MPP_MINT" => "So11111111111111111111111111111111111111112",
+      "MPP_PAY_TO" => pubkey(2),
+      "PORT" => "4568"
+    ) do
+      require_relative "../examples/sinatra-app"
+
+      response = Rack::MockRequest.new(RubyMppSinatraExample).get("/health")
+
+      assert_equal 200, response.status
+      assert_equal({"ok" => true}, JSON.parse(response.body))
+    end
+  end
+
+  private
+
+  def with_env(values)
+    previous = values.to_h { |key, _value| [key, ENV[key]] }
+    values.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    previous.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+  end
+end

--- a/ruby/test/handler_paths_test.rb
+++ b/ruby/test/handler_paths_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class HandlerPathsTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def test_pull_settlement_simulates_sends_confirms_and_consumes
+    request = charge_request
+    rpc = FakeRpc.new(signature: valid_signature)
+    handler = handler_with(rpc)
+    transaction = Base64.strict_encode64(legacy_transaction(
+      account_keys: [pubkey(1), request.recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+    credential = SolanaMpp::Core::Credential.new(
+      challenge: challenges.create_challenge(request).to_echo,
+      payload: {"transaction" => transaction}
+    )
+
+    response = handler.handle(credential.to_authorization_header, request)
+
+    assert_equal 200, response.status
+    assert_equal 1, rpc.simulated_transactions.length
+    assert_equal 1, rpc.sent_transactions.length
+  end
+
+  def test_pull_rejects_simulation_failure
+    request = charge_request
+    rpc = FakeRpc.new(simulation_error: {"InstructionError" => [0, "Custom"]})
+    handler = handler_with(rpc)
+    transaction = Base64.strict_encode64(legacy_transaction(
+      account_keys: [pubkey(1), request.recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+    credential = SolanaMpp::Core::Credential.new(challenge: challenges.create_challenge(request).to_echo, payload: {"transaction" => transaction})
+
+    response = handler.handle(credential.to_authorization_header, request)
+
+    assert_equal 402, response.status
+    assert_match(/Simulation failed/, response.body["message"])
+  end
+
+  def test_pull_rejects_wrong_surfpool_network
+    handler = handler_with(FakeRpc.new, network: "devnet")
+
+    error = assert_raises(SolanaMpp::VerificationError) do
+      handler.send(:check_network_blockhash, SolanaMpp::Server::ChargeHandler::SURFPOOL_BLOCKHASH_PREFIX + "abc")
+    end
+    assert_match(/Signed against localnet/, error.message)
+  end
+
+  def test_push_fetch_timeout_and_failed_meta
+    request = charge_request
+    timeout = handler_with(FakeRpc.new(transaction_response: nil), attempts: 1)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenges.create_challenge(request).to_echo, payload: {"signature" => valid_signature})
+    response = timeout.handle(credential.to_authorization_header, request)
+
+    assert_equal 402, response.status
+    assert_match(/Timed out fetching/, response.body["message"])
+
+    failed = handler_with(FakeRpc.new(transaction_response: {"meta" => {"err" => {"bad" => true}}, "transaction" => ["x", "base64"]}))
+    response = failed.handle(credential.to_authorization_header, request)
+
+    assert_equal 402, response.status
+    assert_match(/failed/, response.body["message"])
+  end
+
+  def test_push_rejects_missing_transaction_metadata_and_wire
+    request = charge_request
+    credential = SolanaMpp::Core::Credential.new(challenge: challenges.create_challenge(request).to_echo, payload: {"signature" => valid_signature})
+
+    missing_meta = handler_with(FakeRpc.new(transaction_response: {"transaction" => ["tx", "base64"]}))
+    response = missing_meta.handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/missing transaction metadata/, response.body["message"])
+
+    missing_wire = handler_with(FakeRpc.new(transaction_response: {"meta" => {"err" => nil}, "transaction" => []}))
+    response = missing_wire.handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/missing base64 transaction/, response.body["message"])
+  end
+
+  def test_rack_middleware_protects_only_configured_path
+    request = charge_request
+    handler = handler_with(FakeRpc.new)
+    app = ->(_env) { [200, {"content-type" => "text/plain"}, ["open"]] }
+    middleware = SolanaMpp::Server::RackMiddleware.new(app, handler: handler, request: request, path: "/paid")
+
+    status, _headers, body = middleware.call("PATH_INFO" => "/open")
+    assert_equal 200, status
+    assert_equal ["open"], body
+
+    status, headers, _body = middleware.call("PATH_INFO" => "/paid")
+    assert_equal 402, status
+    assert headers.key?(SolanaMpp::Core::Headers::WWW_AUTHENTICATE)
+  end
+
+  private
+
+  def challenges
+    @challenges ||= SolanaMpp::Server::ChargeServer.new(secret_key: "secret", realm: "api")
+  end
+
+  def handler_with(rpc, network: "localnet", attempts: 40)
+    SolanaMpp::Server::ChargeHandler.new(
+      challenges: challenges,
+      rpc: rpc,
+      replay_store: SolanaMpp::MemoryStore.new,
+      network: network,
+      confirmation_attempts: attempts,
+      confirmation_delay: 0
+    )
+  end
+
+  def valid_signature
+    SolanaMpp::Solana::Base58.encode(("b" * 64).b)
+  end
+end

--- a/ruby/test/run.rb
+++ b/ruby/test/run.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Dir[File.join(__dir__, "**/*_test.rb")].sort.each { |path| require path }

--- a/ruby/test/server_test.rb
+++ b/ruby/test/server_test.rb
@@ -1,0 +1,757 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class FakeRpc
+  attr_reader :sent_transactions, :simulated_transactions
+
+  def initialize(signature: "3mJr7AoUXx2Wqd", transaction_response: nil, statuses: nil, simulation_error: nil)
+    @signature = signature
+    @transaction_response = transaction_response
+    @statuses = statuses || [{"err" => nil, "confirmationStatus" => "confirmed"}]
+    @simulation_error = simulation_error
+    @sent_transactions = []
+    @simulated_transactions = []
+  end
+
+  def simulate_transaction(transaction_base64)
+    @simulated_transactions << transaction_base64
+    {"err" => @simulation_error}
+  end
+
+  def send_raw_transaction(transaction_base64)
+    @sent_transactions << transaction_base64
+    @signature
+  end
+
+  def signature_statuses(_signatures)
+    @statuses
+  end
+
+  def transaction_base64(_signature)
+    @transaction_response
+  end
+end
+
+class SequenceRpc < FakeRpc
+  def initialize(responses:)
+    super()
+    @responses = responses
+  end
+
+  def transaction_base64(_signature)
+    @responses.shift
+  end
+end
+
+class ChargeServerTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def setup
+    @server = SolanaMpp::Server::ChargeServer.new(secret_key: "secret", realm: "api")
+  end
+
+  def test_creates_and_verifies_expected_credential
+    request = charge_request(external_id: "order-1")
+    challenge = @server.create_challenge(request)
+    credential = SolanaMpp::Core::Credential.new(
+      challenge: challenge.to_echo,
+      payload: {"signature" => valid_signature}
+    )
+    verifier = SolanaMpp::Server::TransactionVerifier.new
+
+    result = @server.verify_authorization_header(
+      credential.to_authorization_header,
+      verifier: verifier,
+      expected_request: request
+    )
+
+    assert result.ok?
+    assert_equal valid_signature, result.reference
+  end
+
+  def test_blockhash_provider_injects_recent_blockhash_without_mutating_request
+    request = charge_request
+    server = SolanaMpp::Server::ChargeServer.new(
+      secret_key: "secret",
+      realm: "api",
+      blockhash_provider: -> { "recent-blockhash" }
+    )
+
+    challenge = server.create_challenge(request)
+    decoded = challenge.decode_request
+
+    assert_equal "recent-blockhash", decoded.fetch("methodDetails").fetch("recentBlockhash")
+    refute request.method_details.key?("recentBlockhash")
+  end
+
+  def test_rejects_method_details_replay_with_same_amount_currency_and_recipient
+    cheap = charge_request
+    expensive = charge_request(method_details: {"network" => "localnet", "decimals" => 6, "splits" => [{"recipient" => pubkey(3), "amount" => "250"}]})
+    challenge = @server.create_challenge(cheap)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+
+    result = @server.verify_authorization_header(
+      credential.to_authorization_header,
+      verifier: SolanaMpp::Server::TransactionVerifier.new,
+      expected_request: expensive
+    )
+
+    refute result.ok?
+    assert_match(/Method details mismatch/, result.reason)
+  end
+
+  def test_rejects_cross_route_amount_replay
+    cheap = charge_request(amount: "500")
+    expensive = charge_request(amount: "1000")
+    challenge = @server.create_challenge(cheap)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+
+    result = @server.verify_authorization_header(
+      credential.to_authorization_header,
+      verifier: SolanaMpp::Server::TransactionVerifier.new,
+      expected_request: expensive
+    )
+
+    refute result.ok?
+    assert_match(/Amount mismatch/, result.reason)
+  end
+
+  def test_rejects_expired_challenge
+    request = charge_request
+    challenge = @server.create_challenge(request, expires: "2020-01-01T00:00:00Z")
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+
+    result = @server.verify_authorization_header(
+      credential.to_authorization_header,
+      verifier: SolanaMpp::Server::TransactionVerifier.new,
+      expected_request: request
+    )
+
+    refute result.ok?
+    assert_equal "challenge expired", result.reason
+  end
+
+  def test_rejects_wrong_secret_and_wrong_realm
+    request = charge_request
+    issuer = SolanaMpp::Server::ChargeServer.new(secret_key: "other", realm: "api")
+    credential = SolanaMpp::Core::Credential.new(challenge: issuer.create_challenge(request).to_echo, payload: {"signature" => valid_signature})
+
+    result = @server.verify_authorization_header(credential.to_authorization_header, verifier: SolanaMpp::Server::TransactionVerifier.new, expected_request: request)
+    refute result.ok?
+    assert_match(/challenge verification failed/, result.reason)
+
+    issuer = SolanaMpp::Server::ChargeServer.new(secret_key: "secret", realm: "other")
+    credential = SolanaMpp::Core::Credential.new(challenge: issuer.create_challenge(request).to_echo, payload: {"signature" => valid_signature})
+    result = @server.verify_authorization_header(credential.to_authorization_header, verifier: SolanaMpp::Server::TransactionVerifier.new, expected_request: request)
+    refute result.ok?
+    assert_match(/does not match this server|challenge verification failed/, result.reason)
+  end
+
+  def test_rejects_wrong_method_with_valid_hmac
+    request = charge_request
+    challenge = SolanaMpp::Core::Challenge.with_secret(
+      secret_key: "secret",
+      realm: "api",
+      method: "stripe",
+      intent: "charge",
+      request: request.to_h
+    )
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+
+    result = @server.verify_authorization_header(credential.to_authorization_header, verifier: SolanaMpp::Server::TransactionVerifier.new, expected_request: request)
+
+    refute result.ok?
+    assert_match(/method/, result.reason)
+  end
+
+  def test_rejects_wrong_intent_currency_and_recipient_with_valid_hmac
+    request = charge_request
+    challenge = SolanaMpp::Core::Challenge.with_secret(secret_key: "secret", realm: "api", method: "solana", intent: "session", request: request.to_h)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+    result = @server.verify_authorization_header(credential.to_authorization_header, verifier: SolanaMpp::Server::TransactionVerifier.new, expected_request: request)
+    refute result.ok?
+    assert_match(/intent/, result.reason)
+
+    challenge = @server.create_challenge(charge_request(currency: "USDC"))
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+    result = @server.verify_authorization_header(credential.to_authorization_header, verifier: SolanaMpp::Server::TransactionVerifier.new, expected_request: request)
+    refute result.ok?
+    assert_match(/Currency mismatch/, result.reason)
+
+    challenge = @server.create_challenge(charge_request(recipient: pubkey(3)))
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+    result = @server.verify_authorization_header(credential.to_authorization_header, verifier: SolanaMpp::Server::TransactionVerifier.new, expected_request: request)
+    refute result.ok?
+    assert_match(/Recipient mismatch/, result.reason)
+  end
+
+  private
+
+  def valid_signature
+    SolanaMpp::Solana::Base58.encode(("a" * 64).b)
+  end
+end
+
+class RackMiddlewareTest < Minitest::Test
+  def test_accepts_callable_request_for_fresh_challenge_data
+    handler = Object.new
+    calls = 0
+    handled_request = nil
+    request_factory = lambda do |_env|
+      calls += 1
+      SolanaMpp::Intent::ChargeRequest.new(amount: calls.to_s, currency: "SOL", recipient: "recipient")
+    end
+    payment = SolanaMpp::Server::PaymentRequiredResponse.new(headers: {"x-test" => "ok"}, body: {"error" => "payment_required"})
+    handler.define_singleton_method(:handle) do |_authorization, request|
+      handled_request = request
+      payment
+    end
+    app = ->(_env) { [404, {}, ["not_found"]] }
+    middleware = SolanaMpp::Server::RackMiddleware.new(app, handler: handler, request: request_factory, path: "/paid")
+
+    status, headers, body = middleware.call({"PATH_INFO" => "/paid"})
+
+    assert_equal 402, status
+    assert_equal "ok", headers["x-test"]
+    assert_equal [{"error" => "payment_required"}], body.map { |chunk| JSON.parse(chunk) }
+    assert_equal 1, calls
+    assert_equal "1", handled_request.amount
+  end
+end
+
+class TransactionVerifierTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def setup
+    @verifier = SolanaMpp::Server::TransactionVerifier.new
+  end
+
+  def test_verifies_sol_transfer_and_memo
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    tx = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM, PROGRAMS::MEMO_PROGRAM, PROGRAMS::COMPUTE_BUDGET_PROGRAM],
+      instructions: [
+        compiled_instruction(4, [], [3].pack("C") + u64(1)),
+        compiled_instruction(4, [], [2].pack("C") + u32(200_000)),
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000)),
+        compiled_instruction(3, [], "order-1")
+      ]
+    )
+    request = charge_request(external_id: "order-1")
+
+    result = @verifier.verify_transaction_payload(tx, request)
+
+    assert result.ok?, result.reason
+  end
+
+  def test_verifies_non_ascii_external_id_memo_bytes
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    memo = "order-é"
+    tx = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM, PROGRAMS::MEMO_PROGRAM],
+      instructions: [
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000)),
+        compiled_instruction(3, [], memo.b)
+      ]
+    )
+    request = charge_request(external_id: memo)
+
+    result = @verifier.verify_transaction_payload(tx, request)
+
+    assert result.ok?, result.reason
+  end
+
+  def test_rejects_unexpected_program
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    unexpected = pubkey(7)
+    tx = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM, unexpected],
+      instructions: [
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000)),
+        compiled_instruction(3, [], "")
+      ]
+    )
+
+    result = @verifier.verify_transaction_payload(tx, charge_request)
+
+    refute result.ok?
+    assert_match(/Unexpected program/, result.reason)
+  end
+
+  def test_rejects_fee_payer_funding_sol_transfer
+    fee_payer = pubkey(1)
+    recipient = pubkey(2)
+    tx = tx_base64(
+      account_keys: [fee_payer, recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+    request = charge_request(method_details: {"feePayer" => true, "feePayerKey" => fee_payer})
+
+    result = @verifier.verify_transaction_payload(tx, request)
+
+    refute result.ok?
+    assert_match(/fee payer cannot fund/, result.reason)
+  end
+
+  def test_rejects_compute_budget_above_limit
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    tx = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM, PROGRAMS::COMPUTE_BUDGET_PROGRAM],
+      instructions: [
+        compiled_instruction(3, [], [2].pack("C") + u32(200_001)),
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000))
+      ]
+    )
+
+    result = @verifier.verify_transaction_payload(tx, charge_request)
+
+    refute result.ok?
+    assert_match(/Compute unit limit/, result.reason)
+  end
+
+  def test_rejects_signature_wrong_length
+    assert_raises(ArgumentError) { @verifier.validate_signature("abc") }
+  end
+
+  def test_verifier_rejects_missing_payload_and_invalid_base64
+    challenge = SolanaMpp::Core::Challenge.with_secret(secret_key: "secret", realm: "api", method: "solana", intent: "charge", request: charge_request.to_h)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {})
+
+    result = @verifier.verify(credential, challenge)
+    refute result.ok?
+    assert_match(/missing transaction or signature/, result.reason)
+
+    result = @verifier.verify_transaction_payload("not base64", charge_request)
+    refute result.ok?
+    assert_match(/invalid transaction payload/, result.reason)
+  end
+
+  def test_verifies_pull_transaction_against_expected_route_request
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    tx = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+    challenge = SolanaMpp::Core::Challenge.with_secret(secret_key: "secret", realm: "api", method: "solana", intent: "charge", request: charge_request.to_h)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"transaction" => tx})
+    expected = charge_request(method_details: {"network" => "localnet", "decimals" => 6, "splits" => [{"recipient" => pubkey(3), "amount" => "250"}]})
+
+    result = @verifier.verify(credential, challenge, expected_request: expected)
+
+    refute result.ok?
+    assert_match(/No matching SOL transfer/, result.reason)
+  end
+
+  def test_rejects_split_amount_boundaries
+    tx = tx_base64(
+      account_keys: [pubkey(1), pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+    too_many = 9.times.map { |index| {"recipient" => pubkey(index + 10), "amount" => "1"} }
+    result = @verifier.verify_transaction_payload(tx, charge_request(method_details: {"splits" => too_many}))
+    refute result.ok?
+    assert_match(/too many splits/, result.reason)
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(method_details: {"splits" => [{"recipient" => pubkey(3), "amount" => "1000"}]}))
+    refute result.ok?
+    assert_match(/split amounts exceed/, result.reason)
+  end
+
+  def test_rejects_fee_payer_missing_key_and_mismatch
+    tx = tx_base64(
+      account_keys: [pubkey(1), pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(method_details: {"feePayer" => true}))
+    refute result.ok?
+    assert_match(/feePayer=true requires/, result.reason)
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(method_details: {"feePayer" => true, "feePayerKey" => pubkey(3)}))
+    refute result.ok?
+    assert_match(/fee payer mismatch/, result.reason)
+  end
+
+  def test_verifies_spl_transfer_checked
+    owner = pubkey(1)
+    recipient = pubkey(2)
+    mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    source_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    dest_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: recipient, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    tx = tx_base64(
+      account_keys: [owner, source_ata, mint, dest_ata, PROGRAMS::TOKEN_PROGRAM],
+      instructions: [compiled_instruction(4, [1, 2, 3, 0], [12].pack("C") + u64(1000) + [6].pack("C"))]
+    )
+    request = charge_request(currency: mint, recipient: recipient, method_details: {"network" => "localnet", "decimals" => 6, "tokenProgram" => PROGRAMS::TOKEN_PROGRAM})
+
+    result = @verifier.verify_transaction_payload(tx, request)
+
+    assert result.ok?, result.reason
+  end
+
+  def test_verifies_spl_split_with_idempotent_ata_creation
+    owner = pubkey(1)
+    recipient = pubkey(2)
+    split_owner = pubkey(3)
+    mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    source_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    dest_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: recipient, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    split_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: split_owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    tx = tx_base64(
+      account_keys: [owner, source_ata, mint, dest_ata, PROGRAMS::TOKEN_PROGRAM, PROGRAMS::ASSOCIATED_TOKEN_PROGRAM, split_owner, split_ata, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [
+        compiled_instruction(4, [1, 2, 3, 0], [12].pack("C") + u64(750) + [6].pack("C")),
+        compiled_instruction(5, [0, 7, 6, 2, 8, 4], "\x01".b),
+        compiled_instruction(4, [1, 2, 7, 0], [12].pack("C") + u64(250) + [6].pack("C"))
+      ]
+    )
+    request = charge_request(
+      amount: "1000",
+      currency: mint,
+      recipient: recipient,
+      method_details: {
+        "network" => "localnet",
+        "decimals" => 6,
+        "tokenProgram" => PROGRAMS::TOKEN_PROGRAM,
+        "splits" => [{"recipient" => split_owner, "amount" => "250", "ataCreationRequired" => true}]
+      }
+    )
+
+    result = @verifier.verify_transaction_payload(tx, request)
+
+    assert result.ok?, result.reason
+  end
+
+  def test_rejects_missing_required_ata_creation_for_split
+    owner = pubkey(1)
+    recipient = pubkey(2)
+    split_owner = pubkey(3)
+    mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    source_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    dest_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: recipient, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    split_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: split_owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    tx = tx_base64(
+      account_keys: [owner, source_ata, mint, dest_ata, PROGRAMS::TOKEN_PROGRAM, split_ata],
+      instructions: [
+        compiled_instruction(4, [1, 2, 3, 0], [12].pack("C") + u64(750) + [6].pack("C")),
+        compiled_instruction(4, [1, 2, 5, 0], [12].pack("C") + u64(250) + [6].pack("C"))
+      ]
+    )
+    request = charge_request(
+      amount: "1000",
+      currency: mint,
+      recipient: recipient,
+      method_details: {
+        "network" => "localnet",
+        "decimals" => 6,
+        "tokenProgram" => PROGRAMS::TOKEN_PROGRAM,
+        "splits" => [{"recipient" => split_owner, "amount" => "250", "ataCreationRequired" => true}]
+      }
+    )
+
+    result = @verifier.verify_transaction_payload(tx, request)
+
+    refute result.ok?
+    assert_match(/Missing required ATA creation/, result.reason)
+  end
+
+  def test_rejects_invalid_ata_creation_shapes
+    owner = pubkey(1)
+    recipient = pubkey(2)
+    split_owner = pubkey(3)
+    unauthorized_owner = pubkey(4)
+    wrong_ata = pubkey(5)
+    wrong_payer = pubkey(6)
+    wrong_mint = pubkey(7)
+    wrong_program = pubkey(8)
+    unsupported_token_program = pubkey(9)
+    mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    source_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    dest_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: recipient, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    split_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: split_owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    unauthorized_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: unauthorized_owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    keys = [owner, source_ata, mint, dest_ata, PROGRAMS::TOKEN_PROGRAM, PROGRAMS::ASSOCIATED_TOKEN_PROGRAM, split_owner, split_ata, PROGRAMS::SYSTEM_PROGRAM, wrong_payer, wrong_ata, wrong_mint, wrong_program, unsupported_token_program, PROGRAMS::TOKEN_2022_PROGRAM, unauthorized_owner, unauthorized_ata]
+    base_request = charge_request(
+      amount: "1000",
+      currency: mint,
+      recipient: recipient,
+      method_details: {
+        "network" => "localnet",
+        "decimals" => 6,
+        "tokenProgram" => PROGRAMS::TOKEN_PROGRAM,
+        "splits" => [{"recipient" => split_owner, "amount" => "250", "ataCreationRequired" => true}]
+      }
+    )
+    cases = [
+      [[0, 7, 6, 2, 8, 4], "\x00".b, base_request, /Only idempotent/],
+      [[0, 7, 6, 2, 8], "\x01".b, base_request, /account layout/],
+      [[9, 7, 6, 2, 8, 4], "\x01".b, base_request, /payer/],
+      [[0, 7, 6, 11, 8, 4], "\x01".b, base_request, /mint/],
+      [[0, 7, 6, 2, 12, 4], "\x01".b, base_request, /System Program/],
+      [[0, 7, 6, 2, 8, 13], "\x01".b, base_request, /unsupported token program/],
+      [[0, 7, 6, 2, 8, 14], "\x01".b, base_request, /token program/],
+      [[0, 10, 6, 2, 8, 4], "\x01".b, base_request, /address/],
+      [[0, 16, 15, 2, 8, 4], "\x01".b, base_request, /owner/]
+    ]
+
+    cases.each do |accounts, data, request, message|
+      tx = tx_base64(
+        account_keys: keys,
+        instructions: [
+          compiled_instruction(4, [1, 2, 3, 0], [12].pack("C") + u64(750) + [6].pack("C")),
+          compiled_instruction(5, accounts, data),
+          compiled_instruction(4, [1, 2, 7, 0], [12].pack("C") + u64(250) + [6].pack("C"))
+        ]
+      )
+
+      result = @verifier.verify_transaction_payload(tx, request)
+
+      refute result.ok?
+      assert_match message, result.reason
+    end
+  end
+
+  def test_rejects_sol_ata_creation_and_unexpected_memo
+    tx = tx_base64(
+      account_keys: [pubkey(1), pubkey(2), PROGRAMS::SYSTEM_PROGRAM, PROGRAMS::MEMO_PROGRAM],
+      instructions: [
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000)),
+        compiled_instruction(3, [], "unexpected")
+      ]
+    )
+
+    result = @verifier.verify_transaction_payload(tx, charge_request)
+    refute result.ok?
+    assert_match(/Unexpected program instruction/, result.reason)
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(method_details: {"splits" => [{"recipient" => pubkey(3), "amount" => "1", "ataCreationRequired" => true}]}))
+    refute result.ok?
+    assert_match(/ataCreationRequired requires/, result.reason)
+  end
+
+  def test_rejects_compute_budget_price_and_unsupported_shapes
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    expensive = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM, PROGRAMS::COMPUTE_BUDGET_PROGRAM],
+      instructions: [
+        compiled_instruction(3, [], [3].pack("C") + u64(5_000_001)),
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000))
+      ]
+    )
+    result = @verifier.verify_transaction_payload(expensive, charge_request)
+    refute result.ok?
+    assert_match(/Compute unit price/, result.reason)
+
+    unsupported = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM, PROGRAMS::COMPUTE_BUDGET_PROGRAM],
+      instructions: [
+        compiled_instruction(3, [], [9].pack("C")),
+        compiled_instruction(2, [0, 1], u32(2) + u64(1000))
+      ]
+    )
+    result = @verifier.verify_transaction_payload(unsupported, charge_request)
+    refute result.ok?
+    assert_match(/Unsupported compute budget/, result.reason)
+  end
+
+  def test_rejects_memo_too_long_and_missing_expected_memo
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    tx = tx_base64(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(external_id: "x" * 567))
+    refute result.ok?
+    assert_match(/memo cannot exceed/, result.reason)
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(external_id: "order"))
+    refute result.ok?
+    assert_match(/No memo instruction/, result.reason)
+  end
+
+  def test_rejects_missing_recipient_and_bad_split_amount
+    tx = tx_base64(
+      account_keys: [pubkey(1), pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+    no_recipient = SolanaMpp::Intent::ChargeRequest.new(amount: "1000", currency: "SOL")
+    result = @verifier.verify_transaction_payload(tx, no_recipient)
+    refute result.ok?
+    assert_match(/recipient is required/, result.reason)
+
+    result = @verifier.verify_transaction_payload(tx, charge_request(method_details: {"splits" => [{"recipient" => pubkey(3), "amount" => "bad"}]}))
+    refute result.ok?
+    assert_match(/split.amount/, result.reason)
+  end
+
+  def test_rejects_spl_wrong_destination_and_fee_payer_authority
+    owner = pubkey(1)
+    recipient = pubkey(2)
+    mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    source_ata = SolanaMpp::Solana::AssociatedToken.derive(owner: owner, mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    wrong_dest = SolanaMpp::Solana::AssociatedToken.derive(owner: pubkey(3), mint: mint, token_program: PROGRAMS::TOKEN_PROGRAM)
+    tx = tx_base64(
+      account_keys: [owner, source_ata, mint, wrong_dest, PROGRAMS::TOKEN_PROGRAM],
+      instructions: [compiled_instruction(4, [1, 2, 3, 0], [12].pack("C") + u64(1000) + [6].pack("C"))]
+    )
+    request = charge_request(currency: mint, recipient: recipient, method_details: {"network" => "localnet", "decimals" => 6, "tokenProgram" => PROGRAMS::TOKEN_PROGRAM})
+    result = @verifier.verify_transaction_payload(tx, request)
+    refute result.ok?
+    assert_match(/No matching SPL/, result.reason)
+
+    request = charge_request(currency: mint, recipient: recipient, method_details: {"network" => "localnet", "decimals" => 6, "tokenProgram" => PROGRAMS::TOKEN_PROGRAM, "feePayer" => true, "feePayerKey" => owner})
+    result = @verifier.verify_transaction_payload(tx, request)
+    refute result.ok?
+    assert_match(/fee payer cannot authorize|No matching SPL/, result.reason)
+  end
+
+  private
+
+  def tx_base64(account_keys:, instructions:)
+    Base64.strict_encode64(legacy_transaction(account_keys: account_keys, instructions: instructions))
+  end
+end
+
+class ChargeHandlerTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def test_returns_402_without_authorization
+    handler = handler_with(FakeRpc.new)
+    assert_nil handler.fee_payer_pubkey
+
+    response = handler.handle(nil, charge_request)
+
+    assert_equal 402, response.status
+    assert response.headers.key?(SolanaMpp::Core::Headers::WWW_AUTHENTICATE)
+  end
+
+  def test_fee_payer_pubkey_and_missing_payload_response
+    keypair = SolanaMpp::Solana::Keypair.new(Array.new(64, 1))
+    handler = SolanaMpp::Server::ChargeHandler.new(
+      challenges: handler_challenges,
+      rpc: FakeRpc.new,
+      replay_store: SolanaMpp::MemoryStore.new,
+      fee_payer: keypair,
+      network: "localnet"
+    )
+    assert_equal keypair.public_key.to_s, handler.fee_payer_pubkey
+
+    request = charge_request
+    credential = SolanaMpp::Core::Credential.new(challenge: handler_challenges.create_challenge(request).to_echo, payload: {})
+    response = handler.handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/missing transaction or signature/, response.body["message"])
+  end
+
+  def test_settles_push_signature_by_fetching_transaction
+    request = charge_request
+    transaction = Base64.strict_encode64(legacy_transaction(
+      account_keys: [pubkey(1), request.recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+    rpc = FakeRpc.new(transaction_response: {"meta" => {"err" => nil}, "transaction" => [transaction, "base64"]})
+    handler = handler_with(rpc)
+    challenge = handler_challenges.create_challenge(request)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+
+    response = handler.handle(credential.to_authorization_header, request)
+
+    assert_equal 200, response.status
+    assert_equal valid_signature, response.signature
+  end
+
+  def test_rejects_replayed_signature
+    store = SolanaMpp::MemoryStore.new
+    store.put_if_absent("solana-charge:consumed:#{valid_signature}", true)
+    handler = handler_with(FakeRpc.new(transaction_response: transaction_response), store: store)
+    request = charge_request
+    credential = SolanaMpp::Core::Credential.new(challenge: handler_challenges.create_challenge(request).to_echo, payload: {"signature" => valid_signature})
+
+    response = handler.handle(credential.to_authorization_header, request)
+
+    assert_equal 402, response.status
+    assert_match(/already consumed/, response.body["message"])
+  end
+
+  def test_push_mode_reports_transaction_lookup_failures
+    request = charge_request
+    challenge = handler_challenges.create_challenge(request)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"signature" => valid_signature})
+
+    response = handler_with(SequenceRpc.new(responses: [nil]), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/Timed out fetching transaction/, response.body["message"])
+
+    response = handler_with(SequenceRpc.new(responses: [{"transaction" => ["tx", "base64"]}]), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/missing transaction metadata/, response.body["message"])
+
+    response = handler_with(SequenceRpc.new(responses: [{"meta" => {"err" => "boom"}, "transaction" => ["tx", "base64"]}]), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/failed/, response.body["message"])
+
+    response = handler_with(SequenceRpc.new(responses: [{"meta" => {"err" => nil}, "transaction" => []}]), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/missing base64 transaction/, response.body["message"])
+  end
+
+  def test_pull_mode_reports_simulation_and_confirmation_failures
+    request = charge_request
+    transaction = Base64.strict_encode64(legacy_transaction(
+      account_keys: [pubkey(1), request.recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+    challenge = handler_challenges.create_challenge(request)
+    credential = SolanaMpp::Core::Credential.new(challenge: challenge.to_echo, payload: {"transaction" => transaction})
+
+    response = handler_with(FakeRpc.new(simulation_error: "boom"), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/Simulation failed/, response.body["message"])
+
+    response = handler_with(FakeRpc.new(statuses: [nil]), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/Timed out waiting/, response.body["message"])
+
+    response = handler_with(FakeRpc.new(statuses: [{"err" => "boom", "confirmationStatus" => "confirmed"}]), attempts: 1).handle(credential.to_authorization_header, request)
+    assert_equal 402, response.status
+    assert_match(/failed/, response.body["message"])
+  end
+
+  private
+
+  def handler_challenges
+    @handler_challenges ||= SolanaMpp::Server::ChargeServer.new(secret_key: "secret", realm: "api")
+  end
+
+  def handler_with(rpc, store: SolanaMpp::MemoryStore.new, attempts: 40)
+    SolanaMpp::Server::ChargeHandler.new(
+      challenges: handler_challenges,
+      rpc: rpc,
+      replay_store: store,
+      network: "localnet",
+      confirmation_attempts: attempts,
+      confirmation_delay: 0
+    )
+  end
+
+  def valid_signature
+    SolanaMpp::Solana::Base58.encode(("a" * 64).b)
+  end
+
+  def transaction_response
+    transaction = Base64.strict_encode64(legacy_transaction(
+      account_keys: [pubkey(1), pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+    {"meta" => {"err" => nil}, "transaction" => [transaction, "base64"]}
+  end
+end

--- a/ruby/test/support_test.rb
+++ b/ruby/test/support_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+
+class SupportTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def test_memory_store_and_file_store_replay_boundaries
+    memory = SolanaMpp::MemoryStore.new
+    assert memory.put_if_absent("k", true)
+    refute memory.put_if_absent("k", true)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "store.json")
+      store = SolanaMpp::FileStore.new(path)
+      assert store.put_if_absent("sig", true)
+      refute store.put_if_absent("sig", true)
+      assert_instance_of SolanaMpp::FileStore, SolanaMpp::FileStore.new(path)
+    end
+  end
+
+  def test_stablecoin_resolution_and_token_programs
+    assert_nil SolanaMpp::Common::StablecoinMints.resolve("SOL", "localnet")
+    assert_equal "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", SolanaMpp::Common::StablecoinMints.resolve("USDC", "localnet")
+    assert_equal "SomeMint111111111111111111111111111111111", SolanaMpp::Common::StablecoinMints.resolve("SomeMint111111111111111111111111111111111", "localnet")
+    assert_equal SolanaMpp::Common::StablecoinMints::TOKEN_2022_PROGRAM, SolanaMpp::Common::StablecoinMints.token_program_for("PYUSD", "devnet")
+    assert_equal SolanaMpp::Common::StablecoinMints::TOKEN_PROGRAM, SolanaMpp::Common::StablecoinMints.token_program_for("USDC", "localnet")
+    assert_equal "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", SolanaMpp::Common::StablecoinMints.resolve("USDC", "unknown")
+    assert_equal "USDC", SolanaMpp::Common::StablecoinMints.symbol_for("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "mainnet-beta")
+    assert_nil SolanaMpp::Common::StablecoinMints.symbol_for("unknown", "localnet")
+  end
+
+  def test_base58_round_trip_and_invalid_character
+    encoded = SolanaMpp::Solana::Base58.encode("\x00\x00abc".b)
+    assert_equal "\x00\x00abc".b, SolanaMpp::Solana::Base58.decode(encoded)
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Base58.decode("0") }
+  end
+
+  def test_keypair_from_json_array_and_errors
+    bytes = Array.new(64, 1)
+    keypair = SolanaMpp::Solana::Keypair.from_json_array(JSON.generate(bytes))
+
+    assert_equal 64, keypair.sign("hello").bytesize
+    assert_equal pubkey(1), keypair.public_key.to_s
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Keypair.from_json_array(JSON.generate([1, 2])) }
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Keypair.from_json_array(JSON.generate({"bad" => true})) }
+  end
+
+  def test_public_key_binary_and_invalid_length_edges
+    bytes = "\x01".b * 32
+    key = SolanaMpp::Solana::PublicKey.new(bytes)
+
+    assert_equal key, SolanaMpp::Solana::PublicKey.new(key.to_s)
+    refute_equal key, Object.new
+    assert_raises(ArgumentError) { SolanaMpp::Solana::PublicKey.new("\x01".b * 31) }
+  end
+
+  def test_rpc_client_success_and_error_paths
+    response = Struct.new(:body)
+    calls = []
+    with_rpc_http(lambda { |request|
+      calls << JSON.parse(request.body)
+      response.new(JSON.generate({"result" => {"value" => {"blockhash" => pubkey(9)}}}))
+    }) do |clients|
+      client = SolanaMpp::Solana::RpcClient.new("http://localhost:8899")
+      assert_equal pubkey(9), client.latest_blockhash
+      assert_equal 5, clients.first.open_timeout
+      assert_equal 10, clients.first.read_timeout
+      assert_equal 10, clients.first.write_timeout
+    end
+    assert_equal "getLatestBlockhash", calls.first.fetch("method")
+
+    with_rpc_http(lambda { |_request| response.new(JSON.generate({"error" => {"message" => "boom"}})) }) do
+      error = assert_raises(SolanaMpp::Error) { SolanaMpp::Solana::RpcClient.new("http://localhost:8899").call("bad") }
+      assert_match(/boom/, error.message)
+    end
+  end
+
+  def test_rpc_client_custom_timeouts_and_timeout_errors
+    with_rpc_http(lambda { |_request| raise Net::ReadTimeout }) do |clients|
+      client = SolanaMpp::Solana::RpcClient.new("https://localhost:8899", open_timeout: 1, read_timeout: 2, write_timeout: 3)
+      error = assert_raises(SolanaMpp::Error) { client.call("getLatestBlockhash") }
+
+      assert_match(/timed out/, error.message)
+      assert_equal true, clients.first.use_ssl
+      assert_equal 1, clients.first.open_timeout
+      assert_equal 2, clients.first.read_timeout
+      assert_equal 3, clients.first.write_timeout
+    end
+  end
+
+  def test_rpc_client_wraps_socket_level_network_errors
+    with_rpc_http(lambda { |_request| raise Errno::ECONNRESET }) do
+      client = SolanaMpp::Solana::RpcClient.new("http://localhost:8899")
+      error = assert_raises(SolanaMpp::Error) { client.call("getLatestBlockhash") }
+
+      assert_match(/Solana RPC request failed/, error.message)
+      assert_match(/ECONNRESET/, error.message)
+    end
+  end
+
+  def test_rpc_client_works_without_write_timeout_setter
+    response = Struct.new(:body)
+    with_rpc_http(lambda { |_request| response.new(JSON.generate({"result" => {"ok" => true}})) }, supports_write_timeout: false) do |clients|
+      result = SolanaMpp::Solana::RpcClient.new("http://localhost:8899").call("custom")
+
+      assert_equal({"ok" => true}, result)
+      refute clients.first.respond_to?(:write_timeout=)
+    end
+  end
+
+  def test_rpc_client_method_shapes
+    response = Struct.new(:body)
+    results = {
+      "simulateTransaction" => {"value" => {"err" => nil}},
+      "sendTransaction" => "sig",
+      "getSignatureStatuses" => {"value" => [{"confirmationStatus" => "confirmed"}]},
+      "getTransaction" => {"transaction" => ["tx", "base64"], "meta" => {"err" => nil}}
+    }
+    with_rpc_http(lambda { |request|
+      method = JSON.parse(request.body).fetch("method")
+      response.new(JSON.generate({"result" => results.fetch(method)}))
+    }) do
+      client = SolanaMpp::Solana::RpcClient.new("http://localhost:8899")
+      assert_equal({"err" => nil}, client.simulate_transaction("abc"))
+      assert_equal "sig", client.send_raw_transaction("abc")
+      assert_equal [{"confirmationStatus" => "confirmed"}], client.signature_statuses(["sig"])
+      assert_equal({"transaction" => ["tx", "base64"], "meta" => {"err" => nil}}, client.transaction_base64("sig"))
+    end
+  end
+
+  def with_rpc_http(callable, supports_write_timeout: true)
+    original = Net::HTTP.method(:new)
+    clients = []
+    fake_class = Class.new do
+      attr_accessor :use_ssl, :open_timeout, :read_timeout, :write_timeout
+
+      def initialize(callable)
+        @callable = callable
+      end
+
+      def start
+        yield self
+      end
+
+      def request(request)
+        @callable.call(request)
+      end
+    end
+    fake_class.send(:undef_method, :write_timeout=) unless supports_write_timeout
+    Net::HTTP.define_singleton_method(:new) do |_host, _port|
+      fake_class.new(callable).tap { |client| clients << client }
+    end
+    yield clients
+  ensure
+    Net::HTTP.define_singleton_method(:new) { |host, port| original.call(host, port) }
+  end
+end

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+if ENV["COVERAGE"] == "1"
+  require "simplecov"
+  SimpleCov.enable_coverage :branch
+  SimpleCov.start do
+    add_filter "/test/"
+    add_filter "/examples/"
+    minimum_coverage line: 92, branch: 90
+  end
+end
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "minitest/autorun"
+require "solana_mpp"
+
+module RubyMppTestHelpers
+  PROGRAMS = SolanaMpp::Common::StablecoinMints
+
+  def base58(bytes)
+    SolanaMpp::Solana::Base58.encode(bytes.pack("C*"))
+  end
+
+  def pubkey(byte)
+    base58([byte] * 32)
+  end
+
+  def compact_u16(value)
+    SolanaMpp::Solana::Transaction.compact_u16(value)
+  end
+
+  def u32(value)
+    [value].pack("L<")
+  end
+
+  def u64(value)
+    [value].pack("Q<")
+  end
+
+  def compiled_instruction(program_index, accounts, data)
+    [program_index].pack("C") + compact_u16(accounts.length) + accounts.pack("C*") + compact_u16(data.bytesize) + data
+  end
+
+  def legacy_transaction(account_keys:, instructions:, recent_blockhash: pubkey(9), signatures: nil)
+    keys = account_keys.map { |key| SolanaMpp::Solana::Base58.decode(key) }
+    message = +""
+    message << [signatures&.length || 1, 0, 0].pack("C*")
+    message << compact_u16(keys.length)
+    keys.each { |key| message << key }
+    message << SolanaMpp::Solana::Base58.decode(recent_blockhash)
+    message << compact_u16(instructions.length)
+    instructions.each { |ix| message << ix }
+    sigs = signatures || ["\x00".b * 64]
+    compact_u16(sigs.length) + sigs.join + message
+  end
+
+  def charge_request(overrides = {})
+    SolanaMpp::Intent::ChargeRequest.new(
+      amount: "1000",
+      currency: "SOL",
+      recipient: pubkey(2),
+      method_details: {"network" => "localnet", "decimals" => 6}, **overrides
+    )
+  end
+end

--- a/ruby/test/transaction_test.rb
+++ b/ruby/test/transaction_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TransactionTest < Minitest::Test
+  include RubyMppTestHelpers
+
+  def test_parses_and_serializes_legacy_transaction
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    raw = legacy_transaction(
+      account_keys: [payer, recipient, PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    )
+
+    tx = SolanaMpp::Solana::Transaction.from_bytes(raw)
+
+    assert_equal "legacy", tx.version
+    assert_equal payer, tx.message.account_keys[0]
+    assert_equal recipient, tx.message.account_keys[1]
+    assert_equal raw, tx.to_bytes
+    assert_match(/\A[1-9A-HJ-NP-Za-km-z]+\z/, tx.primary_signature)
+  end
+
+  def test_parses_v0_transaction_without_address_lookups
+    payer = pubkey(1)
+    recipient = pubkey(2)
+    message = +""
+    message << [0x80, 1, 0, 0].pack("C*")
+    message << compact_u16(3)
+    [payer, recipient, PROGRAMS::SYSTEM_PROGRAM].each { |key| message << SolanaMpp::Solana::Base58.decode(key) }
+    message << SolanaMpp::Solana::Base58.decode(pubkey(9))
+    message << compact_u16(1)
+    message << compiled_instruction(2, [0, 1], u32(2) + u64(1000))
+    message << compact_u16(0)
+    raw = compact_u16(1) + ("\x00".b * 64) + message
+
+    tx = SolanaMpp::Solana::Transaction.from_bytes(raw)
+
+    assert_equal 0, tx.version
+    assert_empty tx.message.address_table_lookups
+    assert_equal raw, tx.to_bytes
+  end
+
+  def test_rejects_truncated_transaction
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Transaction.from_bytes("\x01\x00".b) }
+  end
+
+  def test_rejects_unsupported_version_and_signer_not_found
+    raw = compact_u16(0) + [0x81, 1, 0, 0].pack("C*")
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Transaction.from_bytes(raw) }
+
+    tx = SolanaMpp::Solana::Transaction.from_bytes(legacy_transaction(
+      account_keys: [pubkey(1), pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+    keypair = SolanaMpp::Solana::Keypair.new(Array.new(64, 9))
+    assert_raises(SolanaMpp::VerificationError) { tx.sign_with(keypair) }
+  end
+
+  def test_rejects_fee_payer_when_not_required_signer
+    keypair = SolanaMpp::Solana::Keypair.new(Array.new(64, 1))
+    tx = SolanaMpp::Solana::Transaction.from_bytes(legacy_transaction(
+      account_keys: [keypair.public_key.to_s, pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      signatures: [],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+
+    assert_raises(SolanaMpp::VerificationError) { tx.sign_with(keypair) }
+  end
+
+  def test_signs_when_fee_payer_is_required_signer
+    keypair = SolanaMpp::Solana::Keypair.new(Array.new(64, 1))
+    tx = SolanaMpp::Solana::Transaction.from_bytes(legacy_transaction(
+      account_keys: [keypair.public_key.to_s, pubkey(2), PROGRAMS::SYSTEM_PROGRAM],
+      signatures: ["\x00".b * 64],
+      instructions: [compiled_instruction(2, [0, 1], u32(2) + u64(1000))]
+    ))
+
+    tx.sign_with(keypair)
+
+    refute_equal "\x00".b * 64, tx.signatures.first
+  end
+
+  def test_from_base64_invalid_and_cursor_boundaries
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Transaction.from_base64("%%%") }
+    assert_equal [0x80, 0x01].pack("C*"), SolanaMpp::Solana::Transaction.compact_u16(128)
+    cursor = SolanaMpp::Solana::Cursor.new("\xff\xff\xff\xff".b)
+    assert_raises(ArgumentError) { cursor.compact_u16 }
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Cursor.new("").peek }
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Cursor.new("").byte }
+    assert_raises(ArgumentError) { SolanaMpp::Solana::Cursor.new("a").bytes(2) }
+  end
+
+  def test_derives_associated_token_address
+    owner = "11111111111111111111111111111111"
+    mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+
+    ata = SolanaMpp::Solana::AssociatedToken.derive(
+      owner: owner,
+      mint: mint,
+      token_program: PROGRAMS::TOKEN_PROGRAM
+    )
+
+    assert_match(/\A[1-9A-HJ-NP-Za-km-z]{32,44}\z/, ata)
+  end
+
+  def test_program_address_derivation_handles_high_bump_bytes
+    program_id = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+
+    _address, bump = SolanaMpp::Solana::PublicKey.find_program_address(["seed"], program_id)
+
+    assert_operator bump, :<=, 255
+    assert_equal 1, [bump].pack("C").bytesize
+  end
+end

--- a/skills/pay-sdk-implementation/references/interop-harness.md
+++ b/skills/pay-sdk-implementation/references/interop-harness.md
@@ -44,6 +44,13 @@ The server must:
 - Return a successful JSON body after payment
 - Include the `interopScenario.settlementHeader` header on success
 
+Keep server adapters thin. A new server adapter should only spin up the
+expected endpoint, translate environment variables into the language SDK's
+server configuration, and return HTTP responses. It should not duplicate
+scenario expectations. The canonical TypeScript/Vitest harness owns the
+assertions: status, response body, recipient/split balance deltas, and the
+settled Surfpool transaction shape.
+
 ### Client `result` message
 
 ```json
@@ -182,5 +189,12 @@ in that file are the pattern.
   token account before serving — see
   `rust/src/bin/interop_server.rs` and
   `rust/examples/payment_link_server.rs:160-186` for the pattern.
+- **Expectations are centralized.** For successful charge scenarios,
+  the harness fetches the settlement signature from Surfpool and
+  verifies the resulting transaction includes expected SPL
+  `transferChecked` instructions, split amounts, required idempotent
+  ATA creation instructions, and memos. It also fails on unexpected
+  extra `transferChecked` instructions for the scenario mint. Do not
+  re-implement those checks in every language adapter.
 - **Don't pin a parallel Solana SDK** in the interop adapter. Path-
   depend on your main package and reuse its primitives.

--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -27,7 +27,16 @@ Required fields:
 - `role`: `"server"`
 - `port`: local TCP port where the protected resource is served
 
-The server must expose the shared scenario resource path from `interopScenario.resourcePath` and protect it with the MPP `charge` flow. It should return a successful JSON response after payment and include the settlement header named by `interopScenario.settlementHeader`.
+The server must expose the shared scenario resource path from
+`interopScenario.resourcePath` and protect it with the MPP `charge` flow. It
+should return a successful JSON response after payment and include the
+settlement header named by `interopScenario.settlementHeader`.
+
+Server adapters should stay thin: read the harness environment, spin up the
+expected endpoint, route requests through the language SDK server, and return
+HTTP responses. Do not duplicate scenario expectations in each server adapter.
+The Vitest harness is responsible for asserting status, response body,
+recipient/split balance deltas, and the settled transaction shape in Surfpool.
 
 ### Client adapters
 
@@ -118,12 +127,17 @@ The current scenario set covers only the `charge` intent. It includes a basic
 payment, a split payment that requires the server fee payer to create the split
 recipient ATA, a negative network-mismatch payment, and a cross-route replay
 attempt where a credential issued for a cheaper route is replayed against a
-more expensive route. Scenarios can restrict the clients or servers they run
-against when an adapter does not yet report a structured failure for that
-negative case. Selecting `session` or `subscription` currently fails fast with a
-clear unsupported-intent error. Future coverage for those intents should add
-explicit scenarios behind the same selector instead of widening the default CI
-matrix implicitly.
+more expensive route. For successful charge scenarios, the harness fetches the
+settlement signature from Surfpool and centrally asserts the resulting
+transaction includes the expected SPL `transferChecked` instructions, split
+amounts, required idempotent ATA creation instructions, and memos. It also
+fails when the transaction contains unexpected extra `transferChecked`
+instructions for the scenario mint. Scenarios can restrict the clients or
+servers they run against when an adapter does not yet report a structured
+failure for that negative case. Selecting `session` or `subscription` currently
+fails fast with a clear unsupported-intent error. Future coverage for those
+intents should add explicit scenarios behind the same selector instead of
+widening the default CI matrix implicitly.
 
 ## Running
 
@@ -151,4 +165,7 @@ pnpm test
 `tests/interop` needs to install after the TypeScript package has produced its
 `dist` files.
 
-The harness starts Surfpool through `start-surfnet-proxy.mjs`, funds the test accounts, starts each enabled server adapter, runs each enabled client adapter against it, and verifies the recipient balance delta.
+The harness starts Surfpool through `start-surfnet-proxy.mjs`, funds the test
+accounts, starts each enabled server adapter, runs each enabled client adapter
+against it, verifies recipient/split balance deltas, and verifies the settled
+transaction shape for successful charge scenarios.

--- a/tests/interop/ruby-server/server.rb
+++ b/tests/interop/ruby-server/server.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "json"
+require "socket"
+require_relative "../../../ruby/lib/solana_mpp"
+
+# Read a required environment variable for the interop adapter.
+def require_env(name)
+  value = ENV[name]
+  if value.nil? || value.empty?
+    warn "Missing required env: #{name}"
+    exit 2
+  end
+  value
+end
+
+# Read an optional environment variable.
+def optional_env(name, default)
+  value = ENV[name]
+  value.nil? || value.empty? ? default : value
+end
+
+# Build a Solana keypair from the harness byte-array format.
+def keypair_from_env(name)
+  SolanaMpp::Solana::Keypair.from_json_array(require_env(name))
+end
+
+rpc_url = require_env("MPP_INTEROP_RPC_URL")
+network = optional_env("MPP_INTEROP_NETWORK", "localnet")
+mint = require_env("MPP_INTEROP_MINT")
+amount = require_env("MPP_INTEROP_AMOUNT")
+pay_to = require_env("MPP_INTEROP_PAY_TO")
+secret_key = optional_env("MPP_INTEROP_SECRET_KEY", "mpp-interop-secret-key")
+resource_path = optional_env("MPP_INTEROP_RESOURCE_PATH", "/paid")
+settlement_header = optional_env("MPP_INTEROP_SETTLEMENT_HEADER", "x-payment-settlement-signature")
+replay_path = ENV["MPP_INTEROP_REPLAY_SOURCE_PATH"]
+replay_amount = ENV["MPP_INTEROP_REPLAY_SOURCE_AMOUNT"]
+splits = JSON.parse(optional_env("MPP_INTEROP_SPLITS", "[]"))
+unless splits.is_a?(Array)
+  warn "MPP_INTEROP_SPLITS must decode to an array"
+  exit 2
+end
+
+rpc = SolanaMpp::Solana::RpcClient.new(rpc_url)
+fee_payer = keypair_from_env("MPP_INTEROP_FEE_PAYER_SECRET_KEY")
+handler = SolanaMpp::Server::ChargeHandler.new(
+  challenges: SolanaMpp::Server::ChargeServer.new(
+    secret_key: secret_key,
+    realm: "MPP Interop"
+  ),
+  rpc: rpc,
+  replay_store: SolanaMpp::MemoryStore.new,
+  fee_payer: fee_payer,
+  network: network,
+  settlement_header: settlement_header
+)
+
+# Build one request object for the selected route amount.
+def build_charge_request(rpc, amount, mint, pay_to, network, fee_payer_key, splits)
+  method_details = {
+    "network" => network,
+    "decimals" => 6,
+    "feePayer" => true,
+    "feePayerKey" => fee_payer_key,
+    "recentBlockhash" => rpc.latest_blockhash
+  }
+  method_details["splits"] = splits unless splits.empty?
+  SolanaMpp::Intent::ChargeRequest.new(
+    amount: amount,
+    currency: mint,
+    recipient: pay_to,
+    description: "Ruby interop protected content",
+    method_details: method_details
+  )
+end
+
+# Read one HTTP request from a socket.
+def read_request(conn)
+  request_line = conn.gets
+  return nil if request_line.nil? || request_line.strip.empty?
+
+  method, raw_path = request_line.strip.split(/\s+/, 3)
+  headers = {}
+  while (line = conn.gets)
+    line = line.delete_suffix("\r\n")
+    break if line.empty?
+
+    name, value = line.split(":", 2)
+    next if value.nil?
+    headers[name.downcase] = value.strip
+  end
+  {method: method, path: raw_path, headers: headers}
+end
+
+# Write one HTTP response to a socket.
+def write_response(conn, status, headers, body)
+  reason = {
+    200 => "OK",
+    402 => "Payment Required",
+    404 => "Not Found",
+    500 => "Server Error"
+  }.fetch(status, "Server Error")
+  payload = body.is_a?(String) ? body : JSON.generate(body)
+  merged = {"connection" => "close", "content-length" => payload.bytesize.to_s}.merge(headers)
+  conn.write("HTTP/1.1 #{status} #{reason}\r\n")
+  merged.each { |name, value| conn.write("#{name}: #{value}\r\n") }
+  conn.write("\r\n")
+  conn.write(payload)
+end
+
+listener = TCPServer.new("127.0.0.1", 0)
+port = listener.addr[1]
+$stdout.write(JSON.generate({
+  type: "ready",
+  implementation: "ruby",
+  role: "server",
+  port: port,
+  capabilities: ["charge"]
+}) + "\n")
+$stdout.flush
+
+shutdown = proc do
+  listener.close unless listener.closed?
+  exit 0
+end
+Signal.trap("TERM", &shutdown)
+Signal.trap("INT", &shutdown)
+
+loop do
+  conn = listener.accept
+  begin
+    req = read_request(conn)
+    if req.nil?
+      conn.close
+      next
+    end
+
+    if req[:method] == "GET" && req[:path] == "/health"
+      write_response(conn, 200, {"content-type" => "application/json"}, {"ok" => true})
+      conn.close
+      next
+    end
+
+    protected_amount = if req[:method] == "GET" && req[:path] == resource_path
+      amount
+    elsif req[:method] == "GET" && replay_path && req[:path] == replay_path
+      replay_amount || amount
+    end
+
+    if protected_amount.nil?
+      write_response(conn, 404, {"content-type" => "application/json"}, {"error" => "not_found"})
+      conn.close
+      next
+    end
+
+    request = build_charge_request(rpc, protected_amount, mint, pay_to, network, handler.fee_payer_pubkey, splits)
+    response = handler.handle(req[:headers]["authorization"], request)
+    write_response(conn, response.status, response.headers, response.body)
+    conn.close
+  rescue StandardError => e
+    warn "interop ruby server error: #{e.message}"
+    begin
+      write_response(conn, 500, {"content-type" => "application/json"}, {"error" => e.message})
+    rescue StandardError
+      nil
+    ensure
+      conn.close unless conn.closed?
+    end
+  end
+end

--- a/tests/interop/src/implementations.ts
+++ b/tests/interop/src/implementations.ts
@@ -95,4 +95,15 @@ export const serverImplementations: ImplementationDefinition[] = [
     command: ["php", "php-server/server.php"],
     enabled: isEnabled("php", "MPP_INTEROP_SERVERS", false),
   },
+  {
+    id: "ruby",
+    label: "Ruby HTTP server",
+    role: "server",
+    command: [
+      "sh",
+      "-c",
+      "cd ../../ruby && bundle exec ruby ../tests/interop/ruby-server/server.rb",
+    ],
+    enabled: isEnabled("ruby", "MPP_INTEROP_SERVERS", false),
+  },
 ];

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -1,6 +1,11 @@
 import net from "node:net";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { createSolanaRpc } from "@solana/kit";
+import {
+  createSolanaRpc,
+  getBase64Codec,
+  getCompiledTransactionMessageDecoder,
+  getTransactionDecoder,
+} from "@solana/kit";
 import { Surfnet } from "surfpool-sdk";
 import { InteropScenario, selectInteropScenarios } from "../src/contracts";
 import {
@@ -12,6 +17,8 @@ import { runClient, startServer, stopServer } from "../src/process";
 type RunningServer = Awaited<ReturnType<typeof startServer>>;
 
 const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const MINT_ACCOUNT_SIZE = 82;
 
 const runningServers: RunningServer[] = [];
@@ -19,6 +26,18 @@ const runningServers: RunningServer[] = [];
 let surfnet: Surfnet | undefined;
 let interopEnv: Record<string, string> | undefined;
 let splitRecipients: Record<string, string> = {};
+
+type CompiledInstruction = {
+  accountIndices: readonly number[];
+  data: Uint8Array;
+  programAddressIndex: number;
+};
+
+type CompiledMessage = {
+  addressTableLookups?: readonly unknown[];
+  instructions: readonly CompiledInstruction[];
+  staticAccounts: readonly unknown[];
+};
 
 async function canBindLocalSocket(): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
@@ -193,6 +212,12 @@ describe("mpp interop", () => {
               });
               expect(typeof result.settlement).toBe("string");
               expect(result.settlement).not.toHaveLength(0);
+              await expectSettledTransactionShape(
+                surfnet,
+                scenario,
+                scenarioEnv,
+                result.settlement,
+              );
               expect(finalBalance - initialBalance).toBe(
                 primaryDelta(scenario),
               );
@@ -242,6 +267,241 @@ function environmentForScenario(
       })),
     ),
   };
+}
+
+async function expectSettledTransactionShape(
+  surfnet: Surfnet,
+  scenario: InteropScenario,
+  scenarioEnv: Record<string, string>,
+  settlement: unknown,
+): Promise<void> {
+  if (typeof settlement !== "string" || settlement.length === 0) {
+    throw new Error(`Scenario ${scenario.id} did not return a settlement signature`);
+  }
+
+  const transaction = await fetchTransactionBase64(
+    scenarioEnv.MPP_INTEROP_RPC_URL,
+    settlement,
+  );
+  const message = decodeTransactionMessage(transaction);
+  expect(message.addressTableLookups ?? []).toHaveLength(0);
+
+  const matchedInstructions = new Set<number>();
+  const expectedTransferCount = 1 + (scenario.splits?.length ?? 0);
+  const primaryAmount = primaryDelta(scenario);
+  expectSplTransferChecked(
+    message,
+    {
+      destination: surfnet.getAta(
+        scenarioEnv.MPP_INTEROP_PAY_TO,
+        scenarioEnv.MPP_INTEROP_MINT,
+      ),
+      mint: scenarioEnv.MPP_INTEROP_MINT,
+      amount: primaryAmount,
+      decimals: 6,
+    },
+    matchedInstructions,
+  );
+
+  for (const split of scenario.splits ?? []) {
+    const recipient = splitRecipients[split.recipientKey];
+    const destination = surfnet.getAta(recipient, scenarioEnv.MPP_INTEROP_MINT);
+    expectSplTransferChecked(
+      message,
+      {
+        destination,
+        mint: scenarioEnv.MPP_INTEROP_MINT,
+        amount: BigInt(split.amount),
+        decimals: 6,
+      },
+      matchedInstructions,
+    );
+
+    if (split.ataCreationRequired === true) {
+      expectIdempotentAtaCreation(message, {
+        ata: destination,
+        owner: recipient,
+        mint: scenarioEnv.MPP_INTEROP_MINT,
+      });
+    }
+
+    if (split.memo) {
+      expectMemo(message, split.memo);
+    }
+  }
+
+  expectTransferCheckedCount(message, scenarioEnv.MPP_INTEROP_MINT, expectedTransferCount);
+}
+
+async function fetchTransactionBase64(
+  rpcUrl: string,
+  signature: string,
+): Promise<string> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getTransaction",
+      params: [
+        signature,
+        {
+          commitment: "confirmed",
+          encoding: "base64",
+          maxSupportedTransactionVersion: 0,
+        },
+      ],
+    }),
+  });
+  const payload = (await response.json()) as {
+    error?: { message?: string };
+    result?: {
+      meta?: { err?: unknown };
+      transaction?: [string, string];
+    } | null;
+  };
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "getTransaction failed");
+  }
+  if (!payload.result) {
+    throw new Error(`getTransaction returned no result for ${signature}`);
+  }
+  expect(payload.result.meta?.err ?? null).toBeNull();
+  const transaction = payload.result.transaction?.[0];
+  if (!transaction) {
+    throw new Error(`getTransaction returned no base64 transaction for ${signature}`);
+  }
+  return transaction;
+}
+
+function decodeTransactionMessage(transactionBase64: string): CompiledMessage {
+  const txBytes = getBase64Codec().encode(transactionBase64);
+  const decoded = getTransactionDecoder().decode(txBytes);
+  return getCompiledTransactionMessageDecoder().decode(
+    decoded.messageBytes,
+  ) as unknown as CompiledMessage;
+}
+
+function expectSplTransferChecked(
+  message: CompiledMessage,
+  expected: {
+    destination: string;
+    mint: string;
+    amount: bigint;
+    decimals: number;
+  },
+  matchedInstructions: Set<number>,
+): void {
+  const match = message.instructions.findIndex((instruction, index) => {
+    if (matchedInstructions.has(index)) {
+      return false;
+    }
+    if (accountAt(message, instruction.programAddressIndex) !== TOKEN_PROGRAM) {
+      return false;
+    }
+    if (instruction.data[0] !== 12) {
+      return false;
+    }
+    if (instruction.accountIndices.length < 4) {
+      return false;
+    }
+
+    const amount = readU64Le(instruction.data, 1);
+    const decimals = instruction.data[9];
+    return (
+      accountAt(message, instruction.accountIndices[1]) === expected.mint &&
+      accountAt(message, instruction.accountIndices[2]) === expected.destination &&
+      amount === expected.amount &&
+      decimals === expected.decimals
+    );
+  });
+
+  expect(
+    match,
+    `missing transferChecked mint=${expected.mint} destination=${expected.destination} amount=${expected.amount}`,
+  ).not.toBe(-1);
+  matchedInstructions.add(match);
+}
+
+function expectIdempotentAtaCreation(
+  message: CompiledMessage,
+  expected: {
+    ata: string;
+    owner: string;
+    mint: string;
+  },
+): void {
+  const match = message.instructions.find((instruction) => {
+    if (accountAt(message, instruction.programAddressIndex) !== ASSOCIATED_TOKEN_PROGRAM) {
+      return false;
+    }
+    if (instruction.data[0] !== 1) {
+      return false;
+    }
+    return (
+      accountAt(message, instruction.accountIndices[1]) === expected.ata &&
+      accountAt(message, instruction.accountIndices[2]) === expected.owner &&
+      accountAt(message, instruction.accountIndices[3]) === expected.mint &&
+      accountAt(message, instruction.accountIndices[4]) === SYSTEM_PROGRAM &&
+      accountAt(message, instruction.accountIndices[5]) === TOKEN_PROGRAM
+    );
+  });
+
+  expect(
+    match,
+    `missing idempotent ATA creation ata=${expected.ata} owner=${expected.owner} mint=${expected.mint}`,
+  ).toBeDefined();
+}
+
+function expectTransferCheckedCount(
+  message: CompiledMessage,
+  mint: string,
+  expectedCount: number,
+): void {
+  const transfers = message.instructions.filter((instruction) => {
+    if (accountAt(message, instruction.programAddressIndex) !== TOKEN_PROGRAM) {
+      return false;
+    }
+    if (instruction.data[0] !== 12 || instruction.accountIndices.length < 4) {
+      return false;
+    }
+    return accountAt(message, instruction.accountIndices[1]) === mint;
+  });
+
+  expect(
+    transfers,
+    `unexpected transferChecked instruction count for mint=${mint}`,
+  ).toHaveLength(expectedCount);
+}
+
+function expectMemo(message: CompiledMessage, memo: string): void {
+  const encoder = new TextEncoder();
+  const expected = encoder.encode(memo);
+  const match = message.instructions.find((instruction) => {
+    if (accountAt(message, instruction.programAddressIndex) !== "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr") {
+      return false;
+    }
+    return bytesEqual(instruction.data, expected);
+  });
+
+  expect(match, `missing memo instruction ${memo}`).toBeDefined();
+}
+
+function accountAt(message: CompiledMessage, index: number): string {
+  return String(message.staticAccounts[index]);
+}
+
+function readU64Le(bytes: Uint8Array, offset: number): bigint {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return view.getBigUint64(offset, true);
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
 }
 
 async function splitBalances(


### PR DESCRIPTION
## What

- Replaces the earlier Ruby charge server shape with the PHP-calibrated language SDK gate.
- Adds Ruby server-side support for `mpp/charge/pull` and `mpp/charge/push`.
- Adds a Ruby package under `ruby/` with:
  - protocol wire-format helpers for challenge, credential, receipt, headers, canonical JSON, and base64url
  - charge request model
  - challenge issuance and verification
  - pull settlement with pre-settlement structural verification, fee-payer signing, simulation retry, broadcast, confirmation, replay consume, and receipt emission
  - push settlement with signature validation, `getTransaction`, transaction metadata failure checks, structural verification, replay consume, and receipt emission
  - minimal Solana helpers for Base58, keypairs, transactions, associated token address derivation, and JSON-RPC
- Adds runnable examples:
  - `ruby/examples/simple-server.rb`
  - `ruby/examples/sinatra-app.rb`
- Adds a direct Ruby server adapter at `tests/interop/ruby-server/server.rb`.
- Adds Ruby CI, root justfile wrappers, root README matrix updates, local Ruby README, lint, audit, and line/branch coverage gates.

## Why

Ludo asked us to calibrate on one language/intent first and then streamline the same standard across languages. PHP is now the calibrated reference. This Ruby pass applies that standard instead of only adding a thin verifier:

- language-local Justfile
- runnable README and examples
- simple server plus Sinatra app example
- full settlement lifecycle
- recentBlockhash challenge flow
- stablecoin mint/token-program helper
- direct language-owned interop server
- manual DX checks
- 90%+ line and branch coverage on security-critical paths
- explicit server-only scope and unsupported cells

The implementation keeps Ruby server-side only for this pass and treats Stripe's `mpp-rb` as ecosystem/layout inspiration, not as the wire-format source of truth.

## Source of truth

- `skills/pay-sdk-implementation/SKILL.md`
- `skills/pay-sdk-implementation/references/coding-conventions.md`
- `skills/pay-sdk-implementation/references/ci-quality-coverage.md`
- `skills/pay-sdk-implementation/references/interop-harness.md`
- `skills/pay-sdk-implementation/references/readme-template.md`
- `skills/pay-sdk-implementation/references/intents/mpp-charge-pull.md`
- `skills/pay-sdk-implementation/references/intents/mpp-charge-push.md`
- Rust reference:
  - `rust/src/server/charge.rs`
  - `rust/src/bin/interop_server.rs`
  - `rust/src/protocol/core/challenge.rs`
  - `rust/src/protocol/core/headers.rs`
  - `rust/src/protocol/intents/charge.rs`
  - `rust/src/client/charge.rs`
- PHP calibrated reference from #92/#94:
  - `php/src/Server/SolanaChargeHandler.php`
  - `php/src/Server/SolanaChargeTransactionVerifier.php`
  - `tests/interop/php-server/server.php`
- Ruby best-practice source:
  - Standard Ruby
  - skills.sh `mindrally/skills/ruby`
  - Stripe `mpp-rb` package layout as ecosystem inspiration

## Verified

- `cd ruby && PATH=/opt/homebrew/opt/ruby/bin:$PATH RUBOCOP_CACHE_ROOT=/private/tmp/mpp-ruby-rubocop-cache /opt/homebrew/opt/ruby/bin/bundle exec standardrb`
- `cd ruby && PATH=/opt/homebrew/opt/ruby/bin:$PATH /opt/homebrew/opt/ruby/bin/bundle exec bundle-audit check --update`
- `cd ruby && PATH=/opt/homebrew/opt/ruby/bin:$PATH COVERAGE=1 /opt/homebrew/opt/ruby/bin/bundle exec ruby -Itest test/run.rb`
  - 72 runs
  - 311 assertions
  - 0 failures
  - 0 errors
  - line coverage: 98.46%
  - branch coverage: 90.09%
- `cd tests/interop && pnpm typecheck`
- `cd tests/interop && MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SERVERS=ruby MPP_INTEROP_SCENARIOS=charge-basic,charge-split-ata,charge-network-mismatch,charge-cross-route-replay pnpm exec vitest run test/e2e.test.ts --testNamePattern "typescript client pays ruby server"`
  - 4 tests passed
- `cd tests/interop && MPP_INTEROP_CLIENTS=rust MPP_INTEROP_SERVERS=ruby MPP_INTEROP_SCENARIOS=charge-basic,charge-split-ata,charge-network-mismatch,charge-cross-route-replay pnpm exec vitest run test/e2e.test.ts --testNamePattern "rust client pays ruby server"`
  - 2 Rust-client-compatible tests passed
- Manual simple-server:
  - server starts on `127.0.0.1:4567`
  - unpaid `curl -i http://127.0.0.1:4567/paid` returns `402 Payment Required`
  - response includes `WWW-Authenticate: Payment ...`
- Manual Sinatra app:
  - server starts on `127.0.0.1:4579`
  - `curl -i http://127.0.0.1:4579/health` returns `200 OK`
  - unpaid `curl -i http://127.0.0.1:4579/paid` returns `402 Payment Required`
  - response includes `WWW-Authenticate: Payment ...`
- `git diff --check origin/main..HEAD`

## Manual DX note

After the latest default-configuration update, `pay curl
http://127.0.0.1:4582/paid` was attempted and returned `Server returned 402
again after payment`. The unpaid 402 path, direct examples, and TypeScript/Rust
interop remain green, but the public `pay` CLI success path needs one more
focused follow-up before I claim it on the latest head.

## Known limitations

- Ruby is server-side only in this pass.
- Ruby client support is not included.
- Ruby payment-link renderer is not included.
- `mpp/session`, `mpp/subscription`, and all x402 cells remain unsupported.
- CI registers Ruby as an opt-in interop server adapter.
