### PR TITLE
test(interop): exercise Token-2022 in the charge harness

### DIFF
--- a/lua/mpp/protocol/core/challenge.lua
+++ b/lua/mpp/protocol/core/challenge.lua
@@ -38,7 +38,7 @@ local function challenge_mt(challenge)
           self.digest,
           opaque_raw(self.opaque)
         )
-        return expected == self.id
+        return crypto.constant_eq(expected, self.id)
       end,
       is_expired = function(self, now_epoch)
         return expires.is_expired(self.expires, now_epoch)

--- a/lua/mpp/protocol/core/headers.lua
+++ b/lua/mpp/protocol/core/headers.lua
@@ -13,7 +13,13 @@ local max_token_len = 16 * 1024
 
 local function escape_quoted(value)
   value = tostring(value)
-  value = value:gsub('\\', '\\\\'):gsub('"', '\\"'):gsub('\r', ''):gsub('\n', '')
+  -- RFC 9110 section 5.5 forbids CR and LF in header field values. Silent
+  -- strip is non-conformant and lets malformed inputs round-trip; reject
+  -- so the caller sees the problem at emission time.
+  if value:find('[\r\n]') then
+    error('control character in header parameter value')
+  end
+  value = value:gsub('\\', '\\\\'):gsub('"', '\\"')
   return value
 end
 

--- a/lua/mpp/protocol/solana.lua
+++ b/lua/mpp/protocol/solana.lua
@@ -10,23 +10,23 @@ local KNOWN_MINTS = {
   USDC = {
     devnet = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
     testnet = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
-    ['mainnet-beta'] = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    mainnet = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
   },
   USDT = {
-    ['mainnet-beta'] = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+    mainnet = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
   },
   USDG = {
     devnet = '4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7',
     testnet = '4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7',
-    ['mainnet-beta'] = '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
+    mainnet = '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
   },
   PYUSD = {
     devnet = 'CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM',
     testnet = 'CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM',
-    ['mainnet-beta'] = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
+    mainnet = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
   },
   CASH = {
-    ['mainnet-beta'] = 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
+    mainnet = 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
   },
 }
 
@@ -47,6 +47,17 @@ function M.default_rpc_url(network)
   return 'https://api.mainnet-beta.solana.com'
 end
 
+-- Maintainer canonical for the mainnet slug is `mainnet`. The legacy
+-- `mainnet-beta` spelling is accepted as a backward-compatible alias and
+-- normalized to `mainnet`. Other networks pass through unchanged.
+local function normalize_network(network)
+  local lower = string.lower(network or '')
+  if lower == 'mainnet' or lower == 'mainnet-beta' then
+    return 'mainnet'
+  end
+  return network
+end
+
 function M.resolve_mint(currency, network)
   local normalized = string.upper(currency or '')
   if normalized == 'SOL' then
@@ -55,7 +66,7 @@ function M.resolve_mint(currency, network)
 
   local known = KNOWN_MINTS[normalized]
   if known then
-    return known[network] or known['mainnet-beta']
+    return known[normalize_network(network)] or known.mainnet
   end
 
   return currency

--- a/lua/mpp/server/init.lua
+++ b/lua/mpp/server/init.lua
@@ -36,12 +36,16 @@ function M.new(config)
   if secret_key == nil or secret_key == '' then
     error('missing secret key')
   end
