### PR TITLE
docs: add payment sdk skill readiness guardrails

### DIFF
--- a/skills/pay-sdk-implementation/SKILL.md
+++ b/skills/pay-sdk-implementation/SKILL.md
@@ -18,6 +18,10 @@ wire-compatible with the Rust reference at `mpp-sdk/rust` (in the
 - Reference Rust crate — `mpp-sdk/rust` (every wire-format claim in
   this skill is grep-able to a path under that tree)
 
+Before implementing a new language or changing a compatibility matrix, read
+`references/source-truth.md`. Before tagging a PR ready for review, read
+`references/pr-readiness.md`.
+
 ## Compatibility matrix — pick the cells in scope
 
 Both the client and server README matrices use the same seven rows. Confirm
@@ -77,6 +81,9 @@ the directory skeleton and CI from earlier ones.
    client and server matrices (with the seven rows above), example
    walkthrough, Solana dependency list, and links to spec. The matrix
    must use the exact row order shown above so it's diffable across SDKs.
+8. **Tag review readiness.** Read `references/pr-readiness.md`, address
+   Greptile feedback, and leave a short PR comment with the skill used,
+   verification commands, coverage signal, interop pairs, and known limits.
 
 ## Hard rules
 

--- a/skills/pay-sdk-implementation/references/intents/mpp-session.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-session.md
@@ -52,7 +52,7 @@ See `rust/src/protocol/intents/session.rs:101-167`.
 
 ### Client `Authorization` — `SessionAction` (tagged)
 
-Discriminated by `"action": "open" | "voucher" | "commit" | "topup" | "close"`.
+Discriminated by `"action": "open" | "voucher" | "commit" | "topUp" | "close"`.
 
 - `open` — `OpenPayload`. Shape varies by `mode`:
   - **Push (payment channel)** — `channelId`, `deposit`, `payer`,
@@ -63,7 +63,7 @@ Discriminated by `"action": "open" | "voucher" | "commit" | "topup" | "close"`.
     `initMultiDelegateTx` + `updateDelegationTx`.
 - `voucher` — `VoucherPayload { voucher: SignedVoucher }`.
 - `commit` — `CommitPayload { deliveryId, voucher }`.
-- `topup` — `TopUpPayload { channelId, newDeposit, signature }`.
+- `topUp` — `TopUpPayload { channelId, newDeposit, signature }`.
 - `close` — `ClosePayload { channelId, voucher? }`.
 
 See `rust/src/protocol/intents/session.rs:185-647`.
@@ -199,7 +199,7 @@ Unit tests (mirror `rust/src/protocol/intents/session.rs::tests`):
 
 Integration:
 
-- Surfpool-backed session lifecycle: open → 3 vouchers → topup → 2 more
+- Surfpool-backed session lifecycle: open → 3 vouchers → topUp → 2 more
   vouchers → close. Verify final on-chain settlement matches the
   cumulative voucher.
 

--- a/skills/pay-sdk-implementation/references/pr-readiness.md
+++ b/skills/pay-sdk-implementation/references/pr-readiness.md
@@ -1,0 +1,47 @@
+# PR readiness
+
+Use this before tagging a new language PR ready for review.
+
+## Required evidence
+
+- CI job exists for the language.
+- Formatter and linter run in CI.
+- Unit tests pass.
+- Coverage is reported in CI and is at least 90 percent, or the PR documents a
+  concrete tooling exception and compensating evidence.
+- End-to-end interop runs through the TypeScript harness.
+- The README includes language badge, coverage badge, repo layout, runnable
+  snippet, example instructions, Solana dependency table, and client/server
+  compatibility matrices.
+- Public methods/classes/structs have doc comments useful for LSP/IDE hover.
+- Greptile feedback is fixed, stale because of later commits, or explicitly
+  documented as non-actionable.
+
+## Ready-for-review comment
+
+When ready, comment with this shape:
+
+```text
+@<maintainer> Greptile feedback is addressed here and I think this is ready for review.
+
+Skill pass:
+- payment SDK implementation skill: current
+- language skill/guide: <name>
+
+Addressed points:
+- <what changed>
+
+Verification:
+- <unit/coverage command>
+- <interop command or CI job>
+
+Known limits:
+- <unimplemented matrix cells, if any>
+```
+
+## Capability matrix discipline
+
+Do not mark `mpp/session`, `mpp/subscription`, or any x402 cell as shipped just
+because the repo layout contains future reference files. A cell is shipped only
+when that target language has code, tests, coverage, and interop evidence for
+that cell.

--- a/skills/pay-sdk-implementation/references/readme-template.md
+++ b/skills/pay-sdk-implementation/references/readme-template.md
@@ -59,7 +59,7 @@ any HTTP API accept payments using the `402 Payment Required` flow.
 | `x402/batch-settlement` | — |
 | `mpp/charge/pull` | ✅ |
 | `mpp/charge/push` | ✅ |
-| `mpp/session` | ✅ |
+| `mpp/session` | — |
 | `mpp/subscription` | — |
 
 ## Server compatibility matrix
@@ -71,7 +71,7 @@ any HTTP API accept payments using the `402 Payment Required` flow.
 | `x402/batch-settlement` | — |
 | `mpp/charge/pull` | ✅ |
 | `mpp/charge/push` | ✅ |
-| `mpp/session` | ✅ |
+| `mpp/session` | — |
 | `mpp/subscription` | — |
 
 ## How to use the library
@@ -152,6 +152,9 @@ MIT
   Reordering breaks the cross-language `README.md` table at the root.
 - **Use `—` not "n/a"** for un-shipped cells. The root README's matrix
   comparison and Playwright snapshot tests pattern-match the symbol.
+- **Do not mark optional cells as shipped by default.** `mpp/session`,
+  `mpp/subscription`, and all x402 rows stay `—` until the target SDK has
+  matching unit tests, coverage, and interop evidence for that exact cell.
 - **Badges:** language + coverage are mandatory; tests count is
   optional (used by Rust which doesn't report a coverage % yet).
 - **Snippets must be runnable.** Each `<lang>` block should compile or

--- a/skills/pay-sdk-implementation/references/repo-layout.md
+++ b/skills/pay-sdk-implementation/references/repo-layout.md
@@ -37,16 +37,16 @@ in the intent leaves translate directly:
 │   │   │   └── types.<ext>          ← MethodName, IntentName, Base64UrlJson, ReceiptStatus
 │   │   ├── intents/
 │   │   │   ├── charge.<ext>         ← ChargeRequest (string amounts; methodDetails)
-│   │   │   └── session.<ext>        ← SessionRequest, OpenPayload, VoucherData, Commit/Close/TopUp
+│   │   │   └── session.<ext>        ← add only when implementing mpp/session
 │   │   └── solana.<ext>             ← programs::*, mints::*, resolve_stablecoin_mint
 │   ├── server/
 │   │   ├── charge.<ext>             ← Mpp handler: charge(), charge_with_options(), verify_credential[_with_expected]()
-│   │   ├── session.<ext>            ← Session lifecycle handler
+│   │   ├── session.<ext>            ← add only when implementing mpp/session
 │   │   ├── html.<ext>               ← Payment-link page renderer
 │   │   └── html/                    ← Generated payment-link assets (DO NOT EDIT BY HAND)
 │   ├── client/
 │   │   ├── charge.<ext>             ← build_charge_transaction, build_credential_header
-│   │   ├── session.<ext>            ← Session client (open, voucher, commit, close)
+│   │   ├── session.<ext>            ← add only when implementing mpp/session
 │   │   ├── http_stream.<ext>        ← Optional: SSE / metered streaming helper
 │   │   └── payment_channels.<ext>   ← Optional: payment-channels program client
 │   └── bin/                         ← or `cmd/`, `scripts/` — interop adapters

--- a/skills/pay-sdk-implementation/references/source-truth.md
+++ b/skills/pay-sdk-implementation/references/source-truth.md
@@ -1,0 +1,47 @@
+# Source truth and current research
+
+Read this before making protocol claims, changing compatibility matrices, or
+starting a new language port.
+
+## Authoritative references
+
+Use these in order:
+
+1. Local `solana-foundation/mpp-sdk/rust` code and tests.
+2. HTTP Payment Authentication / MPP docs: <https://paymentauth.org>
+3. Tempo MPP spec PRs: <https://github.com/tempoxyz/mpp-specs>
+4. Existing TypeScript SDK and interop harness in this repo.
+5. Solana SPL Token, Token-2022, ATA, transaction, and signer references.
+
+For x402 rows in the matrix, use:
+
+1. Local `solana-foundation/x402-sdk` Rust/TypeScript behavior when available.
+2. x402 Foundation docs: <https://docs.x402.org/introduction>
+3. x402 Foundation repo/specs: <https://github.com/x402-foundation/x402>
+
+Do not let x402 rows define MPP semantics, and do not let MPP session semantics
+define x402 `batch-settlement` without maintainer confirmation.
+
+## Solana Foundation references discovered
+
+- `solana-foundation/mpp-sdk`: Rust reference, TypeScript SDK, interop harness,
+  and this implementation skill.
+- `solana-foundation/x402-sdk`: current x402 Rust/TypeScript and interop
+  reference for x402 rows.
+- `solana-foundation/pay`: pay skill, MPP/x402 client references, session
+  server references, and metering types.
+- `solana-foundation/templates`, `kora`, `moneymq`, and `solana-com`: related
+  x402 examples/types/docs. Useful for ecosystem context, not primary MPP
+  protocol authority.
+
+## Matrix rule
+
+Every matrix cell defaults to not shipped unless that exact cell has evidence.
+
+- `mpp/charge/pull` and `mpp/charge/push` are the baseline cells for new SDKs.
+- `mpp/session` is optional and must not appear as shipped in charge-only SDKs.
+- `mpp/subscription` remains unshipped until the spec and implementation land.
+- x402 cells stay unshipped in MPP SDK ports unless the target language PR
+  explicitly implements and verifies that x402 cell.
+
+Prefer `—` plus a known-limits note over optimistic support claims.


### PR DESCRIPTION
## Summary
- add source-truth/current-research notes for payment SDK language ports
- add a PR-readiness checklist that captures skill pass, Greptile feedback, coverage, and interop evidence
- fix the README/repo-layout templates so optional `mpp/session` support is not advertised or scaffolded by default

## Why
This follows the skill-driven review flow from #90 while addressing the Greptile concern that charge-only language ports could accidentally claim session support.

## Notes
- no runtime code changed
- `mpp/session` remains documented and implemented in Rust, but new SDK templates now require explicit implementation evidence before marking it shipped
- x402 rows remain matrix-visible but unshipped unless a target language PR explicitly implements and verifies that cell

## Verification
- `git diff --check origin/main...HEAD`
- `rg -n "mpp/session.*✅|session\\.<ext>.*Session" skills/pay-sdk-implementation/references/readme-template.md skills/pay-sdk-implementation/references/repo-layout.md`
