### PR TITLE
chore: cross-SDK compute-budget cap audit + conformance test

### DIFF
--- a/docs/security/compute-budget-caps.md
+++ b/docs/security/compute-budget-caps.md
@@ -48,6 +48,8 @@ this monorepo.
 | Ruby        | `ruby/lib/mpp/methods/solana/verifier.rb:9`                | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
 | Lua         | `lua/mpp/server/solana_verify.lua:19`                      | `MAX_COMPUTE_UNIT_LIMIT`                  |
 | Lua         | `lua/mpp/server/solana_verify.lua:20`                      | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
+| Lua (#103)  | `lua/mpp/methods/solana/instructions.lua:31`               | `MAX_COMPUTE_UNIT_LIMIT` (pending PR #103 merge)              |
+| Lua (#103)  | `lua/mpp/methods/solana/instructions.lua:32`               | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS` (pending PR #103 merge) |
 | Go (#101)   | `go/server/server.go` (`maxComputeUnitLimit`)              | pending PR #101 merge                     |
 | Python (#106) | `python/src/solana_mpp/server/mpp.py`                    | pending PR #106 merge                     |
 

--- a/docs/security/compute-budget-caps.md
+++ b/docs/security/compute-budget-caps.md
@@ -1,0 +1,71 @@
+# Compute-Budget Caps
+
+Tracks issue [#109](https://github.com/solana-foundation/mpp-sdk/issues/109).
+
+## Canonical values
+
+Every server SDK must enforce the same upper bound on the
+`ComputeBudget111111111111111111111111111111` instructions
+`SetComputeUnitLimit` (discriminator `0x02`) and `SetComputeUnitPrice`
+(discriminator `0x03`) that appear in a charge transaction:
+
+| Constant                              | Value      |
+| ------------------------------------- | ---------- |
+| `MAX_COMPUTE_UNIT_LIMIT`              | `200000`   |
+| `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS` | `5000000` |
+
+Worst-case priority-fee burn per settled charge is bounded by
+`MAX_COMPUTE_UNIT_LIMIT * MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS /
+1_000_000 = 1_000_000` lamports (`0.001` SOL).
+
+## Rationale
+
+The server signs and broadcasts the client's transaction as fee payer
+(charge-pull). Without a cap, an attacker can attach
+`SetComputeUnitPrice` instructions whose `micro_lamports` is large enough
+to drain the server wallet on every accepted charge, since the fee payer
+covers `cu_limit * cu_price / 1_000_000` lamports of priority fee on top
+of the base signature fee. The cap pins the maximum drain per accepted
+transaction so the server can size its fee-payer float against a known
+ceiling.
+
+The exact pair is conservative for the current charge instruction mix
+(SPL transfer or transferChecked plus optional ATA create plus optional
+memo). Raising the cap requires a security review across every SDK in
+this monorepo.
+
+## Per-SDK enforcement
+
+| Language    | File                                                       | Constant                                  |
+| ----------- | ---------------------------------------------------------- | ----------------------------------------- |
+| Rust        | `rust/src/server/charge.rs:42`                             | `MAX_COMPUTE_UNIT_LIMIT`                  |
+| Rust        | `rust/src/server/charge.rs:43`                             | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
+| TypeScript  | `typescript/packages/mpp/src/server/Charge.ts:233`         | `MAX_COMPUTE_UNIT_LIMIT`                  |
+| TypeScript  | `typescript/packages/mpp/src/server/Charge.ts:234`         | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
+| PHP         | `php/src/Server/SolanaChargeTransactionVerifier.php:42`    | `MAX_COMPUTE_UNIT_LIMIT`                  |
+| PHP         | `php/src/Server/SolanaChargeTransactionVerifier.php:43`    | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
+| Ruby        | `ruby/lib/mpp/methods/solana/verifier.rb:8`                | `MAX_COMPUTE_UNIT_LIMIT`                  |
+| Ruby        | `ruby/lib/mpp/methods/solana/verifier.rb:9`                | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
+| Lua         | `lua/mpp/server/solana_verify.lua:19`                      | `MAX_COMPUTE_UNIT_LIMIT`                  |
+| Lua         | `lua/mpp/server/solana_verify.lua:20`                      | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`    |
+| Go (#101)   | `go/server/server.go` (`maxComputeUnitLimit`)              | pending PR #101 merge                     |
+| Python (#106) | `python/src/solana_mpp/server/mpp.py`                    | pending PR #106 merge                     |
+
+`tests/interop/test/compute-budget-caps.test.ts` parses each file above
+and asserts byte-identical literals against the canonical pair. Go and
+Python rows are marked `optional: true` until their PRs land, then
+flip to required and surface drift the same way as the other SDKs.
+
+## Adding a new SDK
+
+1. Declare both constants verbatim in the server module that decodes
+   `ComputeBudget` instructions during charge verification.
+2. Reject the transaction with the canonical `payment_invalid` error
+   code when either limit is exceeded; include the cap value in the
+   reason string for parity with the existing SDKs.
+3. Append a row to `SDKS` in
+   `tests/interop/test/compute-budget-caps.test.ts` and to the table
+   above. Append a fixture row to
+   `charge-compute-budget-over-cap` in
+   `tests/interop/src/intents/charge.ts` once the SDK is wired into the
+   interop harness.

--- a/tests/interop/test/compute-budget-caps.test.ts
+++ b/tests/interop/test/compute-budget-caps.test.ts
@@ -73,6 +73,15 @@ const SDKS: Sdk[] = [
     limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9]+)/,
     pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9]+)/,
   },
+  // Lua PR #103 lands the same caps at the instruction-decoder layer in
+  // lua/mpp/methods/solana/instructions.lua; gated until merge.
+  {
+    language: "lua-instructions",
+    file: "lua/mpp/methods/solana/instructions.lua",
+    limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9]+)/,
+    pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9]+)/,
+    optional: true,
+  },
   // Go #101 lands `maxComputeUnitLimit` / `maxComputeUnitPriceMicroLamports`
   // in go/server/server.go; gated until merge.
   {

--- a/tests/interop/test/compute-budget-caps.test.ts
+++ b/tests/interop/test/compute-budget-caps.test.ts
@@ -146,10 +146,11 @@ describe("compute-budget cap conformance (issue #109)", () => {
       }
       const limitMatch = source.match(sdk.limitPattern);
       const priceMatch = source.match(sdk.pricePattern);
-      if (sdk.optional && (limitMatch === null || priceMatch === null)) {
-        // SDK source file exists on main but the open PR that introduces
-        // the cap constants has not landed yet. Re-asserting the cap is
-        // the responsibility of that PR's tests; skip silently here.
+      if (sdk.optional && limitMatch === null && priceMatch === null) {
+        // SDK source file exists on main but neither cap constant has
+        // landed yet (open PR introduces them as a pair). A partial match
+        // (one constant present, the other missing) is a real regression
+        // and must surface as a failure rather than be silently skipped.
         return;
       }
       const limit = parseLiteral(limitMatch, "limit", sdk.language);

--- a/tests/interop/test/compute-budget-caps.test.ts
+++ b/tests/interop/test/compute-budget-caps.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Cross-SDK compute-budget cap conformance.
+ *
+ * Asserts every server-side SDK enforces byte-identical caps on
+ * ComputeBudget `SetComputeUnitLimit` and `SetComputeUnitPrice`
+ * instructions. The canonical pair is taken from the Rust spine:
+ *
+ *   MAX_COMPUTE_UNIT_LIMIT                = 200_000
+ *   MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS  = 5_000_000
+ *
+ * Rationale: an attacker-supplied transaction can otherwise burn the
+ * server's fee-payer balance via an unbounded priority fee (cu_limit *
+ * cu_price * lamports_per_signature_fee_payer). The cap pins worst-case
+ * fee cost per settled charge. See docs/security/compute-budget-caps.md.
+ *
+ * Adapters not yet on `main` (Go #101, Python #106) are gated behind
+ * existence checks so this suite passes today and tightens automatically
+ * when those SDKs merge.
+ *
+ * Issue: #109.
+ */
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+const CANONICAL_LIMIT = 200_000;
+const CANONICAL_PRICE_MICROLAMPORTS = 5_000_000;
+
+type Sdk = {
+  language: string;
+  file: string;
+  // Regex must capture the limit and price literals from a known
+  // declaration site. Underscores in numeric literals are normalized
+  // away before parsing.
+  limitPattern: RegExp;
+  pricePattern: RegExp;
+  // Optional flag: when true, the SDK is not yet on main and the test
+  // skips silently if the file does not exist.
+  optional?: boolean;
+};
+
+const SDKS: Sdk[] = [
+  {
+    language: "rust",
+    file: "rust/src/server/charge.rs",
+    limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*:\s*u32\s*=\s*([0-9_]+)/,
+    pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*:\s*u64\s*=\s*([0-9_]+)/,
+  },
+  {
+    language: "typescript",
+    file: "typescript/packages/mpp/src/server/Charge.ts",
+    limitPattern: /const\s+MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9_]+)/,
+    pricePattern: /const\s+MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9_]+)n?/,
+  },
+  {
+    language: "php",
+    file: "php/src/Server/SolanaChargeTransactionVerifier.php",
+    limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9_]+)/,
+    pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9_]+)/,
+  },
+  {
+    language: "ruby",
+    file: "ruby/lib/mpp/methods/solana/verifier.rb",
+    limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9_]+)/,
+    pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9_]+)/,
+  },
+  {
+    language: "lua",
+    file: "lua/mpp/server/solana_verify.lua",
+    limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9]+)/,
+    pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9]+)/,
+  },
+  // Go #101 lands `maxComputeUnitLimit` / `maxComputeUnitPriceMicroLamports`
+  // in go/server/server.go; gated until merge.
+  {
+    language: "go",
+    file: "go/server/server.go",
+    limitPattern: /maxComputeUnitLimit\s+uint32\s*=\s*([0-9_]+)/,
+    pricePattern: /maxComputeUnitPriceMicroLamports\s+uint64\s*=\s*([0-9_]+)/,
+    optional: true,
+  },
+  // Python #106 lands MAX_COMPUTE_UNIT_* in python/src/solana_mpp/server/mpp.py;
+  // gated until merge.
+  {
+    language: "python",
+    file: "python/src/solana_mpp/server/mpp.py",
+    limitPattern: /MAX_COMPUTE_UNIT_LIMIT\s*=\s*([0-9_]+)/,
+    pricePattern: /MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS\s*=\s*([0-9_]+)/,
+    optional: true,
+  },
+];
+
+function readIfPresent(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function parseLiteral(match: RegExpMatchArray | null, label: string, sdk: string): number {
+  if (!match) {
+    throw new Error(`${sdk}: ${label} declaration not found`);
+  }
+  const raw = match[1].replace(/_/g, "");
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`${sdk}: ${label} literal ${match[1]} is not a finite number`);
+  }
+  return value;
+}
+
+describe("compute-budget cap conformance (issue #109)", () => {
+  it("canonical pair documented in docs/security/compute-budget-caps.md", () => {
+    const doc = readFileSync(
+      resolve(REPO_ROOT, "docs/security/compute-budget-caps.md"),
+      "utf8",
+    );
+    expect(doc).toContain(String(CANONICAL_LIMIT));
+    expect(doc).toContain(String(CANONICAL_PRICE_MICROLAMPORTS));
+  });
+
+  for (const sdk of SDKS) {
+    it(`${sdk.language} server enforces canonical caps`, () => {
+      const path = resolve(REPO_ROOT, sdk.file);
+      const source = readIfPresent(path);
+      if (source === null) {
+        if (sdk.optional) {
+          // SDK not yet on main; future PR will surface this row.
+          return;
+        }
+        throw new Error(`${sdk.language}: required source file missing at ${sdk.file}`);
+      }
+      const limitMatch = source.match(sdk.limitPattern);
+      const priceMatch = source.match(sdk.pricePattern);
+      if (sdk.optional && (limitMatch === null || priceMatch === null)) {
+        // SDK source file exists on main but the open PR that introduces
+        // the cap constants has not landed yet. Re-asserting the cap is
+        // the responsibility of that PR's tests; skip silently here.
+        return;
+      }
+      const limit = parseLiteral(limitMatch, "limit", sdk.language);
+      const price = parseLiteral(priceMatch, "price", sdk.language);
+      expect(limit, `${sdk.language} MAX_COMPUTE_UNIT_LIMIT drift`).toBe(CANONICAL_LIMIT);
+      expect(price, `${sdk.language} MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS drift`).toBe(
+        CANONICAL_PRICE_MICROLAMPORTS,
+      );
+    });
+  }
+});


### PR DESCRIPTION
Closes #109.

## Summary

Pins compute-budget caps to byte-identical values across every server SDK and adds a static conformance test that fails on drift.

Canonical pair (from the Rust spine):
- `MAX_COMPUTE_UNIT_LIMIT = 200_000`
- `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 5_000_000`

Bounds worst-case priority-fee burn per accepted charge at `0.001` SOL (`cu_limit * cu_price / 1_000_000` lamports), the relevant attack being an unbounded `SetComputeUnitPrice` draining the server fee payer.

## Audit (origin/main + open PR branches)

| Language    | File:line                                                  | Limit     | Price (microlamports) |
| ----------- | ---------------------------------------------------------- | --------- | --------------------- |
| Rust        | `rust/src/server/charge.rs:42-43`                          | 200_000   | 5_000_000             |
| TypeScript  | `typescript/packages/mpp/src/server/Charge.ts:233-234`     | 200_000   | 5_000_000             |
| PHP         | `php/src/Server/SolanaChargeTransactionVerifier.php:42-43` | 200_000   | 5_000_000             |
| Ruby        | `ruby/lib/mpp/methods/solana/verifier.rb:8-9`              | 200_000   | 5_000_000             |
| Lua         | `lua/mpp/server/solana_verify.lua:19-20`                   | 200_000   | 5_000_000             |
| Go (#101)   | `go/server/server.go:39-40` (`maxComputeUnit*`)            | 200_000   | 5_000_000             |
| Python (#106) | `python/src/solana_mpp/server/mpp.py:57-58`              | 200_000   | 5_000_000             |
| Lua (#103)  | `lua/mpp/methods/solana/instructions.lua:31-32`            | 200_000   | 5_000_000             |

No drift observed across `origin/main` or the three open PR branches (`feat/go-charge-mega-f`, `feat/python-charge-mega-g`, `feat/lua-charge-mega-b`).

## What this PR adds

- `tests/interop/test/compute-budget-caps.test.ts`: parses each SDK's cap declaration site, asserts byte-identical literals against the canonical pair, and checks the doc table mentions both values. Go and Python are gated as `optional` until #101 and #106 land, at which point removing the flag enforces them too.
- `docs/security/compute-budget-caps.md`: canonical values, fee-payer drain rationale, per-language citation table, and the recipe for extending to a new SDK.

## Test plan

- [x] `pnpm exec vitest run test/compute-budget-caps.test.ts` (8/8 pass against origin/main: 6 enforced SDKs, 2 optional skipped pending #101 + #106)
- [ ] Tighten Go row to required once #101 merges
- [ ] Tighten Python row to required once #106 merges