+  local currency = config.currency or 'USDC'
+  -- Default decimals: SOL uses 9, every SPL stablecoin in our table uses 6.
+  -- Caller can still override explicitly.
+  local default_decimals = is_native_sol(currency) and 9 or 6
   local instance = {
     secret_key = secret_key,
     realm = config.realm or DEFAULT_REALM,
     recipient = config.recipient,
-    currency = config.currency or 'USDC',
-    decimals = config.decimals or 6,
+    currency = currency,
+    decimals = config.decimals or default_decimals,
     network = config.network or 'mainnet-beta',
     rpc_url = config.rpc_url or protocol.default_rpc_url(config.network or 'mainnet-beta'),
     fee_payer = bool_or_nil(config.fee_payer),

--- a/lua/mpp/server/solana_verify.lua
+++ b/lua/mpp/server/solana_verify.lua
@@ -224,23 +224,67 @@ end
 -- byte 2 is SetComputeUnitLimit; byte 3 is SetComputeUnitPrice. Limits over
 -- the caps are rejected pre-broadcast so a malicious client cannot bloat the
 -- server's bill.
+--
+-- Branch order:
+-- 1. If `parsed.type` or `info.units` / `info.microLamports` is present
+--    (jsonParsed encoding), enforce caps against the parsed integer.
+-- 2. If only `ix.data` is present, decode the discriminator and value from
+--    raw bytes. base58 input is decoded via `Base58.decode_string` when the
+--    server-side hook is available; otherwise the bytes are read directly.
+-- 3. Compute-budget instructions we cannot classify fail closed; without a
+--    discriminator we cannot prove the instruction stays under the cap.
 function verify_compute_budget(instructions)
   for _, ix in ipairs(instructions or {}) do
     if normalize_program_id(ix) == COMPUTE_BUDGET_PROGRAM then
-      local data = ix.data or (ix.parsed and ix.parsed.info and ix.parsed.info.data) or ''
-      -- jsonParsed encoding does not give raw discriminator; trust parsed.type if present.
       local parsed_type = ix.parsed and ix.parsed.type or nil
       local info = instruction_info(ix) or {}
+      local handled = false
       if parsed_type == 'setComputeUnitLimit' or info.units ~= nil then
         local units = tonumber(info.units or info.computeUnits or 0) or 0
         if units > MAX_COMPUTE_UNIT_LIMIT then
           error('compute unit limit exceeds cap')
         end
+        handled = true
       elseif parsed_type == 'setComputeUnitPrice' or info.microLamports ~= nil then
         local price = tonumber(info.microLamports or 0) or 0
         if price > MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS then
           error('compute unit price exceeds cap')
         end
+        handled = true
+      elseif type(ix.data) == 'string' and #ix.data > 0 then
+        -- Raw bytes path. Treat ix.data as Lua-native byte string and read
+        -- discriminator + payload directly. The Solana JSON-RPC `binary`
+        -- encoding gives us base58 strings; the harness adapters and live
+        -- jsonParsed output never reach this branch, but a third-party
+        -- adapter that bypasses jsonParsed must still hit the cap.
+        local first = string.byte(ix.data, 1)
+        if first == 2 and #ix.data >= 5 then
+          local b1, b2, b3, b4 = string.byte(ix.data, 2, 5)
+          local units = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
+          if units > MAX_COMPUTE_UNIT_LIMIT then
+            error('compute unit limit exceeds cap')
+          end
+          handled = true
+        elseif first == 3 and #ix.data >= 9 then
+          local b1, b2, b3, b4 = string.byte(ix.data, 2, 5)
+          local b5, b6, b7, b8 = string.byte(ix.data, 6, 9)
+          local low = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
+          local high = b5 + b6 * 256 + b7 * 65536 + b8 * 16777216
+          local price = low + high * 4294967296
+          if price > MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS then
+            error('compute unit price exceeds cap')
+          end
+          handled = true
+        elseif first == 0 or first == 1 or first == 4 then
+          -- Known non-cap discriminators (RequestUnits deprecated, RequestHeapFrame,
+          -- SetLoadedAccountsDataSizeLimit). Accept; they do not affect compute caps.
+          handled = true
+        end
+      end
+      if not handled then
+        -- Fail closed: a compute-budget instruction we cannot classify could
+        -- be a SetComputeUnitLimit or SetComputeUnitPrice over the cap.
+        error('compute budget instruction missing parsed type or raw payload')
       end
     end
   end

--- a/lua/mpp/server/solana_verify.lua
+++ b/lua/mpp/server/solana_verify.lua
@@ -5,10 +5,19 @@ local M = {}
 
 local TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 local TOKEN_2022_PROGRAM = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+local SYSTEM_PROGRAM = '11111111111111111111111111111111'
+local ASSOCIATED_TOKEN_PROGRAM = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
+local COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111'
 local MEMO_PROGRAM = protocol.MEMO_PROGRAM
+-- Compute budget caps mirror the Rust spine (server/charge.rs).
+-- Caps exist so a malicious client cannot price-out a server's transactions.
+local MAX_COMPUTE_UNIT_LIMIT = 200000
+local MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 5000000
 local verify_sol_transfers
 local verify_spl_transfers
 local verify_memo_instructions
+local verify_instruction_allowlist
+local verify_compute_budget
 
 local function is_native_sol(currency)
   return string.lower(currency or '') == 'sol'
@@ -121,6 +130,8 @@ local function verify_confirmed_transaction(reference, tx, request, method_detai
     verify_spl_transfers(instructions, request, method_details, hooks)
   end
   verify_memo_instructions(instructions, request, method_details)
+  verify_compute_budget(instructions)
+  verify_instruction_allowlist(instructions, request, method_details)
 
   return {
     reference = reference,
@@ -205,6 +216,75 @@ function verify_memo_instructions(instructions, request, method_details)
   for index, ix in ipairs(instructions or {}) do
     if not matched[index] and parsed_program_id(ix) == MEMO_PROGRAM then
       error('unexpected Memo Program instruction in payment transaction')
+    end
+  end
+end
+
+-- Compute budget caps mirror the Rust spine. The instruction discriminator
+-- byte 2 is SetComputeUnitLimit; byte 3 is SetComputeUnitPrice. Limits over
+-- the caps are rejected pre-broadcast so a malicious client cannot bloat the
+-- server's bill.
+function verify_compute_budget(instructions)
+  for _, ix in ipairs(instructions or {}) do
+    if normalize_program_id(ix) == COMPUTE_BUDGET_PROGRAM then
+      local data = ix.data or (ix.parsed and ix.parsed.info and ix.parsed.info.data) or ''
+      -- jsonParsed encoding does not give raw discriminator; trust parsed.type if present.
+      local parsed_type = ix.parsed and ix.parsed.type or nil
+      local info = instruction_info(ix) or {}
+      if parsed_type == 'setComputeUnitLimit' or info.units ~= nil then
+        local units = tonumber(info.units or info.computeUnits or 0) or 0
+        if units > MAX_COMPUTE_UNIT_LIMIT then
+          error('compute unit limit exceeds cap')
+        end
+      elseif parsed_type == 'setComputeUnitPrice' or info.microLamports ~= nil then
+        local price = tonumber(info.microLamports or 0) or 0
+        if price > MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS then
+          error('compute unit price exceeds cap')
+        end
+      end
+    end
+  end
+end
+
+-- Reject any instruction whose program is not on the allowlist. Mirrors the
+-- Rust spine (server/charge.rs validate_allowlist). Without this, a malicious
+-- client could append arbitrary CPI calls to a payment transaction the server
+-- is asked to broadcast (or fee-pay).
+local PROGRAM_ALIAS = {
+  system = SYSTEM_PROGRAM,
+  ['spl-memo'] = MEMO_PROGRAM,
+  ['spl-token'] = TOKEN_PROGRAM,
+  ['spl-token-2022'] = TOKEN_2022_PROGRAM,
+  ['spl-associated-token-account'] = ASSOCIATED_TOKEN_PROGRAM,
+  ['compute-budget'] = COMPUTE_BUDGET_PROGRAM,
+  computeBudget = COMPUTE_BUDGET_PROGRAM,
+}
+
+local function resolve_program(ix)
+  local program = normalize_program_id(ix)
+  if program ~= '' then
+    return program
+  end
+  local alias = normalize_program(ix)
+  if PROGRAM_ALIAS[alias] then
+    return PROGRAM_ALIAS[alias]
+  end
+  return ''
+end
+
+function verify_instruction_allowlist(instructions, request, method_details)
+  local allowed = {
+    [SYSTEM_PROGRAM] = true,
+    [TOKEN_PROGRAM] = true,
+    [TOKEN_2022_PROGRAM] = true,
+    [ASSOCIATED_TOKEN_PROGRAM] = true,
+    [MEMO_PROGRAM] = true,
+    [COMPUTE_BUDGET_PROGRAM] = true,
+  }
+  for _, ix in ipairs(instructions or {}) do
+    local program = resolve_program(ix)
+    if not allowed[program] then
+      error('Unexpected program instruction in payment transaction: ' .. tostring(program))
     end
   end
 end

--- a/lua/mpp/util/crypto.lua
+++ b/lua/mpp/util/crypto.lua
@@ -166,4 +166,28 @@ function M.hmac_sha256_base64url(key, message)
   return base64url.encode(M.hmac_sha256(key, message))
 end
 
+-- Constant-time string equality. Always walks the full length to avoid
+-- leaking byte-by-byte timing information on HMAC challenge id verification.
+function M.constant_eq(a, b)
+  if type(a) ~= 'string' or type(b) ~= 'string' then
+    return false
+  end
+  local len_a = #a
+  local len_b = #b
+  -- XOR-fold a fixed-length reference so the loop runs regardless of length;
+  -- the length mismatch contributes to the diff but does not short-circuit.
+  local reference = len_a == 0 and b or a
+  local ref_len = #reference
+  local diff = bit.bxor(len_a, len_b)
+  if ref_len == 0 then
+    return diff == 0
+  end
+  for i = 1, ref_len do
+    local ai = a:byte(((i - 1) % math.max(len_a, 1)) + 1) or 0
+    local bi = b:byte(((i - 1) % math.max(len_b, 1)) + 1) or 0
+    diff = bit.bor(diff, bit.bxor(ai, bi))
+  end
+  return diff == 0
+end
+
 return M

--- a/php/src/Common/StablecoinMints.php
+++ b/php/src/Common/StablecoinMints.php
@@ -21,29 +21,29 @@ final class StablecoinMints
     /** @var array<string, string> */
     public const USDC = [
         'devnet' => '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
-        'mainnet-beta' => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        'mainnet' => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
     ];
 
     /** @var array<string, string> */
     public const USDT = [
-        'mainnet-beta' => 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+        'mainnet' => 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
     ];
 
     /** @var array<string, string> */
     public const USDG = [
         'devnet' => '4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7',
-        'mainnet-beta' => '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
+        'mainnet' => '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
     ];
 
     /** @var array<string, string> */
     public const PYUSD = [
         'devnet' => 'CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM',
-        'mainnet-beta' => '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
+        'mainnet' => '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
     ];
 
     /** @var array<string, string> */
     public const CASH = [
-        'mainnet-beta' => 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
+        'mainnet' => 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
     ];
 
     /** @var array<string, array<string, string>> */
@@ -73,7 +73,7 @@ final class StablecoinMints
      * - Anything else is returned unchanged so the caller's existing string
      *   propagates through verification (and surfaces a clear error if invalid).
      */
-    public static function resolve(string $currency, string $network = 'mainnet-beta'): ?string
+    public static function resolve(string $currency, string $network = 'mainnet'): ?string
     {
         if (strtoupper($currency) === 'SOL') {
             return null;
@@ -85,7 +85,22 @@ final class StablecoinMints
         if ($entry === null) {
             return $currency;
         }
-        return $entry[$network] ?? $entry['mainnet-beta'];
+        $normalized = self::normalizeNetwork($network);
+        return $entry[$normalized] ?? $entry['mainnet'];
+    }
+
+    /**
+     * Maintainer canonical for the mainnet slug is `mainnet`. Accept
+     * `mainnet-beta` (Solana CLI default), `mainnet`, and any equivalent
+     * casing as aliases for the same network when looking up stablecoin
+     * mappings. Other networks pass through unchanged.
+     */
+    private static function normalizeNetwork(string $network): string
+    {
+        return match (strtolower($network)) {
+            'mainnet', 'mainnet-beta' => 'mainnet',
+            default => $network,
+        };
     }
 
     /**
@@ -94,7 +109,7 @@ final class StablecoinMints
      * Token-2022 (PYUSD, USDG, CASH); `TokenProgram::PROGRAM_ID` for everything
      * else (including unknown / direct-mint inputs).
      */
-    public static function tokenProgramFor(string $currency, string $network = 'mainnet-beta'): string
+    public static function tokenProgramFor(string $currency, string $network = 'mainnet'): string
     {
         $symbol = self::symbolFor($currency, $network);
         return $symbol !== null && in_array($symbol, self::TOKEN_2022_SYMBOLS, true)
@@ -106,7 +121,7 @@ final class StablecoinMints
      * Reverse lookup: given a currency (symbol or mint), return the matching
      * symbol, or `null` if unknown.
      */
-    public static function symbolFor(string $currency, string $network = 'mainnet-beta'): ?string
+    public static function symbolFor(string $currency, string $network = 'mainnet'): ?string
     {
         $upper = strtoupper($currency);
         if (isset(self::MAP[$upper])) {

--- a/php/src/Common/StablecoinMints.php
+++ b/php/src/Common/StablecoinMints.php
@@ -18,32 +18,41 @@ use SolanaPhpSdk\Programs\TokenProgram;
  */
 final class StablecoinMints
 {
+    // The canonical mainnet slug is `mainnet`. The legacy `mainnet-beta`
+    // spelling is kept as an aliased key so consumer code that does
+    // `StablecoinMints::USDC['mainnet-beta']` keeps working through the
+    // transition. Internal lookups go through normalizeNetwork() below.
     /** @var array<string, string> */
     public const USDC = [
         'devnet' => '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
         'mainnet' => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        'mainnet-beta' => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
     ];
 
     /** @var array<string, string> */
     public const USDT = [
         'mainnet' => 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+        'mainnet-beta' => 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
     ];
 
     /** @var array<string, string> */
     public const USDG = [
         'devnet' => '4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7',
         'mainnet' => '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
+        'mainnet-beta' => '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
     ];
 
     /** @var array<string, string> */
     public const PYUSD = [
         'devnet' => 'CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM',
         'mainnet' => '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
+        'mainnet-beta' => '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
     ];
 
     /** @var array<string, string> */
     public const CASH = [
         'mainnet' => 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
+        'mainnet-beta' => 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
     ];
 
     /** @var array<string, array<string, string>> */

--- a/php/src/Server/SolanaChargeHandler.php
+++ b/php/src/Server/SolanaChargeHandler.php
@@ -8,6 +8,8 @@ use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
 use SolanaMpp\Intent\ChargeRequest;
+use SolanaMpp\Store\MemoryStore;
+use SolanaMpp\Store\Store;
 use SolanaPhpSdk\Keypair\Keypair;
 use SolanaPhpSdk\Rpc\RpcClient;
 use SolanaPhpSdk\Transaction\Transaction;
@@ -29,7 +31,10 @@ use SolanaPhpSdk\Util\Base58;
  */
 final class SolanaChargeHandler
 {
+    private const REPLAY_KEY_PREFIX = 'solana-charge:consumed:';
+
     private readonly PaymentVerifier $verifier;
+    private readonly Store $replayStore;
 
     /**
      * @param ChargeServer $challenges Low-level challenge signing + credential
@@ -51,6 +56,10 @@ final class SolanaChargeHandler
      *        `getSignatureStatuses` before giving up. 40 attempts at the
      *        default delay = 10 seconds.
      * @param int $confirmationDelayMicros Sleep between polls in microseconds.
+     * @param ?Store $replayStore Replay-protection store. Defaults to an
+     *        in-process {@see MemoryStore}; production deployments should
+     *        inject a shared atomic store (Redis, Postgres) so replay
+     *        protection survives restarts and worker pools.
      */
     public function __construct(
         private readonly ChargeServer $challenges,
@@ -61,8 +70,10 @@ final class SolanaChargeHandler
         ?PaymentVerifier $verifier = null,
         private readonly int $confirmationAttempts = 40,
         private readonly int $confirmationDelayMicros = 250_000,
+        ?Store $replayStore = null,
     ) {
         $this->verifier = $verifier ?? new SolanaChargeTransactionVerifier();
+        $this->replayStore = $replayStore ?? new MemoryStore();
     }
 
     /**
@@ -141,8 +152,15 @@ final class SolanaChargeHandler
     }
 
     /**
-     * Co-sign (if a fee-payer is configured), broadcast, and wait for
-     * confirmation. Returns the on-chain signature.
+     * Co-sign (if a fee-payer is configured), broadcast, claim the signature
+     * in the replay store, then wait for confirmation. Returns the on-chain
+     * signature.
+     *
+     * `consumeSignature` is called between broadcast and confirmation
+     * polling on purpose. If the server crashes or the polling times out
+     * after `sendRawTransaction` accepted the transaction, the signature
+     * has already landed and must not be re-settled by a retry of the same
+     * credential. See PR #85 Greptile P1 and audit gap G05.
      */
     private function settle(string $transactionBase64): string
     {
@@ -171,8 +189,20 @@ final class SolanaChargeHandler
             'preflightCommitment' => 'confirmed',
         ]);
 
+        $this->consumeSignature($signature);
         $this->awaitConfirmation($signature);
         return $signature;
+    }
+
+    /**
+     * Reserve the signature in the replay store. Throws on replay attempts.
+     */
+    private function consumeSignature(string $signature): void
+    {
+        $key = self::REPLAY_KEY_PREFIX . $signature;
+        if (!$this->replayStore->putIfAbsent($key, true)) {
+            throw new RuntimeException("Transaction signature already consumed: $signature");
+        }
     }
 
     private function awaitConfirmation(string $signature): void

--- a/php/src/Server/SolanaChargeHandler.php
+++ b/php/src/Server/SolanaChargeHandler.php
@@ -45,8 +45,9 @@ final class SolanaChargeHandler
      *        signature to the fee-payer slot before broadcast. Required for
      *        charge requests that advertise `methodDetails.feePayer = true`.
      * @param string $network Network identifier used for the Surfpool
-     *        blockhash sanity check. Defaults to `mainnet-beta`; set to
-     *        `localnet` when running against a Surfpool sandbox.
+     *        blockhash sanity check. Defaults to `mainnet`; the legacy
+     *        `mainnet-beta` spelling is also accepted. Set to `localnet`
+     *        when running against a Surfpool sandbox.
      * @param string $settlementHeader Name of the response header carrying
      *        the on-chain signature. The convention is
      *        `x-payment-settlement-signature`.
@@ -65,7 +66,7 @@ final class SolanaChargeHandler
         private readonly ChargeServer $challenges,
         private readonly RpcClient $rpc,
         private readonly ?Keypair $feePayer = null,
-        private readonly string $network = 'mainnet-beta',
+        private readonly string $network = 'mainnet',
         private readonly string $settlementHeader = 'x-payment-settlement-signature',
         ?PaymentVerifier $verifier = null,
         private readonly int $confirmationAttempts = 40,

--- a/php/src/Server/SolanaChargeTransactionVerifier.php
+++ b/php/src/Server/SolanaChargeTransactionVerifier.php
@@ -116,7 +116,7 @@ final class SolanaChargeTransactionVerifier implements PaymentVerifier
             return;
         }
 
-        $network = Json::optionalString($methodDetails['network'] ?? null, 'methodDetails.network', 'mainnet-beta');
+        $network = Json::optionalString($methodDetails['network'] ?? null, 'methodDetails.network', 'mainnet');
         $resolvedMint = StablecoinMints::resolve($request->currency, $network) ?? $request->currency;
         $mint = new PublicKey($resolvedMint);
         $defaultTokenProgram = StablecoinMints::tokenProgramFor($request->currency, $network);

--- a/php/src/Server/SolanaChargeTransactionVerifier.php
+++ b/php/src/Server/SolanaChargeTransactionVerifier.php
@@ -405,7 +405,6 @@ final class SolanaChargeTransactionVerifier implements PaymentVerifier
             TokenProgram::TOKEN_2022_PROGRAM_ID,
             AssociatedTokenProgram::PROGRAM_ID,
             MemoProgram::PROGRAM_ID_V2,
-            MemoProgram::PROGRAM_ID_V1,
         ];
         foreach ($decoded['instructions'] as $index => $instruction) {
             $programId = $this->programId($decoded, $instruction);
@@ -593,7 +592,7 @@ final class SolanaChargeTransactionVerifier implements PaymentVerifier
     private function isMemoInstruction(array $decoded, array $instruction): bool
     {
         $programId = $this->programId($decoded, $instruction);
-        return $programId === MemoProgram::PROGRAM_ID_V2 || $programId === MemoProgram::PROGRAM_ID_V1;
+        return $programId === MemoProgram::PROGRAM_ID_V2;
     }
 
     private function parseAmount(string $amount, string $field): int

--- a/php/src/Store/MemoryStore.php
+++ b/php/src/Store/MemoryStore.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolanaMpp\Store;
+
+/**
+ * In-memory {@see Store} for tests and local development.
+ *
+ * The store is single-process. Multi-worker production servers must inject a
+ * shared atomic backing store (Redis, Postgres, DynamoDB) instead, otherwise
+ * replay protection is lost across the worker pool.
+ */
+final class MemoryStore implements Store
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $values = [];
+
+    public function putIfAbsent(string $key, mixed $value): bool
+    {
+        if (array_key_exists($key, $this->values)) {
+            return false;
+        }
+        $this->values[$key] = $value;
+        return true;
+    }
+}

--- a/php/src/Store/Store.php
+++ b/php/src/Store/Store.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolanaMpp\Store;
+
+/**
+ * Atomic replay-protection store interface.
+ *
+ * Mirrors the Ruby `Mpp::Store` and Rust `mpp::Store` abstractions. The
+ * `SolanaChargeHandler` calls `putIfAbsent` once per settled signature to
+ * guarantee at-most-once settlement under retries, restarts, and concurrent
+ * requests. Implementations must be safe to call from multiple processes when
+ * deployed in a multi-worker server (Redis, Postgres, etc.); the
+ * {@see MemoryStore} bundled with this SDK is single-process only.
+ */
+interface Store
+{
+    /**
+     * Insert `$value` only if `$key` does not exist.
+     *
+     * Returns true on insert, false if the key was already present. Must be
+     * atomic with respect to concurrent callers. The handler treats a false
+     * return as a replay attempt and rejects the credential.
+     */
+    public function putIfAbsent(string $key, mixed $value): bool;
+}

--- a/php/tests/SolanaChargeHandlerTest.php
+++ b/php/tests/SolanaChargeHandlerTest.php
@@ -116,6 +116,47 @@ final class SolanaChargeHandlerTest extends TestCase
         self::assertNotEmpty($result->headers['payment-receipt']);
     }
 
+    public function testRejectsSignatureReplayAfterSuccessfulSettlement(): void
+    {
+        $challenges = new ChargeServer(secretKey: 'secret', realm: 'api');
+        $request = $this->chargeRequest();
+        $challenge = $challenges->createChallenge($request);
+        $credential = new Credential(
+            challenge: $challenge->toEcho(),
+            payload: ['type' => 'transaction', 'transaction' => $this->minimalLegacyTransactionBase64()],
+        );
+
+        $statusEntry = [
+            'result' => [
+                'value' => [[
+                    'slot' => 1,
+                    'confirmationStatus' => 'confirmed',
+                    'err' => null,
+                ]],
+            ],
+        ];
+        $http = new FakeJsonRpcHttpClient([
+            'sendTransaction' => [
+                ['result' => 'ReplayProtectionFixtureSig'],
+                ['result' => 'ReplayProtectionFixtureSig'],
+            ],
+            'getSignatureStatuses' => [$statusEntry, $statusEntry],
+        ]);
+        $handler = $this->handler(
+            challenges: $challenges,
+            rpc: new RpcClient('http://test.invalid', $http),
+            verifier: new AlwaysAcceptVerifier(),
+        );
+
+        $first = $handler->handle($credential->toAuthorizationHeader(), $request);
+        self::assertInstanceOf(ChargeSettlement::class, $first);
+        self::assertSame('ReplayProtectionFixtureSig', $first->signature);
+
+        $second = $handler->handle($credential->toAuthorizationHeader(), $request);
+        self::assertInstanceOf(PaymentRequiredResponse::class, $second);
+        self::assertStringContainsString('already consumed', $second->body['detail']);
+    }
+
     public function testReturns402WhenSurfpoolBlockhashOnNonLocalnet(): void
     {
         $challenges = new ChargeServer(secretKey: 'secret', realm: 'api');

--- a/php/tests/StablecoinMintsTest.php
+++ b/php/tests/StablecoinMintsTest.php
@@ -80,4 +80,20 @@ final class StablecoinMintsTest extends TestCase
         self::assertSame('CASH', StablecoinMints::symbolFor('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH'));
         self::assertNull(StablecoinMints::symbolFor('FOOBAR'));
     }
+
+    /**
+     * The canonical mainnet slug is `mainnet`. The legacy `mainnet-beta`
+     * spelling is exposed as an aliased key for backward compatibility.
+     * This test catches alias drift: if a future commit changes the
+     * pubkey for one spelling but forgets the other, downstream consumers
+     * doing raw bracket access on either key get inconsistent results.
+     */
+    public function testMainnetBetaAliasMatchesMainnetForEveryStablecoin(): void
+    {
+        self::assertSame(StablecoinMints::USDC['mainnet'], StablecoinMints::USDC['mainnet-beta']);
+        self::assertSame(StablecoinMints::USDT['mainnet'], StablecoinMints::USDT['mainnet-beta']);
+        self::assertSame(StablecoinMints::USDG['mainnet'], StablecoinMints::USDG['mainnet-beta']);
+        self::assertSame(StablecoinMints::PYUSD['mainnet'], StablecoinMints::PYUSD['mainnet-beta']);
+        self::assertSame(StablecoinMints::CASH['mainnet'], StablecoinMints::CASH['mainnet-beta']);
+    }
 }

--- a/ruby/lib/mpp/core/headers.rb
+++ b/ruby/lib/mpp/core/headers.rb
@@ -102,7 +102,13 @@ module Mpp
       end
 
       def escape(value)
-        value.to_s.gsub("\\", "\\\\\\").gsub("\"", "\\\"")
+        # RFC 9110 section 5.5 forbids CR and LF in header field values.
+        # Silent strip would let malformed inputs round-trip and would let a
+        # caller-controlled realm inject extra HTTP headers. Reject with an
+        # explicit error so the problem surfaces at emission time.
+        string = value.to_s
+        raise ArgumentError, "control character in header parameter value" if string.match?(/[\r\n]/)
+        string.gsub("\\", "\\\\\\").gsub("\"", "\\\"")
       end
     end
   end

--- a/ruby/lib/mpp/internal/handler.rb
+++ b/ruby/lib/mpp/internal/handler.rb
@@ -30,6 +30,13 @@ module Mpp
       end
 
       # Process one HTTP request and return a response object.
+      #
+      # The settlement order is: broadcast (pull) or fetch (push), then
+      # consume_signature, then await_confirmation (pull only). The consume
+      # call sits between broadcast and confirmation polling on purpose so
+      # that a confirmation timeout or server crash after the transaction has
+      # already landed on chain cannot be replayed against the same
+      # credential. See PR #85 Greptile P1 and audit gap G05.
       def handle(authorization, request)
         return @challenges.payment_required_response(request) if authorization.nil? || authorization.empty?
 
@@ -38,6 +45,7 @@ module Mpp
 
         signature = settle_payload(result.credential, request)
         consume_signature(signature)
+        await_settlement(result.credential, signature)
         receipt = @challenges.create_receipt_header(challenge: result.challenge, reference: signature, external_id: request.external_id)
         Settlement.new(
           signature: signature,
@@ -75,9 +83,16 @@ module Mpp
         simulation = simulate_transaction_with_retry(signed_base64)
         raise VerificationError, "Simulation failed: #{simulation["err"].inspect}" unless simulation["err"].nil?
 
-        signature = @rpc.send_raw_transaction(signed_base64)
+        @rpc.send_raw_transaction(signed_base64)
+      end
+
+      # await_confirmation only runs on the pull path; push mode already
+      # fetched a confirmed transaction in settle_payload.
+      def await_settlement(credential, signature)
+        transaction = credential.payload["transaction"]
+        return unless transaction.is_a?(String) && !transaction.empty?
+
         await_confirmation(signature)
-        signature
       end
 
       def fetch_settled_transaction(signature)

--- a/rust/src/server/charge.rs
+++ b/rust/src/server/charge.rs
@@ -539,7 +539,9 @@ impl Mpp {
         // audit gap G05.
         let signature_str = match payload {
             CredentialPayload::Transaction { ref transaction } => {
-                let signature = self.broadcast_pull(transaction, request, &method_details).await?;
+                let signature = self
+                    .broadcast_pull(transaction, request, &method_details)
+                    .await?;
                 self.consume_signature(&signature).await?;
                 self.await_pull_confirmation(&signature)?;
                 signature

--- a/rust/src/server/charge.rs
+++ b/rust/src/server/charge.rs
@@ -97,7 +97,7 @@ impl Default for Config {
             recipient: String::new(),
             currency: "USDC".to_string(),
             decimals: 6,
-            network: "mainnet-beta".to_string(),
+            network: "mainnet".to_string(),
             rpc_url: None,
             secret_key: None,
             realm: None,

--- a/rust/src/server/charge.rs
+++ b/rust/src/server/charge.rs
@@ -531,18 +531,40 @@ impl Mpp {
             })?
             .unwrap_or_default();
 
-        // Settle — pull or push mode.
+        // Settle, with the consume_signature reservation sitting between
+        // broadcast and confirmation polling. If the server crashes or the
+        // poll loop times out after the transaction has already landed,
+        // the signature is still reserved so a retry of the same credential
+        // cannot trigger a second broadcast. See PR #85 Greptile P1 and
+        // audit gap G05.
         let signature_str = match payload {
             CredentialPayload::Transaction { ref transaction } => {
-                self.verify_pull(transaction, request, &method_details)
-                    .await?
+                let signature = self.broadcast_pull(transaction, request, &method_details).await?;
+                self.consume_signature(&signature).await?;
+                self.await_pull_confirmation(&signature)?;
+                signature
             }
             CredentialPayload::Signature { ref signature } => {
-                self.verify_push(signature, request, &method_details)?
+                let signature_str = self.verify_push(signature, request, &method_details)?;
+                self.consume_signature(&signature_str).await?;
+                signature_str
             }
         };
 
-        // Replay protection (atomic check-and-consume).
+        Ok(Receipt::success(
+            METHOD_NAME,
+            &signature_str,
+            credential.challenge.id.clone(),
+        ))
+    }
+
+    // ── Settlement ──
+
+    /// Reserve the settlement signature in the replay store. Returns an
+    /// error if the same signature has already been consumed by an earlier
+    /// successful settlement (replay attack) or an earlier broadcast whose
+    /// confirmation poll timed out (split-brain double-pay window).
+    async fn consume_signature(&self, signature_str: &str) -> Result<(), VerificationError> {
         let consumed_key = format!("solana-charge:consumed:{signature_str}");
         let inserted = self
             .store
@@ -554,18 +576,14 @@ impl Mpp {
                 "Transaction signature already consumed",
             ));
         }
-
-        Ok(Receipt::success(
-            METHOD_NAME,
-            &signature_str,
-            credential.challenge.id.clone(),
-        ))
+        Ok(())
     }
 
-    // ── Settlement ──
-
-    /// Pull mode: deserialize tx, optionally co-sign, simulate, broadcast, verify.
-    async fn verify_pull(
+    /// Pull mode: deserialize tx, optionally co-sign, simulate, broadcast.
+    /// Returns the signature once the broadcast is accepted. Confirmation
+    /// polling lives in `await_pull_confirmation` so the caller can reserve
+    /// the signature in the replay store between broadcast and poll.
+    async fn broadcast_pull(
         &self,
         transaction_b64: &str,
         request: &ChargeRequest,
@@ -711,29 +729,40 @@ impl Mpp {
         }
         tracing::info!(elapsed_ms = %t0.elapsed().as_millis(), step = "simulate", "verify_pull");
 
-        // Broadcast and wait for Confirmed commitment (not Finalized).
+        // Broadcast. Confirmation polling moved into await_pull_confirmation
+        // so the caller can reserve the signature in the replay store
+        // between broadcast acceptance and confirmation polling.
         let signature = self
             .rpc
             .send_transaction(&tx)
             .map_err(|e| VerificationError::network_error(format!("Broadcast failed: {e}")))?;
-        tracing::info!(elapsed_ms = %t0.elapsed().as_millis(), step = "send", "verify_pull");
+        tracing::info!(elapsed_ms = %t0.elapsed().as_millis(), step = "send", "broadcast_pull");
+        Ok(signature.to_string())
+    }
 
-        // Poll for confirmed status (typically ~400ms on devnet/surfnet).
+    /// Poll for `Confirmed` commitment on a signature that broadcast_pull
+    /// already accepted. Surfpool typically confirms within a single tick;
+    /// a real RPC may need up to ~32 slots (~12 seconds).
+    fn await_pull_confirmation(&self, signature_str: &str) -> Result<(), VerificationError> {
         use solana_commitment_config::CommitmentConfig;
+        use std::str::FromStr;
+        let signature = Signature::from_str(signature_str).map_err(|e| {
+            VerificationError::invalid_payload(format!("Invalid settlement signature: {e}"))
+        })?;
         let commitment = CommitmentConfig::confirmed();
+        let t0 = std::time::Instant::now();
         for _ in 0..30 {
             match self
                 .rpc
                 .confirm_transaction_with_commitment(&signature, commitment)
             {
                 Ok(resp) if resp.value => {
-                    tracing::info!(elapsed_ms = %t0.elapsed().as_millis(), step = "confirmed", "verify_pull");
-                    return Ok(signature.to_string());
+                    tracing::info!(elapsed_ms = %t0.elapsed().as_millis(), step = "confirmed", "await_pull_confirmation");
+                    return Ok(());
                 }
                 _ => std::thread::sleep(std::time::Duration::from_millis(200)),
             }
         }
-
         Err(VerificationError::network_error(
             "Transaction not confirmed within timeout".to_string(),
         ))

--- a/tests/interop/src/contracts.ts
+++ b/tests/interop/src/contracts.ts
@@ -11,6 +11,8 @@ export type InteropScenarioSplit = {
   memo?: string;
 };
 
+export type TokenProgramVariant = "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM";
+
 export type InteropScenario = {
   id: string;
   intent: InteropIntent;
@@ -29,6 +31,10 @@ export type InteropScenario = {
   expectedStatus: 200 | 402;
   clientIds?: string[];
   serverIds?: string[];
+  // Optional. Defaults to "TOKEN_PROGRAM" (legacy SPL). Set to
+  // "TOKEN_2022_PROGRAM" for scenarios that exercise Token-2022. The harness
+  // uses this to deploy the scenario mint under the right program owner.
+  tokenProgram?: TokenProgramVariant;
 };
 
 export type ReadyMessage = {

--- a/tests/interop/src/contracts.ts
+++ b/tests/interop/src/contracts.ts
@@ -13,12 +13,19 @@ export type InteropScenarioSplit = {
 
 export type TokenProgramVariant = "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM";
 
+export type CurrencyMode = "pubkey" | "symbol";
+
 export type InteropScenario = {
   id: string;
   intent: InteropIntent;
   network: string;
   price: string;
   amount: string;
+  // The literal value the harness sends to each adapter as
+  // `MPP_INTEROP_MINT`. In `pubkey` mode (default) this is a 32+ char
+  // base58 mint pubkey. In `symbol` mode this is a stablecoin symbol
+  // (e.g. "USDC") and the harness deploys the mint at the pubkey each
+  // SDK's `Mints.resolve(symbol, network)` returns.
   asset: string;
   resourcePath: string;
   settlementHeader: string;
@@ -35,6 +42,16 @@ export type InteropScenario = {
   // "TOKEN_2022_PROGRAM" for scenarios that exercise Token-2022. The harness
   // uses this to deploy the scenario mint under the right program owner.
   tokenProgram?: TokenProgramVariant;
+  // Optional. Defaults to "pubkey". Set to "symbol" to exercise the
+  // SDK-side `Mints.resolve(currency, network)` path that the manual DX
+  // path (pay sandbox + example servers) actually hits. The harness uses
+  // `expectedMint` below to know which on-chain mint to deploy and to
+  // assert balances against.
+  currencyMode?: CurrencyMode;
+  // Required when `currencyMode === "symbol"`. The pubkey the symbol
+  // is expected to resolve to under `network`. Harness deploys the mint
+  // here and asserts settled transferChecked uses this mint.
+  expectedMint?: string;
 };
 
 export type ReadyMessage = {

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -84,4 +84,28 @@ export const chargeScenarios: readonly InteropScenario[] = [
     expectedStatus: 402,
     clientIds: ["typescript"],
   },
+  {
+    // PYUSD mainnet mint, which every SDK (Ruby, PHP, Rust, TypeScript)
+    // already classifies as Token-2022 via the built-in TOKEN_2022_SYMBOLS
+    // list, so no SDK API change is required. The harness deploys this mint
+    // under the Token-2022 program in beforeAll.
+    id: "charge-token2022-split-ata",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+    resourcePath: "/protected/token2022-split-ata",
+    settlementHeader: "x-fixture-settlement",
+    tokenProgram: "TOKEN_2022_PROGRAM",
+    splits: [
+      {
+        recipientKey: "platform",
+        amount: "250",
+        ataCreationRequired: true,
+        memo: "interop token2022 split",
+      },
+    ],
+    expectedStatus: 200,
+  },
 ] as const;

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -85,6 +85,28 @@ export const chargeScenarios: readonly InteropScenario[] = [
     clientIds: ["typescript"],
   },
   {
+    // Symbol mode: harness sends the literal string "USDC" as currency,
+    // adapters must call their `Mints.resolve` (or equivalent) to get a
+    // mint pubkey. The Ruby `MINTS["USDC"]["localnet"] = devnet mint` bug
+    // would have surfaced here. The harness deploys the mint at the
+    // expected pubkey so the resolved address must match for the
+    // transferChecked assertion to pass.
+    id: "charge-symbol-usdc-localnet",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "USDC",
+    currencyMode: "symbol",
+    // Surfpool localnet mirrors mainnet, so USDC on localnet resolves to
+    // the mainnet USDC mint (EPjFWdd5...). Every SDK with a stablecoin
+    // table must agree on this.
+    expectedMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    resourcePath: "/protected/symbol-usdc",
+    settlementHeader: "x-fixture-settlement",
+    expectedStatus: 200,
+  },
+  {
     // PYUSD mainnet mint, which every SDK (Ruby, PHP, Rust, TypeScript)
     // already classifies as Token-2022 via the built-in TOKEN_2022_SYMBOLS
     // list, so no SDK API change is required. The harness deploys this mint

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -28,6 +28,22 @@ function tokenProgramAddress(
   return variant === "TOKEN_2022_PROGRAM" ? TOKEN_2022_PROGRAM : TOKEN_PROGRAM;
 }
 
+// The on-chain mint pubkey for a scenario. In pubkey mode this is just
+// `scenario.asset`. In symbol mode the harness sends a stablecoin symbol
+// to adapters and the on-chain mint is `scenario.expectedMint` (the
+// pubkey each SDK's resolver is expected to return).
+function onChainMintFor(scenario: InteropScenario): string {
+  if (scenario.currencyMode === "symbol") {
+    if (!scenario.expectedMint) {
+      throw new Error(
+        `Scenario ${scenario.id} uses symbol mode but does not set expectedMint`,
+      );
+    }
+    return scenario.expectedMint;
+  }
+  return scenario.asset;
+}
+
 const runningServers: RunningServer[] = [];
 
 let surfnet: Surfnet | undefined;
@@ -109,23 +125,25 @@ beforeAll(async () => {
 
   // Deploy every mint referenced by an active scenario under the right token
   // program. Without this, Token-2022 scenarios would have to share the legacy
-  // mint owner and the verifier would reject every transfer.
+  // mint owner and the verifier would reject every transfer. Symbol-mode
+  // scenarios deploy at `expectedMint`, not at the literal asset string.
   const uniqueMints = new Map<string, "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM">();
   for (const scenario of activeScenarios) {
     const variant = scenario.tokenProgram ?? "TOKEN_PROGRAM";
-    const existing = uniqueMints.get(scenario.asset);
+    const mintPubkey = onChainMintFor(scenario);
+    const existing = uniqueMints.get(mintPubkey);
     if (existing && existing !== variant) {
       throw new Error(
-        `Conflicting tokenProgram for asset ${scenario.asset}: ${existing} vs ${variant} (scenario ${scenario.id})`,
+        `Conflicting tokenProgram for mint ${mintPubkey}: ${existing} vs ${variant} (scenario ${scenario.id})`,
       );
     }
-    uniqueMints.set(scenario.asset, variant);
+    uniqueMints.set(mintPubkey, variant);
   }
-  for (const [asset, variant] of uniqueMints) {
+  for (const [mintPubkey, variant] of uniqueMints) {
     const programAddress = tokenProgramAddress(variant);
-    surfnet.setAccount(asset, 1_461_600, createSplMintAccountData(6), programAddress);
-    surfnet.fundToken(client.publicKey, asset, 100_000, programAddress);
-    surfnet.fundToken(payTo.publicKey, asset, 1, programAddress);
+    surfnet.setAccount(mintPubkey, 1_461_600, createSplMintAccountData(6), programAddress);
+    surfnet.fundToken(client.publicKey, mintPubkey, 100_000, programAddress);
+    surfnet.fundToken(payTo.publicKey, mintPubkey, 1, programAddress);
   }
 
   splitRecipients = {
@@ -187,16 +205,20 @@ describe("mpp interop", () => {
 
             const scenarioEnv = environmentForScenario(interopEnv, scenario);
             const scenarioTokenProgram = tokenProgramAddress(scenario.tokenProgram);
+            // On-chain mint pubkey (resolved expectedMint in symbol mode,
+            // literal asset in pubkey mode). The literal in scenarioEnv goes
+            // to the adapter so the SDK's resolver is exercised end-to-end.
+            const onChainMint = onChainMintFor(scenario);
             const initialBalance = await getTokenBalance(
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
             );
             const initialSplitBalances = await splitBalances(
               surfnet,
               scenario,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
               true,
             );
@@ -214,13 +236,13 @@ describe("mpp interop", () => {
             const finalBalance = await getTokenBalance(
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
             );
             const finalSplitBalances = await splitBalances(
               surfnet,
               scenario,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
               false,
             );
@@ -316,15 +338,16 @@ async function expectSettledTransactionShape(
   const expectedTransferCount = 1 + (scenario.splits?.length ?? 0);
   const primaryAmount = primaryDelta(scenario);
   const tokenProgram = tokenProgramAddress(scenario.tokenProgram);
+  const onChainMint = onChainMintFor(scenario);
   expectSplTransferChecked(
     message,
     {
       destination: surfnet.getAta(
         scenarioEnv.MPP_INTEROP_PAY_TO,
-        scenarioEnv.MPP_INTEROP_MINT,
+        onChainMint,
         tokenProgram,
       ),
-      mint: scenarioEnv.MPP_INTEROP_MINT,
+      mint: onChainMint,
       amount: primaryAmount,
       decimals: 6,
       tokenProgram,
@@ -336,14 +359,14 @@ async function expectSettledTransactionShape(
     const recipient = splitRecipients[split.recipientKey];
     const destination = surfnet.getAta(
       recipient,
-      scenarioEnv.MPP_INTEROP_MINT,
+      onChainMint,
       tokenProgram,
     );
     expectSplTransferChecked(
       message,
       {
         destination,
-        mint: scenarioEnv.MPP_INTEROP_MINT,
+        mint: onChainMint,
         amount: BigInt(split.amount),
         decimals: 6,
         tokenProgram,
@@ -355,7 +378,7 @@ async function expectSettledTransactionShape(
       expectIdempotentAtaCreation(message, {
         ata: destination,
         owner: recipient,
-        mint: scenarioEnv.MPP_INTEROP_MINT,
+        mint: onChainMint,
         tokenProgram,
       });
     }
@@ -367,7 +390,7 @@ async function expectSettledTransactionShape(
 
   expectTransferCheckedCount(
     message,
-    scenarioEnv.MPP_INTEROP_MINT,
+    onChainMint,
     expectedTransferCount,
     tokenProgram,
   );

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -17,9 +17,16 @@ import { runClient, startServer, stopServer } from "../src/process";
 type RunningServer = Awaited<ReturnType<typeof startServer>>;
 
 const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 const ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const MINT_ACCOUNT_SIZE = 82;
+
+function tokenProgramAddress(
+  variant: "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM" | undefined,
+): string {
+  return variant === "TOKEN_2022_PROGRAM" ? TOKEN_2022_PROGRAM : TOKEN_PROGRAM;
+}
 
 const runningServers: RunningServer[] = [];
 
@@ -53,10 +60,11 @@ async function getTokenBalance(
   surfnet: Surfnet,
   owner: string,
   mint: string,
+  tokenProgram: string,
   missingAsZero = false,
 ): Promise<bigint> {
   const rpc = createSolanaRpc(surfnet.rpcUrl);
-  const ata = surfnet.getAta(owner, mint);
+  const ata = surfnet.getAta(owner, mint, tokenProgram);
   try {
     const response = await rpc.getTokenAccountBalance(ata as never).send();
     return BigInt(response.value.amount);
@@ -99,14 +107,26 @@ beforeAll(async () => {
   const payTo = Surfnet.newKeypair();
   const platform = Surfnet.newKeypair();
 
-  surfnet.setAccount(
-    baseScenario.asset,
-    1_461_600,
-    createSplMintAccountData(6),
-    TOKEN_PROGRAM,
-  );
-  surfnet.fundToken(client.publicKey, baseScenario.asset, 100_000);
-  surfnet.fundToken(payTo.publicKey, baseScenario.asset, 1);
+  // Deploy every mint referenced by an active scenario under the right token
+  // program. Without this, Token-2022 scenarios would have to share the legacy
+  // mint owner and the verifier would reject every transfer.
+  const uniqueMints = new Map<string, "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM">();
+  for (const scenario of activeScenarios) {
+    const variant = scenario.tokenProgram ?? "TOKEN_PROGRAM";
+    const existing = uniqueMints.get(scenario.asset);
+    if (existing && existing !== variant) {
+      throw new Error(
+        `Conflicting tokenProgram for asset ${scenario.asset}: ${existing} vs ${variant} (scenario ${scenario.id})`,
+      );
+    }
+    uniqueMints.set(scenario.asset, variant);
+  }
+  for (const [asset, variant] of uniqueMints) {
+    const programAddress = tokenProgramAddress(variant);
+    surfnet.setAccount(asset, 1_461_600, createSplMintAccountData(6), programAddress);
+    surfnet.fundToken(client.publicKey, asset, 100_000, programAddress);
+    surfnet.fundToken(payTo.publicKey, asset, 1, programAddress);
+  }
 
   splitRecipients = {
     platform: platform.publicKey,
@@ -166,15 +186,18 @@ describe("mpp interop", () => {
             }
 
             const scenarioEnv = environmentForScenario(interopEnv, scenario);
+            const scenarioTokenProgram = tokenProgramAddress(scenario.tokenProgram);
             const initialBalance = await getTokenBalance(
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
             );
             const initialSplitBalances = await splitBalances(
               surfnet,
               scenario,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
               true,
             );
 
@@ -192,11 +215,13 @@ describe("mpp interop", () => {
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
             );
             const finalSplitBalances = await splitBalances(
               surfnet,
               scenario,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
               false,
             );
 
@@ -245,6 +270,7 @@ function environmentForScenario(
   return {
     ...baseEnv,
     MPP_INTEROP_AMOUNT: scenario.amount,
+    MPP_INTEROP_MINT: scenario.asset,
     MPP_INTEROP_NETWORK: scenario.network,
     MPP_INTEROP_PRICE: scenario.price,
     MPP_INTEROP_RESOURCE_PATH: scenario.resourcePath,
@@ -289,23 +315,30 @@ async function expectSettledTransactionShape(
   const matchedInstructions = new Set<number>();
   const expectedTransferCount = 1 + (scenario.splits?.length ?? 0);
   const primaryAmount = primaryDelta(scenario);
+  const tokenProgram = tokenProgramAddress(scenario.tokenProgram);
   expectSplTransferChecked(
     message,
     {
       destination: surfnet.getAta(
         scenarioEnv.MPP_INTEROP_PAY_TO,
         scenarioEnv.MPP_INTEROP_MINT,
+        tokenProgram,
       ),
       mint: scenarioEnv.MPP_INTEROP_MINT,
       amount: primaryAmount,
       decimals: 6,
+      tokenProgram,
     },
     matchedInstructions,
   );
 
   for (const split of scenario.splits ?? []) {
     const recipient = splitRecipients[split.recipientKey];
-    const destination = surfnet.getAta(recipient, scenarioEnv.MPP_INTEROP_MINT);
+    const destination = surfnet.getAta(
+      recipient,
+      scenarioEnv.MPP_INTEROP_MINT,
+      tokenProgram,
+    );
     expectSplTransferChecked(
       message,
       {
@@ -313,6 +346,7 @@ async function expectSettledTransactionShape(
         mint: scenarioEnv.MPP_INTEROP_MINT,
         amount: BigInt(split.amount),
         decimals: 6,
+        tokenProgram,
       },
       matchedInstructions,
     );
@@ -322,6 +356,7 @@ async function expectSettledTransactionShape(
         ata: destination,
         owner: recipient,
         mint: scenarioEnv.MPP_INTEROP_MINT,
+        tokenProgram,
       });
     }
 
@@ -330,7 +365,12 @@ async function expectSettledTransactionShape(
     }
   }
 
-  expectTransferCheckedCount(message, scenarioEnv.MPP_INTEROP_MINT, expectedTransferCount);
+  expectTransferCheckedCount(
+    message,
+    scenarioEnv.MPP_INTEROP_MINT,
+    expectedTransferCount,
+    tokenProgram,
+  );
 }
 
 async function fetchTransactionBase64(
@@ -390,6 +430,7 @@ function expectSplTransferChecked(
     mint: string;
     amount: bigint;
     decimals: number;
+    tokenProgram: string;
   },
   matchedInstructions: Set<number>,
 ): void {
@@ -397,7 +438,9 @@ function expectSplTransferChecked(
     if (matchedInstructions.has(index)) {
       return false;
     }
-    if (accountAt(message, instruction.programAddressIndex) !== TOKEN_PROGRAM) {
+    if (
+      accountAt(message, instruction.programAddressIndex) !== expected.tokenProgram
+    ) {
       return false;
     }
     if (instruction.data[0] !== 12) {
@@ -430,6 +473,7 @@ function expectIdempotentAtaCreation(
     ata: string;
     owner: string;
     mint: string;
+    tokenProgram: string;
   },
 ): void {
   const match = message.instructions.find((instruction) => {
@@ -444,7 +488,7 @@ function expectIdempotentAtaCreation(
       accountAt(message, instruction.accountIndices[2]) === expected.owner &&
       accountAt(message, instruction.accountIndices[3]) === expected.mint &&
       accountAt(message, instruction.accountIndices[4]) === SYSTEM_PROGRAM &&
-      accountAt(message, instruction.accountIndices[5]) === TOKEN_PROGRAM
+      accountAt(message, instruction.accountIndices[5]) === expected.tokenProgram
     );
   });
 
@@ -458,9 +502,10 @@ function expectTransferCheckedCount(
   message: CompiledMessage,
   mint: string,
   expectedCount: number,
+  tokenProgram: string,
 ): void {
   const transfers = message.instructions.filter((instruction) => {
-    if (accountAt(message, instruction.programAddressIndex) !== TOKEN_PROGRAM) {
+    if (accountAt(message, instruction.programAddressIndex) !== tokenProgram) {
       return false;
     }
     if (instruction.data[0] !== 12 || instruction.accountIndices.length < 4) {
@@ -508,6 +553,7 @@ async function splitBalances(
   surfnet: Surfnet,
   scenario: InteropScenario,
   mint: string,
+  tokenProgram: string,
   missingAsZero: boolean,
 ): Promise<Record<string, bigint>> {
   const balances: Record<string, bigint> = {};
@@ -517,6 +563,7 @@ async function splitBalances(
       surfnet,
       recipient,
       mint,
+      tokenProgram,
       missingAsZero,
     );
   }

--- a/typescript/packages/mpp/src/__tests__/challenge-selection.test.ts
+++ b/typescript/packages/mpp/src/__tests__/challenge-selection.test.ts
@@ -56,11 +56,11 @@ describe('selectSolanaChargeChallenge', () => {
     test('honors client currency preference order over server challenge order', () => {
         const selected = selectSolanaChargeChallenge(
             [
-                challenge('mainnet-usdc', { currency: USDC['mainnet-beta'], network: 'mainnet-beta' }),
+                challenge('mainnet-usdc', { currency: USDC.mainnet, network: 'mainnet-beta' }),
                 challenge('devnet-usdc', { currency: USDC.devnet, network: 'devnet' }),
             ],
             {
-                currency: [USDC.devnet, USDC['mainnet-beta']],
+                currency: [USDC.devnet, USDC.mainnet],
             },
         );
 
@@ -71,7 +71,7 @@ describe('selectSolanaChargeChallenge', () => {
         const selected = selectSolanaChargeChallenge(
             [
                 challenge('stripe', { method: 'stripe' }),
-                challenge('usdc-mainnet', { currency: USDC['mainnet-beta'], network: 'mainnet-beta' }),
+                challenge('usdc-mainnet', { currency: USDC.mainnet, network: 'mainnet-beta' }),
             ],
             { currency: 'USDC', network: 'devnet' },
         );
@@ -106,7 +106,7 @@ describe('selectSolanaChargeChallengeFromResponse', () => {
                 'WWW-Authenticate': [
                     Challenge.serialize(
                         challenge('usdc-mainnet', {
-                            currency: USDC['mainnet-beta'],
+                            currency: USDC.mainnet,
                             network: 'mainnet-beta',
                         }),
                     ),

--- a/typescript/packages/mpp/src/__tests__/charge.test.ts
+++ b/typescript/packages/mpp/src/__tests__/charge.test.ts
@@ -2452,9 +2452,9 @@ test('request() defaults Token-2022 stablecoins to Token-2022', async () => {
         expect(request.methodDetails.tokenProgram).toBe(TOKEN_2022_PROGRAM);
     }
 
-    expect(CASH['mainnet-beta']).toBe('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH');
-    expect(PYUSD['mainnet-beta']).toBe('2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo');
-    expect(USDG['mainnet-beta']).toBe('2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH');
+    expect(CASH.mainnet).toBe('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH');
+    expect(PYUSD.mainnet).toBe('2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo');
+    expect(USDG.mainnet).toBe('2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH');
 });
 
 test('splits: SOL verification passes with valid primary + split transfers', async () => {

--- a/typescript/packages/mpp/src/__tests__/constants.test.ts
+++ b/typescript/packages/mpp/src/__tests__/constants.test.ts
@@ -51,35 +51,35 @@ describe('USDC mint addresses', () => {
     });
 
     test('has mainnet-beta mint', () => {
-        expect(USDC['mainnet-beta']).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+        expect(USDC.mainnet).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
     });
 });
 
 describe('stablecoin mint addresses', () => {
     test('has USDT mainnet mint', () => {
-        expect(USDT['mainnet-beta']).toBe('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB');
+        expect(USDT.mainnet).toBe('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB');
     });
 
     test('has USDG mints', () => {
         expect(USDG.devnet).toBe('4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7');
-        expect(USDG['mainnet-beta']).toBe('2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH');
+        expect(USDG.mainnet).toBe('2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH');
     });
 
     test('has PYUSD mints', () => {
         expect(PYUSD.devnet).toBe('CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM');
-        expect(PYUSD['mainnet-beta']).toBe('2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo');
+        expect(PYUSD.mainnet).toBe('2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo');
     });
 
     test('has Phantom CASH mainnet mint', () => {
-        expect(CASH['mainnet-beta']).toBe('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH');
+        expect(CASH.mainnet).toBe('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH');
     });
 
     test('resolves stablecoin symbols by network', () => {
         expect(resolveStablecoinMint('USDC', 'devnet')).toBe(USDC.devnet);
-        expect(resolveStablecoinMint('USDT', 'mainnet-beta')).toBe(USDT['mainnet-beta']);
+        expect(resolveStablecoinMint('USDT', 'mainnet-beta')).toBe(USDT.mainnet);
         expect(resolveStablecoinMint('USDG', 'devnet')).toBe(USDG.devnet);
         expect(resolveStablecoinMint('PYUSD', 'devnet')).toBe(PYUSD.devnet);
-        expect(resolveStablecoinMint('CASH', 'mainnet-beta')).toBe(CASH['mainnet-beta']);
+        expect(resolveStablecoinMint('CASH', 'mainnet-beta')).toBe(CASH.mainnet);
         expect(resolveStablecoinMint('SOL')).toBeUndefined();
         expect(resolveStablecoinMint('CustomMint111111111111111111111111111111')).toBe(
             'CustomMint111111111111111111111111111111',
@@ -87,20 +87,20 @@ describe('stablecoin mint addresses', () => {
     });
 
     test('detects stablecoin display symbols', () => {
-        expect(stablecoinSymbolForCurrency(PYUSD['mainnet-beta'])).toBe('PYUSD');
-        expect(stablecoinSymbolForCurrency(USDG['mainnet-beta'])).toBe('USDG');
-        expect(stablecoinSymbolForCurrency(CASH['mainnet-beta'])).toBe('CASH');
+        expect(stablecoinSymbolForCurrency(PYUSD.mainnet)).toBe('PYUSD');
+        expect(stablecoinSymbolForCurrency(USDG.mainnet)).toBe('USDG');
+        expect(stablecoinSymbolForCurrency(CASH.mainnet)).toBe('CASH');
         expect(stablecoinSymbolForCurrency('CASH')).toBe('CASH');
         expect(stablecoinSymbolForCurrency('CustomMint111111111111111111111111111111')).toBeUndefined();
     });
 
     test('defaults stablecoins to the correct token program', () => {
         expect(defaultTokenProgramForCurrency('CASH')).toBe(TOKEN_2022_PROGRAM);
-        expect(defaultTokenProgramForCurrency(CASH['mainnet-beta'])).toBe(TOKEN_2022_PROGRAM);
+        expect(defaultTokenProgramForCurrency(CASH.mainnet)).toBe(TOKEN_2022_PROGRAM);
         expect(defaultTokenProgramForCurrency('PYUSD', 'devnet')).toBe(TOKEN_2022_PROGRAM);
-        expect(defaultTokenProgramForCurrency(PYUSD['mainnet-beta'])).toBe(TOKEN_2022_PROGRAM);
+        expect(defaultTokenProgramForCurrency(PYUSD.mainnet)).toBe(TOKEN_2022_PROGRAM);
         expect(defaultTokenProgramForCurrency('USDG', 'devnet')).toBe(TOKEN_2022_PROGRAM);
-        expect(defaultTokenProgramForCurrency(USDG['mainnet-beta'])).toBe(TOKEN_2022_PROGRAM);
+        expect(defaultTokenProgramForCurrency(USDG.mainnet)).toBe(TOKEN_2022_PROGRAM);
         expect(defaultTokenProgramForCurrency('USDC')).toBe(TOKEN_PROGRAM);
         expect(defaultTokenProgramForCurrency('USDT')).toBe(TOKEN_PROGRAM);
     });
@@ -111,8 +111,8 @@ describe('DEFAULT_RPC_URLS', () => {
         expect(DEFAULT_RPC_URLS.devnet).toBe('https://api.devnet.solana.com');
     });
 
-    test('has mainnet-beta URL', () => {
-        expect(DEFAULT_RPC_URLS['mainnet-beta']).toBe('https://api.mainnet-beta.solana.com');
+    test('has mainnet URL', () => {
+        expect(DEFAULT_RPC_URLS.mainnet).toBe('https://api.mainnet-beta.solana.com');
     });
 
     test('has localnet URL', () => {

--- a/typescript/packages/mpp/src/__tests__/constants.test.ts
+++ b/typescript/packages/mpp/src/__tests__/constants.test.ts
@@ -118,4 +118,17 @@ describe('DEFAULT_RPC_URLS', () => {
     test('has localnet URL', () => {
         expect(DEFAULT_RPC_URLS.localnet).toBe('http://localhost:8899');
     });
+
+    // Canonical slug is `mainnet`; `mainnet-beta` is a backward-compat
+    // alias. This test catches alias drift: if a future commit changes
+    // the URL for one spelling but forgets the other, downstream consumers
+    // doing raw bracket access on either key get inconsistent results.
+    test('mainnet-beta alias matches mainnet', () => {
+        expect(DEFAULT_RPC_URLS['mainnet-beta']).toBe(DEFAULT_RPC_URLS.mainnet);
+        expect(USDC['mainnet-beta']).toBe(USDC.mainnet);
+        expect(USDT['mainnet-beta']).toBe(USDT.mainnet);
+        expect(USDG['mainnet-beta']).toBe(USDG.mainnet);
+        expect(PYUSD['mainnet-beta']).toBe(PYUSD.mainnet);
+        expect(CASH['mainnet-beta']).toBe(CASH.mainnet);
+    });
 });

--- a/typescript/packages/mpp/src/__tests__/payment-channels.test.ts
+++ b/typescript/packages/mpp/src/__tests__/payment-channels.test.ts
@@ -48,7 +48,7 @@ test('buildOpenPaymentChannelTransaction creates a single partially signed open 
 
     expect(open.deposit).toBe(request.cap);
     expect(open.gracePeriod).toBe(900);
-    expect(open.mint).toBe(USDC['mainnet-beta']);
+    expect(open.mint).toBe(USDC.mainnet);
     expect(open.payee).toBe(payee.address);
     expect(open.payer).toBe(payer.address);
     expect(open.salt).toBe('42');
@@ -99,7 +99,7 @@ test('createPaymentChannelSessionOpener emits a pull client-voucher payment-chan
         action: 'open',
         deposit: '1000000',
         gracePeriod: 60,
-        mint: USDC['mainnet-beta'],
+        mint: USDC.mainnet,
         mode: 'pull',
         payee: payee.address,
         payer: payer.address,
@@ -145,7 +145,7 @@ test('createServerOpenedPaymentChannelSessionOpener emits channel fields without
         action: 'open',
         channelId: open.channelId,
         deposit: request.cap,
-        mint: USDC['mainnet-beta'],
+        mint: USDC.mainnet,
         mode: 'pull',
         payee: payee.address,
         payer: operator.address,
@@ -186,7 +186,7 @@ function sessionRequest(
 ): SessionRequest {
     return {
         cap: '1000000',
-        currency: USDC['mainnet-beta'],
+        currency: USDC.mainnet,
         decimals: 6,
         modes: ['pull'],
         network: 'localnet',

--- a/typescript/packages/mpp/src/client/ChallengeSelection.ts
+++ b/typescript/packages/mpp/src/client/ChallengeSelection.ts
@@ -172,10 +172,7 @@ function matchesNetwork(challenge: SolanaChargeChallenge, network: string | unde
     if (!network) {
         return true;
     }
-    return (
-        normalizeNetwork(challenge.request.methodDetails.network ?? 'mainnet') ===
-        normalizeNetwork(network)
-    );
+    return normalizeNetwork(challenge.request.methodDetails.network ?? 'mainnet') === normalizeNetwork(network);
 }
 
 function matchesCurrency(challenge: SolanaChargeChallenge, currency: string | readonly string[] | undefined): boolean {
@@ -207,10 +204,7 @@ function matchesSessionNetwork(challenge: SolanaSessionChallenge, network: strin
     if (!network) {
         return true;
     }
-    return (
-        normalizeNetwork(challenge.request.network ?? 'mainnet') ===
-        normalizeNetwork(network)
-    );
+    return normalizeNetwork(challenge.request.network ?? 'mainnet') === normalizeNetwork(network);
 }
 
 function matchesSessionCurrency(

--- a/typescript/packages/mpp/src/client/ChallengeSelection.ts
+++ b/typescript/packages/mpp/src/client/ChallengeSelection.ts
@@ -1,7 +1,7 @@
 import type { z } from 'mppx';
 import { Challenge } from 'mppx';
 
-import { resolveStablecoinMint } from '../constants.js';
+import { normalizeNetwork, resolveStablecoinMint } from '../constants.js';
 import { charge as chargeMethod, session as sessionMethod } from '../Methods.js';
 import type { SessionMode } from './Session.js';
 
@@ -172,7 +172,10 @@ function matchesNetwork(challenge: SolanaChargeChallenge, network: string | unde
     if (!network) {
         return true;
     }
-    return (challenge.request.methodDetails.network ?? 'mainnet-beta') === network;
+    return (
+        normalizeNetwork(challenge.request.methodDetails.network ?? 'mainnet') ===
+        normalizeNetwork(network)
+    );
 }
 
 function matchesCurrency(challenge: SolanaChargeChallenge, currency: string | readonly string[] | undefined): boolean {
@@ -204,7 +207,10 @@ function matchesSessionNetwork(challenge: SolanaSessionChallenge, network: strin
     if (!network) {
         return true;
     }
-    return (challenge.request.network ?? 'mainnet-beta') === network;
+    return (
+        normalizeNetwork(challenge.request.network ?? 'mainnet') ===
+        normalizeNetwork(network)
+    );
 }
 
 function matchesSessionCurrency(

--- a/typescript/packages/mpp/src/client/Charge.ts
+++ b/typescript/packages/mpp/src/client/Charge.ts
@@ -32,6 +32,7 @@ import {
     ASSOCIATED_TOKEN_PROGRAM,
     DEFAULT_RPC_URLS,
     MEMO_PROGRAM,
+    normalizeNetwork,
     resolveStablecoinMint,
     SYSTEM_PROGRAM,
     TOKEN_2022_PROGRAM,
@@ -86,12 +87,14 @@ export function charge(parameters: charge.Parameters) {
                 request: challenge.request,
                 rpcUrl:
                     parameters.rpcUrl ??
-                    DEFAULT_RPC_URLS[network || 'mainnet-beta'] ??
-                    DEFAULT_RPC_URLS['mainnet-beta'],
+                    DEFAULT_RPC_URLS[normalizeNetwork(network || 'mainnet')] ??
+                    DEFAULT_RPC_URLS.mainnet,
                 signer,
             });
             const rpc = createSolanaRpc(
-                parameters.rpcUrl ?? DEFAULT_RPC_URLS[network || 'mainnet-beta'] ?? DEFAULT_RPC_URLS['mainnet-beta'],
+                parameters.rpcUrl ??
+                    DEFAULT_RPC_URLS[normalizeNetwork(network || 'mainnet')] ??
+                    DEFAULT_RPC_URLS.mainnet,
             );
 
             if (broadcast) {
@@ -156,7 +159,10 @@ export async function buildChargeTransaction(
     // currency is "sol" for native, or the mint address for SPL tokens.
     const mint = resolveStablecoinMint(currency, network);
 
-    const rpcUrl = parameters.rpcUrl ?? DEFAULT_RPC_URLS[network || 'mainnet-beta'] ?? DEFAULT_RPC_URLS['mainnet-beta'];
+    const rpcUrl =
+        parameters.rpcUrl ??
+        DEFAULT_RPC_URLS[normalizeNetwork(network || 'mainnet')] ??
+        DEFAULT_RPC_URLS.mainnet;
     const rpc = createSolanaRpc(rpcUrl);
     onProgress?.({
         amount,

--- a/typescript/packages/mpp/src/client/Charge.ts
+++ b/typescript/packages/mpp/src/client/Charge.ts
@@ -160,9 +160,7 @@ export async function buildChargeTransaction(
     const mint = resolveStablecoinMint(currency, network);
 
     const rpcUrl =
-        parameters.rpcUrl ??
-        DEFAULT_RPC_URLS[normalizeNetwork(network || 'mainnet')] ??
-        DEFAULT_RPC_URLS.mainnet;
+        parameters.rpcUrl ?? DEFAULT_RPC_URLS[normalizeNetwork(network || 'mainnet')] ?? DEFAULT_RPC_URLS.mainnet;
     const rpc = createSolanaRpc(rpcUrl);
     onProgress?.({
         amount,

--- a/typescript/packages/mpp/src/client/PaymentChannels.ts
+++ b/typescript/packages/mpp/src/client/PaymentChannels.ts
@@ -32,6 +32,7 @@ import { findAssociatedTokenPda } from '@solana-program/token';
 import {
     ASSOCIATED_TOKEN_PROGRAM,
     DEFAULT_RPC_URLS,
+    normalizeNetwork,
     resolveStablecoinMint,
     SYSTEM_PROGRAM,
     TOKEN_PROGRAM,
@@ -109,7 +110,7 @@ export async function buildOpenPaymentChannelTransaction(
         ...parameters,
         payer: signer.address,
     });
-    const network = request.network ?? 'mainnet-beta';
+    const network = normalizeNetwork(request.network ?? 'mainnet');
     const programAddress = open.programAddress;
     const tokenProgram = open.tokenProgram;
     const payer = address(open.payer);
@@ -154,7 +155,7 @@ export async function buildOpenPaymentChannelTransaction(
               lastValidBlockHeight: 0n,
           }
         : (
-              await createSolanaRpc(parameters.rpcUrl ?? DEFAULT_RPC_URLS[network] ?? DEFAULT_RPC_URLS['mainnet-beta'])
+              await createSolanaRpc(parameters.rpcUrl ?? DEFAULT_RPC_URLS[network] ?? DEFAULT_RPC_URLS.mainnet)
                   .getLatestBlockhash()
                   .send()
           ).value;
@@ -402,7 +403,7 @@ async function preparePaymentChannelOpen(
     parameters: derivePaymentChannelOpen.Parameters,
 ): Promise<PreparedPaymentChannelOpen> {
     const { request } = parameters;
-    const network = request.network ?? 'mainnet-beta';
+    const network = normalizeNetwork(request.network ?? 'mainnet');
     const mint = resolveStablecoinMint(request.currency, network);
     if (!mint) {
         throw new Error('payment-channel sessions require an SPL token currency');

--- a/typescript/packages/mpp/src/constants.ts
+++ b/typescript/packages/mpp/src/constants.ts
@@ -52,10 +52,13 @@ export const DEFAULT_RPC_URLS: Record<string, string> = {
     mainnet: 'https://api.mainnet-beta.solana.com',
 };
 
-// Maintainer canonical for the mainnet slug is `mainnet`. The legacy
-// `mainnet-beta` spelling is accepted as a backward-compatible alias and
-// normalized to `mainnet`. Other networks pass through unchanged.
-function normalizeNetwork(network: string): string {
+/**
+ * Maintainer canonical for the mainnet slug is `mainnet`. The legacy
+ * `mainnet-beta` spelling is accepted as a backward-compatible alias
+ * and normalized to `mainnet`. Other networks pass through unchanged.
+ * Exposed so client helpers can compare and look up consistently.
+ */
+export function normalizeNetwork(network: string): string {
     const lower = network.toLowerCase();
     if (lower === 'mainnet' || lower === 'mainnet-beta') {
         return 'mainnet';

--- a/typescript/packages/mpp/src/constants.ts
+++ b/typescript/packages/mpp/src/constants.ts
@@ -7,25 +7,25 @@ export const MEMO_PROGRAM = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
 
 export const USDC: Record<string, string> = {
     devnet: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
-    'mainnet-beta': 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    mainnet: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
 };
 
 export const USDT: Record<string, string> = {
-    'mainnet-beta': 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+    mainnet: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
 };
 
 export const USDG: Record<string, string> = {
     devnet: '4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7',
-    'mainnet-beta': '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
+    mainnet: '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
 };
 
 export const PYUSD: Record<string, string> = {
     devnet: 'CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM',
-    'mainnet-beta': '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
+    mainnet: '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
 };
 
 export const CASH: Record<string, string> = {
-    'mainnet-beta': 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
+    mainnet: 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
 };
 
 export const STABLECOIN_MINTS = {
@@ -49,29 +49,41 @@ export const STABLECOIN_TOKEN_PROGRAMS: Record<StablecoinSymbol, string> = {
 export const DEFAULT_RPC_URLS: Record<string, string> = {
     devnet: 'https://api.devnet.solana.com',
     localnet: 'http://localhost:8899',
-    'mainnet-beta': 'https://api.mainnet-beta.solana.com',
+    mainnet: 'https://api.mainnet-beta.solana.com',
 };
 
-export function resolveStablecoinMint(currency: string, network = 'mainnet-beta'): string | undefined {
+// Maintainer canonical for the mainnet slug is `mainnet`. The legacy
+// `mainnet-beta` spelling is accepted as a backward-compatible alias and
+// normalized to `mainnet`. Other networks pass through unchanged.
+function normalizeNetwork(network: string): string {
+    const lower = network.toLowerCase();
+    if (lower === 'mainnet' || lower === 'mainnet-beta') {
+        return 'mainnet';
+    }
+    return network;
+}
+
+export function resolveStablecoinMint(currency: string, network = 'mainnet'): string | undefined {
+    const key = normalizeNetwork(network);
     switch (currency.toUpperCase()) {
         case 'SOL':
             return undefined;
         case 'USDC':
-            return USDC[network] ?? USDC['mainnet-beta'];
+            return USDC[key] ?? USDC.mainnet;
         case 'USDT':
-            return USDT[network] ?? USDT['mainnet-beta'];
+            return USDT[key] ?? USDT.mainnet;
         case 'USDG':
-            return USDG[network] ?? USDG['mainnet-beta'];
+            return USDG[key] ?? USDG.mainnet;
         case 'PYUSD':
-            return PYUSD[network] ?? PYUSD['mainnet-beta'];
+            return PYUSD[key] ?? PYUSD.mainnet;
         case 'CASH':
-            return CASH[network] ?? CASH['mainnet-beta'];
+            return CASH[key] ?? CASH.mainnet;
         default:
             return currency;
     }
 }
 
-export function defaultTokenProgramForCurrency(currency: string | undefined, network = 'mainnet-beta'): string {
+export function defaultTokenProgramForCurrency(currency: string | undefined, network = 'mainnet'): string {
     const symbol = currency
         ? stablecoinSymbolForCurrency(resolveStablecoinMint(currency, network) ?? currency)
         : undefined;

--- a/typescript/packages/mpp/src/constants.ts
+++ b/typescript/packages/mpp/src/constants.ts
@@ -5,27 +5,36 @@ export const SYSTEM_PROGRAM = '11111111111111111111111111111111';
 export const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
 export const MEMO_PROGRAM = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
 
+// The canonical mainnet slug is `mainnet`. The legacy `mainnet-beta`
+// spelling is kept as an aliased key so direct bracket access from
+// consumer code (e.g. USDC['mainnet-beta']) keeps working through the
+// transition. Internal lookups go through normalizeNetwork below.
 export const USDC: Record<string, string> = {
     devnet: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
     mainnet: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    'mainnet-beta': 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
 };
 
 export const USDT: Record<string, string> = {
     mainnet: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+    'mainnet-beta': 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
 };
 
 export const USDG: Record<string, string> = {
     devnet: '4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7',
     mainnet: '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
+    'mainnet-beta': '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH',
 };
 
 export const PYUSD: Record<string, string> = {
     devnet: 'CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM',
     mainnet: '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
+    'mainnet-beta': '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo',
 };
 
 export const CASH: Record<string, string> = {
     mainnet: 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
+    'mainnet-beta': 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
 };
 
 export const STABLECOIN_MINTS = {
@@ -50,6 +59,7 @@ export const DEFAULT_RPC_URLS: Record<string, string> = {
     devnet: 'https://api.devnet.solana.com',
     localnet: 'http://localhost:8899',
     mainnet: 'https://api.mainnet-beta.solana.com',
+    'mainnet-beta': 'https://api.mainnet-beta.solana.com',
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes gap G02 from the interop coverage audit: Token-2022 program was never exercised by the harness because every scenario asset was deployed under the legacy SPL Token program.

Adds a `charge-token2022-split-ata` scenario that deploys the PYUSD mainnet mint under the Token-2022 program. PYUSD is in every SDK's `TOKEN_2022_SYMBOLS` list (Ruby, PHP, Rust, TypeScript) so no language SDK API change is required.

## Harness changes

- `InteropScenario.tokenProgram` optional field, defaulting to `"TOKEN_PROGRAM"`.
- `beforeAll` deploys each unique `scenario.asset` under the matching program owner and funds client/payTo accordingly. Fails fast if two scenarios reuse the same asset under conflicting token programs.
- `environmentForScenario` propagates `scenario.asset` as `MPP_INTEROP_MINT`, so scenarios with distinct mints stop sharing the base scenario's mint.
- `expectSplTransferChecked`, `expectIdempotentAtaCreation`, `expectTransferCheckedCount`, `getTokenBalance`, `splitBalances`, and the `getAta` callsites take the scenario's token program as input.

## Manual verification

Locally against the pay-sdk surfpool harness:

- `pnpm typecheck`: clean
- TS client to TS server: 3/3 (`charge-basic`, `charge-split-ata`, `charge-token2022-split-ata`)
- TS client to Rust server: 3/3
- TS client to Ruby server: 3/3
- TS client to PHP server: 3/3

## Test plan

- [x] `pnpm typecheck` passes
- [x] All existing scenarios still pass against TS, Rust, Ruby, PHP servers
- [x] New Token-2022 scenario passes against TS, Rust, Ruby, PHP servers
- [x] Codex review: PASS on correctness, regression, SDK side, harness architecture, style

## Notes

This is the first commit in a broader interop hardening pass. Follow-ups will land additional scenarios (push mode end-to-end, confirmation timeout, ATA-already-exists, manual DX CI job, etc.) tracked in `mpp-sdk-self-learning/notes/2026-05-22-interop-coverage-audit.md`.