### PR TITLE
test(interop): add decimals, ATA-already-exists, compute budget cap, SOL native, splits bounds scenarios

### DIFF
--- a/rust/src/bin/interop_server.rs
+++ b/rust/src/bin/interop_server.rs
@@ -22,7 +22,7 @@ const HEALTH_PATH: &str = "/health";
 const DEFAULT_PRICE: &str = "0.001";
 const DEFAULT_SECRET_KEY: &str = "mpp-interop-secret-key";
 const DEFAULT_SETTLEMENT_HEADER: &str = "x-fixture-settlement";
-const TOKEN_DECIMALS: u8 = 6;
+const DEFAULT_TOKEN_DECIMALS: u8 = 6;
 
 #[derive(Clone)]
 struct InteropState {
@@ -95,13 +95,17 @@ fn read_state() -> Result<InteropState, Box<dyn std::error::Error + Send + Sync>
     };
     let secret_key =
         env::var("MPP_INTEROP_SECRET_KEY").unwrap_or_else(|_| DEFAULT_SECRET_KEY.to_string());
+    let decimals = match env::var("MPP_INTEROP_DECIMALS") {
+        Ok(raw) if !raw.is_empty() => raw.parse::<u8>()?,
+        _ => DEFAULT_TOKEN_DECIMALS,
+    };
     let splits = read_splits()?;
 
     Ok(InteropState {
         mpp: Mpp::new(Config {
             recipient: pay_to,
             currency: mint,
-            decimals: TOKEN_DECIMALS,
+            decimals,
             network,
             rpc_url: Some(rpc_url),
             secret_key: Some(secret_key),

--- a/tests/interop/src/contracts.ts
+++ b/tests/interop/src/contracts.ts
@@ -52,6 +52,29 @@ export type InteropScenario = {
   // is expected to resolve to under `network`. Harness deploys the mint
   // here and asserts settled transferChecked uses this mint.
   expectedMint?: string;
+  // Optional. Defaults to 6. Drives both the mint account `data[44]`
+  // byte at deploy time and the assertion `decimals` byte at `data[9]`
+  // of every transferChecked instruction. Adapters that accept a
+  // configurable decimals value read `MPP_INTEROP_DECIMALS` from env.
+  decimals?: number;
+  // Optional. When set the harness pre-creates the platform recipient's
+  // ATA for the scenario mint with a zero balance before the test
+  // starts, so the idempotent ATA-create instruction in the settled
+  // transaction is exercised against an already-existing account.
+  preCreatePlatformAta?: boolean;
+  // Optional. When set the TypeScript client passes the override to
+  // `solana.charge({ computeUnitLimit, computeUnitPrice })`. Used by
+  // G14 (compute budget over-cap) to force the server-side allowlist
+  // cap to reject. Ignored by clients other than `typescript`.
+  clientComputeUnitLimit?: number;
+  clientComputeUnitPrice?: string;
+  // Optional. When set to `"SOL"` the scenario exercises the native
+  // SOL transfer path (System Program transfer, lamports, decimals 9,
+  // no SPL token program). The harness funds the client wallet with
+  // lamports via `surfnet.fundSol`, skips the SPL mint deploy, and the
+  // assertion helpers expect a System Program transfer instruction
+  // (discriminator 2) instead of an SPL transferChecked.
+  assetKind?: "spl" | "sol";
 };
 
 export type ReadyMessage = {

--- a/tests/interop/src/contracts.ts
+++ b/tests/interop/src/contracts.ts
@@ -11,6 +11,8 @@ export type InteropScenarioSplit = {
   memo?: string;
 };
 
+export type TokenProgramVariant = "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM";
+
 export type InteropScenario = {
   id: string;
   intent: InteropIntent;
@@ -29,6 +31,10 @@ export type InteropScenario = {
   expectedStatus: 200 | 402;
   clientIds?: string[];
   serverIds?: string[];
+  // Optional. Defaults to "TOKEN_PROGRAM" (legacy SPL). Set to
+  // "TOKEN_2022_PROGRAM" for scenarios that exercise Token-2022. The harness
+  // uses this to deploy the scenario mint under the right program owner.
+  tokenProgram?: TokenProgramVariant;
 };
 
 export type ReadyMessage = {

--- a/tests/interop/src/contracts.ts
+++ b/tests/interop/src/contracts.ts
@@ -13,12 +13,19 @@ export type InteropScenarioSplit = {
 
 export type TokenProgramVariant = "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM";
 
+export type CurrencyMode = "pubkey" | "symbol";
+
 export type InteropScenario = {
   id: string;
   intent: InteropIntent;
   network: string;
   price: string;
   amount: string;
+  // The literal value the harness sends to each adapter as
+  // `MPP_INTEROP_MINT`. In `pubkey` mode (default) this is a 32+ char
+  // base58 mint pubkey. In `symbol` mode this is a stablecoin symbol
+  // (e.g. "USDC") and the harness deploys the mint at the pubkey each
+  // SDK's `Mints.resolve(symbol, network)` returns.
   asset: string;
   resourcePath: string;
   settlementHeader: string;
@@ -35,6 +42,16 @@ export type InteropScenario = {
   // "TOKEN_2022_PROGRAM" for scenarios that exercise Token-2022. The harness
   // uses this to deploy the scenario mint under the right program owner.
   tokenProgram?: TokenProgramVariant;
+  // Optional. Defaults to "pubkey". Set to "symbol" to exercise the
+  // SDK-side `Mints.resolve(currency, network)` path that the manual DX
+  // path (pay sandbox + example servers) actually hits. The harness uses
+  // `expectedMint` below to know which on-chain mint to deploy and to
+  // assert balances against.
+  currencyMode?: CurrencyMode;
+  // Required when `currencyMode === "symbol"`. The pubkey the symbol
+  // is expected to resolve to under `network`. Harness deploys the mint
+  // here and asserts settled transferChecked uses this mint.
+  expectedMint?: string;
 };
 
 export type ReadyMessage = {

--- a/tests/interop/src/fixtures/typescript/charge-client.ts
+++ b/tests/interop/src/fixtures/typescript/charge-client.ts
@@ -51,12 +51,18 @@ function isClientSideSplitRejection(error: unknown): boolean {
   if (/Splits consume the entire amount/i.test(error.message)) {
     return true;
   }
-  // G28a: when the server refuses to construct (e.g. splits > 8) it
-  // serves a 402 body without a `WWW-Authenticate` header. mppx's
-  // wrapped fetch then throws this exact message before exposing the
-  // 402 response to the caller. The allowlist stays narrow: only
-  // this two-word literal symptom of "server emitted a 402 with no
-  // Solana challenge" maps to a synthetic 402 here.
+  // Server-side rejection symptom: the server emits a 402 body with no
+  // `WWW-Authenticate` header (mppx's wrapped fetch throws this exact
+  // message before exposing the underlying 402 response to the caller).
+  // Today this branch covers two distinct cases that both fail at the
+  // server's request construction stage:
+  //   - G28a splits > 8.
+  //   - G14 compute budget over-cap (limit > 200_000 or price > 5_000_000).
+  // Both have expectedStatus 402 so the test result is correct. The
+  // allowlist stays narrow to this one two-word literal so it does not
+  // accidentally absorb unrelated client-side regressions; if mppx ever
+  // changes the message both scenarios surface together and the failure
+  // is easy to diagnose.
   return /Missing WWW-Authenticate header/i.test(error.message);
 }
 

--- a/tests/interop/src/fixtures/typescript/charge-client.ts
+++ b/tests/interop/src/fixtures/typescript/charge-client.ts
@@ -24,27 +24,43 @@ async function main() {
       ? await runCrossRouteReplay(targetUrl, environment, signer)
       : await payTarget(targetUrl, environment, signer);
   } catch (error) {
-    // G28b. The TS client's `buildChargeTransaction` refuses to build a
-    // credential when `splits` consume the entire amount, raising
-    // before any request reaches the server. The harness treats this
-    // as the correct 402-class outcome: the credential was rejected
-    // pre-broadcast. Emit a synthetic result so the assertion layer
-    // sees `status: 402` instead of an opaque process exit.
-    reportClientSideRejection(
-      error,
-      environment.settlementHeader,
-    );
-    return;
+    // G28b. `buildChargeTransaction` refuses to build a credential
+    // when `splits` consume the entire amount, raising before any
+    // request reaches the server. The harness treats that one
+    // specific pre-broadcast rejection as the correct 402-class
+    // outcome. Every other thrown error is a real fixture or SDK
+    // failure and must surface as a non-zero exit so the harness
+    // sees it. We allowlist by error message rather than catching
+    // all to avoid masking unrelated regressions (Codex review of
+    // this PR).
+    if (isClientSideSplitRejection(error)) {
+      reportClientSideRejection(error);
+      return;
+    }
+    throw error;
   }
 
   await reportResult(paidResponse, environment.settlementHeader);
 }
 
-function reportClientSideRejection(
-  error: unknown,
-  settlementHeader: string,
-): void {
-  void settlementHeader;
+function isClientSideSplitRejection(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  // G28b: client-side pre-broadcast rejection.
+  if (/Splits consume the entire amount/i.test(error.message)) {
+    return true;
+  }
+  // G28a: when the server refuses to construct (e.g. splits > 8) it
+  // serves a 402 body without a `WWW-Authenticate` header. mppx's
+  // wrapped fetch then throws this exact message before exposing the
+  // 402 response to the caller. The allowlist stays narrow: only
+  // this two-word literal symptom of "server emitted a 402 with no
+  // Solana challenge" maps to a synthetic 402 here.
+  return /Missing WWW-Authenticate header/i.test(error.message);
+}
+
+function reportClientSideRejection(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   console.log(
     JSON.stringify({

--- a/tests/interop/src/fixtures/typescript/charge-client.ts
+++ b/tests/interop/src/fixtures/typescript/charge-client.ts
@@ -18,11 +18,49 @@ async function main() {
   const signer = await createKeyPairSignerFromBytes(
     environment.clientSecretKey,
   );
-  const paidResponse = environment.replaySource
-    ? await runCrossRouteReplay(targetUrl, environment, signer)
-    : await payTarget(targetUrl, environment, signer);
+  let paidResponse: Response;
+  try {
+    paidResponse = environment.replaySource
+      ? await runCrossRouteReplay(targetUrl, environment, signer)
+      : await payTarget(targetUrl, environment, signer);
+  } catch (error) {
+    // G28b. The TS client's `buildChargeTransaction` refuses to build a
+    // credential when `splits` consume the entire amount, raising
+    // before any request reaches the server. The harness treats this
+    // as the correct 402-class outcome: the credential was rejected
+    // pre-broadcast. Emit a synthetic result so the assertion layer
+    // sees `status: 402` instead of an opaque process exit.
+    reportClientSideRejection(
+      error,
+      environment.settlementHeader,
+    );
+    return;
+  }
 
   await reportResult(paidResponse, environment.settlementHeader);
+}
+
+function reportClientSideRejection(
+  error: unknown,
+  settlementHeader: string,
+): void {
+  void settlementHeader;
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(
+    JSON.stringify({
+      type: "result",
+      implementation: "typescript",
+      role: "client",
+      ok: false,
+      status: 402,
+      responseHeaders: {},
+      responseBody: {
+        error: "client_rejected_credential",
+        message,
+      },
+      settlement: null,
+    }),
+  );
 }
 
 async function payTarget(
@@ -35,6 +73,12 @@ async function payTarget(
       solana.charge({
         signer,
         rpcUrl: environment.rpcUrl,
+        ...(environment.computeUnitLimit !== undefined
+          ? { computeUnitLimit: environment.computeUnitLimit }
+          : {}),
+        ...(environment.computeUnitPrice !== undefined
+          ? { computeUnitPrice: environment.computeUnitPrice }
+          : {}),
       }),
     ],
   });

--- a/tests/interop/src/fixtures/typescript/charge-server.ts
+++ b/tests/interop/src/fixtures/typescript/charge-server.ts
@@ -39,20 +39,37 @@ async function main() {
   const feePayerSigner = await createKeyPairSignerFromBytes(
     environment.feePayerSecretKey,
   );
-  const mppx = Mppx.create({
-    secretKey: environment.secretKey,
-    methods: [
-      solana.charge({
-        recipient: environment.payTo,
-        currency: environment.mint,
-        decimals: 6,
-        network: environment.network,
-        rpcUrl: environment.rpcUrl,
-        signer: feePayerSigner,
-        splits: environment.splits,
-      }),
-    ],
-  });
+  const isSolNative = environment.assetKind === "sol";
+  const currency = isSolNative ? "sol" : environment.mint;
+  // G28a. `solana.charge({ splits })` validates split count at
+  // construction time and throws on > 8 entries. The harness treats
+  // a construct-time rejection as the correct 402-class outcome: the
+  // server refuses to issue a challenge. We capture the error and
+  // serve 402 on every protected request below, mirroring the
+  // "challenge_unavailable" failure mode end-to-end.
+  // The exact return type of Mppx.create depends on the inferred
+  // methods tuple, which Typescript widens here. `unknown` plus a
+  // narrow cast at the call site is sufficient for the fixture.
+  let mppx: unknown;
+  let constructError: Error | undefined;
+  try {
+    mppx = Mppx.create({
+      secretKey: environment.secretKey,
+      methods: [
+        solana.charge({
+          recipient: environment.payTo,
+          currency,
+          decimals: environment.decimals,
+          network: environment.network,
+          rpcUrl: environment.rpcUrl,
+          signer: feePayerSigner,
+          splits: environment.splits,
+        }),
+      ],
+    });
+  } catch (error) {
+    constructError = error instanceof Error ? error : new Error(String(error));
+  }
 
   const server = http.createServer(async (request, response) => {
     try {
@@ -78,9 +95,32 @@ async function main() {
         return;
       }
 
-      const result = await mppx.charge({
+      if (!mppx || constructError) {
+        response.writeHead(402, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            error: "challenge_unavailable",
+            message: constructError?.message ?? "mppx not initialized",
+          }),
+        );
+        return;
+      }
+
+      const result = await (
+        mppx as {
+          charge: (params: {
+            amount: string;
+            currency: string;
+            description: string;
+          }) => (request: Request) => Promise<{
+            status: number;
+            challenge?: Response;
+            withReceipt: (response: Response) => Response;
+          }>;
+        }
+      ).charge({
         amount: amountForPath(url.pathname, environment),
-        currency: environment.mint,
+        currency,
         description: "Surfpool-backed protected content",
       })(toWebRequest(request, body));
 

--- a/tests/interop/src/fixtures/typescript/charge-server.ts
+++ b/tests/interop/src/fixtures/typescript/charge-server.ts
@@ -42,11 +42,13 @@ async function main() {
   const isSolNative = environment.assetKind === "sol";
   const currency = isSolNative ? "sol" : environment.mint;
   // G28a. `solana.charge({ splits })` validates split count at
-  // construction time and throws on > 8 entries. The harness treats
-  // a construct-time rejection as the correct 402-class outcome: the
-  // server refuses to issue a challenge. We capture the error and
-  // serve 402 on every protected request below, mirroring the
-  // "challenge_unavailable" failure mode end-to-end.
+  // construction time and throws on > 8 entries. That one specific
+  // construct-time rejection is the correct 402-class outcome and
+  // gets surfaced as `challenge_unavailable` on protected requests.
+  // Other Mppx.create failures (bad signer, unsupported currency,
+  // env regressions) must crash the fixture so the harness sees a
+  // real error instead of a misleading 402 (Codex review of this
+  // PR). We allowlist by error message text rather than catching all.
   // The exact return type of Mppx.create depends on the inferred
   // methods tuple, which Typescript widens here. `unknown` plus a
   // narrow cast at the call site is sufficient for the fixture.
@@ -68,7 +70,11 @@ async function main() {
       ],
     });
   } catch (error) {
-    constructError = error instanceof Error ? error : new Error(String(error));
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/splits cannot exceed/i.test(message)) {
+      throw error;
+    }
+    constructError = error instanceof Error ? error : new Error(message);
   }
 
   const server = http.createServer(async (request, response) => {

--- a/tests/interop/src/fixtures/typescript/shared.ts
+++ b/tests/interop/src/fixtures/typescript/shared.ts
@@ -22,6 +22,15 @@ export type InteropEnvironment = {
   }>;
   clientSecretKey: Uint8Array;
   feePayerSecretKey: Uint8Array;
+  decimals: number;
+  // SOL-native scenarios pass `MPP_INTEROP_ASSET_KIND=sol` and the
+  // server fixture must build the charge with `currency: "sol"` and
+  // skip the SPL token-program path. SPL scenarios pass the literal
+  // `MPP_INTEROP_MINT` through to the SDK so the resolver is
+  // exercised.
+  assetKind: "spl" | "sol";
+  computeUnitLimit?: number;
+  computeUnitPrice?: bigint;
 };
 
 function readRequiredEnv(name: string): string {
@@ -67,7 +76,33 @@ export function readInteropEnvironment(): InteropEnvironment {
     ) as InteropEnvironment["splits"],
     clientSecretKey: parseSecretKey("MPP_INTEROP_CLIENT_SECRET_KEY"),
     feePayerSecretKey: parseSecretKey("MPP_INTEROP_FEE_PAYER_SECRET_KEY"),
+    decimals: parseDecimals(process.env.MPP_INTEROP_DECIMALS),
+    assetKind:
+      (process.env.MPP_INTEROP_ASSET_KIND ?? "spl").toLowerCase() === "sol"
+        ? "sol"
+        : "spl",
+    computeUnitLimit:
+      process.env.MPP_INTEROP_COMPUTE_UNIT_LIMIT &&
+      process.env.MPP_INTEROP_COMPUTE_UNIT_LIMIT.trim() !== ""
+        ? Number(process.env.MPP_INTEROP_COMPUTE_UNIT_LIMIT)
+        : undefined,
+    computeUnitPrice:
+      process.env.MPP_INTEROP_COMPUTE_UNIT_PRICE &&
+      process.env.MPP_INTEROP_COMPUTE_UNIT_PRICE.trim() !== ""
+        ? BigInt(process.env.MPP_INTEROP_COMPUTE_UNIT_PRICE)
+        : undefined,
   };
+}
+
+function parseDecimals(raw: string | undefined): number {
+  if (!raw || raw.trim() === "") {
+    return 6;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0 || value > 9) {
+    throw new Error(`Invalid MPP_INTEROP_DECIMALS: ${raw}`);
+  }
+  return value;
 }
 
 export const fixtureSettlementHeader = interopScenario.settlementHeader;

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -130,4 +130,138 @@ export const chargeScenarios: readonly InteropScenario[] = [
     ],
     expectedStatus: 200,
   },
+  {
+    // G07. 9-decimal SPL mint. Harness deploys the mint with data[44]=9,
+    // adapters receive MPP_INTEROP_DECIMALS=9 and must build the
+    // challenge with `decimals: 9`. Assertion helper checks
+    // transferChecked data[9] equals 9.
+    id: "charge-decimals-9",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "KTHzp63RATgvE5RoRRqVbY7hMWntARQ6dPQhMtfY9oA",
+    resourcePath: "/protected/decimals-9",
+    settlementHeader: "x-fixture-settlement",
+    decimals: 9,
+    // The Rust interop server fixture computes amount as
+    // `price * 10^decimals`, which diverges from the TS fixture's
+    // env-driven amount. Restricting to the TS server keeps the
+    // assertion's primary delta aligned with the on-wire amount.
+    // The Rust SDK itself is exercised via the client adapter against
+    // the TS server in this scenario.
+    serverIds: ["typescript"],
+    expectedStatus: 200,
+  },
+  {
+    // G13. Idempotent ATA create instruction must still pass when the
+    // platform recipient's ATA already exists. Harness pre-creates the
+    // ATA with a zero balance via `surfnet.fundToken(platform, mint, 0,
+    // programAddress)` before the test runs. Assertions otherwise
+    // identical to charge-split-ata.
+    id: "charge-split-ata-idempotent",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    resourcePath: "/protected/split-ata-idempotent",
+    settlementHeader: "x-fixture-settlement",
+    preCreatePlatformAta: true,
+    splits: [
+      {
+        recipientKey: "platform",
+        amount: "250",
+        ataCreationRequired: true,
+        memo: "interop split idempotent",
+      },
+    ],
+    expectedStatus: 200,
+  },
+  {
+    // G14. TypeScript client injects an over-cap compute budget
+    // (limit 200_001, over the 200_000 server cap). Server must reject
+    // with the compute-budget allowlist error. Rust/Ruby/PHP clients
+    // cannot inject custom compute budget through the env-driven
+    // harness path, so this scenario is TypeScript-client only. Every
+    // active server is expected to enforce the cap.
+    id: "charge-compute-budget-over-cap",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    resourcePath: "/protected/compute-budget-over-cap",
+    settlementHeader: "x-fixture-settlement",
+    clientIds: ["typescript"],
+    clientComputeUnitLimit: 200_001,
+    expectedStatus: 402,
+  },
+  {
+    // G27. Native SOL transfer path. Currency is the lowercase string
+    // `sol`, decimals 9, asset kind sol, no SPL mint deploy. The
+    // settled transaction must contain a System Program transfer
+    // (discriminator u32 LE = 2) instead of an SPL transferChecked.
+    // The harness funds the client with lamports via `surfnet.fundSol`.
+    id: "charge-sol-native",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000000",
+    asset: "sol",
+    resourcePath: "/protected/sol-native",
+    settlementHeader: "x-fixture-settlement",
+    assetKind: "sol",
+    decimals: 9,
+    // Only the TS server fixture currently threads currency="sol"
+    // through the env. Rust/Ruby/PHP server fixtures default decimals
+    // to 6 and pass MPP_INTEROP_MINT straight to the SDK, so for now
+    // this scenario runs against the TS server only.
+    serverIds: ["typescript"],
+    expectedStatus: 200,
+  },
+  {
+    // G28a. Splits > 8. Server (every SDK) must reject before
+    // emitting a challenge. The TypeScript client is the only one that
+    // can drive a 9-split request through the env-only path, so this
+    // is typescript-client only. Splits are intentionally tiny so the
+    // sum stays well under amount.
+    id: "charge-splits-too-many",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    resourcePath: "/protected/splits-too-many",
+    settlementHeader: "x-fixture-settlement",
+    clientIds: ["typescript"],
+    splits: [
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+      { recipientKey: "platform", amount: "1" },
+    ],
+    expectedStatus: 402,
+  },
+  {
+    // G28b. Single split whose amount equals total amount, so the
+    // primary recipient delta is zero. Server (every SDK) must reject
+    // because the primary amount must be strictly positive.
+    id: "charge-splits-sum-equals-amount",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    resourcePath: "/protected/splits-sum-equals-amount",
+    settlementHeader: "x-fixture-settlement",
+    clientIds: ["typescript"],
+    splits: [{ recipientKey: "platform", amount: "1000" }],
+    expectedStatus: 402,
+  },
 ] as const;

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -84,4 +84,28 @@ export const chargeScenarios: readonly InteropScenario[] = [
     expectedStatus: 402,
     clientIds: ["typescript"],
   },
+  {
+    // PYUSD mainnet mint, which every SDK (Ruby, PHP, Rust, TypeScript)
+    // already classifies as Token-2022 via the built-in TOKEN_2022_SYMBOLS
+    // list, so no SDK API change is required. The harness deploys this mint
+    // under the Token-2022 program in beforeAll.
+    id: "charge-token2022-split-ata",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+    resourcePath: "/protected/token2022-split-ata",
+    settlementHeader: "x-fixture-settlement",
+    tokenProgram: "TOKEN_2022_PROGRAM",
+    splits: [
+      {
+        recipientKey: "platform",
+        amount: "250",
+        ataCreationRequired: true,
+        memo: "interop token2022 split",
+      },
+    ],
+    expectedStatus: 200,
+  },
 ] as const;

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -85,6 +85,28 @@ export const chargeScenarios: readonly InteropScenario[] = [
     clientIds: ["typescript"],
   },
   {
+    // Symbol mode: harness sends the literal string "USDC" as currency,
+    // adapters must call their `Mints.resolve` (or equivalent) to get a
+    // mint pubkey. The Ruby `MINTS["USDC"]["localnet"] = devnet mint` bug
+    // would have surfaced here. The harness deploys the mint at the
+    // expected pubkey so the resolved address must match for the
+    // transferChecked assertion to pass.
+    id: "charge-symbol-usdc-localnet",
+    intent: "charge",
+    network: "localnet",
+    price: "0.001",
+    amount: "1000",
+    asset: "USDC",
+    currencyMode: "symbol",
+    // Surfpool localnet mirrors mainnet, so USDC on localnet resolves to
+    // the mainnet USDC mint (EPjFWdd5...). Every SDK with a stablecoin
+    // table must agree on this.
+    expectedMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    resourcePath: "/protected/symbol-usdc",
+    settlementHeader: "x-fixture-settlement",
+    expectedStatus: 200,
+  },
+  {
     // PYUSD mainnet mint, which every SDK (Ruby, PHP, Rust, TypeScript)
     // already classifies as Token-2022 via the built-in TOKEN_2022_SYMBOLS
     // list, so no SDK API change is required. The harness deploys this mint

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -21,6 +21,9 @@ const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 const ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const MINT_ACCOUNT_SIZE = 82;
+const SOL_NATIVE_DECIMALS = 9;
+const DEFAULT_SPL_DECIMALS = 6;
+const CLIENT_SOL_FUND_LAMPORTS = 5_000_000_000;
 
 function tokenProgramAddress(
   variant: "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM" | undefined,
@@ -31,8 +34,12 @@ function tokenProgramAddress(
 // The on-chain mint pubkey for a scenario. In pubkey mode this is just
 // `scenario.asset`. In symbol mode the harness sends a stablecoin symbol
 // to adapters and the on-chain mint is `scenario.expectedMint` (the
-// pubkey each SDK's resolver is expected to return).
-function onChainMintFor(scenario: InteropScenario): string {
+// pubkey each SDK's resolver is expected to return). For SOL-native
+// scenarios there is no mint at all.
+function onChainMintFor(scenario: InteropScenario): string | null {
+  if (isSolNative(scenario)) {
+    return null;
+  }
   if (scenario.currencyMode === "symbol") {
     if (!scenario.expectedMint) {
       throw new Error(
@@ -42,6 +49,17 @@ function onChainMintFor(scenario: InteropScenario): string {
     return scenario.expectedMint;
   }
   return scenario.asset;
+}
+
+function isSolNative(scenario: InteropScenario): boolean {
+  return scenario.assetKind === "sol";
+}
+
+function scenarioDecimals(scenario: InteropScenario): number {
+  if (typeof scenario.decimals === "number") {
+    return scenario.decimals;
+  }
+  return isSolNative(scenario) ? SOL_NATIVE_DECIMALS : DEFAULT_SPL_DECIMALS;
 }
 
 const runningServers: RunningServer[] = [];
@@ -92,6 +110,36 @@ async function getTokenBalance(
   }
 }
 
+async function getLamportBalance(
+  surfnet: Surfnet,
+  owner: string,
+): Promise<bigint> {
+  const rpc = createSolanaRpc(surfnet.rpcUrl);
+  const response = await rpc.getBalance(owner as never).send();
+  return BigInt(response.value);
+}
+
+// Balance helper that dispatches on scenario asset kind. For SPL
+// scenarios it reads the recipient ATA token balance; for SOL-native
+// scenarios it reads recipient lamports.
+async function getPrimaryRecipientBalance(
+  surfnet: Surfnet,
+  scenario: InteropScenario,
+  owner: string,
+  mint: string | null,
+  tokenProgram: string,
+): Promise<bigint> {
+  if (isSolNative(scenario)) {
+    return await getLamportBalance(surfnet, owner);
+  }
+  if (!mint) {
+    throw new Error(
+      `Scenario ${scenario.id} has no on-chain mint but is not SOL-native`,
+    );
+  }
+  return await getTokenBalance(surfnet, owner, mint, tokenProgram);
+}
+
 function createSplMintAccountData(decimals: number): Uint8Array {
   const data = new Uint8Array(MINT_ACCOUNT_SIZE);
   const view = new DataView(data.buffer);
@@ -123,25 +171,50 @@ beforeAll(async () => {
   const payTo = Surfnet.newKeypair();
   const platform = Surfnet.newKeypair();
 
-  // Deploy every mint referenced by an active scenario under the right token
-  // program. Without this, Token-2022 scenarios would have to share the legacy
-  // mint owner and the verifier would reject every transfer. Symbol-mode
-  // scenarios deploy at `expectedMint`, not at the literal asset string.
-  const uniqueMints = new Map<string, "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM">();
+  // Deploy every mint referenced by an active SPL scenario under the
+  // right token program with the right decimals byte. SOL-native
+  // scenarios contribute lamport funding instead. Symbol-mode
+  // scenarios deploy at `expectedMint`, not at the literal asset
+  // string. Conflicting tokenProgram or decimals for the same mint
+  // pubkey across scenarios is an authoring bug.
+  type MintConfig = {
+    variant: "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM";
+    decimals: number;
+  };
+  const uniqueMints = new Map<string, MintConfig>();
+  let needsSolFunding = false;
   for (const scenario of activeScenarios) {
+    if (isSolNative(scenario)) {
+      needsSolFunding = true;
+      continue;
+    }
     const variant = scenario.tokenProgram ?? "TOKEN_PROGRAM";
+    const decimals = scenarioDecimals(scenario);
     const mintPubkey = onChainMintFor(scenario);
+    if (!mintPubkey) {
+      continue;
+    }
     const existing = uniqueMints.get(mintPubkey);
-    if (existing && existing !== variant) {
+    if (existing && existing.variant !== variant) {
       throw new Error(
-        `Conflicting tokenProgram for mint ${mintPubkey}: ${existing} vs ${variant} (scenario ${scenario.id})`,
+        `Conflicting tokenProgram for mint ${mintPubkey}: ${existing.variant} vs ${variant} (scenario ${scenario.id})`,
       );
     }
-    uniqueMints.set(mintPubkey, variant);
+    if (existing && existing.decimals !== decimals) {
+      throw new Error(
+        `Conflicting decimals for mint ${mintPubkey}: ${existing.decimals} vs ${decimals} (scenario ${scenario.id})`,
+      );
+    }
+    uniqueMints.set(mintPubkey, { variant, decimals });
   }
-  for (const [mintPubkey, variant] of uniqueMints) {
-    const programAddress = tokenProgramAddress(variant);
-    surfnet.setAccount(mintPubkey, 1_461_600, createSplMintAccountData(6), programAddress);
+  for (const [mintPubkey, config] of uniqueMints) {
+    const programAddress = tokenProgramAddress(config.variant);
+    surfnet.setAccount(
+      mintPubkey,
+      1_461_600,
+      createSplMintAccountData(config.decimals),
+      programAddress,
+    );
     surfnet.fundToken(client.publicKey, mintPubkey, 100_000, programAddress);
     surfnet.fundToken(payTo.publicKey, mintPubkey, 1, programAddress);
   }
@@ -149,6 +222,35 @@ beforeAll(async () => {
   splitRecipients = {
     platform: platform.publicKey,
   };
+
+  // G13. Pre-create the platform recipient's ATA for any scenario that
+  // requests it. `fundToken` with zero amount is the lowest-friction
+  // way to call the underlying surfnet cheatcode without changing the
+  // settled token balance the test asserts against.
+  for (const scenario of activeScenarios) {
+    if (!scenario.preCreatePlatformAta) {
+      continue;
+    }
+    const mintPubkey = onChainMintFor(scenario);
+    if (!mintPubkey) {
+      throw new Error(
+        `Scenario ${scenario.id} requested preCreatePlatformAta but has no on-chain mint`,
+      );
+    }
+    const variant = scenario.tokenProgram ?? "TOKEN_PROGRAM";
+    surfnet.fundToken(
+      platform.publicKey,
+      mintPubkey,
+      0,
+      tokenProgramAddress(variant),
+    );
+  }
+
+  // G27. SOL-native scenarios need the client wallet pre-funded with
+  // lamports so the system transfer can succeed.
+  if (needsSolFunding) {
+    surfnet.fundSol(client.publicKey, CLIENT_SOL_FUND_LAMPORTS);
+  }
 
   interopEnv = {
     MPP_INTEROP_RPC_URL: surfnet.rpcUrl,
@@ -206,11 +308,13 @@ describe("mpp interop", () => {
             const scenarioEnv = environmentForScenario(interopEnv, scenario);
             const scenarioTokenProgram = tokenProgramAddress(scenario.tokenProgram);
             // On-chain mint pubkey (resolved expectedMint in symbol mode,
-            // literal asset in pubkey mode). The literal in scenarioEnv goes
-            // to the adapter so the SDK's resolver is exercised end-to-end.
+            // literal asset in pubkey mode, or null for SOL-native). The
+            // literal in scenarioEnv goes to the adapter so the SDK's
+            // resolver is exercised end-to-end.
             const onChainMint = onChainMintFor(scenario);
-            const initialBalance = await getTokenBalance(
+            const initialBalance = await getPrimaryRecipientBalance(
               surfnet,
+              scenario,
               scenarioEnv.MPP_INTEROP_PAY_TO,
               onChainMint,
               scenarioTokenProgram,
@@ -233,8 +337,9 @@ describe("mpp interop", () => {
               scenarioEnv,
             );
 
-            const finalBalance = await getTokenBalance(
+            const finalBalance = await getPrimaryRecipientBalance(
               surfnet,
+              scenario,
               scenarioEnv.MPP_INTEROP_PAY_TO,
               onChainMint,
               scenarioTokenProgram,
@@ -244,7 +349,10 @@ describe("mpp interop", () => {
               scenario,
               onChainMint,
               scenarioTokenProgram,
-              false,
+              // For 402 scenarios the recipient ATA may never have
+              // been created on-chain; treat missing as zero so the
+              // delta assertion below still holds.
+              scenario.expectedStatus === 402,
             );
 
             expect(result.status, JSON.stringify(result, null, 2)).toBe(
@@ -273,7 +381,9 @@ describe("mpp interop", () => {
               ).toEqual(expectedSplitDeltas(scenario));
             } else {
               expect(result.ok, JSON.stringify(result, null, 2)).toBe(false);
-              expect(finalBalance - initialBalance).toBe(0n);
+              if (!isSolNative(scenario)) {
+                expect(finalBalance - initialBalance).toBe(0n);
+              }
               expect(
                 splitDeltas(initialSplitBalances, finalSplitBalances),
               ).toEqual(expectedZeroSplitDeltas(scenario));
@@ -289,13 +399,15 @@ function environmentForScenario(
   baseEnv: Record<string, string>,
   scenario: InteropScenario,
 ): Record<string, string> {
-  return {
+  const env: Record<string, string> = {
     ...baseEnv,
     MPP_INTEROP_AMOUNT: scenario.amount,
     MPP_INTEROP_MINT: scenario.asset,
     MPP_INTEROP_NETWORK: scenario.network,
     MPP_INTEROP_PRICE: scenario.price,
     MPP_INTEROP_RESOURCE_PATH: scenario.resourcePath,
+    MPP_INTEROP_DECIMALS: String(scenarioDecimals(scenario)),
+    MPP_INTEROP_ASSET_KIND: isSolNative(scenario) ? "sol" : "spl",
     ...(scenario.replaySource
       ? {
           MPP_INTEROP_REPLAY_SOURCE_AMOUNT: scenario.replaySource.amount,
@@ -315,6 +427,13 @@ function environmentForScenario(
       })),
     ),
   };
+  if (typeof scenario.clientComputeUnitLimit === "number") {
+    env.MPP_INTEROP_COMPUTE_UNIT_LIMIT = String(scenario.clientComputeUnitLimit);
+  }
+  if (typeof scenario.clientComputeUnitPrice === "string") {
+    env.MPP_INTEROP_COMPUTE_UNIT_PRICE = scenario.clientComputeUnitPrice;
+  }
+  return env;
 }
 
 async function expectSettledTransactionShape(
@@ -334,11 +453,29 @@ async function expectSettledTransactionShape(
   const message = decodeTransactionMessage(transaction);
   expect(message.addressTableLookups ?? []).toHaveLength(0);
 
+  // G27. SOL-native scenarios expect a System Program transfer, not
+  // SPL transferChecked. The system transfer discriminator is u32 LE
+  // = 2 in the first 4 bytes of the instruction data, followed by a
+  // u64 LE lamports amount.
+  if (isSolNative(scenario)) {
+    expectSystemProgramTransfer(message, {
+      destination: scenarioEnv.MPP_INTEROP_PAY_TO,
+      amount: primaryDelta(scenario),
+    });
+    return;
+  }
+
   const matchedInstructions = new Set<number>();
   const expectedTransferCount = 1 + (scenario.splits?.length ?? 0);
   const primaryAmount = primaryDelta(scenario);
   const tokenProgram = tokenProgramAddress(scenario.tokenProgram);
   const onChainMint = onChainMintFor(scenario);
+  if (!onChainMint) {
+    throw new Error(
+      `Scenario ${scenario.id} is not SOL-native but resolves to no on-chain mint`,
+    );
+  }
+  const decimals = scenarioDecimals(scenario);
   expectSplTransferChecked(
     message,
     {
@@ -349,7 +486,7 @@ async function expectSettledTransactionShape(
       ),
       mint: onChainMint,
       amount: primaryAmount,
-      decimals: 6,
+      decimals,
       tokenProgram,
     },
     matchedInstructions,
@@ -368,7 +505,7 @@ async function expectSettledTransactionShape(
         destination,
         mint: onChainMint,
         amount: BigInt(split.amount),
-        decimals: 6,
+        decimals,
         tokenProgram,
       },
       matchedInstructions,
@@ -394,6 +531,42 @@ async function expectSettledTransactionShape(
     expectedTransferCount,
     tokenProgram,
   );
+}
+
+function expectSystemProgramTransfer(
+  message: CompiledMessage,
+  expected: { destination: string; amount: bigint },
+): void {
+  const match = message.instructions.find((instruction) => {
+    if (
+      accountAt(message, instruction.programAddressIndex) !== SYSTEM_PROGRAM
+    ) {
+      return false;
+    }
+    // System Program transfer discriminator (4-byte u32 LE = 2),
+    // followed by a u64 LE lamports value (8 bytes). Total 12 bytes.
+    if (instruction.data.length < 12) {
+      return false;
+    }
+    const view = new DataView(
+      instruction.data.buffer,
+      instruction.data.byteOffset,
+      instruction.data.byteLength,
+    );
+    if (view.getUint32(0, true) !== 2) {
+      return false;
+    }
+    if (instruction.accountIndices.length < 2) {
+      return false;
+    }
+    const destination = accountAt(message, instruction.accountIndices[1]);
+    const amount = view.getBigUint64(4, true);
+    return destination === expected.destination && amount === expected.amount;
+  });
+  expect(
+    match,
+    `missing system transfer destination=${expected.destination} amount=${expected.amount}`,
+  ).toBeDefined();
 }
 
 async function fetchTransactionBase64(
@@ -575,13 +748,22 @@ function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
 async function splitBalances(
   surfnet: Surfnet,
   scenario: InteropScenario,
-  mint: string,
+  mint: string | null,
   tokenProgram: string,
   missingAsZero: boolean,
 ): Promise<Record<string, bigint>> {
   const balances: Record<string, bigint> = {};
   for (const split of scenario.splits ?? []) {
     const recipient = splitRecipients[split.recipientKey];
+    if (isSolNative(scenario)) {
+      balances[split.recipientKey] = await getLamportBalance(surfnet, recipient);
+      continue;
+    }
+    if (!mint) {
+      throw new Error(
+        `Scenario ${scenario.id} has splits but no on-chain mint`,
+      );
+    }
     balances[split.recipientKey] = await getTokenBalance(
       surfnet,
       recipient,

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -381,9 +381,12 @@ describe("mpp interop", () => {
               ).toEqual(expectedSplitDeltas(scenario));
             } else {
               expect(result.ok, JSON.stringify(result, null, 2)).toBe(false);
-              if (!isSolNative(scenario)) {
-                expect(finalBalance - initialBalance).toBe(0n);
-              }
+              // Lamport balances are always accessible (unlike SPL token
+              // accounts, which can be missing when a 402 fires before
+              // any ATA creation), so assert zero delta for SOL-native
+              // 402s too. Catches a future SOL-native scenario that
+              // accidentally triggers a transfer despite returning 402.
+              expect(finalBalance - initialBalance).toBe(0n);
               expect(
                 splitDeltas(initialSplitBalances, finalSplitBalances),
               ).toEqual(expectedZeroSplitDeltas(scenario));

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -28,6 +28,22 @@ function tokenProgramAddress(
   return variant === "TOKEN_2022_PROGRAM" ? TOKEN_2022_PROGRAM : TOKEN_PROGRAM;
 }
 
+// The on-chain mint pubkey for a scenario. In pubkey mode this is just
+// `scenario.asset`. In symbol mode the harness sends a stablecoin symbol
+// to adapters and the on-chain mint is `scenario.expectedMint` (the
+// pubkey each SDK's resolver is expected to return).
+function onChainMintFor(scenario: InteropScenario): string {
+  if (scenario.currencyMode === "symbol") {
+    if (!scenario.expectedMint) {
+      throw new Error(
+        `Scenario ${scenario.id} uses symbol mode but does not set expectedMint`,
+      );
+    }
+    return scenario.expectedMint;
+  }
+  return scenario.asset;
+}
+
 const runningServers: RunningServer[] = [];
 
 let surfnet: Surfnet | undefined;
@@ -109,23 +125,25 @@ beforeAll(async () => {
 
   // Deploy every mint referenced by an active scenario under the right token
   // program. Without this, Token-2022 scenarios would have to share the legacy
-  // mint owner and the verifier would reject every transfer.
+  // mint owner and the verifier would reject every transfer. Symbol-mode
+  // scenarios deploy at `expectedMint`, not at the literal asset string.
   const uniqueMints = new Map<string, "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM">();
   for (const scenario of activeScenarios) {
     const variant = scenario.tokenProgram ?? "TOKEN_PROGRAM";
-    const existing = uniqueMints.get(scenario.asset);
+    const mintPubkey = onChainMintFor(scenario);
+    const existing = uniqueMints.get(mintPubkey);
     if (existing && existing !== variant) {
       throw new Error(
-        `Conflicting tokenProgram for asset ${scenario.asset}: ${existing} vs ${variant} (scenario ${scenario.id})`,
+        `Conflicting tokenProgram for mint ${mintPubkey}: ${existing} vs ${variant} (scenario ${scenario.id})`,
       );
     }
-    uniqueMints.set(scenario.asset, variant);
+    uniqueMints.set(mintPubkey, variant);
   }
-  for (const [asset, variant] of uniqueMints) {
+  for (const [mintPubkey, variant] of uniqueMints) {
     const programAddress = tokenProgramAddress(variant);
-    surfnet.setAccount(asset, 1_461_600, createSplMintAccountData(6), programAddress);
-    surfnet.fundToken(client.publicKey, asset, 100_000, programAddress);
-    surfnet.fundToken(payTo.publicKey, asset, 1, programAddress);
+    surfnet.setAccount(mintPubkey, 1_461_600, createSplMintAccountData(6), programAddress);
+    surfnet.fundToken(client.publicKey, mintPubkey, 100_000, programAddress);
+    surfnet.fundToken(payTo.publicKey, mintPubkey, 1, programAddress);
   }
 
   splitRecipients = {
@@ -187,16 +205,20 @@ describe("mpp interop", () => {
 
             const scenarioEnv = environmentForScenario(interopEnv, scenario);
             const scenarioTokenProgram = tokenProgramAddress(scenario.tokenProgram);
+            // On-chain mint pubkey (resolved expectedMint in symbol mode,
+            // literal asset in pubkey mode). The literal in scenarioEnv goes
+            // to the adapter so the SDK's resolver is exercised end-to-end.
+            const onChainMint = onChainMintFor(scenario);
             const initialBalance = await getTokenBalance(
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
             );
             const initialSplitBalances = await splitBalances(
               surfnet,
               scenario,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
               true,
             );
@@ -214,13 +236,13 @@ describe("mpp interop", () => {
             const finalBalance = await getTokenBalance(
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
             );
             const finalSplitBalances = await splitBalances(
               surfnet,
               scenario,
-              scenarioEnv.MPP_INTEROP_MINT,
+              onChainMint,
               scenarioTokenProgram,
               false,
             );
@@ -316,15 +338,16 @@ async function expectSettledTransactionShape(
   const expectedTransferCount = 1 + (scenario.splits?.length ?? 0);
   const primaryAmount = primaryDelta(scenario);
   const tokenProgram = tokenProgramAddress(scenario.tokenProgram);
+  const onChainMint = onChainMintFor(scenario);
   expectSplTransferChecked(
     message,
     {
       destination: surfnet.getAta(
         scenarioEnv.MPP_INTEROP_PAY_TO,
-        scenarioEnv.MPP_INTEROP_MINT,
+        onChainMint,
         tokenProgram,
       ),
-      mint: scenarioEnv.MPP_INTEROP_MINT,
+      mint: onChainMint,
       amount: primaryAmount,
       decimals: 6,
       tokenProgram,
@@ -336,14 +359,14 @@ async function expectSettledTransactionShape(
     const recipient = splitRecipients[split.recipientKey];
     const destination = surfnet.getAta(
       recipient,
-      scenarioEnv.MPP_INTEROP_MINT,
+      onChainMint,
       tokenProgram,
     );
     expectSplTransferChecked(
       message,
       {
         destination,
-        mint: scenarioEnv.MPP_INTEROP_MINT,
+        mint: onChainMint,
         amount: BigInt(split.amount),
         decimals: 6,
         tokenProgram,
@@ -355,7 +378,7 @@ async function expectSettledTransactionShape(
       expectIdempotentAtaCreation(message, {
         ata: destination,
         owner: recipient,
-        mint: scenarioEnv.MPP_INTEROP_MINT,
+        mint: onChainMint,
         tokenProgram,
       });
     }
@@ -367,7 +390,7 @@ async function expectSettledTransactionShape(
 
   expectTransferCheckedCount(
     message,
-    scenarioEnv.MPP_INTEROP_MINT,
+    onChainMint,
     expectedTransferCount,
     tokenProgram,
   );

--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -17,9 +17,16 @@ import { runClient, startServer, stopServer } from "../src/process";
 type RunningServer = Awaited<ReturnType<typeof startServer>>;
 
 const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 const ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const MINT_ACCOUNT_SIZE = 82;
+
+function tokenProgramAddress(
+  variant: "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM" | undefined,
+): string {
+  return variant === "TOKEN_2022_PROGRAM" ? TOKEN_2022_PROGRAM : TOKEN_PROGRAM;
+}
 
 const runningServers: RunningServer[] = [];
 
@@ -53,10 +60,11 @@ async function getTokenBalance(
   surfnet: Surfnet,
   owner: string,
   mint: string,
+  tokenProgram: string,
   missingAsZero = false,
 ): Promise<bigint> {
   const rpc = createSolanaRpc(surfnet.rpcUrl);
-  const ata = surfnet.getAta(owner, mint);
+  const ata = surfnet.getAta(owner, mint, tokenProgram);
   try {
     const response = await rpc.getTokenAccountBalance(ata as never).send();
     return BigInt(response.value.amount);
@@ -99,14 +107,26 @@ beforeAll(async () => {
   const payTo = Surfnet.newKeypair();
   const platform = Surfnet.newKeypair();
 
-  surfnet.setAccount(
-    baseScenario.asset,
-    1_461_600,
-    createSplMintAccountData(6),
-    TOKEN_PROGRAM,
-  );
-  surfnet.fundToken(client.publicKey, baseScenario.asset, 100_000);
-  surfnet.fundToken(payTo.publicKey, baseScenario.asset, 1);
+  // Deploy every mint referenced by an active scenario under the right token
+  // program. Without this, Token-2022 scenarios would have to share the legacy
+  // mint owner and the verifier would reject every transfer.
+  const uniqueMints = new Map<string, "TOKEN_PROGRAM" | "TOKEN_2022_PROGRAM">();
+  for (const scenario of activeScenarios) {
+    const variant = scenario.tokenProgram ?? "TOKEN_PROGRAM";
+    const existing = uniqueMints.get(scenario.asset);
+    if (existing && existing !== variant) {
+      throw new Error(
+        `Conflicting tokenProgram for asset ${scenario.asset}: ${existing} vs ${variant} (scenario ${scenario.id})`,
+      );
+    }
+    uniqueMints.set(scenario.asset, variant);
+  }
+  for (const [asset, variant] of uniqueMints) {
+    const programAddress = tokenProgramAddress(variant);
+    surfnet.setAccount(asset, 1_461_600, createSplMintAccountData(6), programAddress);
+    surfnet.fundToken(client.publicKey, asset, 100_000, programAddress);
+    surfnet.fundToken(payTo.publicKey, asset, 1, programAddress);
+  }
 
   splitRecipients = {
     platform: platform.publicKey,
@@ -166,15 +186,18 @@ describe("mpp interop", () => {
             }
 
             const scenarioEnv = environmentForScenario(interopEnv, scenario);
+            const scenarioTokenProgram = tokenProgramAddress(scenario.tokenProgram);
             const initialBalance = await getTokenBalance(
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
             );
             const initialSplitBalances = await splitBalances(
               surfnet,
               scenario,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
               true,
             );
 
@@ -192,11 +215,13 @@ describe("mpp interop", () => {
               surfnet,
               scenarioEnv.MPP_INTEROP_PAY_TO,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
             );
             const finalSplitBalances = await splitBalances(
               surfnet,
               scenario,
               scenarioEnv.MPP_INTEROP_MINT,
+              scenarioTokenProgram,
               false,
             );
 
@@ -245,6 +270,7 @@ function environmentForScenario(
   return {
     ...baseEnv,
     MPP_INTEROP_AMOUNT: scenario.amount,
+    MPP_INTEROP_MINT: scenario.asset,
     MPP_INTEROP_NETWORK: scenario.network,
     MPP_INTEROP_PRICE: scenario.price,
     MPP_INTEROP_RESOURCE_PATH: scenario.resourcePath,
@@ -289,23 +315,30 @@ async function expectSettledTransactionShape(
   const matchedInstructions = new Set<number>();
   const expectedTransferCount = 1 + (scenario.splits?.length ?? 0);
   const primaryAmount = primaryDelta(scenario);
+  const tokenProgram = tokenProgramAddress(scenario.tokenProgram);
   expectSplTransferChecked(
     message,
     {
       destination: surfnet.getAta(
         scenarioEnv.MPP_INTEROP_PAY_TO,
         scenarioEnv.MPP_INTEROP_MINT,
+        tokenProgram,
       ),
       mint: scenarioEnv.MPP_INTEROP_MINT,
       amount: primaryAmount,
       decimals: 6,
+      tokenProgram,
     },
     matchedInstructions,
   );
 
   for (const split of scenario.splits ?? []) {
     const recipient = splitRecipients[split.recipientKey];
-    const destination = surfnet.getAta(recipient, scenarioEnv.MPP_INTEROP_MINT);
+    const destination = surfnet.getAta(
+      recipient,
+      scenarioEnv.MPP_INTEROP_MINT,
+      tokenProgram,
+    );
     expectSplTransferChecked(
       message,
       {
@@ -313,6 +346,7 @@ async function expectSettledTransactionShape(
         mint: scenarioEnv.MPP_INTEROP_MINT,
         amount: BigInt(split.amount),
         decimals: 6,
+        tokenProgram,
       },
       matchedInstructions,
     );
@@ -322,6 +356,7 @@ async function expectSettledTransactionShape(
         ata: destination,
         owner: recipient,
         mint: scenarioEnv.MPP_INTEROP_MINT,
+        tokenProgram,
       });
     }
 
@@ -330,7 +365,12 @@ async function expectSettledTransactionShape(
     }
   }
 
-  expectTransferCheckedCount(message, scenarioEnv.MPP_INTEROP_MINT, expectedTransferCount);
+  expectTransferCheckedCount(
+    message,
+    scenarioEnv.MPP_INTEROP_MINT,
+    expectedTransferCount,
+    tokenProgram,
+  );
 }
 
 async function fetchTransactionBase64(
@@ -390,6 +430,7 @@ function expectSplTransferChecked(
     mint: string;
     amount: bigint;
     decimals: number;
+    tokenProgram: string;
   },
   matchedInstructions: Set<number>,
 ): void {
@@ -397,7 +438,9 @@ function expectSplTransferChecked(
     if (matchedInstructions.has(index)) {
       return false;
     }
-    if (accountAt(message, instruction.programAddressIndex) !== TOKEN_PROGRAM) {
+    if (
+      accountAt(message, instruction.programAddressIndex) !== expected.tokenProgram
+    ) {
       return false;
     }
     if (instruction.data[0] !== 12) {
@@ -430,6 +473,7 @@ function expectIdempotentAtaCreation(
     ata: string;
     owner: string;
     mint: string;
+    tokenProgram: string;
   },
 ): void {
   const match = message.instructions.find((instruction) => {
@@ -444,7 +488,7 @@ function expectIdempotentAtaCreation(
       accountAt(message, instruction.accountIndices[2]) === expected.owner &&
       accountAt(message, instruction.accountIndices[3]) === expected.mint &&
       accountAt(message, instruction.accountIndices[4]) === SYSTEM_PROGRAM &&
-      accountAt(message, instruction.accountIndices[5]) === TOKEN_PROGRAM
+      accountAt(message, instruction.accountIndices[5]) === expected.tokenProgram
     );
   });
 
@@ -458,9 +502,10 @@ function expectTransferCheckedCount(
   message: CompiledMessage,
   mint: string,
   expectedCount: number,
+  tokenProgram: string,
 ): void {
   const transfers = message.instructions.filter((instruction) => {
-    if (accountAt(message, instruction.programAddressIndex) !== TOKEN_PROGRAM) {
+    if (accountAt(message, instruction.programAddressIndex) !== tokenProgram) {
       return false;
     }
     if (instruction.data[0] !== 12 || instruction.accountIndices.length < 4) {
@@ -508,6 +553,7 @@ async function splitBalances(
   surfnet: Surfnet,
   scenario: InteropScenario,
   mint: string,
+  tokenProgram: string,
   missingAsZero: boolean,
 ): Promise<Record<string, bigint>> {
   const balances: Record<string, bigint> = {};
@@ -517,6 +563,7 @@ async function splitBalances(
       surfnet,
       recipient,
       mint,
+      tokenProgram,
       missingAsZero,
     );
   }

--- a/tests/interop/test/intent-selection.test.ts
+++ b/tests/interop/test/intent-selection.test.ts
@@ -28,6 +28,14 @@ describe("interop scenario selection", () => {
       "charge-split-ata",
       "charge-network-mismatch",
       "charge-cross-route-replay",
+      "charge-symbol-usdc-localnet",
+      "charge-token2022-split-ata",
+      "charge-decimals-9",
+      "charge-split-ata-idempotent",
+      "charge-compute-budget-over-cap",
+      "charge-sol-native",
+      "charge-splits-too-many",
+      "charge-splits-sum-equals-amount",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Closes five harness gaps from the audit v2 plan (`notes/2026-05-22-interop-coverage-audit-v2.md`, §4) without any SDK locking changes. The PR is harness-only.

Gaps closed:
- G07 decimals other than 6: `charge-decimals-9`.
- G13 ATA already exists (idempotent no-op): `charge-split-ata-idempotent`.
- G14 compute budget over-cap: `charge-compute-budget-over-cap`.
- G27 SOL native transfer: `charge-sol-native`.
- G28 splits bounds: `charge-splits-too-many` and `charge-splits-sum-equals-amount`.

This PR also picks up the two harness foundation commits from #96 (Token-2022 base scenario, symbol-mode harness with `onChainMintFor`), excluding the TS spine prettier reformat conflicts and the PHP `mainnet-beta` alias change (the latter conflicts on `php/src/Common/StablecoinMints.php`, which is part of #96 and not yet on `main`). The remaining ten commits of #96 (SDK locking work) are independent and stay queued behind that PR.

## Deliberate exclusions (separate PRs)

- G03 push mode end-to-end: needs a new client variant (pre-broadcast + signature credential) in both `tests/interop/ts-client/` and `tests/interop/rust-client/`. Separate PR.
- G09 confirmation timeout via fault-inject proxy: the proxy is its own design surface (per-method rules, count/every semantics, state reset between tests). Audit v2 §6. Separate PR.
- G15 multi-challenge `WWW-Authenticate`: depends on the RFC conformance PR landing the quote-aware splitter in Ruby/PHP/Lua. Separate PR.

## Changes

- `tests/interop/src/contracts.ts`: extend `InteropScenario` with `decimals`, `preCreatePlatformAta`, `clientComputeUnitLimit`, `clientComputeUnitPrice`, `assetKind` (`spl` default, `sol` for native).
- `tests/interop/test/e2e.test.ts`:
  - `onChainMintFor` returns `string | null` (null for SOL-native).
  - `scenarioDecimals` helper; mint deploy loop refuses to deploy the same pubkey under conflicting `tokenProgram` or `decimals` across scenarios.
  - `getPrimaryRecipientBalance` and `splitBalances` dispatch on SOL vs SPL; the latter treats a missing recipient ATA as zero balance for 402 scenarios.
  - `expectSystemProgramTransfer` checks System Program transfer (u32 LE discriminator = 2) for SOL-native scenarios; SPL path now reads decimals from the scenario instead of hardcoding 6.
  - `beforeAll` pre-creates the platform recipient ATA when `preCreatePlatformAta` is set, and funds client lamports via `surfnet.fundSol` when any scenario is SOL-native.
  - `environmentForScenario` threads `MPP_INTEROP_DECIMALS`, `MPP_INTEROP_ASSET_KIND`, `MPP_INTEROP_COMPUTE_UNIT_LIMIT`, `MPP_INTEROP_COMPUTE_UNIT_PRICE` to adapters.
- `tests/interop/src/fixtures/typescript/{shared,charge-client,charge-server}.ts`:
  - `InteropEnvironment` gains `decimals`, `assetKind`, `computeUnitLimit`, `computeUnitPrice`.
  - Server passes `currency = "sol"` when `assetKind` is sol and `decimals = environment.decimals` to `solana.charge`.
  - Client threads `computeUnitLimit`/`computeUnitPrice` to `solana.charge`.
  - Narrow allowlists translate two specific SDK construct/build-time rejections (G28a `splits cannot exceed`, G28b `Splits consume the entire amount`, plus `Missing WWW-Authenticate header` symptom of G28a server response) to synthetic 402 results. Every other error rethrows so the harness sees a real failure.
- `rust/src/bin/interop_server.rs`: read `MPP_INTEROP_DECIMALS` from env, fallback 6.
- `tests/interop/src/intents/charge.ts`: five new scenarios.
- `tests/interop/test/intent-selection.test.ts`: updated to match the new scenario list.

## Test plan

All commands run from `tests/interop/`. Cited line is the literal `Test Files`/`Tests` line printed by vitest.

- `pnpm typecheck` -> exits 0 (clean tsc --noEmit).
- `MPP_INTEROP_SERVERS=typescript MPP_INTEROP_CLIENTS=typescript pnpm test`
  -> `Test Files  3 passed (3)`, `Tests  19 passed (19)`. All five new scenarios green against TS server + TS client, plus the seven existing scenarios.
- `MPP_INTEROP_SERVERS=typescript,rust MPP_INTEROP_CLIENTS=typescript,rust pnpm test`
  -> `Test Files  3 passed (3)`, `Tests  41 passed (41)`. Full TS+Rust cross matrix.
- `MPP_INTEROP_SERVERS=typescript MPP_INTEROP_CLIENTS=rust MPP_INTEROP_SCENARIOS=charge-basic,charge-split-ata-idempotent,charge-decimals-9,charge-sol-native pnpm test`
  -> `Tests  11 passed (11)`. Rust client to TS server, including SOL native and decimals 9.
- `MPP_INTEROP_SERVERS=rust MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SCENARIOS=charge-basic,charge-split-ata-idempotent,charge-compute-budget-over-cap,charge-splits-too-many,charge-splits-sum-equals-amount pnpm test`
  -> `Tests  12 passed (12)`. TS client to Rust server.
- `MPP_INTEROP_SERVERS=php,ruby MPP_INTEROP_CLIENTS=typescript MPP_INTEROP_SCENARIOS=charge-basic,charge-split-ata,charge-split-ata-idempotent,charge-compute-budget-over-cap,charge-splits-too-many,charge-splits-sum-equals-amount pnpm test`
  -> `Tests  19 passed (19)`. TS client to PHP and Ruby servers exercising G13, G14, G28.

Scenario-level coverage by server:
- `charge-decimals-9` (G07): `serverIds: ["typescript"]`. The Rust interop_server fixture computes amount as `price * 10^decimals` which diverges from the env-driven TS fixture; aligning the two is a separate concern. The Rust SDK is still exercised via the Rust client against the TS server. Rust server now reads `MPP_INTEROP_DECIMALS` (default 6) so future scenarios can use it.
- `charge-sol-native` (G27): `serverIds: ["typescript"]`. Rust/Ruby/PHP server fixtures pass `MPP_INTEROP_MINT` directly to the SDK and would need fixture changes to thread `currency="sol"`. The TS server already supports `currency: "sol"` natively via the SDK.
- `charge-split-ata-idempotent` (G13), `charge-compute-budget-over-cap` (G14), `charge-splits-too-many` and `charge-splits-sum-equals-amount` (G28): green against TS, Rust, PHP, Ruby servers.
- `charge-compute-budget-over-cap`, `charge-splits-too-many`, `charge-splits-sum-equals-amount`: `clientIds: ["typescript"]` because the env-driven Rust client cannot inject custom compute budget or override the splits array shape sent in the challenge.

## Codex review

`codex exec --skip-git-repo-check --sandbox read-only` flagged two real findings on an earlier revision: the TS client and server fixtures used overly broad try/catch that could mask unrelated SDK regressions. Addressed in commit `e35b919` by narrowing the allowlist to the exact error-message symptoms tied to G28a/G28b. No remaining Codex findings.

## Cherry-picked from #96 (rebase-friendly)

- `56a7384 test(interop): exercise Token-2022 in the charge harness`
- `2d8d5a2 test(interop): add symbol-mode harness and a charge-symbol-usdc-localnet scenario` (TS spine prettier conflict resolved with --ours)

The remaining ten #96 commits are the SDK locking work (PHP memo v1 drop, replay store, consume-signature ordering, Lua hardening, canonical network slug, etc.) and stay independent of this harness PR.