### PR TITLE
docs(skill): add language SDK readiness gate

### DIFF
--- a/skills/pay-sdk-implementation/SKILL.md
+++ b/skills/pay-sdk-implementation/SKILL.md
@@ -57,11 +57,13 @@ the directory skeleton and CI from earlier ones.
    strict-types guidance, Standard Ruby + Rack guidance) and document the
    selected source in the SDK README.
 4. **Wire CI before code.** Read `references/ci-quality-coverage.md` and
-   add a GitHub Actions job that mirrors `test-rust`/`test-python` in
-   `.github/workflows/ci.yml`, with a ≥90 % coverage gate, formatter and
-   linter steps, and the `html-assets` download. Push CI green on an
-   empty skeleton before adding intent code so regressions are caught
-   immediately.
+   add a language-specific GitHub Actions workflow
+   (`.github/workflows/<lang>.yml`) unless the maintainer explicitly asks
+   for a shared workflow job. The workflow must mirror the reference test
+   jobs with a ≥90 % coverage gate, formatter and linter steps, dependency
+   audit, and `html-assets` download when the SDK ships server-side payment
+   links. Push CI green on an empty skeleton before adding intent code so
+   regressions are caught immediately.
 5. **Implement intent code.** For **each** matrix cell the user enabled,
    read the matching file under `references/intents/`. Each leaf is
    self-contained: wire format, server obligations, client obligations,

--- a/skills/pay-sdk-implementation/SKILL.md
+++ b/skills/pay-sdk-implementation/SKILL.md
@@ -47,13 +47,15 @@ the directory skeleton and CI from earlier ones.
    matrix cells are in scope this pass, (c) the package name. Use
    `AskUserQuestion` if any of these are unclear.
 2. **Lay out the repo.** Read `references/repo-layout.md` and create the
-   directory tree, package manifest, and `justfile` recipes. Do this
-   before writing any protocol code — the layout drives the import paths
-   the intents docs assume.
+   directory tree, package manifest, language-local `justfile`, examples,
+   and interop adapter skeleton. Do this before writing any protocol code
+   — the layout drives the import paths the intents docs assume.
 3. **Pick conventions.** Read `references/coding-conventions.md` and lock
    in the formatter, linter, type-checker, error type, and async runtime
-   for the language. This file also lists the per-language style guides
-   (PSR-12 for PHP, Standard Ruby, etc.) the SDK must follow.
+   for the language. Also identify and read a current language
+   best-practice skill or equivalent source (for example PHP PSR-12 +
+   strict-types guidance, Standard Ruby + Rack guidance) and document the
+   selected source in the SDK README.
 4. **Wire CI before code.** Read `references/ci-quality-coverage.md` and
    add a GitHub Actions job that mirrors `test-rust`/`test-python` in
    `.github/workflows/ci.yml`, with a ≥90 % coverage gate, formatter and
@@ -67,9 +69,11 @@ the directory skeleton and CI from earlier ones.
    Rust file paths cited in the leaf to disambiguate anything that's
    under-specified.
 6. **Add the interop adapter.** Read `references/interop-harness.md`,
