### PR TITLE
fix(php,ruby,lua): RFC conformance for auth params, canonical JSON, multi-challenge, RFC 3339

### DIFF
--- a/lua/mpp/expires.lua
+++ b/lua/mpp/expires.lua
@@ -10,10 +10,32 @@ local function days_from_civil(year, month, day)
   return era * 146097 + doe - 719468
 end
 
+local function days_in_month(year, month)
+  if month == 2 then
+    local leap = (year % 4 == 0 and year % 100 ~= 0) or (year % 400 == 0)
+    return leap and 29 or 28
+  end
+  if month == 4 or month == 6 or month == 9 or month == 11 then
+    return 30
+  end
+  return 31
+end
+
+-- Strict RFC 3339 date-time grammar (sec 5.6).
+-- Accepts: T/t separator, Z/z or +/-HH:MM offset, optional 1..9 digit fractional seconds.
+-- Rejects: missing time-offset, lowercase compat from older parser only, calendar dates that do not exist, year > 9999.
 function M.parse_rfc3339(value)
-  local year, month, day, hour, min, sec = value:match('^(%d%d%d%d)%-(%d%d)%-(%d%d)T(%d%d):(%d%d):(%d%d)Z$')
+  if type(value) ~= 'string' then
+    return nil, 'invalid RFC3339 timestamp'
+  end
+  local year, month, day, hour, min, sec, frac, offset = value:match(
+    '^(%d%d%d%d)%-(%d%d)%-(%d%d)[Tt](%d%d):(%d%d):(%d%d)%.?(%d*)([Zz%+%-][%d:]*)$'
+  )
   if not year then
     return nil, 'invalid RFC3339 timestamp'
+  end
+  if #frac > 9 then
+    return nil, 'fractional seconds exceed 9 digits'
   end
   year = tonumber(year)
   month = tonumber(month)
@@ -22,12 +44,40 @@ function M.parse_rfc3339(value)
   min = tonumber(min)
   sec = tonumber(sec)
 
-  if month < 1 or month > 12 or day < 1 or day > 31 or hour > 23 or min > 59 or sec > 60 then
-    return nil, 'invalid RFC3339 timestamp'
+  if year > 9999 then
+    return nil, 'invalid RFC3339 year'
+  end
+  if month < 1 or month > 12 then
+    return nil, 'invalid RFC3339 month'
+  end
+  if hour > 23 or min > 59 or sec > 59 then
+    return nil, 'invalid RFC3339 time-of-day'
+  end
+  if day < 1 or day > days_in_month(year, month) then
+    return nil, 'invalid RFC3339 calendar date'
+  end
+
+  local offset_secs = 0
+  if offset == 'Z' or offset == 'z' then
+    offset_secs = 0
+  else
+    local sign, oh, om = offset:match('^([%+%-])(%d%d):(%d%d)$')
+    if not sign then
+      return nil, 'invalid RFC3339 offset'
+    end
+    oh = tonumber(oh)
+    om = tonumber(om)
+    if oh > 23 or om > 59 then
+      return nil, 'invalid RFC3339 offset'
+    end
+    offset_secs = (oh * 60 + om) * 60
+    if sign == '+' then
+      offset_secs = -offset_secs
+    end
   end
 
   local days = days_from_civil(year, month, day)
-  return ((days * 24 + hour) * 60 + min) * 60 + sec
+  return ((days * 24 + hour) * 60 + min) * 60 + sec + offset_secs
 end
 
 function M.is_expired(value, now_epoch)

--- a/lua/mpp/init.lua
+++ b/lua/mpp/init.lua
@@ -42,4 +42,5 @@ return {
   ParseReceipt = headers.parse_receipt,
   ParseUnits = intents.parse_units,
   ParseWWWAuthenticate = headers.parse_www_authenticate,
+  ParseWWWAuthenticateAll = headers.parse_www_authenticate_all,
 }

--- a/lua/mpp/protocol/core/headers.lua
+++ b/lua/mpp/protocol/core/headers.lua
@@ -79,14 +79,84 @@ local function parse_auth_params(input)
   return params
 end
 
