### PR TITLE
fix(interop): drain surfpool events in vitest path to unblock tail scenarios

### DIFF
--- a/tests/interop/test/e2e.test.ts
+++ b/tests/interop/test/e2e.test.ts
@@ -1,5 +1,5 @@
 import net from "node:net";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   createSolanaRpc,
   getBase64Codec,
@@ -65,6 +65,7 @@ function scenarioDecimals(scenario: InteropScenario): number {
 const runningServers: RunningServer[] = [];
 
 let surfnet: Surfnet | undefined;
+let surfnetDrainTimer: NodeJS.Timeout | undefined;
 let interopEnv: Record<string, string> | undefined;
 let splitRecipients: Record<string, string> = {};
 
@@ -166,6 +167,18 @@ beforeAll(async () => {
   }
 
   surfnet = Surfnet.start();
+  // Periodically drain the JS-side surfpool event queue. The Rust
+  // server fixture broadcasts via this in-process surfpool RPC, and
+  // each broadcast enqueues commit/log events on the JS side. Without
+  // a periodic drain, the queue backs up over a full matrix run and
+  // surfpool's RPC stops responding to subsequent simulate/broadcast
+  // calls, which surfaces as a 120s adapter-output timeout on
+  // charge-idempotent-resubmit (the matrix's tail scenario). The
+  // 1s cadence matches tests/interop/start-surfnet-proxy.mjs, which
+  // already does this for the proxy-mode launcher. See Ludo-7 / PR #102.
+  surfnetDrainTimer = setInterval(() => {
+    surfnet?.drainEvents();
+  }, 1_000);
 
   const client = Surfnet.newKeypair();
   const payTo = Surfnet.newKeypair();
@@ -278,6 +291,13 @@ afterEach(async () => {
     if (server) {
       await stopServer(server);
     }
+  }
+});
+
+afterAll(() => {
+  if (surfnetDrainTimer) {
+    clearInterval(surfnetDrainTimer);
+    surfnetDrainTimer = undefined;
   }
 });
 


### PR DESCRIPTION
## Summary

The vitest interop harness (`tests/interop/test/e2e.test.ts`) never called `surfnet.drainEvents()` from `beforeAll`. Over a full 54-scenario matrix run, the JS-side event queue from the in-process surfpool RPC backed up until simulate/broadcast calls from the rust server fixture stopped returning. The tail scenario (`charge-idempotent-resubmit`, ts client x rust server) was the first to hit the wall and timed out at 120s waiting for the adapter's first-hop response.

The companion proxy script `tests/interop/start-surfnet-proxy.mjs` already drained on a 1s cadence; the vitest path was the missing piece.

## Fix

Add a 1s `setInterval` in `beforeAll` that calls `surfnet.drainEvents()`, matching the cadence used by `start-surfnet-proxy.mjs`. Clear the interval in `afterAll`. Self-contained 21-line change in `tests/interop/test/e2e.test.ts`.

## Matrix evidence

Two consecutive clean runs on a fresh branch off `origin/main` (commit `9170a9a`, PR #102 merge):

- Run A: 70 passed / 70 total (4 files), 89.35s wall, 88.90s test time
- Run B: 70 passed / 70 total (4 files), 89.02s wall, 88.52s test time

70 = 54 e2e scenarios + 16 unit/contract tests across `canonical-json.test.ts`, `intent-selection.test.ts`, `process.test.ts`. Without this fix, the matrix hangs on the idempotent-resubmit tail scenario at 120s timeout.

## Test plan

- [x] `pnpm --filter @solana/mpp build`
- [x] `pnpm install --frozen-lockfile` in `tests/interop`
- [x] `pnpm test` in `tests/interop` (Run A: 70/70 green, 89s)
- [x] `pnpm test` in `tests/interop` (Run B: 70/70 green, 89s)

Head SHA: `1b05c59`