-   create `tests/interop/<lang>-client/` (and a `bin/interop_server` if
-   you're shipping a server), and register it in
-   `tests/interop/src/implementations.ts`. Run the focused matrix
+   create `tests/interop/<lang>-client/` (and a direct language
+   `bin/interop_server` if you're shipping a server), and register it in
+   `tests/interop/src/implementations.ts`. The language runtime must own
+   the payment lifecycle it claims; do not hide missing settlement logic
+   behind a TypeScript proxy. Run the focused matrix
    (`MPP_INTEROP_CLIENTS=<lang> MPP_INTEROP_SERVERS=rust pnpm test` and
    the inverse) before flipping `enabled: true`.
 7. **Write the README last.** Read `references/readme-template.md` and
@@ -77,6 +81,11 @@ the directory skeleton and CI from earlier ones.
    client and server matrices (with the seven rows above), example
    walkthrough, Solana dependency list, and links to spec. The matrix
    must use the exact row order shown above so it's diffable across SDKs.
+8. **Prove local readiness.** Read `references/pr-readiness-gate.md` and
+   record a local verification transcript before saying the PR is ready:
+   source files read, unit-test count, coverage percent, static checks,
+   focused interop pairs, manual `curl` / `pay curl` example result,
+   framework example startup, and known limitations.
 
 ## Hard rules
 
@@ -104,6 +113,14 @@ the directory skeleton and CI from earlier ones.
   signatures, or `claude.ai/code` URLs anywhere in committed artifacts.
 - **Interop is the truth.** A unit-test green SDK that fails interop
   against Rust is a bug. Run the harness before declaring a cell done.
+- **Examples are executable contracts.** A server-side SDK is not ready
+  until its simple-server and framework middleware examples start
+  locally, unpaid `curl` returns 402, and `pay curl` returns 200.
+- **Server support includes settlement.** For `mpp/charge`, claiming
+  server support means the SDK issues the challenge, verifies the
+  credential, performs or verifies settlement, records replay state, and
+  returns a receipt. If it only verifies headers, mark it explicitly as
+  verification-only and keep the README matrix at `—`.
 
 ## When the user asks for something this skill does not cover
 

--- a/skills/pay-sdk-implementation/references/ci-quality-coverage.md
+++ b/skills/pay-sdk-implementation/references/ci-quality-coverage.md
@@ -1,14 +1,18 @@
 # CI, quality, coverage
 
-The reference CI is `mpp-sdk/.github/workflows/ci.yml`. Copy the
-shape of `test-rust` (or `test-python`/`test-go` for the closest
-language fit), add formatter + linter steps, gate coverage at ≥ 90 %.
+The reference CI shape lives in the existing language workflows under
+`mpp-sdk/.github/workflows/`. New SDKs should normally get a dedicated
+language workflow file such as `.github/workflows/ruby.yml` or
+`.github/workflows/php.yml`; keep `.github/workflows/ci.yml` focused on
+the shared TypeScript/Rust/Go/root jobs unless the maintainer explicitly
+asks for the language job to live there.
 
 ## Required jobs per SDK
 
-A new-language SDK needs **all** of the following jobs. Put them in
-`ci.yml` or a dedicated language workflow if the repo already uses that
-shape for the language:
+A new-language SDK needs **all** of the following jobs. Put the
+language-owned jobs in `.github/workflows/<lang>.yml`; keep shared
+cross-language harness jobs in `ci.yml` unless the repo already has a
+more specific workflow for that harness:
 
 1. **`test-<lang>`** — unit tests + coverage upload + format/lint check.
 2. **`integration`** (existing) — already runs against Surfnet; once the
@@ -17,6 +21,24 @@ shape for the language:
    the way `Run Rust client interop smoke` is set up (one line for
    `<lang> client × ts server`, one for `ts client × <lang> server`,
    one self-pair).
+
+## Template — `.github/workflows/<lang>.yml`
+
+Each new SDK should start with a dedicated workflow file:
+
+```yaml
+name: <Language>
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call:
+
+jobs:
+```
+
+Then add the language test job below.
 
 ## Template — `test-<lang>` job
 
@@ -192,6 +214,10 @@ the new language:
 - **Job names matter** — `report.yml` aggregates per-job coverage by
   artifact name. Use `<lang>-coverage` and
   `surfpool-reports-<lang>` exactly.
+- **Workflow ownership matters** — do not add every new language's unit
+  test job to `.github/workflows/ci.yml`. A dedicated workflow file keeps
+  maintainer review, reruns, and future language-specific CI changes
+  isolated.
 - **Manual DX is not replaced by CI.** CI proves repeatability; it does
   not prove the README path is runnable. Before marking a server SDK PR
   ready, run the language's simple-server example locally and verify

--- a/skills/pay-sdk-implementation/references/ci-quality-coverage.md
+++ b/skills/pay-sdk-implementation/references/ci-quality-coverage.md
@@ -6,7 +6,9 @@ language fit), add formatter + linter steps, gate coverage at ≥ 90 %.
 
 ## Required jobs per SDK
 
-A new-language SDK needs **all** of the following jobs in `ci.yml`:
+A new-language SDK needs **all** of the following jobs. Put them in
+`ci.yml` or a dedicated language workflow if the repo already uses that
+shape for the language:
 
 1. **`test-<lang>`** — unit tests + coverage upload + format/lint check.
 2. **`integration`** (existing) — already runs against Surfnet; once the
@@ -98,6 +100,10 @@ If the language's coverage tool cannot enforce a gate, write a small
 script in `<lang>/scripts/check_coverage.<sh|py>` modeled on
 `go/scripts/check_coverage.sh`.
 
+The local command and CI command must be the same path where possible.
+Prefer `cd <lang> && just test-cover` in CI over duplicating long
+coverage commands in YAML.
+
 ## Linting and formatting
 
 Every public SDK has **format check + lint** running in CI. Failures
@@ -168,3 +174,11 @@ the new language:
 - **Job names matter** — `report.yml` aggregates per-job coverage by
   artifact name. Use `<lang>-coverage` and
   `surfpool-reports-<lang>` exactly.
+- **Manual DX is not replaced by CI.** CI proves repeatability; it does
+  not prove the README path is runnable. Before marking a server SDK PR
+  ready, run the language's simple-server example locally and verify
+  unpaid `curl` returns 402 while `pay curl` returns 200.
+- **Server examples should be exercised in tests.** Add unit or
+  integration coverage that imports the simple-server / middleware
+  wiring where the language allows it. Do not leave example code as an
+  untested copy of the README.

--- a/skills/pay-sdk-implementation/references/ci-quality-coverage.md
+++ b/skills/pay-sdk-implementation/references/ci-quality-coverage.md
@@ -104,6 +104,24 @@ The local command and CI command must be the same path where possible.
 Prefer `cd <lang> && just test-cover` in CI over duplicating long
 coverage commands in YAML.
 
+## Coverage quality
+
+Do not treat the coverage percentage as the whole signal for payment
+verifier/server code. The report should drive targeted tests over the
+actual control flow:
+
+- function / method coverage for public API and verifier helpers
+- line / statement coverage as the numeric CI gate
+- branch / decision coverage for success/failure protocol paths
+- condition coverage for fail-closed guards
+- path coverage for lifecycle flows such as issue challenge -> verify
+  credential -> settle/fetch -> replay consume -> receipt
+
+Prefer adding tests that cover protocol decisions over tests that only
+raise the percentage. Examples: malformed-vs-valid payloads, pull-vs-push
+settlement, replay hit/miss, on-chain error/not-found/timeout, split/ATA
+validation, network mismatch, and cross-route replay.
+
 ## Linting and formatting
 
 Every public SDK has **format check + lint** running in CI. Failures

--- a/skills/pay-sdk-implementation/references/coding-conventions.md
+++ b/skills/pay-sdk-implementation/references/coding-conventions.md
@@ -4,6 +4,12 @@ The SDK reads as idiomatic in its target language. The Rust crate is the
 reference for **wire format and module structure**, not for code style.
 Use the language's canonical style guide and tooling.
 
+For each language PR, also select and read one current language
+best-practice skill or credible source before implementation. Document
+that source in the SDK README and use it during the local readiness
+pass. Examples: PHP strict types + PSR-12, Ruby Standard/Rack
+conventions, Swift API Design Guidelines, Kotlin Coding Conventions.
+
 ## Per-language style guides
 
 | Language | Style | Formatter | Linter | Type-checker | Test runner |

--- a/skills/pay-sdk-implementation/references/intents/mpp-charge-pull.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-charge-pull.md
@@ -89,6 +89,8 @@ Implement these steps in `server::charge::verify` (mirror
 5. **Network blockhash gate.** Before broadcasting, call
    `check_network_blockhash(network, tx.message.recent_blockhash())`
    to reject mainnet keys pointed at a sandbox server (and vice versa).
+   Server challenges must include a fresh `methodDetails.recentBlockhash`
+   when the server expects to co-sign or broadcast.
 6. **Pre-broadcast verifier.** Decode the transaction (accept legacy
    bincode `Transaction`, then fall back to `VersionedTransaction`);
    walk the instructions; verify:
@@ -108,6 +110,10 @@ Implement these steps in `server::charge::verify` (mirror
    on-chain settlement so a failed broadcast doesn't burn the signature.
 10. **Receipt.** Return `Receipt::success(method="solana",
     reference=signature, challengeId=challenge.id)`.
+
+Server support is not complete until the SDK owns this full lifecycle.
+Verification-only helpers are useful, but they do not justify a
+server-side README checkmark.
 
 ## Client obligations
 
@@ -173,6 +179,13 @@ adapter at `rust/src/bin/interop_client.rs`:
 - **Network gate first.** Calling `check_network_blockhash` before
   decoding instructions is cheaper than letting broadcast fail with a
   generic blockhash error.
+- **Stablecoin mint helper belongs in the SDK.** Expose the same
+  `resolve_stablecoin_mint` / token-program behavior as Rust so
+  examples, interop, and applications do not each open-code mint
+  resolution.
+- **Manual example verification is mandatory.** Run the simple-server
+  locally and prove unpaid `curl` returns 402 while `pay curl` returns
+  200 before marking pull-mode server support ready.
 
 ## Test plan
 
@@ -200,6 +213,7 @@ Integration test:
   `rust/tests/charge_integration.rs`. Cover SOL transfer, SPL transfer,
   splits with ATA creation, fee-payer mode.
 
-Interop scenario: `charge-basic` and `charge-split-ata` in
-`tests/interop/src/contracts.ts`. Both must pass against the Rust
-server before the new SDK is enabled by default.
+Interop scenario: `charge-basic`, `charge-split-ata`,
+`charge-network-mismatch`, and `charge-cross-route-replay` in
+`tests/interop/src/contracts.ts`. These must pass in every relevant
+focused pair before the new SDK is enabled by default.

--- a/skills/pay-sdk-implementation/references/intents/mpp-charge-push.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-charge-push.md
@@ -64,6 +64,12 @@ signature } => self.verify_push(...) }` at `rust/src/server/charge.rs:541`):
 7. **Receipt.** Same as pull mode — `Receipt::success(method="solana",
    reference=signature, challengeId=challenge.id)`.
 
+Push-mode server support should reuse the same structural verifier,
+expected-request pinning, replay store, and receipt path as pull mode.
+Only the settlement source changes: pull receives a transaction to
+broadcast, push receives a signature and fetches the settled
+transaction from RPC.
+
 ## Client obligations
 
 The push client builds the transaction the same way as pull, then
@@ -113,6 +119,10 @@ see the service worker pattern in
 - **Signature length / encoding.** Solana signatures are 64 bytes; the
   base58 encoding length is 87-88 chars. Reject anything outside that
   range up-front.
+- **Duplicate settlement behavior must match pull.** A signature seen
+  once is consumed for both modes. Add a regression test that verifies a
+  consumed pull signature cannot be re-used through push and a consumed
+  push signature cannot be re-used through pull.
 
 ## Test plan
 

--- a/skills/pay-sdk-implementation/references/interop-harness.md
+++ b/skills/pay-sdk-implementation/references/interop-harness.md
@@ -41,6 +41,9 @@ The server must:
 
 - Expose the shared resource path from `interopScenario.resourcePath`
 - Protect it with the MPP `charge` flow
+- Use the target language SDK for challenge issuance, credential
+  verification, settlement / settlement verification, replay state, and
+  receipt generation
 - Return a successful JSON body after payment
 - Include the `interopScenario.settlementHeader` header on success
 
@@ -184,3 +187,11 @@ in that file are the pattern.
   `rust/examples/payment_link_server.rs:160-186` for the pattern.
 - **Don't pin a parallel Solana SDK** in the interop adapter. Path-
   depend on your main package and reuse its primitives.
+- **Interop is not a wrapper acceptance test.** A language server that
+  shells out to TypeScript for settlement has not proven server support.
+  The adapter may reuse shared fixtures, but the protected endpoint must
+  execute the target SDK's server path.
+- **Add one intent file per role.** Keep test vectors consolidated by
+  intent: one server intent file and one client intent file per intent
+  in the harness. This keeps future `session` / `subscription` vectors
+  from becoming mixed with `charge`.

--- a/skills/pay-sdk-implementation/references/pr-readiness-gate.md
+++ b/skills/pay-sdk-implementation/references/pr-readiness-gate.md
@@ -1,0 +1,81 @@
+# PR readiness gate
+
+Use this gate before marking any language PR ready for review. Keep the
+transcript local while working, then summarize the evidence in the PR
+body.
+
+## Source of truth read
+
+Record the exact sources used for the pass:
+
+- This skill's `SKILL.md` and every referenced file for the enabled
+  matrix cells.
+- Rust reference files cited by those intent leaves.
+- The current language implementation and README.
+- One language best-practice skill or credible source, read before code.
+- Relevant examples and interop adapters in Rust / TypeScript.
+
+Do not claim parity from memory. If a source says "see X.rs", open it.
+
+## Unit tests
+
+Record:
+
+- Test command.
+- Number of tests run.
+- Coverage percent and the gate used.
+- New tests added for every new behavior.
+
+The default coverage gate for new SDKs is 90 percent. If a legacy SDK has
+a lower gate, keep the lower gate only if the PR explicitly explains why
+raising it is out of scope.
+
+## Static checks
+
+Record the language-local commands for:
+
+- Format check.
+- Lint.
+- Type/static analysis when the language has a standard tool.
+- Dependency audit.
+
+These commands should be available through the language-local `justfile`
+and, where useful, mirrored by root justfile recipes.
+
+## Interop
+
+Record all focused cells that apply:
+
+- TypeScript client -> language server.
+- Rust client -> language server.
+- Language client -> Rust server.
+- Language client -> language server, when the language has both roles.
+
+Server adapters must run the target language's SDK directly. They must
+not depend on a TypeScript wrapper for challenge issuance, settlement,
+or replay behavior.
+
+## Manual DX
+
+Before review, manually run the documented examples:
+
+- Start the simple-server example.
+- Confirm unpaid `curl` returns 402.
+- Confirm `pay curl` returns 200.
+- Start the framework middleware example (Laravel for PHP, Rack for
+  Ruby, or the idiomatic equivalent).
+
+If manual verification needs Surfpool or another service, document the
+exact command and whether it was run locally or left as a CI-only check.
+
+## Known limitations
+
+State limitations plainly:
+
+- Client-only or server-only.
+- Pull-only or push-only.
+- Verification-only vs full settlement.
+- Unsupported intents.
+- Missing coverage tooling or manual DX gaps.
+
+Do not hide limitations behind green unit tests.

--- a/skills/pay-sdk-implementation/references/pr-readiness-gate.md
+++ b/skills/pay-sdk-implementation/references/pr-readiness-gate.md
@@ -84,6 +84,10 @@ Before review, manually run the documented examples:
 - Confirm `pay curl` returns 200.
 - Start the framework middleware example (Laravel for PHP, Rack for
   Ruby, or the idiomatic equivalent).
+- Confirm the framework middleware example returns the same unpaid `curl`
+  402 and paid `pay curl` 200 as the simple server, unless the PR body
+  explicitly explains why that framework path is CI-only or externally
+  blocked.
 
 If manual verification needs Surfpool or another service, document the
 exact command and whether it was run locally or left as a CI-only check.

--- a/skills/pay-sdk-implementation/references/pr-readiness-gate.md
+++ b/skills/pay-sdk-implementation/references/pr-readiness-gate.md
@@ -58,6 +58,8 @@ Record the language-local commands for:
 - Lint.
 - Type/static analysis when the language has a standard tool.
 - Dependency audit.
+- Dedicated language workflow path, usually
+  `.github/workflows/<lang>.yml`.
 
 These commands should be available through the language-local `justfile`
 and, where useful, mirrored by root justfile recipes.

--- a/skills/pay-sdk-implementation/references/pr-readiness-gate.md
+++ b/skills/pay-sdk-implementation/references/pr-readiness-gate.md
@@ -25,10 +25,30 @@ Record:
 - Number of tests run.
 - Coverage percent and the gate used.
 - New tests added for every new behavior.
+- Critical branch/condition/path decisions covered, not just the line
+  percentage.
 
 The default coverage gate for new SDKs is 90 percent. If a legacy SDK has
 a lower gate, keep the lower gate only if the PR explicitly explains why
 raising it is out of scope.
+
+For payment verifier/server code, line coverage is only the floor. Before
+marking a PR ready, list the decision table you exercised:
+
+- pull vs push credential payloads
+- valid vs malformed credentials
+- request/challenge match vs cross-route mismatch
+- network match vs network mismatch
+- on-chain ok vs on-chain error vs not-found/timeout
+- replay miss vs replay hit
+- primary payment vs split payment
+- ATA required vs optional vs malformed ATA
+- allowed instruction vs allowed-but-unmatched vs disallowed program
+- client-paid fees vs server fee-payer
+
+Formal MC/DC measurement is not required unless the language tooling makes
+it cheap, but security-critical boolean guards should have tests showing
+that each meaningful condition can change the outcome.
 
 ## Static checks
 

--- a/skills/pay-sdk-implementation/references/readme-template.md
+++ b/skills/pay-sdk-implementation/references/readme-template.md
@@ -33,7 +33,7 @@ any HTTP API accept payments using the `402 Payment Required` flow.
 ├── src/protocol/        # Wire format (challenge, headers, intents)
 ├── src/server/          # 402 challenge issuance + credential verification
 ├── src/client/          # Build credentials from a challenge
-├── examples/            # Minimal protected endpoint
+├── examples/            # Simple server + framework middleware examples
 └── tests/               # Unit + Surfpool-backed integration
 `​``
 
@@ -91,15 +91,37 @@ tripping to source.
 ## How to use the example
 
 `​``bash
-cd <dir>/examples
-<run-payment-link-server-cmd>
-# In another terminal:
-curl -i http://localhost:3001/fortune
+cd <dir>
+just example-simple
+
+# In another terminal: payment required
+curl -i http://localhost:3001/paid
+
+# payment successful
+pay curl http://localhost:3001/paid
 `​``
 
-The example serves one protected endpoint that returns a fortune cookie
-after a paid 402 challenge succeeds. Run against
-[Surfpool](https://surfpool.run) on `:8899` for the localnet flow.
+The simple server serves one protected endpoint and exercises the same
+SDK server path used by interop. Server-side SDKs also include a
+framework middleware example (`Laravel`, `Rack`, or the idiomatic
+equivalent) that can be started with `just example-framework`.
+
+Run against [Surfpool](https://surfpool.run) on `:8899` for the
+localnet flow.
+
+## Local verification
+
+`​``bash
+just test
+just lint
+just test-cover
+just example-simple
+curl -i http://localhost:3001/paid
+pay curl http://localhost:3001/paid
+`​``
+
+Before a PR is marked ready, include the test count, coverage percent,
+interop pairs, and manual example result in the PR body.
 
 ## Solana dependencies
 
@@ -158,5 +180,9 @@ MIT
   run end-to-end against the example server on `:3001`. If the
   language has a REPL, the snippet should be REPL-pastable. Don't
   invent placeholders like `... rest of imports`.
+- **Examples are part of the SDK contract.** The simple-server and
+  framework middleware examples must use SDK APIs, not hand-written
+  protocol shortcuts. They should be imported or executed by tests when
+  the language tooling makes that practical.
 - **Solana dependency table** is the single source of truth for the
   versions a consumer pins. Keep it in sync with the manifest.

--- a/skills/pay-sdk-implementation/references/repo-layout.md
+++ b/skills/pay-sdk-implementation/references/repo-layout.md
@@ -26,6 +26,7 @@ in the intent leaves translate directly:
 <new-lang>/
 ├── <manifest>                       ← language-native manifest (Cargo.toml,
 │                                      pyproject.toml, package.json, composer.json…)
+├── justfile                         ← language-local install/build/test/lint/coverage recipes
 ├── src/                             ← or `lib/`, `pkg/`, `<package>/` per idiom
 │   ├── error.<ext>                  ← Error enum + Result alias
 │   ├── expires.<ext>                ← RFC 3339 helpers (`expires::minutes(5)`)
@@ -53,7 +54,8 @@ in the intent leaves translate directly:
 │       ├── interop_client.<ext>
 │       └── interop_server.<ext>
 ├── examples/
-│   └── payment_link_server.<ext>    ← One protected endpoint on :3001-ish
+│   ├── simple-server/               ← One protected endpoint on :3001-ish
+│   └── <framework>-middleware/      ← Laravel for PHP, Rack for Ruby, etc.
 └── tests/
     ├── charge_integration.<ext>     ← Surfpool-backed end-to-end
     └── ...                          ← Unit tests per module (or `src/.../*_test.<ext>` per idiom)
@@ -106,8 +108,9 @@ prefix:
 
 ## `justfile` recipes
 
-Add one section per language, matching the existing pattern in
-`mpp-sdk/justfile`. The required recipes are:
+Add a language-local `justfile` first, then add root wrappers in
+`mpp-sdk/justfile` that delegate to it. The local recipes are the
+developer contract for CI, manual verification, and PR review:
 
 ```just
 # ── <Language> ──
@@ -135,6 +138,14 @@ Add one section per language, matching the existing pattern in
 # Coverage with ≥90% gate
 <l>-test-cover:
     cd <dir> && <coverage-cmd-with-fail-under-90>
+
+# Start the simple protected endpoint used by the README
+<l>-example-simple:
+    cd <dir> && <run-simple-server-cmd>
+
+# Start the framework middleware example, if the SDK ships server support
+<l>-example-framework:
+    cd <dir> && <run-framework-example-cmd>
 ```
 
 Then add the new `<l>-test` to the `test` target, `<l>-fmt` to the
@@ -158,3 +169,17 @@ If the target language has no canonical Solana SDK, open-code the
 small set of constants you need from `protocol/solana.<ext>` and the
 two or three transaction/instruction structures used in charge. Do
 **not** pull in a heavy chain client just for one helper.
+
+## Example and interop ownership
+
+Server-side SDKs must own their examples and interop server in the
+target language:
+
+- The simple-server example is the smallest complete paid endpoint.
+- The framework middleware example demonstrates idiomatic integration
+  without hiding protocol logic in the app layer.
+- `bin/interop_server` (or the language idiom) must use the SDK's own
+  challenge, settlement, replay, and receipt code.
+
+A TypeScript helper may start infrastructure, but it must not stand in
+for the language SDK's server lifecycle.

--- a/skills/pay-sdk-implementation/references/repo-layout.md
+++ b/skills/pay-sdk-implementation/references/repo-layout.md
@@ -116,36 +116,75 @@ developer contract for CI, manual verification, and PR review:
 # ── <Language> ──
 
 # Install <language> deps
+install:
+    <install-cmd>
+
+# Build <language> package
+build:
+    <build-cmd>
+
+# Test
+test:
+    <test-cmd>
+
+# Format
+fmt:
+    <fmt-cmd>
+
+# Lint
+lint:
+    <lint-cmd>
+
+# Coverage with ≥90% gate
+test-cover:
+    <coverage-cmd-with-fail-under-90>
+
+# Start the simple protected endpoint used by the README
+example-simple:
+    <run-simple-server-cmd>
+
+# Start the framework middleware example, if the SDK ships server support
+example-framework:
+    <run-framework-example-cmd>
+```
+
+Root wrappers in `mpp-sdk/justfile` should delegate to those local
+recipes:
+
+```just
+# ── <Language> root wrappers ──
+
+# Install <language> deps
 <l>-install:
-    cd <dir> && <install-cmd>
+    cd <dir> && just install
 
 # Build <language> package
 <l>-build:
-    cd <dir> && <build-cmd>
+    cd <dir> && just build
 
 # Test
 <l>-test:
-    cd <dir> && <test-cmd>
+    cd <dir> && just test
 
 # Format
 <l>-fmt:
-    cd <dir> && <fmt-cmd>
+    cd <dir> && just fmt
 
 # Lint
 <l>-lint:
-    cd <dir> && <lint-cmd>
+    cd <dir> && just lint
 
 # Coverage with ≥90% gate
 <l>-test-cover:
-    cd <dir> && <coverage-cmd-with-fail-under-90>
+    cd <dir> && just test-cover
 
 # Start the simple protected endpoint used by the README
 <l>-example-simple:
-    cd <dir> && <run-simple-server-cmd>
+    cd <dir> && just example-simple
 
 # Start the framework middleware example, if the SDK ships server support
 <l>-example-framework:
-    cd <dir> && <run-framework-example-cmd>
+    cd <dir> && just example-framework
 ```
 
 Then add the new `<l>-test` to the `test` target, `<l>-fmt` to the


### PR DESCRIPTION
## What
- Updates the pay SDK implementation skill with the PHP calibration lessons from #92.
- Adds a reusable PR readiness gate for new language SDK PRs.
- Makes manual example verification, language-local justfiles, framework examples, settlement lifecycle, replay handling, interop ownership, and coverage/static checks explicit.
- Adds coverage-quality guidance so payment verifier/server PRs exercise branch/condition/path decisions, not just a line percentage.

## Why
Ludo's #92 pass showed that CI and unit tests were not enough by themselves. The skill now captures the review standard before we continue with Ruby and the remaining language PRs.

## Verified
- Read the repo skill and relevant references.
- Checked the rendered Markdown content locally.
-  passes.

## Notes
This is docs/skill-only. No runtime SDK behavior changes.