-function M.extract_payment_scheme(header)
-  for part in header:gmatch('[^,]+') do
-    local trimmed = part:gsub('^%s+', ''):gsub('%s+$', '')
-    if trimmed:sub(1, #M.PAYMENT_SCHEME + 1):lower() == string.lower(M.PAYMENT_SCHEME) .. ' ' then
-      return trimmed
+-- Quote-aware split of a WWW-Authenticate header value into individual `Payment` chunks (RFC 7235 sec 4.1).
+local function split_payment_challenge_values(header)
+  local len = #header
+  local starts = {}
+  local in_quote = false
+  local escaped = false
+  local i = 1
+  local scheme = M.PAYMENT_SCHEME
+  local slen = #scheme
+
+  local function is_scheme_start(pos)
+    if pos + slen > len then return false end
+    if header:sub(pos, pos + slen - 1):lower() ~= scheme:lower() then return false end
+    local nxt = header:sub(pos + slen, pos + slen)
+    if nxt ~= ' ' and nxt ~= '\t' then return false end
+    local prev = pos - 1
+    while prev >= 1 and (header:sub(prev, prev) == ' ' or header:sub(prev, prev) == '\t') do
+      prev = prev - 1
+    end
+    return prev < 1 or header:sub(prev, prev) == ','
+  end
+
+  while i <= len do
+    local ch = header:sub(i, i)
+    if in_quote then
+      if escaped then
+        escaped = false
+      elseif ch == '\\' then
+        escaped = true
+      elseif ch == '"' then
+        in_quote = false
+      end
+      i = i + 1
+    elseif ch == '"' then
+      in_quote = true
+      i = i + 1
+    elseif is_scheme_start(i) then
+      starts[#starts + 1] = i
+      i = i + slen
+    else
+      i = i + 1
     end
   end
-  return nil
+
+  if #starts == 0 then
+    return {}
+  end
+
+  local chunks = {}
+  for idx, start in ipairs(starts) do
+    local finish = starts[idx + 1] and (starts[idx + 1] - 1) or len
+    local chunk = header:sub(start, finish):gsub('^%s+', ''):gsub('%s+$', '')
+    chunk = chunk:gsub(',%s*$', '')
+    if chunk ~= '' then
+      chunks[#chunks + 1] = chunk
+    end
+  end
+  return chunks
+end
+
+function M.split_payment_challenge_values(header)
+  return split_payment_challenge_values(header)
+end
+
+function M.extract_payment_scheme(header)
+  local chunks = split_payment_challenge_values(header)
+  return chunks[1]
+end
+
+function M.parse_www_authenticate_all(headers)
+  local list = type(headers) == 'string' and { headers } or headers
+  local results = {}
+  for _, h in ipairs(list) do
+    for _, chunk in ipairs(split_payment_challenge_values(h)) do
+      results[#results + 1] = M.parse_www_authenticate(chunk)
+    end
+  end
+  return results
 end
 
 function M.parse_www_authenticate(header)

--- a/lua/mpp/protocol/core/headers.lua
+++ b/lua/mpp/protocol/core/headers.lua
@@ -148,12 +148,18 @@ function M.extract_payment_scheme(header)
   return chunks[1]
 end
 
+-- Parse all `Payment` challenges across one or more WWW-Authenticate values (RFC 7235 sec 4.1).
+-- Returns only successfully-parsed challenges; malformed individual challenges are skipped, mirroring
+-- the Rust spine which exposes Vec<Result<PaymentChallenge, Error>> and filters at the call site.
 function M.parse_www_authenticate_all(headers)
   local list = type(headers) == 'string' and { headers } or headers
   local results = {}
   for _, h in ipairs(list) do
     for _, chunk in ipairs(split_payment_challenge_values(h)) do
-      results[#results + 1] = M.parse_www_authenticate(chunk)
+      local ok, value = pcall(M.parse_www_authenticate, chunk)
+      if ok then
+        results[#results + 1] = value
+      end
     end
   end
   return results

--- a/lua/mpp/util/json.lua
+++ b/lua/mpp/util/json.lua
@@ -21,19 +21,157 @@ local function is_array(value)
   return max == count
 end
 
+-- Decode a UTF-8 byte string into a list of codepoints.
+-- Returns nil and error message for invalid UTF-8 or lone surrogates.
+local function utf8_codepoints(value)
+  local out = {}
+  local i = 1
+  local len = #value
+  while i <= len do
+    local b1 = value:byte(i)
+    local cp
+    local advance
+    if b1 < 0x80 then
+      cp = b1
+      advance = 1
+    elseif b1 < 0xC2 then
+      return nil, 'invalid UTF-8 lead byte'
+    elseif b1 < 0xE0 then
+      if i + 1 > len then return nil, 'truncated UTF-8' end
+      local b2 = value:byte(i + 1)
+      if b2 < 0x80 or b2 >= 0xC0 then return nil, 'invalid UTF-8 continuation' end
+      cp = (b1 - 0xC0) * 64 + (b2 - 0x80)
+      advance = 2
+    elseif b1 < 0xF0 then
+      if i + 2 > len then return nil, 'truncated UTF-8' end
+      local b2, b3 = value:byte(i + 1), value:byte(i + 2)
+      if b2 < 0x80 or b2 >= 0xC0 or b3 < 0x80 or b3 >= 0xC0 then return nil, 'invalid UTF-8 continuation' end
+      cp = (b1 - 0xE0) * 4096 + (b2 - 0x80) * 64 + (b3 - 0x80)
+      if cp >= 0xD800 and cp <= 0xDFFF then return nil, 'lone surrogate' end
+    advance = 3
+    elseif b1 < 0xF5 then
+      if i + 3 > len then return nil, 'truncated UTF-8' end
+      local b2, b3, b4 = value:byte(i + 1), value:byte(i + 2), value:byte(i + 3)
+      if b2 < 0x80 or b2 >= 0xC0 or b3 < 0x80 or b3 >= 0xC0 or b4 < 0x80 or b4 >= 0xC0 then return nil, 'invalid UTF-8 continuation' end
+      cp = (b1 - 0xF0) * 262144 + (b2 - 0x80) * 4096 + (b3 - 0x80) * 64 + (b4 - 0x80)
+      advance = 4
+    else
+      return nil, 'invalid UTF-8 lead byte'
+    end
+    out[#out + 1] = cp
+    i = i + advance
+  end
+  return out
+end
+
 local function encode_string(value)
-  local replacements = {
-    ['\\'] = '\\\\',
-    ['"'] = '\\"',
-    ['\b'] = '\\b',
-    ['\f'] = '\\f',
-    ['\n'] = '\\n',
-    ['\r'] = '\\r',
-    ['\t'] = '\\t',
-  }
-  return '"' .. value:gsub('[%z\1-\31\\"]', function(ch)
-    return replacements[ch] or string.format('\\u%04x', ch:byte())
-  end) .. '"'
+  local cps, err = utf8_codepoints(value)
+  if not cps then
+    error('cannot encode string: ' .. err)
+  end
+  local buf = { '"' }
+  for _, cp in ipairs(cps) do
+    if cp == 0x5C then
+      buf[#buf + 1] = '\\\\'
+    elseif cp == 0x22 then
+      buf[#buf + 1] = '\\"'
+    elseif cp == 0x08 then
+      buf[#buf + 1] = '\\b'
+    elseif cp == 0x09 then
+      buf[#buf + 1] = '\\t'
+    elseif cp == 0x0A then
+      buf[#buf + 1] = '\\n'
+    elseif cp == 0x0C then
+      buf[#buf + 1] = '\\f'
+    elseif cp == 0x0D then
+      buf[#buf + 1] = '\\r'
+    elseif cp < 0x20 then
+      buf[#buf + 1] = string.format('\\u%04x', cp)
+    elseif cp < 0x80 then
+      buf[#buf + 1] = string.char(cp)
+    elseif cp < 0x800 then
+      buf[#buf + 1] = string.char(0xC0 + math.floor(cp / 64), 0x80 + (cp % 64))
+    elseif cp < 0x10000 then
+      buf[#buf + 1] = string.char(
+        0xE0 + math.floor(cp / 4096),
+        0x80 + math.floor(cp / 64) % 64,
+        0x80 + (cp % 64)
+      )
+    else
+      buf[#buf + 1] = string.char(
+        0xF0 + math.floor(cp / 262144),
+        0x80 + math.floor(cp / 4096) % 64,
+        0x80 + math.floor(cp / 64) % 64,
+        0x80 + (cp % 64)
+      )
+    end
+  end
+  buf[#buf + 1] = '"'
+  return table.concat(buf)
+end
+
+-- UTF-16 code-unit comparison for JCS key ordering (RFC 8785 sec 3.2.3).
+local function utf16_units(value)
+  local cps, err = utf8_codepoints(value)
+  if not cps then
+    error('cannot order key: ' .. err)
+  end
+  local units = {}
+  for _, cp in ipairs(cps) do
+    if cp < 0x10000 then
+      units[#units + 1] = cp
+    else
+      local off = cp - 0x10000
+      units[#units + 1] = 0xD800 + math.floor(off / 1024)
+      units[#units + 1] = 0xDC00 + (off % 1024)
+    end
+  end
+  return units
+end
+
+local function compare_utf16(a, b)
+  local au = utf16_units(a)
+  local bu = utf16_units(b)
+  local n = math.min(#au, #bu)
+  for i = 1, n do
+    if au[i] ~= bu[i] then
+      return au[i] < bu[i]
+    end
+  end
+  return #au < #bu
+end
+
+-- ES6 ToString number serialization (ECMA-262 7.1.12.1) for JCS (RFC 8785 sec 3.2.2.3).
+local function encode_number(value)
+  if value ~= value or value == math.huge or value == -math.huge then
+    error('cannot encode non-finite number')
+  end
+  if value == 0 then
+    return '0'
+  end
+  if value == math.floor(value) and math.abs(value) < 1e21 then
+    return string.format('%d', value)
+  end
+  -- Use %.17g for round-trip precision then strip trailing zeros and normalize exponent.
+  local repr = string.format('%.17g', value)
+  -- Try shorter %.15g first if it round-trips; this mirrors most ES6 ToString outputs.
+  local short = string.format('%.15g', value)
+  if tonumber(short) == value then
+    repr = short
+  end
+  local e_idx = repr:find('[eE]')
+  if e_idx then
+    local mantissa = repr:sub(1, e_idx - 1)
+    local exp_str = repr:sub(e_idx + 1)
+    mantissa = mantissa:gsub('0+$', ''):gsub('%.$', '')
+    if mantissa == '' or mantissa == '-' then
+      mantissa = mantissa .. '0'
+    end
+    local exp_int = tonumber(exp_str)
+    local sign = exp_int >= 0 and '+' or '-'
+    return mantissa .. 'e' .. sign .. math.abs(exp_int)
+  end
+  return repr
 end
 
 local function encode_value(value)
@@ -45,11 +183,7 @@ local function encode_value(value)
   elseif kind == 'boolean' then
     return value and 'true' or 'false'
   elseif kind == 'number' then
-    if value ~= value or value == math.huge or value == -math.huge then
-      error('cannot encode non-finite number')
-    end
-    local formatted = string.format('%.14g', value)
-    return formatted
+    return encode_number(value)
   elseif kind == 'string' then
     return encode_string(value)
   elseif kind == 'table' then
@@ -64,7 +198,7 @@ local function encode_value(value)
     for key, _ in pairs(value) do
       keys[#keys + 1] = key
     end
-    table.sort(keys)
+    table.sort(keys, compare_utf16)
     local parts = {}
     for i = 1, #keys do
       local key = keys[i]

--- a/lua/mpp/util/json.lua
+++ b/lua/mpp/util/json.lua
@@ -141,6 +141,57 @@ local function compare_utf16(a, b)
   return #au < #bu
 end
 
+-- Render digits + decimal exponent k as ES6 ToString (ECMA-262 7.1.12.1).
+local function format_es6_number(sign, digits, k)
+  local n = #digits
+  if k >= 0 and k <= 20 then
+    if n <= k + 1 then
+      return sign .. digits .. string.rep('0', k + 1 - n)
+    end
+    return sign .. digits:sub(1, k + 1) .. '.' .. digits:sub(k + 2)
+  end
+  if k < 0 and k > -7 then
+    return sign .. '0.' .. string.rep('0', -k - 1) .. digits
+  end
+  local mantissa = n == 1 and digits or (digits:sub(1, 1) .. '.' .. digits:sub(2))
+  local exp_sign = k >= 0 and '+' or '-'
+  return sign .. mantissa .. 'e' .. exp_sign .. math.abs(k)
+end
+
+-- Return digits, k (decimal exponent of leading digit) for the shortest round-trip decimal of abs(value).
+local function shortest_digits_and_exponent(abs_value)
+  local short = string.format('%.15g', abs_value)
+  local repr = (tonumber(short) == abs_value) and short or string.format('%.17g', abs_value)
+  local mantissa, exp_str
+  local e_idx = repr:find('[eE]')
+  if e_idx then
+    mantissa = repr:sub(1, e_idx - 1)
+    exp_str = repr:sub(e_idx + 1)
+  else
+    mantissa = repr
+    exp_str = '0'
+  end
+  local exp_int = tonumber(exp_str)
+  local dot_pos = mantissa:find('%.', 1, false)
+  local int_part, frac_part
+  if dot_pos then
+    int_part = mantissa:sub(1, dot_pos - 1)
+    frac_part = mantissa:sub(dot_pos + 1)
+  else
+    int_part = mantissa
+    frac_part = ''
+  end
+  local combined = int_part .. frac_part
+  local stripped = combined:gsub('^0+', '')
+  local leading_zeros = #combined - #stripped
+  local digits = stripped:gsub('0+$', '')
+  if digits == '' then
+    digits = '0'
+  end
+  local decimal_exponent = exp_int + #int_part - 1 - leading_zeros
+  return digits, decimal_exponent
+end
+
 -- ES6 ToString number serialization (ECMA-262 7.1.12.1) for JCS (RFC 8785 sec 3.2.2.3).
 local function encode_number(value)
   if value ~= value or value == math.huge or value == -math.huge then
@@ -149,29 +200,9 @@ local function encode_number(value)
   if value == 0 then
     return '0'
   end
-  if value == math.floor(value) and math.abs(value) < 1e21 then
-    return string.format('%d', value)
-  end
-  -- Use %.17g for round-trip precision then strip trailing zeros and normalize exponent.
-  local repr = string.format('%.17g', value)
-  -- Try shorter %.15g first if it round-trips; this mirrors most ES6 ToString outputs.
-  local short = string.format('%.15g', value)
-  if tonumber(short) == value then
-    repr = short
-  end
-  local e_idx = repr:find('[eE]')
-  if e_idx then
-    local mantissa = repr:sub(1, e_idx - 1)
-    local exp_str = repr:sub(e_idx + 1)
-    mantissa = mantissa:gsub('0+$', ''):gsub('%.$', '')
-    if mantissa == '' or mantissa == '-' then
-      mantissa = mantissa .. '0'
-    end
-    local exp_int = tonumber(exp_str)
-    local sign = exp_int >= 0 and '+' or '-'
-    return mantissa .. 'e' .. sign .. math.abs(exp_int)
-  end
-  return repr
+  local sign = value < 0 and '-' or ''
+  local digits, k = shortest_digits_and_exponent(math.abs(value))
+  return format_es6_number(sign, digits, k)
 end
 
 local function encode_value(value)

--- a/lua/mpp/util/json.lua
+++ b/lua/mpp/util/json.lua
@@ -48,7 +48,7 @@ local function utf8_codepoints(value)
       if b2 < 0x80 or b2 >= 0xC0 or b3 < 0x80 or b3 >= 0xC0 then return nil, 'invalid UTF-8 continuation' end
       cp = (b1 - 0xE0) * 4096 + (b2 - 0x80) * 64 + (b3 - 0x80)
       if cp >= 0xD800 and cp <= 0xDFFF then return nil, 'lone surrogate' end
-    advance = 3
+      advance = 3
     elseif b1 < 0xF5 then
       if i + 3 > len then return nil, 'truncated UTF-8' end
       local b2, b3, b4 = value:byte(i + 1), value:byte(i + 2), value:byte(i + 3)

--- a/lua/tests/core_spec.lua
+++ b/lua/tests/core_spec.lua
@@ -122,3 +122,20 @@ t.test('expires parser is strict RFC 3339', function()
   t.assert_true(expires.parse_rfc3339('2099-13-01T00:00:00Z') == nil)
   t.assert_true(expires.parse_rfc3339('2099-01-01T24:00:00Z') == nil)
 end)
+
+t.test('parse_www_authenticate_all skips malformed challenge and returns valid siblings', function()
+  -- First challenge has invalid base64url in request; second is valid. Should yield one challenge.
+  local header = 'Payment id="bad", realm="r", method="solana", intent="charge", request="!!!", '
+              .. 'Payment id="ok", realm="r", method="solana", intent="charge", request="e30"'
+  local results = mpp.ParseWWWAuthenticateAll(header)
+  t.assert_equal(#results, 1)
+  t.assert_equal(results[1].id, 'ok')
+end)
+
+t.test('canonical JSON ES6 ToString boundary cases', function()
+  local json = require('mpp.util.json')
+  t.assert_equal(json.encode(1e-6), '0.000001')
+  t.assert_equal(json.encode(1e-7), '1e-7')
+  t.assert_equal(json.encode(1e20), '100000000000000000000')
+  t.assert_equal(json.encode(0.1 + 0.2), '0.30000000000000004')
+end)

--- a/lua/tests/core_spec.lua
+++ b/lua/tests/core_spec.lua
@@ -69,3 +69,56 @@ t.test('extract payment scheme ignores other auth parts', function()
   local scheme = mpp.ExtractPaymentScheme('Bearer abc, Payment xyz')
   t.assert_equal(scheme, 'Payment xyz')
 end)
+
+t.test('parse_www_authenticate_all parses multi-challenge header (RFC 7235 sec 4.1)', function()
+  local header = 'Payment id="a", realm="r1", method="solana", intent="charge", request="e30", '
+              .. 'Payment id="b", realm="r2", method="solana", intent="charge", request="e30"'
+  local results = mpp.ParseWWWAuthenticateAll(header)
+  t.assert_equal(#results, 2)
+  t.assert_equal(results[1].id, 'a')
+  t.assert_equal(results[2].id, 'b')
+end)
+
+t.test('parse_www_authenticate_all ignores Payment inside quoted realm', function()
+  local header = 'Payment id="a", realm="api, Payment realm", method="solana", intent="charge", request="e30", '
+              .. 'Payment id="b", realm="r2", method="solana", intent="charge", request="e30"'
+  local results = mpp.ParseWWWAuthenticateAll(header)
+  t.assert_equal(#results, 2)
+  t.assert_equal(results[1].realm, 'api, Payment realm')
+  t.assert_equal(results[2].id, 'b')
+end)
+
+t.test('canonical JSON sorts keys by UTF-16 code units (RFC 8785 sec 3.2.3)', function()
+  local json = require('mpp.util.json')
+  -- 'é' (U+00E9) > 'f' (U+0066) in UTF-16 code-unit order, so 'f' sorts first.
+  local encoded = json.encode({ ['é'] = 1, f = 2 })
+  t.assert_equal(encoded, '{"f":2,"\xC3\xA9":1}')
+end)
+
+t.test('canonical JSON serializes numbers per ES6 ToString', function()
+  local json = require('mpp.util.json')
+  t.assert_equal(json.encode(1e21), '1e+21')
+  t.assert_equal(json.encode(0.1), '0.1')
+  t.assert_equal(json.encode(-0.0), '0')
+  t.assert_equal(json.encode(42), '42')
+end)
+
+t.test('canonical JSON rejects lone surrogates', function()
+  local json = require('mpp.util.json')
+  local lone = string.char(0xED, 0xA0, 0xB4)
+  local ok = pcall(json.encode, { k = lone })
+  t.assert_true(not ok)
+end)
+
+t.test('expires parser is strict RFC 3339', function()
+  local expires = require('mpp.expires')
+  t.assert_true(expires.parse_rfc3339('2099-01-01T00:00:00Z') ~= nil)
+  t.assert_true(expires.parse_rfc3339('2099-01-01T00:00:00+00:00') ~= nil)
+  t.assert_true(expires.parse_rfc3339('2099-01-01T00:00:00.123Z') ~= nil)
+  t.assert_true(expires.parse_rfc3339('2099-01-01t00:00:00z') ~= nil)
+  t.assert_true(expires.parse_rfc3339('tomorrow') == nil)
+  t.assert_true(expires.parse_rfc3339('10000-01-01T00:00:00Z') == nil)
+  t.assert_true(expires.parse_rfc3339('2099-02-30T00:00:00Z') == nil)
+  t.assert_true(expires.parse_rfc3339('2099-13-01T00:00:00Z') == nil)
+  t.assert_true(expires.parse_rfc3339('2099-01-01T24:00:00Z') == nil)
+end)

--- a/php/src/Core/Base64Url.php
+++ b/php/src/Core/Base64Url.php
@@ -44,11 +44,7 @@ final class Base64Url
      */
     public static function encodeJson(array $value): string
     {
-        try {
-            return self::encode(json_encode(self::canonicalizeJson($value), JSON_THROW_ON_ERROR));
-        } catch (JsonException $error) {
-            throw new InvalidArgumentException('Invalid JSON value', previous: $error);
-        }
+        return self::encode(Json::canonicalize($value));
     }
 
     /**
@@ -69,52 +65,6 @@ final class Base64Url
         }
 
         return Json::object($decoded, 'JSON value');
-    }
-
-    /**
-     * @param array<array-key, mixed>|bool|float|int|string|null $value
-     * @return array<array-key, mixed>|bool|float|int|string|null
-     */
-    private static function canonicalizeJson(array|bool|float|int|string|null $value): array|bool|float|int|string|null
-    {
-        if (!is_array($value)) {
-            return self::canonicalizeScalar($value);
-        }
-
-        if (array_is_list($value)) {
-            $items = [];
-            foreach ($value as $nested) {
-                $items[] = is_array($nested) ? self::canonicalizeJson($nested) : self::canonicalizeScalar($nested);
-            }
-
-            return $items;
-        }
-
-        ksort($value, SORT_STRING);
-        foreach ($value as $key => $nested) {
-            unset($value[$key]);
-            $value[(string)$key] = is_array($nested) ? self::canonicalizeJson($nested) : self::canonicalizeScalar($nested);
-        }
-
-        return $value;
-    }
-
-    /**
-     * @return bool|float|int|string|null
-     */
-    private static function canonicalizeScalar(mixed $value): bool|float|int|string|null
-    {
-        if (
-            $value === null ||
-            is_bool($value) ||
-            is_float($value) ||
-            is_int($value) ||
-            is_string($value)
-        ) {
-            return $value;
-        }
-
-        throw new InvalidArgumentException('JSON value must be a scalar, object, or list');
     }
 
     private static function pad(string $value): string

--- a/php/src/Core/Challenge.php
+++ b/php/src/Core/Challenge.php
@@ -108,7 +108,12 @@ final class Challenge
     }
 
     /**
-     * Return true when the challenge expiry is invalid or in the past.
+     * Strict RFC 3339 date-time grammar (sec 5.6); lowercase t/z accepted on parse, year 4 digits.
+     */
+    private const RFC3339_PATTERN = '/^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|z|[+-]\d{2}:\d{2})$/';
+
+    /**
+     * Return true when the challenge expiry is invalid or in the past (fail-closed).
      */
     public function isExpired(?DateTimeImmutable $now = null): bool
     {
@@ -116,7 +121,25 @@ final class Challenge
             return false;
         }
 
-        $expiresAt = DateTimeImmutable::createFromFormat(DATE_ATOM, $this->expires);
+        if (preg_match(self::RFC3339_PATTERN, $this->expires, $m) !== 1) {
+            return true;
+        }
+        $year = (int)$m[1];
+        $month = (int)$m[2];
+        $day = (int)$m[3];
+        $hour = (int)$m[4];
+        $minute = (int)$m[5];
+        $second = (int)$m[6];
+        if ($month < 1 || $month > 12 || $day < 1 || $day > 31 || $hour > 23 || $minute > 59 || $second > 59) {
+            return true;
+        }
+        if ($year > 9999 || !checkdate($month, $day, $year)) {
+            return true;
+        }
+
+        $expiresAt = DateTimeImmutable::createFromFormat(DATE_ATOM, $this->expires)
+            ?: DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sp', $this->expires)
+            ?: DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.up', $this->expires);
         if ($expiresAt === false) {
             return true;
         }

--- a/php/src/Core/Challenge.php
+++ b/php/src/Core/Challenge.php
@@ -108,9 +108,9 @@ final class Challenge
     }
 
     /**
-     * Strict RFC 3339 date-time grammar (sec 5.6); lowercase t/z accepted on parse, year 4 digits.
+     * Strict RFC 3339 date-time grammar (sec 5.6); accepts lowercase t/z on parse, year 4 digits.
      */
-    private const RFC3339_PATTERN = '/^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|z|[+-]\d{2}:\d{2})$/';
+    private const RFC3339_PATTERN = '/^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|z|([+-])(\d{2}):(\d{2}))$/';
 
     /**
      * Return true when the challenge expiry is invalid or in the past (fail-closed).
@@ -130,16 +130,30 @@ final class Challenge
         $hour = (int)$m[4];
         $minute = (int)$m[5];
         $second = (int)$m[6];
+        $offsetTag = $m[8];
         if ($month < 1 || $month > 12 || $day < 1 || $day > 31 || $hour > 23 || $minute > 59 || $second > 59) {
             return true;
         }
         if ($year > 9999 || !checkdate($month, $day, $year)) {
             return true;
         }
+        if ($offsetTag !== 'Z' && $offsetTag !== 'z') {
+            $offHour = isset($m[10]) ? (int)$m[10] : 0;
+            $offMin = isset($m[11]) ? (int)$m[11] : 0;
+            if ($offHour > 23 || $offMin > 59) {
+                return true;
+            }
+        }
 
-        $expiresAt = DateTimeImmutable::createFromFormat(DATE_ATOM, $this->expires)
-            ?: DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sp', $this->expires)
-            ?: DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.up', $this->expires);
+        // Normalize lowercase t/z to uppercase before delegating to DateTimeImmutable (DATE_ATOM is strict).
+        $normalized = strtr($this->expires, ['t' => 'T', 'z' => 'Z']);
+        $expiresAt = DateTimeImmutable::createFromFormat(DATE_ATOM, $normalized);
+        if ($expiresAt === false) {
+            $expiresAt = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.up', $normalized);
+        }
+        if ($expiresAt === false) {
+            $expiresAt = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $normalized);
+        }
         if ($expiresAt === false) {
             return true;
         }

--- a/php/src/Core/Headers.php
+++ b/php/src/Core/Headers.php
@@ -42,6 +42,101 @@ final class Headers
     }
 
     /**
+     * Parse all Payment challenges across one or more WWW-Authenticate header values (RFC 7235 sec 4.1).
+     *
+     * @param iterable<string>|string $headers
+     * @return array<int, Challenge>
+     */
+    public static function parseWwwAuthenticateAll(iterable|string $headers): array
+    {
+        $list = is_string($headers) ? [$headers] : $headers;
+        $challenges = [];
+        foreach ($list as $header) {
+            foreach (self::splitPaymentChallengeValues($header) as $chunk) {
+                $challenges[] = self::parseWwwAuthenticate($chunk);
+            }
+        }
+
+        return $challenges;
+    }
+
+    /**
+     * Split a header value into individual `Payment` challenge chunks (quote-aware).
+     *
+     * @return array<int, string>
+     */
+    private static function splitPaymentChallengeValues(string $header): array
+    {
+        $length = strlen($header);
+        $starts = [];
+        $inQuote = false;
+        $escaped = false;
+        $i = 0;
+        $scheme = self::PAYMENT_SCHEME;
+        $sLen = strlen($scheme);
+
+        while ($i < $length) {
+            $ch = $header[$i];
+            if ($inQuote) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($ch === '\\') {
+                    $escaped = true;
+                } elseif ($ch === '"') {
+                    $inQuote = false;
+                }
+                $i++;
+                continue;
+            }
+            if ($ch === '"') {
+                $inQuote = true;
+                $i++;
+                continue;
+            }
+            if (self::isPaymentSchemeStart($header, $i, $scheme, $sLen, $length)) {
+                $starts[] = $i;
+                $i += $sLen;
+                continue;
+            }
+            $i++;
+        }
+
+        if ($starts === []) {
+            return [];
+        }
+
+        $chunks = [];
+        foreach ($starts as $index => $start) {
+            $end = $starts[$index + 1] ?? $length;
+            $chunk = trim(substr($header, $start, $end - $start));
+            $chunk = rtrim($chunk, ', ');
+            if ($chunk !== '') {
+                $chunks[] = $chunk;
+            }
+        }
+        return $chunks;
+    }
+
+    private static function isPaymentSchemeStart(string $header, int $index, string $scheme, int $sLen, int $length): bool
+    {
+        if ($index + $sLen >= $length) {
+            return false;
+        }
+        if (strcasecmp(substr($header, $index, $sLen), $scheme) !== 0) {
+            return false;
+        }
+        $next = $header[$index + $sLen];
+        if ($next !== ' ' && $next !== "\t") {
+            return false;
+        }
+        $prev = $index - 1;
+        while ($prev >= 0 && ($header[$prev] === ' ' || $header[$prev] === "\t")) {
+            $prev--;
+        }
+        return $prev < 0 || $header[$prev] === ',';
+    }
+
+    /**
      * Parse a WWW-Authenticate header into a Payment challenge.
      */
     public static function parseWwwAuthenticate(string $header): Challenge

--- a/php/src/Core/Headers.php
+++ b/php/src/Core/Headers.php
@@ -44,6 +44,9 @@ final class Headers
     /**
      * Parse all Payment challenges across one or more WWW-Authenticate header values (RFC 7235 sec 4.1).
      *
+     * Returns successfully-parsed challenges; malformed individual challenges are skipped, mirroring the
+     * Rust spine which exposes Vec<Result<PaymentChallenge, Error>> and filters at the call site.
+     *
      * @param iterable<string>|string $headers
      * @return array<int, Challenge>
      */
@@ -53,7 +56,11 @@ final class Headers
         $challenges = [];
         foreach ($list as $header) {
             foreach (self::splitPaymentChallengeValues($header) as $chunk) {
-                $challenges[] = self::parseWwwAuthenticate($chunk);
+                try {
+                    $challenges[] = self::parseWwwAuthenticate($chunk);
+                } catch (InvalidArgumentException) {
+                    // skip malformed challenge, keep parsing siblings
+                }
             }
         }
 

--- a/php/src/Core/Json.php
+++ b/php/src/Core/Json.php
@@ -12,6 +12,156 @@ use InvalidArgumentException;
 final class Json
 {
     /**
+     * Encode a value as RFC 8785 canonical JSON.
+     *
+     * Sorts object keys by UTF-16 code-unit order, serializes numbers per ES6 ToString
+     * (ECMA-262 7.1.12.1), and rejects NaN, Infinity, and lone surrogates.
+     */
+    public static function canonicalize(mixed $value): string
+    {
+        return self::encodeValue($value);
+    }
+
+    private static function encodeValue(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_int($value)) {
+            return (string)$value;
+        }
+        if (is_float($value)) {
+            return self::encodeNumber($value);
+        }
+        if (is_string($value)) {
+            return self::encodeString($value);
+        }
+        if (is_array($value)) {
+            if (array_is_list($value)) {
+                $parts = array_map(fn ($item) => self::encodeValue($item), $value);
+                return '[' . implode(',', $parts) . ']';
+            }
+            return self::encodeObject($value);
+        }
+        throw new InvalidArgumentException('unsupported JSON value');
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function encodeObject(array $value): string
+    {
+        $stringKeyed = [];
+        foreach ($value as $key => $item) {
+            $stringKey = (string)$key;
+            if (array_key_exists($stringKey, $stringKeyed)) {
+                throw new InvalidArgumentException('duplicate object key');
+            }
+            $stringKeyed[$stringKey] = $item;
+        }
+        $keys = array_keys($stringKeyed);
+        usort($keys, static function (string $a, string $b): int {
+            return self::compareUtf16($a, $b);
+        });
+        $parts = [];
+        foreach ($keys as $key) {
+            $parts[] = self::encodeString($key) . ':' . self::encodeValue($stringKeyed[$key]);
+        }
+        return '{' . implode(',', $parts) . '}';
+    }
+
+    /**
+     * Compare two UTF-8 strings by UTF-16 code-unit order (RFC 8785 sec 3.2.3).
+     */
+    private static function compareUtf16(string $a, string $b): int
+    {
+        $au = mb_convert_encoding($a, 'UTF-16BE', 'UTF-8');
+        $bu = mb_convert_encoding($b, 'UTF-16BE', 'UTF-8');
+        $aLen = strlen($au);
+        $bLen = strlen($bu);
+        $n = min($aLen, $bLen);
+        for ($i = 0; $i < $n; $i += 2) {
+            $ax = (ord($au[$i]) << 8) | ord($au[$i + 1]);
+            $bx = (ord($bu[$i]) << 8) | ord($bu[$i + 1]);
+            if ($ax !== $bx) {
+                return $ax <=> $bx;
+            }
+        }
+        return $aLen <=> $bLen;
+    }
+
+    /**
+     * ES6 ToString number serialization for JCS (RFC 8785 sec 3.2.2.3).
+     */
+    private static function encodeNumber(float $value): string
+    {
+        if (is_nan($value)) {
+            throw new InvalidArgumentException('cannot encode NaN');
+        }
+        if (is_infinite($value)) {
+            throw new InvalidArgumentException('cannot encode Infinity');
+        }
+        if ($value === 0.0 || $value === -0.0) {
+            return '0';
+        }
+        if ($value === floor($value) && abs($value) < 1e21) {
+            return (string)(int)$value;
+        }
+        // Use round-trip-precision serialization (PHP 7.1+ defaults to 17 with serialize_precision=-1).
+        $repr = (string)$value;
+        // PHP may emit "1.0E+21" or "1.0e+21"; normalize to ES6 form.
+        if (stripos($repr, 'e') !== false) {
+            $parts = preg_split('/[eE]/', $repr);
+            if ($parts === false || count($parts) !== 2) {
+                return $repr;
+            }
+            [$mantissa, $exp] = $parts;
+            $mantissa = rtrim(rtrim($mantissa, '0'), '.');
+            if ($mantissa === '' || $mantissa === '-') {
+                $mantissa .= '0';
+            }
+            $expInt = (int)$exp;
+            $sign = $expInt >= 0 ? '+' : '-';
+            return $mantissa . 'e' . $sign . abs($expInt);
+        }
+        return $repr;
+    }
+
+    /**
+     * Emit a JCS-conformant JSON string literal (RFC 8785 sec 3.2.2.2), rejecting lone surrogates.
+     */
+    private static function encodeString(string $value): string
+    {
+        // Validate UTF-8 then walk codepoints.
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            throw new InvalidArgumentException('invalid UTF-8 in string');
+        }
+        $codepoints = mb_str_split($value, 1, 'UTF-8');
+        $buf = '"';
+        foreach ($codepoints as $char) {
+            $cp = mb_ord($char, 'UTF-8');
+            if ($cp >= 0xD800 && $cp <= 0xDFFF) {
+                throw new InvalidArgumentException('lone surrogate in string');
+            }
+            $buf .= match (true) {
+                $char === '\\' => '\\\\',
+                $char === '"' => '\\"',
+                $char === "\b" => '\\b',
+                $char === "\t" => '\\t',
+                $char === "\n" => '\\n',
+                $char === "\f" => '\\f',
+                $char === "\r" => '\\r',
+                $cp < 0x20 => sprintf('\\u%04x', $cp),
+                default => $char,
+            };
+        }
+        return $buf . '"';
+    }
+
+    /**
      * Require a decoded JSON value to be an object-shaped array.
      *
      * @return array<string, mixed>

--- a/php/src/Core/Json.php
+++ b/php/src/Core/Json.php
@@ -94,7 +94,10 @@ final class Json
     }
 
     /**
-     * ES6 ToString number serialization for JCS (RFC 8785 sec 3.2.2.3).
+     * ES6 ToString (ECMA-262 7.1.12.1) number serialization for JCS (RFC 8785 sec 3.2.2.3).
+     *
+     * Plain decimal notation when the shortest round-trip representation has decimal exponent k
+     * with -6 < k <= 20, exponential form otherwise.
      */
     private static function encodeNumber(float $value): string
     {
@@ -104,30 +107,73 @@ final class Json
         if (is_infinite($value)) {
             throw new InvalidArgumentException('cannot encode Infinity');
         }
-        if ($value === 0.0 || $value === -0.0) {
+        if ($value === 0.0) {
             return '0';
         }
-        if ($value === floor($value) && abs($value) < 1e21) {
-            return (string)(int)$value;
+        $sign = $value < 0 ? '-' : '';
+        [$digits, $k] = self::shortestDigitsAndExponent(abs($value));
+        return self::formatEs6Number($sign, $digits, $k);
+    }
+
+    /**
+     * @return array{0: string, 1: int}
+     */
+    private static function shortestDigitsAndExponent(float $absValue): array
+    {
+        // PHP's (string) cast respects serialize_precision but is not always shortest round-trip
+        // for edge values like 0.30000000000000004. Use sprintf with the explicit shortest-trip
+        // %.17g and the shorter %.15g fallback if it round-trips.
+        $short = sprintf('%.15g', $absValue);
+        if ((float)$short === $absValue) {
+            $repr = $short;
+        } else {
+            $repr = sprintf('%.17g', $absValue);
         }
-        // Use round-trip-precision serialization (PHP 7.1+ defaults to 17 with serialize_precision=-1).
-        $repr = (string)$value;
-        // PHP may emit "1.0E+21" or "1.0e+21"; normalize to ES6 form.
         if (stripos($repr, 'e') !== false) {
             $parts = preg_split('/[eE]/', $repr);
-            if ($parts === false || count($parts) !== 2) {
-                return $repr;
+            if (!is_array($parts) || count($parts) !== 2) {
+                return [$repr, 0];
             }
-            [$mantissa, $exp] = $parts;
-            $mantissa = rtrim(rtrim($mantissa, '0'), '.');
-            if ($mantissa === '' || $mantissa === '-') {
-                $mantissa .= '0';
-            }
-            $expInt = (int)$exp;
-            $sign = $expInt >= 0 ? '+' : '-';
-            return $mantissa . 'e' . $sign . abs($expInt);
+            $mantissa = $parts[0];
+            $expInt = (int)$parts[1];
+        } else {
+            $mantissa = $repr;
+            $expInt = 0;
         }
-        return $repr;
+        $dotPos = strpos($mantissa, '.');
+        if ($dotPos === false) {
+            $intPart = $mantissa;
+            $fracPart = '';
+        } else {
+            $intPart = substr($mantissa, 0, $dotPos);
+            $fracPart = substr($mantissa, $dotPos + 1);
+        }
+        $combined = $intPart . $fracPart;
+        $stripped = ltrim($combined, '0');
+        $leadingZeros = strlen($combined) - strlen($stripped);
+        $digits = rtrim($stripped, '0');
+        if ($digits === '') {
+            $digits = '0';
+        }
+        $decimalExponent = $expInt + strlen($intPart) - 1 - $leadingZeros;
+        return [$digits, $decimalExponent];
+    }
+
+    private static function formatEs6Number(string $sign, string $digits, int $k): string
+    {
+        $n = strlen($digits);
+        if ($k >= 0 && $k <= 20) {
+            if ($n <= $k + 1) {
+                return $sign . $digits . str_repeat('0', $k + 1 - $n);
+            }
+            return $sign . substr($digits, 0, $k + 1) . '.' . substr($digits, $k + 1);
+        }
+        if ($k < 0 && $k > -7) {
+            return $sign . '0.' . str_repeat('0', -$k - 1) . $digits;
+        }
+        $mantissa = $n === 1 ? $digits : ($digits[0] . '.' . substr($digits, 1));
+        $expSign = $k >= 0 ? '+' : '-';
+        return $sign . $mantissa . 'e' . $expSign . abs($k);
     }
 
     /**

--- a/php/tests/Base64UrlTest.php
+++ b/php/tests/Base64UrlTest.php
@@ -72,7 +72,7 @@ final class Base64UrlTest extends TestCase
     public function testRejectsNonJsonValuesDuringCanonicalization(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('JSON value must be a scalar, object, or list');
+        $this->expectExceptionMessage('unsupported JSON value');
 
         Base64Url::encodeJson(['object' => (object)['not' => 'json']]);
     }

--- a/php/tests/ChallengeTest.php
+++ b/php/tests/ChallengeTest.php
@@ -49,6 +49,21 @@ final class ChallengeTest extends TestCase
         self::assertTrue($challenge->isExpired(new DateTimeImmutable('2026-01-01T00:00:00+00:00')));
     }
 
+    public function testIsExpiredStrictRfc3339(): void
+    {
+        $now = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+        $mk = fn (string $exp) => Challenge::withSecret('s', 'api', 'solana', 'charge', ['x' => '1'], expires: $exp);
+
+        self::assertFalse($mk('2099-01-01T00:00:00Z')->isExpired($now));
+        self::assertFalse($mk('2099-01-01T00:00:00.123Z')->isExpired($now));
+        self::assertFalse($mk('2099-01-01T00:00:00+00:00')->isExpired($now));
+        self::assertTrue($mk('tomorrow')->isExpired($now));
+        self::assertTrue($mk('10000-01-01T00:00:00Z')->isExpired($now));
+        self::assertTrue($mk('2099-02-30T00:00:00Z')->isExpired($now));
+        self::assertTrue($mk('2099-13-01T00:00:00Z')->isExpired($now));
+        self::assertTrue($mk('2099-01-01T24:00:00Z')->isExpired($now));
+    }
+
     public function testRejectsMissingRequiredChallengeFields(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/php/tests/ChallengeTest.php
+++ b/php/tests/ChallengeTest.php
@@ -62,6 +62,11 @@ final class ChallengeTest extends TestCase
         self::assertTrue($mk('2099-02-30T00:00:00Z')->isExpired($now));
         self::assertTrue($mk('2099-13-01T00:00:00Z')->isExpired($now));
         self::assertTrue($mk('2099-01-01T24:00:00Z')->isExpired($now));
+        // Offset hours/minutes out of range rejected.
+        self::assertTrue($mk('2099-01-01T00:00:00+24:00')->isExpired($now));
+        self::assertTrue($mk('2099-01-01T00:00:00+00:60')->isExpired($now));
+        // Lowercase t/z accepted on parse.
+        self::assertFalse($mk('2099-01-01t00:00:00z')->isExpired($now));
     }
 
     public function testRejectsMissingRequiredChallengeFields(): void

--- a/php/tests/HeadersTest.php
+++ b/php/tests/HeadersTest.php
@@ -158,6 +158,30 @@ final class HeadersTest extends TestCase
         Headers::parseReceipt('not-base64url!');
     }
 
+    public function testParseWwwAuthenticateAllMultiChallenge(): void
+    {
+        $header = 'Payment id="a", realm="r1", method="solana", intent="charge", request="e30", '
+                . 'Payment id="b", realm="r2", method="solana", intent="charge", request="e30"';
+
+        $results = Headers::parseWwwAuthenticateAll($header);
+
+        self::assertCount(2, $results);
+        self::assertSame('a', $results[0]->id);
+        self::assertSame('b', $results[1]->id);
+    }
+
+    public function testParseWwwAuthenticateAllIgnoresPaymentInsideQuotedValue(): void
+    {
+        $header = 'Payment id="a", realm="api, Payment realm", method="solana", intent="charge", request="e30", '
+                . 'Payment id="b", realm="r2", method="solana", intent="charge", request="e30"';
+
+        $results = Headers::parseWwwAuthenticateAll($header);
+
+        self::assertCount(2, $results);
+        self::assertSame('api, Payment realm', $results[0]->realm);
+        self::assertSame('b', $results[1]->id);
+    }
+
     public function testReceiptHeaderRoundTrip(): void
     {
         $receipt = Receipt::success(

--- a/php/tests/HeadersTest.php
+++ b/php/tests/HeadersTest.php
@@ -170,6 +170,17 @@ final class HeadersTest extends TestCase
         self::assertSame('b', $results[1]->id);
     }
 
+    public function testParseWwwAuthenticateAllPartialSuccess(): void
+    {
+        $header = 'Payment id="bad", realm="r", method="BAD", intent="charge", request="e30", '
+                . 'Payment id="ok", realm="r", method="solana", intent="charge", request="e30"';
+
+        $results = Headers::parseWwwAuthenticateAll($header);
+
+        self::assertCount(1, $results);
+        self::assertSame('ok', $results[0]->id);
+    }
+
     public function testParseWwwAuthenticateAllIgnoresPaymentInsideQuotedValue(): void
     {
         $header = 'Payment id="a", realm="api, Payment realm", method="solana", intent="charge", request="e30", '

--- a/php/tests/JsonTest.php
+++ b/php/tests/JsonTest.php
@@ -39,4 +39,46 @@ final class JsonTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         Json::optionalInt('6', 'decimals');
     }
+
+    public function testCanonicalizeNestedKeyOrder(): void
+    {
+        self::assertSame('{"a":[{"a":false,"b":true}],"b":2}', Json::canonicalize(['b' => 2, 'a' => [['b' => true, 'a' => false]]]));
+    }
+
+    public function testCanonicalizeUtf16KeyOrder(): void
+    {
+        // 'é' (U+00E9 = 233) > 'f' (U+0066 = 102) in UTF-16, so 'f' sorts first.
+        self::assertSame('{"f":2,"é":1}', Json::canonicalize(['é' => 1, 'f' => 2]));
+    }
+
+    public function testCanonicalizeNumbers(): void
+    {
+        self::assertSame('1e+21', Json::canonicalize(1e21));
+        self::assertSame('0.1', Json::canonicalize(0.1));
+        self::assertSame('0', Json::canonicalize(-0.0));
+        self::assertSame('0', Json::canonicalize(0));
+        self::assertSame('42', Json::canonicalize(42));
+    }
+
+    public function testCanonicalizeRejectsLoneSurrogate(): void
+    {
+        $lone = "\xED\xA0\xB4"; // UTF-8 byte sequence for lone high surrogate U+D834
+        $this->expectException(InvalidArgumentException::class);
+        // PHP's mb_check_encoding rejects the surrogate byte sequence as invalid UTF-8 (stricter than RFC 8785),
+        // which still satisfies the JCS lone-surrogate rejection requirement.
+        Json::canonicalize(['k' => $lone]);
+    }
+
+    public function testCanonicalizeRejectsNonFinite(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Json::canonicalize(NAN);
+    }
+
+    public function testCanonicalizeEscapesControlChars(): void
+    {
+        self::assertSame('"\\u0001"', Json::canonicalize("\x01"));
+        self::assertSame('"\\n"', Json::canonicalize("\n"));
+        self::assertSame('"\\t"', Json::canonicalize("\t"));
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,0 @@
-lockfileVersion: '9.0'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
-importers:
-
-  .: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/ruby/lib/mpp/core/challenge.rb
+++ b/ruby/lib/mpp/core/challenge.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "openssl"
 require "time"
 
@@ -74,11 +75,34 @@ module Mpp
         secure_compare(expected, id)
       end
 
-      # Return true if the challenge is expired or has an invalid timestamp.
+      # Strict RFC 3339 date-time (sec 5.6) without leap-second support.
+      # Year is exactly 4 digits, T literal accepted upper or lower (per parse SHOULD), fractional seconds 1..9 digits.
+      RFC3339_REGEX = /\A
+        (\d{4})-(\d{2})-(\d{2})         # full-date
+        [Tt]
+        (\d{2}):(\d{2}):(\d{2})         # partial-time
+        (?:\.(\d{1,9}))?                # time-secfrac
+        (Z|z|[+-]\d{2}:\d{2})           # time-offset
+        \z/x
+      private_constant :RFC3339_REGEX
+
+      # Return true if the challenge is expired or has an invalid timestamp (fail-closed).
       def expired?(now: Time.now.utc)
         return false if expires.nil?
 
-        Time.iso8601(expires) <= now
+        match = RFC3339_REGEX.match(expires)
+        return true unless match
+
+        year, month, day = match[1].to_i, match[2].to_i, match[3].to_i
+        hour, minute, second = match[4].to_i, match[5].to_i, match[6].to_i
+        return true if month < 1 || month > 12
+        return true if day < 1 || day > 31
+        return true if hour > 23 || minute > 59 || second > 59
+        return true if year > 9999
+        return true unless Date.valid_date?(year, month, day)
+
+        parsed = Time.iso8601(expires)
+        parsed <= now
       rescue ArgumentError
         true
       end

--- a/ruby/lib/mpp/core/headers.rb
+++ b/ruby/lib/mpp/core/headers.rb
@@ -26,6 +26,71 @@ module Mpp
         "Payment #{parts.join(", ")}"
       end
 
+      # Parse all `Payment` challenges across one or more `WWW-Authenticate` values (RFC 7235 sec 4.1).
+      def parse_www_authenticate_all(headers)
+        Array(headers).flat_map { |header| split_payment_challenge_values(header) }.map { |chunk| parse_www_authenticate(chunk) }
+      end
+
+      # Split a WWW-Authenticate header value into individual Payment challenges (quote-aware).
+      def split_payment_challenge_values(header)
+        bytes = header.to_s
+        starts = []
+        in_quote = false
+        escaped = false
+        i = 0
+        scheme = PAYMENT_SCHEME
+        slen = scheme.length
+        while i < bytes.length
+          ch = bytes[i]
+          if in_quote
+            if escaped
+              escaped = false
+            elsif ch == "\\"
+              escaped = true
+            elsif ch == "\""
+              in_quote = false
+            end
+            i += 1
+            next
+          end
+
+          if ch == "\""
+            in_quote = true
+            i += 1
+            next
+          end
+
+          if payment_scheme_start?(bytes, i, scheme, slen)
+            starts << i
+            i += slen
+            next
+          end
+
+          i += 1
+        end
+
+        return [] if starts.empty?
+
+        starts.each_with_index.map do |start, idx|
+          finish = starts[idx + 1] || bytes.length
+          bytes[start...finish].strip.sub(/,\s*\z/, "").strip
+        end.reject(&:empty?)
+      end
+
+      def payment_scheme_start?(bytes, index, scheme, slen)
+        return false if index + slen >= bytes.length
+
+        prefix = bytes[index, slen]
+        return false unless prefix&.casecmp(scheme)&.zero?
+
+        next_char = bytes[index + slen]
+        return false unless next_char && [" ", "\t"].include?(next_char)
+
+        prev = index - 1
+        prev -= 1 while prev >= 0 && [" ", "\t"].include?(bytes[prev])
+        prev < 0 || bytes[prev] == ","
+      end
+
       # Parse a single `WWW-Authenticate` challenge.
       def parse_www_authenticate(header)
         params = parse_auth_params(strip_payment(header))
@@ -63,11 +128,15 @@ module Mpp
 
       def strip_payment(header)
         value = header.to_s.strip
-        raise ArgumentError, "expected Payment scheme" unless value.downcase.start_with?("payment ")
+        scheme_len = PAYMENT_SCHEME.length
+        unless value.length > scheme_len && value[0, scheme_len].casecmp(PAYMENT_SCHEME).zero? && [" ", "\t"].include?(value[scheme_len])
+          raise ArgumentError, "expected Payment scheme"
+        end
 
-        value[8..].strip
+        value[(scheme_len + 1)..].strip
       end
 
+      # Parse RFC 7235 sec 2.1 auth-params; accepts quoted-string and token form.
       def parse_auth_params(input)
         params = {}
         index = 0
@@ -76,26 +145,38 @@ module Mpp
           break if index >= input.length
 
           key_start = index
-          index += 1 while index < input.length && input[index] != "="
+          index += 1 while index < input.length && input[index] != "=" && input[index] != "," && input[index] != " " && input[index] != "\t"
           key = input[key_start...index]
-          index += 1
-          raise ArgumentError, "expected quoted value" unless input[index] == "\""
+          index += 1 while index < input.length && [" ", "\t"].include?(input[index])
+          raise ArgumentError, "invalid auth parameter" if key.empty? || index >= input.length || input[index] != "="
 
           index += 1
-          value = +""
-          while index < input.length
-            char = input[index]
-            if char == "\\"
-              index += 1
-              value << input[index].to_s
-            elsif char == "\""
-              index += 1
-              break
-            else
-              value << char
-            end
+          index += 1 while index < input.length && [" ", "\t"].include?(input[index])
+
+          value = if index < input.length && input[index] == "\""
             index += 1
+            buf = +""
+            while index < input.length
+              char = input[index]
+              if char == "\\"
+                index += 1
+                buf << input[index].to_s
+              elsif char == "\""
+                index += 1
+                break
+              else
+                buf << char
+              end
+              index += 1
+            end
+            buf
+          else
+            value_start = index
+            index += 1 while index < input.length && input[index] != ","
+            input[value_start...index].rstrip
           end
+
+          raise ArgumentError, "duplicate parameter: #{key}" if params.key?(key)
           params[key] = value
         end
         params

--- a/ruby/lib/mpp/core/headers.rb
+++ b/ruby/lib/mpp/core/headers.rb
@@ -27,8 +27,14 @@ module Mpp
       end
 
       # Parse all `Payment` challenges across one or more `WWW-Authenticate` values (RFC 7235 sec 4.1).
+      # Returns an array of successfully-parsed Challenge objects; malformed individual challenges are skipped.
+      # Mirrors the Rust spine which exposes Vec<Result<PaymentChallenge, Error>> and filters at the call site.
       def parse_www_authenticate_all(headers)
-        Array(headers).flat_map { |header| split_payment_challenge_values(header) }.map { |chunk| parse_www_authenticate(chunk) }
+        Array(headers).flat_map { |header| split_payment_challenge_values(header) }.filter_map do |chunk|
+          parse_www_authenticate(chunk)
+        rescue ArgumentError
+          nil
+        end
       end
 
       # Split a WWW-Authenticate header value into individual Payment challenges (quote-aware).

--- a/ruby/lib/mpp/core/json.rb
+++ b/ruby/lib/mpp/core/json.rb
@@ -73,7 +73,7 @@ module Mpp
         # ES6 ToString (ECMA-262 7.1.12.1) number serialization for JCS (RFC 8785 sec 3.2.2.3).
         #
         # Mirrors V8/JavaScriptCore semantics: plain decimal notation when the shortest
-        # round-trip representation has decimal exponent k with -6 < k <= 21, exponential
+        # round-trip representation has decimal exponent k with -6 < k <= 20, exponential
         # form ("Ne+EE") otherwise.
         def encode_number(value)
           raise ArgumentError, "cannot encode NaN" if value.nan?

--- a/ruby/lib/mpp/core/json.rb
+++ b/ruby/lib/mpp/core/json.rb
@@ -4,24 +4,17 @@ require "json"
 
 module Mpp
   module Core
-    # RFC8785-style canonical JSON encoder for MPP header payloads.
+    # RFC 8785 canonical JSON encoder for MPP header payloads.
+    #
+    # Vendors a small JCS implementation rather than delegating to JSON.generate so the
+    # ordering, number serialization, and surrogate validation rules match the Rust spine.
+    # See RFC 8785 sec 3.2.2 and sec 3.2.3.
     module Json
       module_function
 
-      # Encode a Ruby object with stable object key ordering.
+      # Encode a Ruby object with stable object key ordering (UTF-16 code-unit).
       def canonical_generate(value)
-        case value
-        when Hash
-          "{" + value.keys.map(&:to_s).sort.map { |key|
-            JSON.generate(key) + ":" + canonical_generate(value.fetch(key) { value.fetch(key.to_sym) })
-          }.join(",") + "}"
-        when Array
-          "[" + value.map { |item| canonical_generate(item) }.join(",") + "]"
-        when String, Integer, Float, TrueClass, FalseClass, NilClass
-          JSON.generate(value)
-        else
-          raise ArgumentError, "unsupported JSON value #{value.class}"
-        end
+        encode_value(value)
       end
 
       # Decode JSON and preserve object keys as strings.
@@ -29,6 +22,112 @@ module Mpp
         JSON.parse(value)
       rescue JSON::ParserError => error
         raise ArgumentError, "invalid JSON: #{error.message}"
+      end
+
+      # ── private encoders ──
+
+      class << self
+        private
+
+        def encode_value(value)
+          case value
+          when Hash then encode_object(value)
+          when Array then "[" + value.map { |item| encode_value(item) }.join(",") + "]"
+          when String then encode_string(value)
+          when Integer then value.to_s
+          when Float then encode_number(value)
+          when true then "true"
+          when false then "false"
+          when nil then "null"
+          else
+            raise ArgumentError, "unsupported JSON value #{value.class}"
+          end
+        end
+
+        def encode_object(hash)
+          string_keys = hash.each_with_object({}) do |(key, val), memo|
+            string_key = key.is_a?(Symbol) ? key.to_s : key
+            raise ArgumentError, "object key must be a string" unless string_key.is_a?(String)
+            raise ArgumentError, "duplicate object key #{string_key.inspect}" if memo.key?(string_key)
+
+            memo[string_key] = val
+          end
+          ordered = string_keys.keys.sort_by { |k| utf16_code_units(k) }
+          parts = ordered.map { |k| encode_string(k) + ":" + encode_value(string_keys.fetch(k)) }
+          "{" + parts.join(",") + "}"
+        end
+
+        # Convert a UTF-8 string into an array of UTF-16 code units for ordering (RFC 8785 sec 3.2.3).
+        def utf16_code_units(string)
+          # encode! through UTF-16BE then split into 16-bit units; sort_by uses array comparison.
+          utf16 = string.encode("UTF-16BE", invalid: :replace, undef: :replace).bytes
+          units = []
+          i = 0
+          while i < utf16.length
+            units << ((utf16[i] << 8) | utf16[i + 1])
+            i += 2
+          end
+          units
+        end
+
+        # ES6 ToString (ECMA-262 7.1.12.1) number serialization for JCS (RFC 8785 sec 3.2.2.3).
+        def encode_number(value)
+          raise ArgumentError, "cannot encode NaN" if value.nan?
+          raise ArgumentError, "cannot encode Infinity" if value.infinite?
+          return "0" if value.zero? # collapses -0 to "0"
+          return value.to_i.to_s if value.finite? && value == value.to_i && value.abs < 1e21
+
+          # Use Ruby's shortest-round-trip formatter (Float#to_s is shortest-round-trip since 2.0).
+          # Then normalize to ES6 form: drop ".0" trailing on integers, use lowercase e, e+NN with sign.
+          ruby_repr = value.to_s
+          # Ruby Float#to_s emits "1.0e+21" for 1e21 and "1.0e-7" for 1e-7. ES6 ToString uses "1e+21" / "1e-7".
+          if ruby_repr.include?("e")
+            mantissa, exp = ruby_repr.split("e")
+            mantissa = mantissa.sub(/\.0\z/, "")
+            exp_int = exp.to_i
+            sign = (exp_int >= 0) ? "+" : "-"
+            "#{mantissa}e#{sign}#{exp_int.abs}"
+          else
+            ruby_repr.sub(/\.0\z/, "")
+          end
+        end
+
+        ESCAPE_TABLE = {
+          "\b" => "\\b",
+          "\t" => "\\t",
+          "\n" => "\\n",
+          "\f" => "\\f",
+          "\r" => "\\r",
+          "\"" => "\\\"",
+          "\\" => "\\\\"
+        }.freeze
+
+        # Emit a JCS-conformant JSON string literal (RFC 8785 sec 3.2.2.2), rejecting lone surrogates.
+        def encode_string(string)
+          raise ArgumentError, "object key must be a string" unless string.is_a?(String)
+
+          # Validate UTF-8 and reject any string containing a lone surrogate codepoint.
+          codepoints = string.encode(Encoding::UTF_8).codepoints
+          codepoints.each do |cp|
+            raise ArgumentError, "lone surrogate in string" if cp.between?(0xD800, 0xDFFF)
+          end
+
+          buf = +"\""
+          codepoints.each do |cp|
+            buf << if (esc = ESCAPE_TABLE[[cp].pack("U")])
+              esc
+            elsif cp < 0x20
+              format("\\u%04x", cp)
+            elsif cp <= 0x7E
+              cp.chr(Encoding::UTF_8)
+            else
+              # Non-ASCII: emit raw UTF-8 (JCS does not normalize, RFC 8785 sec 3.2.4).
+              [cp].pack("U")
+            end
+          end
+          buf << "\""
+          buf
+        end
       end
     end
   end

--- a/ruby/lib/mpp/core/json.rb
+++ b/ruby/lib/mpp/core/json.rb
@@ -71,25 +71,61 @@ module Mpp
         end
 
         # ES6 ToString (ECMA-262 7.1.12.1) number serialization for JCS (RFC 8785 sec 3.2.2.3).
+        #
+        # Mirrors V8/JavaScriptCore semantics: plain decimal notation when the shortest
+        # round-trip representation has decimal exponent k with -6 < k <= 21, exponential
+        # form ("Ne+EE") otherwise.
         def encode_number(value)
           raise ArgumentError, "cannot encode NaN" if value.nan?
           raise ArgumentError, "cannot encode Infinity" if value.infinite?
           return "0" if value.zero? # collapses -0 to "0"
-          return value.to_i.to_s if value.finite? && value == value.to_i && value.abs < 1e21
 
-          # Use Ruby's shortest-round-trip formatter (Float#to_s is shortest-round-trip since 2.0).
-          # Then normalize to ES6 form: drop ".0" trailing on integers, use lowercase e, e+NN with sign.
-          ruby_repr = value.to_s
-          # Ruby Float#to_s emits "1.0e+21" for 1e21 and "1.0e-7" for 1e-7. ES6 ToString uses "1e+21" / "1e-7".
-          if ruby_repr.include?("e")
-            mantissa, exp = ruby_repr.split("e")
-            mantissa = mantissa.sub(/\.0\z/, "")
-            exp_int = exp.to_i
-            sign = (exp_int >= 0) ? "+" : "-"
-            "#{mantissa}e#{sign}#{exp_int.abs}"
+          sign = value.negative? ? "-" : ""
+          digits, k = shortest_digits_and_exponent(value.abs)
+          format_es6_number(sign, digits, k)
+        end
+
+        # Return [digits, k] where digits is the shortest decimal mantissa and k is the
+        # decimal exponent of the leading digit, so that value = 0.<digits> * 10^(k+1).
+        def shortest_digits_and_exponent(abs_value)
+          repr = abs_value.to_s # Ruby Float#to_s is shortest-round-trip.
+          if repr.include?("e")
+            mantissa, exp_str = repr.split("e")
+            exp_int = exp_str.to_i
           else
-            ruby_repr.sub(/\.0\z/, "")
+            mantissa = repr
+            exp_int = 0
           end
+          int_part, frac_part = mantissa.split(".")
+          frac_part ||= ""
+          combined = int_part + frac_part
+          # k_repr: the exponent of the leading digit if we treat 'combined' as 0.<combined> * 10^(int_part.length + exp_int).
+          # i.e. value = combined * 10^(exp_int - frac_part.length).
+          # decimal_exponent_of_leading_nonzero = (exp_int + int_part.length) - (number of leading zeros stripped) - 1.
+          stripped = combined.sub(/\A0+/, "")
+          leading_zeros = combined.length - stripped.length
+          digits = stripped.sub(/0+\z/, "")
+          digits = "0" if digits.empty?
+          decimal_exponent = exp_int + int_part.length - 1 - leading_zeros
+          [digits, decimal_exponent]
+        end
+
+        # Render digits + decimal exponent k as ES6 ToString.
+        # Uses plain decimal when -6 < k <= 20, otherwise exponential.
+        def format_es6_number(sign, digits, k)
+          n = digits.length
+          if k.between?(0, 20)
+            if n <= k + 1
+              return sign + digits + ("0" * (k + 1 - n))
+            end
+            return sign + digits[0, k + 1] + "." + digits[(k + 1)..]
+          end
+          if k < 0 && k > -7
+            return sign + "0." + ("0" * (-k - 1)) + digits
+          end
+          mantissa = (n == 1) ? digits : (digits[0] + "." + digits[1..])
+          exp_sign = (k >= 0) ? "+" : "-"
+          sign + mantissa + "e" + exp_sign + k.abs.to_s
         end
 
         ESCAPE_TABLE = {

--- a/ruby/test/core_test.rb
+++ b/ruby/test/core_test.rb
@@ -17,7 +17,161 @@ class CoreTest < Minitest::Test
     assert_raises(ArgumentError) { Mpp::Core::Json.parse("{") }
     assert_equal "hello", Mpp::Core::Base64Url.decode(Base64.strict_encode64("hello"))
     assert_raises(ArgumentError) { Mpp::Core::Headers.parse_www_authenticate("Bearer token") }
-    assert_raises(ArgumentError) { Mpp::Core::Headers.parse_auth_params("id=unquoted") }
+    # Token-form values are valid per RFC 7235 sec 2.1.
+    assert_equal({"id" => "abc"}, Mpp::Core::Headers.parse_auth_params("id=abc"))
+    assert_raises(ArgumentError) { Mpp::Core::Headers.parse_auth_params("=value") }
+    assert_raises(ArgumentError) { Mpp::Core::Headers.parse_auth_params("id=a, id=b") }
+  end
+
+  def test_parse_auth_params_token_form_values
+    params = Mpp::Core::Headers.parse_auth_params("id=abc, realm=api, method=solana, intent=charge, request=e30")
+    assert_equal "abc", params.fetch("id")
+    assert_equal "api", params.fetch("realm")
+    assert_equal "solana", params.fetch("method")
+    assert_equal "e30", params.fetch("request")
+  end
+
+  def test_parse_www_authenticate_all_multi_challenge
+    h = 'Payment id="a", realm="r1", method="solana", intent="charge", request="e30", Payment id="b", realm="r2", method="solana", intent="charge", request="e30"'
+    results = Mpp::Core::Headers.parse_www_authenticate_all([h])
+    assert_equal 2, results.length
+    assert_equal "a", results[0].id
+    assert_equal "b", results[1].id
+  end
+
+  def test_parse_www_authenticate_all_ignores_payment_inside_quoted_value
+    h = 'Payment id="a", realm="api, Payment realm", method="solana", intent="charge", request="e30", Payment id="b", realm="r2", method="solana", intent="charge", request="e30"'
+    results = Mpp::Core::Headers.parse_www_authenticate_all([h])
+    assert_equal 2, results.length
+    assert_equal "api, Payment realm", results[0].realm
+    assert_equal "b", results[1].id
+  end
+
+  def test_canonical_json_utf16_key_order
+    # 'é' (U+00E9) > 'f' (U+0066) in UTF-16 code units, so 'f' sorts first.
+    value = {"é" => 1, "f" => 2}
+    assert_equal '{"f":2,"é":1}', Mpp::Core::Json.canonical_generate(value)
+  end
+
+  def test_canonical_json_es6_number_serialization
+    assert_equal "1e+21", Mpp::Core::Json.canonical_generate(1e21)
+    assert_equal "0.1", Mpp::Core::Json.canonical_generate(0.1)
+    assert_equal "0", Mpp::Core::Json.canonical_generate(-0.0)
+    assert_equal "0", Mpp::Core::Json.canonical_generate(0)
+  end
+
+  def test_canonical_json_rejects_lone_surrogates
+    # Build a UTF-8 byte sequence containing a lone high surrogate (U+D834) via raw bytes.
+    lone = [0xED, 0xA0, 0xB4].pack("C*").force_encoding(Encoding::UTF_8)
+    assert_raises(ArgumentError) { Mpp::Core::Json.canonical_generate({"k" => lone}) }
+  end
+
+  def test_canonical_json_covers_branches
+    assert_equal "true", Mpp::Core::Json.canonical_generate(true)
+    assert_equal "false", Mpp::Core::Json.canonical_generate(false)
+    assert_equal "null", Mpp::Core::Json.canonical_generate(nil)
+    assert_equal "[1,2,3]", Mpp::Core::Json.canonical_generate([1, 2, 3])
+    assert_equal '"\\u0001"', Mpp::Core::Json.canonical_generate("\x01")
+    assert_equal '"\\n"', Mpp::Core::Json.canonical_generate("\n")
+    assert_equal '{"a":1}', Mpp::Core::Json.canonical_generate({a: 1})
+    assert_raises(ArgumentError) { Mpp::Core::Json.canonical_generate({1 => 2}) }
+    assert_raises(ArgumentError) { Mpp::Core::Json.canonical_generate(Float::NAN) }
+    assert_raises(ArgumentError) { Mpp::Core::Json.canonical_generate(Float::INFINITY) }
+    assert_equal "1e-7", Mpp::Core::Json.canonical_generate(1e-7)
+  end
+
+  def test_split_payment_challenge_values_edges
+    # Header that does not contain Payment scheme yields empty.
+    assert_empty Mpp::Core::Headers.parse_www_authenticate_all(["Bearer xyz"])
+    # Tab after Payment.
+    h = "Payment\tid=\"x\", realm=\"api\", method=\"solana\", intent=\"charge\", request=\"e30\""
+    parsed = Mpp::Core::Headers.parse_www_authenticate_all([h])
+    assert_equal 1, parsed.length
+  end
+
+  def test_expires_strict_rfc3339_extra
+    # Month 13 rejected.
+    c = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-13-01T00:00:00Z")
+    assert c.expired?
+    # Minute 60 rejected.
+    c2 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01T00:60:00Z")
+    assert c2.expired?
+    # Day 0 rejected.
+    c3 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-00T00:00:00Z")
+    assert c3.expired?
+  end
+
+  def test_parse_www_authenticate_all_string_input
+    # String (not array) is wrapped via Array().
+    h = 'Payment id="a", realm="r1", method="solana", intent="charge", request="e30"'
+    results = Mpp::Core::Headers.parse_www_authenticate_all(h)
+    assert_equal 1, results.length
+  end
+
+  def test_payment_scheme_start_negatives
+    # "Paymentx" without whitespace is not a scheme start; should yield empty.
+    assert_empty Mpp::Core::Headers.parse_www_authenticate_all(["Paymentid=x"])
+    # Payment preceded by non-comma is not a scheme start.
+    assert_empty Mpp::Core::Headers.parse_www_authenticate_all(["X Payment id=x"])
+  end
+
+  def test_canonical_json_branches_extra
+    # Symbol keys converted.
+    assert_equal '{"a":1,"b":2}', Mpp::Core::Json.canonical_generate({a: 1, b: 2})
+    # Integer.
+    assert_equal "42", Mpp::Core::Json.canonical_generate(42)
+    # Negative number.
+    assert_equal "-3.14", Mpp::Core::Json.canonical_generate(-3.14)
+    # Backslash and quote escapes.
+    assert_equal '"a\\\\b"', Mpp::Core::Json.canonical_generate("a\\b")
+    assert_equal '"a\\"b"', Mpp::Core::Json.canonical_generate("a\"b")
+    # Empty array, empty object.
+    assert_equal "[]", Mpp::Core::Json.canonical_generate([])
+    assert_equal "{}", Mpp::Core::Json.canonical_generate({})
+    # Tab and backspace control chars.
+    assert_equal '"\\t"', Mpp::Core::Json.canonical_generate("\t")
+    assert_equal '"\\b"', Mpp::Core::Json.canonical_generate("\b")
+    assert_equal '"\\f"', Mpp::Core::Json.canonical_generate("\f")
+    assert_equal '"\\r"', Mpp::Core::Json.canonical_generate("\r")
+  end
+
+  def test_expires_strict_rfc3339_branches
+    # Lowercase t accepted.
+    c1 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01t00:00:00Z")
+    refute c1.expired?
+    # Fractional seconds accepted.
+    c2 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01T00:00:00.123Z")
+    refute c2.expired?
+    # Numeric offset accepted.
+    c3 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01T00:00:00+00:00")
+    refute c3.expired?
+    # Invalid calendar date rejected (Feb 30).
+    c4 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-02-30T00:00:00Z")
+    assert c4.expired?
+    # Hour 24 rejected.
+    c5 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01T24:00:00Z")
+    assert c5.expired?
+  end
+
+  def test_parse_auth_params_branches
+    # BWS around `=`.
+    params = Mpp::Core::Headers.parse_auth_params('id ="x" , realm="api"')
+    assert_equal "x", params.fetch("id")
+    assert_equal "api", params.fetch("realm")
+    # Multi-challenge empty header.
+    assert_empty Mpp::Core::Headers.parse_www_authenticate_all([])
+    # Single-value challenge through all helper.
+    h = 'Payment id="x", realm="api", method="solana", intent="charge", request="e30"'
+    assert_equal 1, Mpp::Core::Headers.parse_www_authenticate_all([h]).length
+  end
+
+  def test_expires_strict_rfc3339
+    chal = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01T00:00:00Z")
+    refute chal.expired?
+    chal2 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "tomorrow")
+    assert chal2.expired?, "non-RFC-3339 expires must fail closed"
+    chal3 = Mpp::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "10000-01-01T00:00:00Z")
+    assert chal3.expired?, "5-digit year must fail closed"
   end
 
   def test_header_parser_unescapes_quoted_values

--- a/ruby/test/core_test.rb
+++ b/ruby/test/core_test.rb
@@ -47,6 +47,25 @@ class CoreTest < Minitest::Test
     assert_equal "b", results[1].id
   end
 
+  def test_parse_www_authenticate_all_partial_success
+    # First challenge has an invalid method; second is valid. Should yield one challenge.
+    h = 'Payment id="bad", realm="r", method="BAD", intent="charge", request="e30", ' \
+        'Payment id="ok", realm="r", method="solana", intent="charge", request="e30"'
+    results = Mpp::Core::Headers.parse_www_authenticate_all(h)
+    assert_equal 1, results.length
+    assert_equal "ok", results[0].id
+  end
+
+  def test_canonical_json_es6_extra
+    # ES6 ToString: 1e-6 plain notation, 1e-7 exponential.
+    assert_equal "0.000001", Mpp::Core::Json.canonical_generate(1e-6)
+    assert_equal "1e-7", Mpp::Core::Json.canonical_generate(1e-7)
+    # 1e20 plain notation (still fits in plain form).
+    assert_equal "100000000000000000000", Mpp::Core::Json.canonical_generate(1e20)
+    # 0.1 + 0.2 round-trip preserves precision.
+    assert_equal "0.30000000000000004", Mpp::Core::Json.canonical_generate(0.1 + 0.2)
+  end
+
   def test_canonical_json_utf16_key_order
     # 'é' (U+00E9) > 'f' (U+0066) in UTF-16 code units, so 'f' sorts first.
     value = {"é" => 1, "f" => 2}

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -54,7 +54,11 @@ export const chargeCanonicalJsonVectors: readonly CanonicalJsonVector[] = [
 
 /**
  * Vectors that every JCS implementation must reject (RFC 8785 sec 3.2.2).
- * Lone high surrogate U+D834 outside a surrogate pair.
+ * Reserved for a future cross-SDK harness loop that asserts each
+ * implementation's encoder rejects these inputs; today the per-language
+ * rejection coverage lives inline in each SDK's own unit suite plus the
+ * reference encoder check in `tests/interop/test/canonical-json.test.ts`.
+ * Kept here so the spec-mandated reject set has a single source of truth.
  */
 export const chargeCanonicalJsonRejectVectors: readonly { id: string; reason: string }[] = [
   { id: "lone-surrogate", reason: "lone surrogate" },

--- a/tests/interop/src/intents/charge.ts
+++ b/tests/interop/src/intents/charge.ts
@@ -22,6 +22,44 @@ export const chargeCanonicalJsonVectors: readonly CanonicalJsonVector[] = [
     canonicalJson: '{"a":[{"a":false,"b":true}],"b":2}',
     base64Url: "eyJhIjpbeyJhIjpmYWxzZSwiYiI6dHJ1ZX1dLCJiIjoyfQ",
   },
+  {
+    // RFC 8785 sec 3.2.3: UTF-16 code-unit ordering. 'f' (0x66) < 'é' (0xE9) < 'ƒ' (0x192).
+    id: "utf16-key-ordering",
+    value: { "é": 1, f: 2, "ƒ": 3 },
+    canonicalJson: '{"f":2,"é":1,"ƒ":3}',
+    base64Url: "eyJmIjoyLCLDqSI6MSwixpIiOjN9",
+  },
+  {
+    // RFC 8785 sec 3.2.2.3: ES6 ToString. 1e21 must canonicalize as "1e+21".
+    id: "number-1e21",
+    value: { n: 1e21 },
+    canonicalJson: '{"n":1e+21}',
+    base64Url: "eyJuIjoxZSsyMX0",
+  },
+  {
+    // 0.1 round-trips as "0.1" under ES6 ToString.
+    id: "number-0_1",
+    value: { n: 0.1 },
+    canonicalJson: '{"n":0.1}',
+    base64Url: "eyJuIjowLjF9",
+  },
+  {
+    // Negative zero collapses to "0".
+    id: "number-negative-zero",
+    value: { n: -0 },
+    canonicalJson: '{"n":0}',
+    base64Url: "eyJuIjowfQ",
+  },
+];
+
+/**
+ * Vectors that every JCS implementation must reject (RFC 8785 sec 3.2.2).
+ * Lone high surrogate U+D834 outside a surrogate pair.
+ */
+export const chargeCanonicalJsonRejectVectors: readonly { id: string; reason: string }[] = [
+  { id: "lone-surrogate", reason: "lone surrogate" },
+  { id: "nan", reason: "NaN" },
+  { id: "infinity", reason: "Infinity" },
 ];
 
 export const chargeScenarios: readonly InteropScenario[] = [

--- a/tests/interop/test/canonical-json.test.ts
+++ b/tests/interop/test/canonical-json.test.ts
@@ -1,31 +1,100 @@
 import { describe, expect, it } from "vitest";
 import { chargeCanonicalJsonVectors } from "../src/contracts";
 
-function canonicalizeJson(value: unknown): unknown {
+/**
+ * Reference RFC 8785 (JCS) implementation for harness conformance vectors.
+ *
+ * Sorts object keys by UTF-16 code-unit order, serializes numbers per ES6 ToString,
+ * rejects NaN, Infinity, and lone surrogates. Used to pin the expected canonical
+ * bytes each language SDK must produce.
+ */
+function canonicalizeJson(value: unknown): string {
+  if (value === null) return "null";
+  if (value === true) return "true";
+  if (value === false) return "false";
+  if (typeof value === "number") return encodeNumber(value);
+  if (typeof value === "string") return encodeString(value);
   if (Array.isArray(value)) {
-    return value.map(canonicalizeJson);
+    return "[" + value.map(canonicalizeJson).join(",") + "]";
   }
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, nested]) => [key, canonicalizeJson(nested)]),
-    );
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort(compareUtf16CodeUnits);
+    return "{" + keys.map((k) => encodeString(k) + ":" + canonicalizeJson(obj[k])).join(",") + "}";
   }
-  return value;
+  throw new Error(`unsupported JSON value: ${typeof value}`);
+}
+
+function compareUtf16CodeUnits(a: string, b: string): number {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    const ax = a.charCodeAt(i);
+    const bx = b.charCodeAt(i);
+    if (ax !== bx) return ax - bx;
+  }
+  return a.length - b.length;
+}
+
+function encodeNumber(value: number): string {
+  if (Number.isNaN(value)) throw new Error("cannot encode NaN");
+  if (!Number.isFinite(value)) throw new Error("cannot encode Infinity");
+  if (value === 0) return "0"; // ES6 ToString collapses -0 to "0"
+  // JS String(value) already implements ECMA-262 7.1.12.1 ToString.
+  return String(value);
+}
+
+function encodeString(value: string): string {
+  let out = '"';
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate; require a following low surrogate.
+      const low = value.charCodeAt(i + 1);
+      if (!(low >= 0xdc00 && low <= 0xdfff)) {
+        throw new Error("lone surrogate in string");
+      }
+      out += value[i] + value[i + 1];
+      i++;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new Error("lone surrogate in string");
+    }
+    const ch = value[i];
+    if (ch === "\\") out += "\\\\";
+    else if (ch === '"') out += '\\"';
+    else if (code === 0x08) out += "\\b";
+    else if (code === 0x09) out += "\\t";
+    else if (code === 0x0a) out += "\\n";
+    else if (code === 0x0c) out += "\\f";
+    else if (code === 0x0d) out += "\\r";
+    else if (code < 0x20) out += "\\u" + code.toString(16).padStart(4, "0");
+    else out += ch;
+  }
+  return out + '"';
 }
 
 function encodeBase64Url(value: string): string {
-  return Buffer.from(value).toString("base64url");
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 describe("RFC 8785 canonical JSON vectors", () => {
   for (const vector of chargeCanonicalJsonVectors) {
     it(`${vector.id}: canonical JSON before base64url`, () => {
-      const canonicalJson = JSON.stringify(canonicalizeJson(vector.value));
+      const canonicalJson = canonicalizeJson(vector.value);
 
       expect(canonicalJson).toBe(vector.canonicalJson);
       expect(encodeBase64Url(canonicalJson)).toBe(vector.base64Url);
     });
   }
+
+  it("rejects lone surrogates per RFC 8785 sec 3.2.2", () => {
+    const lone = String.fromCharCode(0xd834);
+    expect(() => canonicalizeJson({ k: lone })).toThrow(/lone surrogate/);
+  });
+
+  it("rejects NaN and Infinity per RFC 8785 sec 3.2.2.3", () => {
+    expect(() => canonicalizeJson(Number.NaN)).toThrow();
+    expect(() => canonicalizeJson(Number.POSITIVE_INFINITY)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

Closes the six RFC conformance findings in `mpp-sdk-self-learning/notes/2026-05-23-ruby-state-report.md` sections F1 through F6 and the matching locking items L10 (RFC 3339 strict) and L12 (canonical JSON) from `2026-05-22-interop-coverage-audit-v2.md`. Touches Ruby, PHP, Lua. The Rust spine is already conformant and is not modified.

Gap IDs closed: **G15** (multi-challenge), **G17** (token-form auth-param values), **G18** (UTF-16 key ordering), **G19** (ES6 number serialization), **G20** (lone surrogate rejection), **G21** (RFC 3339 strict expires).

### F1 - parse_auth_params accepts token-form values (RFC 7235 sec 2.1)
Ruby `parse_auth_params` previously raised `"expected quoted value"` on `id=abc` form. Now accepts both quoted-string and token form, with BWS handling around `=` and duplicate-name rejection. PHP and Lua were already conformant.

### F2 / F3 / F4 - Canonical JSON conformance (RFC 8785)
Each of Ruby (`lib/mpp/core/json.rb`), PHP (`src/Core/Json.php`), and Lua (`mpp/util/json.lua`) now vendors a small JCS implementation rather than delegating to the language JSON encoder. The shared behavior:

- **UTF-16 code-unit key ordering** (sec 3.2.3). Sorting `{"é","f","ƒ"}` yields `f, é, ƒ` (was: byte order for all three).
- **ES6 ToString number serialization** (sec 3.2.2.3, ECMA-262 7.1.12.1). Plain decimal notation when the decimal exponent k satisfies `-6 < k <= 20`, exponential form otherwise. Pinned cases: `1e21 -> "1e+21"`, `1e20 -> "100000000000000000000"`, `0.1 -> "0.1"`, `1e-6 -> "0.000001"`, `1e-7 -> "1e-7"`, `0.1+0.2 -> "0.30000000000000004"`, `-0 -> "0"`.
- **Lone surrogate rejection** (sec 3.2.2). Encoders walk codepoints and refuse lone high/low surrogates.

### F5 - Multi-challenge WWW-Authenticate (RFC 7235 sec 4.1)
Ports Rust's quote-aware splitter to Ruby (`Headers.parse_www_authenticate_all`), PHP (`Headers::parseWwwAuthenticateAll`), Lua (`parse_www_authenticate_all`). Each returns the successfully-parsed challenges and silently skips individually-malformed ones, mirroring Rust's `Vec<Result<PaymentChallenge, Error>>` filter-at-call-site pattern. Lua's previous `extract_payment_scheme` split on bare comma and would have mis-segmented quoted realms containing commas; that path is now built on the same quote-aware splitter.

### F6 - Strict RFC 3339 `expires` validation (sec 5.6)
Each SDK's expiry validator now applies a strict grammar (4-digit year, calendar validation, time-of-day bounds, numeric-offset range check) and fails closed on any parse error. Lowercase `t/z` accepted on parse (per RFC 3339 SHOULD), 5-digit years rejected, Feb 30 rejected, `+24:00` rejected.

### Interop vectors
`tests/interop/src/intents/charge.ts` `chargeCanonicalJsonVectors` extended with `utf16-key-ordering`, `number-1e21`, `number-0_1`, `number-negative-zero`. `tests/interop/test/canonical-json.test.ts` rewritten with a proper JCS reference encoder (UTF-16 sort, ES6 ToString, lone surrogate reject) instead of `localeCompare`.

## Scope and readiness gate

This PR does not modify the example servers, the spec spine, or any of the wire protocols. Readiness gate is **unit + interop + codex**, not manual DX. Multi-challenge harness scenario is a negative case for the old code paths and a positive case for the new parsers; existing interop scenarios are unaffected.

## Test plan

- [x] Ruby: `bundle exec ruby -Ilib:test test/run.rb` -> **109 runs, 424 assertions, 0 failures**.
- [x] Ruby: `COVERAGE=1 bundle exec ruby -Itest test/run.rb` -> Line **98.62%** (1142/1158), Branch **90.04%** (407/452). Gate 92/90.
- [x] Ruby: `bundle exec standardrb` clean.
- [x] Ruby: `bundle exec bundle-audit check` -> No vulnerabilities found.
- [x] PHP: `vendor/bin/phpunit` -> **OK (134 tests, 316 assertions)**.
- [x] PHP: `vendor/bin/phpstan analyse --level=max src` -> `[OK] No errors`.
- [x] PHP: `vendor/bin/php-cs-fixer fix --dry-run` -> no diff.
- [x] PHP: `composer audit` -> `No security vulnerability advisories found`.
- [x] Lua: `lua tests/run.lua` -> all new tests pass, only pre-existing `challenge_to_html` HTML asset failure (unrelated to this PR).
- [x] Rust: `cargo build` clean, `cargo test --lib` -> **539 passed, 0 failed**.
- [x] TypeScript: `pnpm exec vitest run` (typescript workspace) -> **Test Files 15 passed, Tests 184 passed**.
- [x] Interop canonical-json vectors: `pnpm exec vitest run test/canonical-json.test.ts` -> **Test Files 1 passed, Tests 7 passed**.
- [x] Cross-SDK byte-identity check: Ruby, PHP, Lua all produce identical canonical bytes for the new conformance vectors (verified locally with inline scripts).
- [x] Codex review: `codex exec --sandbox read-only` initial review surfaced three substantive findings (ES6 number edge cases, PHP RFC 3339 offset, partial-success semantics), all addressed in the followup commit. Re-review reports `**Findings:** none in the requested areas.`

## References
- ruby-state-report 2026-05-23, sections F1 to F6
- interop-coverage-audit-v2, gap IDs G15 G17 G18 G19 G20 G21, lock IDs L10 L12
- track-c-rfc-standards, rows 4 6 13 14 16 19 25