### PR TITLE
feat(x402): x402 exact v1 (legacy) wire support across 6 SDKs

### DIFF
--- a/docs/x402/exact-v1-spec.md
+++ b/docs/x402/exact-v1-spec.md
@@ -1,0 +1,213 @@
+# x402 EXACT v1 (legacy) wire contract for pay-kit
+
+Language-agnostic spec for the legacy x402 `exact` scheme on Solana/SVM, as
+pay-kit implements it. The **Rust spine is the source of truth**: every rule
+below cites the rust file:line it mirrors. Where the upstream coinbase x402
+spec (Apache-2.0) and the rust spine disagree, **rust wins** and the
+divergence is flagged inline.
+
+x402 v1 and v2 are two **separate parallel wire shapes**. There is no
+v1<->v2 conversion helper; each is parsed and produced natively. v2 stays the
+default producer; v1 is read on the way in and emitted only when the peer
+declared v1.
+
+## Version constants
+
+| Constant | Value | rust |
+| --- | --- | --- |
+| `X402_VERSION_FIELD` | `"x402Version"` | constants.rs:7 |
+| `X402_VERSION_V1` | `1` | constants.rs:10 |
+| `X402_VERSION_V2` | `2` | constants.rs:13 |
+| `EXACT_SCHEME` | `"exact"` | protocol/schemes/exact/types.rs:6 |
+
+## Headers
+
+| Role | v1 header | v2 header | rust |
+| --- | --- | --- | --- |
+| Client payment | `X-PAYMENT` | `PAYMENT-SIGNATURE` | constants.rs:16,25 |
+| Server challenge | `X-PAYMENT-REQUIRED` | `PAYMENT-REQUIRED` | constants.rs:19,28 |
+| Settlement result | `X-PAYMENT-RESPONSE` | `PAYMENT-RESPONSE` | constants.rs:22,31 |
+
+All envelope header values are **standard (padded) base64** of the envelope
+JSON, NOT base64url. The rust producer encodes with
+`base64::engine::general_purpose::STANDARD` (client/exact/payment.rs:110,
+175-178) and the server decodes with the same engine (server/exact.rs:308).
+
+## SVM network names
+
+v1 uses **plain network strings**, not the CAIP-2 identifiers v2 uses.
+
+| Cluster | v1 plain name | v2 CAIP-2 | rust |
+| --- | --- | --- | --- |
+| mainnet-beta | `solana` | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | constants.rs:4 / types.rs:12 |
+| devnet | `solana-devnet` | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | types.rs:15 |
+| testnet | `solana-testnet` | `solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z` | types.rs:18 |
+
+The v1 producer maps the offer's cluster to a v1 slug with
+`v1_network_for_requirements` (client/exact/payment.rs:393-404):
+**devnet-family -> `solana-devnet`, everything else -> `solana`**. Note this
+only emits `solana` or `solana-devnet`; testnet collapses to `solana` on the
+producer side even though the slug `solana-testnet` is otherwise recognized
+on parse.
+
+The v1 server normalizes the inbound plain slug back to CAIP-2 via
+`caip2_network_for_cluster` before comparing networks
+(server/exact.rs:321-326, types.rs:31-39).
+
+## v1 CHALLENGE (server -> client)
+
+The v1 challenge is delivered as the **HTTP 402 JSON body** and/or the
+`X-PAYMENT-REQUIRED` header. The client reads the v2 `PAYMENT-REQUIRED`
+header first, then the v1 `X-PAYMENT-REQUIRED` header, then the body
+(client/exact/payment.rs:237-261).
+
+> **Divergence from the coinbase spec facts.** The spec facts state v1 has
+> "no X-PAYMENT-REQUIRED header; the challenge is a 402 body only". The rust
+> spine DOES define `X402_V1_PAYMENT_REQUIRED_HEADER = "X-PAYMENT-REQUIRED"`
+> (constants.rs:19) and the client parser reads it before the body
+> (payment.rs:246-253). pay-kit **follows rust**: support both the
+> `X-PAYMENT-REQUIRED` header and the 402 body, with the body as the
+> documented fallback.
+
+Challenge JSON shape:
+
+```json
+{
+  "x402Version": 1,
+  "error": "PAYMENT-SIGNATURE header is required",
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "solana-devnet",
+      "maxAmountRequired": "1000",
+      "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+      "resource": "http://localhost:3402/x402/joke",
+      "description": "A random joke",
+      "maxTimeoutSeconds": 60,
+      "extra": { "feePayer": "6AfzJJo1KfhNWKe56wa5EWszTNQ7B1W5Kfh5SY2JkRGQ" }
+    }
+  ]
+}
+```
+
+Key field names, distinct from v2:
+
+- The offer list key is **`accepts`** (plural array) — same key as v2, but
+  v1 offers use the legacy field names below (types.rs:447-459, the
+  `PaymentRequiredEnvelope`).
+- The amount field is **`maxAmountRequired`** (string), not v2's `amount`.
+  The deserializer accepts both (types.rs:337-339).
+- Recipient is **`payTo`** (or legacy `recipient`); asset is **`asset`** (or
+  legacy `currency`); timeout is **`maxTimeoutSeconds`** (or legacy
+  `maxAge`) — same fallback chain rust uses (types.rs:334-355).
+- `extra.feePayer` carries the facilitator fee-payer key; `extra.memo`
+  carries an optional server-pinned memo (<=256 bytes,
+  client/exact/payment.rs:360-391).
+
+The client selects one offer from `accepts` with the same network/currency
+preference logic as v2 (client/exact/payment.rs:288-350): cheapest on the
+preferred network by default, or the highest-priority matching currency when
+a currency preference is supplied.
+
+## v1 PAYMENT request (client -> server)
+
+`X-PAYMENT` header value = standard base64 of:
+
+```json
+{
+  "x402Version": 1,
+  "scheme": "exact",
+  "network": "solana-devnet",
+  "payload": { "transaction": "<base64 partially-signed versioned tx>" }
+}
+```
+
+`scheme` and `network` are **top-level siblings of `payload`** — there is NO
+`accepted` object (unlike v2). This is built by `build_payment_header_v1`
+(client/exact/payment.rs:153-170): it sets `scheme = "exact"`,
+`network = v1_network_for_requirements(...)`, `x402Version = 1`,
+`accepted = None`, `resource = None`. The shared `PaymentSignatureEnvelope`
+struct serializes `scheme`/`network` only when present
+(types.rs:587-608, `skip_serializing_if = "Option::is_none"`), so the v2
+producer omits them and the v1 producer includes them.
+
+`payload.transaction` is the standard-base64 of the bincode-serialized
+partially-signed `VersionedTransaction`
+(client/exact/payment.rs:108-117).
+
+## v1 SETTLEMENT response (server -> client)
+
+`X-PAYMENT-RESPONSE` header value = standard base64 of:
+
+```json
+{
+  "success": true,
+  "transaction": "<signature>",
+  "network": "solana-devnet",
+  "payer": "<payer pubkey>",
+  "errorReason": "<optional, only on failure>"
+}
+```
+
+## Server dual-accept + version gate
+
+The server decodes the inbound `PAYMENT-SIGNATURE`/`X-PAYMENT` envelope and
+dispatches on `x402Version` (server/exact.rs:307-350,
+`parse_payment_signature`):
+
+- **v1 (`x402Version == 1`)**: require top-level `scheme == "exact"`
+  (else `InvalidPayloadType`), then require
+  `caip2_network_for_cluster(network) == expected_network`
+  (server/exact.rs:316-327). There is no `accepted` object to bind in v1, so
+  the per-option match falls back to the first offered requirement
+  (server/exact.rs:438-446).
+- **v2 (`x402Version == 2`)**: require an `accepted` object and bind it
+  field-by-field to the route requirements (server/exact.rs:328-341,
+  476-542).
+- **Any other version**: reject with `Unsupported x402 version: <n>`
+  (server/exact.rs:342-346). A server MUST NOT silently accept an unknown
+  version — it would settle a payment whose wire contract it does not
+  understand.
+
+The facilitator MUST-checks on the signed transaction (compute-budget caps,
+`transferChecked` shape, fee-payer-not-authority, memo bounds) are
+**identical to v2** — both versions reach the same
+`verify_exact_versioned_transaction` after the version gate
+(server/exact.rs:568-569).
+
+The server still **emits v2 challenges by default**: `exact_with_options`
+and `exact_with_payment_options` build envelopes with
+`x402_version = X402_VERSION_V2` (server/exact.rs:182-189, 284-291).
+
+## Client dual-read + emit-declared-version
+
+The client reads the v2 header challenge first, then the v1
+`X-PAYMENT-REQUIRED` header, then the v1/express body
+(client/exact/payment.rs:232-262). It populates the matching offer shape and
+emits the version the server's challenge declared: `build_payment_header`
+emits v2 (payment.rs:132-150), `build_payment_header_v1` emits v1
+(payment.rs:153-170). **v2 stays the default producer.**
+
+## v1 vs v2 field diff (quick reference)
+
+| Concern | v1 | v2 |
+| --- | --- | --- |
+| Client header name | `X-PAYMENT` | `PAYMENT-SIGNATURE` |
+| Challenge header name | `X-PAYMENT-REQUIRED` (+ 402 body) | `PAYMENT-REQUIRED` |
+| Settlement header | `X-PAYMENT-RESPONSE` | `PAYMENT-RESPONSE` |
+| Base64 variant | standard (padded) | standard (padded) |
+| Network identifier | plain (`solana`, `solana-devnet`) | CAIP-2 (`solana:5eykt4...`) |
+| Payment envelope scheme/network | top-level siblings of `payload` | absent |
+| Payment envelope `accepted` | absent | present (echoes the offer) |
+| Challenge amount field | `maxAmountRequired` | `amount` |
+| Server binding | scheme + network only | full `accepted` deepEqual |
+| Default producer | no (read/echo only) | yes |
+
+## Conformance vectors
+
+The cross-SDK harness exercises this contract RPC-free over the decoded
+envelope shape. See `harness/vectors/x402-v1-build.json`,
+`harness/vectors/x402-v1-verify.json`, and the reference oracle in
+`harness/src/conformance/x402.ts` (`buildPaymentHeaderV1`,
+`v1NetworkForOffer`, the v1 arm of `verifyPaymentHeader`).

--- a/docs/x402/exact-v1-spec.md
+++ b/docs/x402/exact-v1-spec.md
@@ -28,10 +28,19 @@ declared v1.
 | Server challenge | `X-PAYMENT-REQUIRED` | `PAYMENT-REQUIRED` | constants.rs:19,28 |
 | Settlement result | `X-PAYMENT-RESPONSE` | `PAYMENT-RESPONSE` | constants.rs:22,31 |
 
-All envelope header values are **standard (padded) base64** of the envelope
-JSON, NOT base64url. The rust producer encodes with
+The **credential** header values (`X-PAYMENT` / `PAYMENT-SIGNATURE`) and the
+v2 **challenge** header (`PAYMENT-REQUIRED`) are **standard (padded) base64**
+of the envelope JSON, NOT base64url. The rust producer encodes with
 `base64::engine::general_purpose::STANDARD` (client/exact/payment.rs:110,
 175-178) and the server decodes with the same engine (server/exact.rs:308).
+
+**Exception — `X-PAYMENT-REQUIRED` (legacy v1 challenge header):** the rust
+client parses this header value as **RAW JSON**, not base64
+(`serde_json::from_str` on the header value, client/exact/payment.rs). pay-kit
+parsers therefore accept the X-PAYMENT-REQUIRED value as raw JSON (and, for
+robustness, also a base64 envelope). No pay-kit server emits this header (it
+emits v2 `PAYMENT-REQUIRED`); it exists only to interoperate with an external
+v1 server that sends it.
 
 ## SVM network names
 

--- a/go/cmd/conformance/x402.go
+++ b/go/cmd/conformance/x402.go
@@ -56,7 +56,20 @@ type X402EnvelopeShape struct {
 	AcceptedAmount        string `json:"acceptedAmount,omitempty"`
 }
 
-const x402VersionV2 = 2
+const (
+	x402VersionV1 = 1
+	x402VersionV2 = 2
+
+	// exactScheme is the only x402 scheme. The legacy v1 envelope carries
+	// it as a top-level sibling of network and payload.
+	exactScheme = "exact"
+
+	// Plain legacy SVM network slugs the v1 wire uses instead of CAIP-2.
+	legacyNetworkMainnet = "solana"
+	legacyNetworkDevnet  = "solana-devnet"
+
+	solanaDevnetCAIP2 = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
+)
 
 // runX402 dispatches an x402-exact vector by mode. build-transaction
 // produces an envelope and emits its shape; verify-transaction runs the
@@ -106,9 +119,6 @@ func buildX402Envelope(vector Vector) (*X402EnvelopeShape, error) {
 	if in.X402Offer == nil {
 		return nil, fmt.Errorf("x402 build vector is missing input.x402Offer")
 	}
-	if in.X402Version != x402VersionV2 {
-		return nil, fmt.Errorf("x402 build vector has unsupported input.x402Version %d", in.X402Version)
-	}
 	tx := in.X402PinnedTransaction
 	if tx == "" {
 		return nil, fmt.Errorf("x402 build vector is missing input.x402PinnedTransaction")
@@ -118,12 +128,29 @@ func buildX402Envelope(vector Vector) (*X402EnvelopeShape, error) {
 		return nil, err
 	}
 
-	// Mirrors client.BuildPaymentHeader: no top-level scheme/network,
-	// accepted echoes the selected offer verbatim.
-	credential := x402.Credential{
-		X402Version: x402VersionV2,
-		Payload:     x402.CredentialPayload{Transaction: tx},
-		Accepted:    entry,
+	var credential x402.Credential
+	switch in.X402Version {
+	case x402VersionV1:
+		// Mirrors client.BuildPaymentHeaderV1: top-level scheme + plain
+		// legacy network slug, NO accepted object (the v1 envelope binds
+		// only scheme+network).
+		credential = x402.Credential{
+			X402Version: x402VersionV1,
+			Scheme:      exactScheme,
+			Network:     v1NetworkForEntry(entry),
+			Payload:     x402.CredentialPayload{Transaction: tx},
+		}
+	case 0, x402VersionV2:
+		// Default producer: v2. No top-level scheme/network leakage,
+		// accepted echoes the selected offer verbatim. An absent version
+		// in the vector means "exercise the default producer".
+		credential = x402.Credential{
+			X402Version: x402VersionV2,
+			Payload:     x402.CredentialPayload{Transaction: tx},
+			Accepted:    entry,
+		}
+	default:
+		return nil, fmt.Errorf("x402 build vector has unsupported input.x402Version %d", in.X402Version)
 	}
 
 	raw, err := json.Marshal(credential)
@@ -132,6 +159,19 @@ func buildX402Envelope(vector Vector) (*X402EnvelopeShape, error) {
 	}
 	header := base64.StdEncoding.EncodeToString(raw)
 	return decodeX402EnvelopeShape(header)
+}
+
+// v1NetworkForEntry maps an offer's network to the plain legacy SVM slug
+// the v1 wire uses, mirroring the production client v1NetworkForEntry and
+// the rust v1_network_for_requirements: only the devnet family is
+// special-cased, everything else (mainnet, testnet) collapses to "solana".
+func v1NetworkForEntry(entry *x402.AcceptsEntry) string {
+	switch entry.Network {
+	case "devnet", "solana-devnet", "localnet", solanaDevnetCAIP2:
+		return legacyNetworkDevnet
+	default:
+		return legacyNetworkMainnet
+	}
 }
 
 // credentialWire is the decode-side shape of a base64(JSON) x402 envelope.
@@ -216,6 +256,18 @@ func verifyX402Envelope(vector Vector) (*X402EnvelopeShape, error) {
 	expectedNetwork := caip2NetworkForCluster(in.X402ServerNetwork)
 
 	switch shape.X402Version {
+	case x402VersionV1:
+		// v1 dual-accept arm: the envelope has no accepted object, so the
+		// server binds only the top-level scheme + network. The scheme
+		// must be "exact" and the plain network slug must normalize to
+		// the route's network. Mirrors the rust parse_payment_signature
+		// v1 arm (server/exact.rs) and the production verifyLegacyBinding.
+		if shape.Scheme != exactScheme {
+			return nil, fmt.Errorf("invalid payload: v1 scheme mismatch: expected %s, got %q", exactScheme, shape.Scheme)
+		}
+		if caip2NetworkForCluster(shape.Network) != expectedNetwork {
+			return nil, fmt.Errorf("network mismatch: expected %s, got %s", expectedNetwork, shape.Network)
+		}
 	case x402VersionV2:
 		// v2 gate: accepted must exist, its network/amount/recipient/asset
 		// must all match the route (accepted-vs-route comparison).

--- a/go/paykit/client.go
+++ b/go/paykit/client.go
@@ -92,7 +92,13 @@ type AdapterRequest struct {
 	Host          string
 	Authorization string
 	PaymentSig    string
-	Gate          *Gate
+	// PaymentSigLegacy carries the legacy x402 `X-PAYMENT` header value
+	// (base64 of a top-level {x402Version, scheme, network, payload}
+	// envelope). The x402 adapter reads the canonical PaymentSig first
+	// and falls back to this so it dual-accepts both wire shapes without
+	// the middleware needing to know which version a client speaks.
+	PaymentSigLegacy string
+	Gate             *Gate
 }
 
 // Builder is the constructor each protocol package registers. paykit.New

--- a/go/paykit/middleware.go
+++ b/go/paykit/middleware.go
@@ -46,12 +46,13 @@ func (c *Client) RequireFunc(resolve GateFunc) func(http.Handler) http.Handler {
 				return
 			}
 			pmt, err := adapter.VerifyAndSettle(&AdapterRequest{
-				Method:        r.Method,
-				Path:          r.URL.Path,
-				Host:          r.Host,
-				Authorization: r.Header.Get("Authorization"),
-				PaymentSig:    r.Header.Get("Payment-Signature"),
-				Gate:          &gate,
+				Method:           r.Method,
+				Path:             r.URL.Path,
+				Host:             r.Host,
+				Authorization:    r.Header.Get("Authorization"),
+				PaymentSig:       r.Header.Get("Payment-Signature"),
+				PaymentSigLegacy: r.Header.Get("X-PAYMENT"),
+				Gate:             &gate,
 			})
 			if err != nil {
 				var perr *PaymentError
@@ -100,10 +101,14 @@ func (c *Client) pickAdapter(gate *Gate, r *http.Request) Adapter {
 	}
 	auth := r.Header.Get("Authorization")
 	sig := r.Header.Get("Payment-Signature")
+	// The legacy x402 client posts its credential in X-PAYMENT instead of
+	// Payment-Signature; treat either as an x402 credential so the adapter
+	// can dual-accept both wire shapes.
+	legacySig := r.Header.Get("X-PAYMENT")
 	for _, s := range accept {
 		switch s {
 		case X402:
-			if sig != "" && c.x402Adapter != nil {
+			if (sig != "" || legacySig != "") && c.x402Adapter != nil {
 				return c.x402Adapter
 			}
 		case MPP:

--- a/go/paykit/middleware_v1_test.go
+++ b/go/paykit/middleware_v1_test.go
@@ -1,0 +1,87 @@
+package paykit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captureAdapter records the AdapterRequest it was handed so the
+// X-PAYMENT (legacy) header threading can be asserted.
+type captureAdapter struct {
+	protocol Protocol
+	pmt      *Payment
+	seen     *AdapterRequest
+}
+
+func (a *captureAdapter) Protocol() Protocol              { return a.protocol }
+func (a *captureAdapter) AcceptsEntry(*Gate) AcceptsEntry { return fakeAccepts{a.protocol} }
+func (a *captureAdapter) ChallengeHeaders(*Gate) map[string]string {
+	return map[string]string{"payment-required": "x"}
+}
+func (a *captureAdapter) VerifyAndSettle(req *AdapterRequest) (*Payment, error) {
+	a.seen = req
+	return a.pmt, nil
+}
+
+func x402Client(adapter Adapter) *Client {
+	return &Client{
+		Config:       Config{Network: SolanaLocalnet, Accept: []Protocol{X402}},
+		x402Adapter:  adapter,
+		errorHandler: DefaultErrorHandler,
+	}
+}
+
+// TestPickAdapterSelectsX402OnLegacyHeader proves a request carrying only
+// the legacy X-PAYMENT header (no Payment-Signature) still routes to the
+// x402 adapter, and the header value is threaded as PaymentSigLegacy.
+func TestPickAdapterSelectsX402OnLegacyHeader(t *testing.T) {
+	pmt := &Payment{Protocol: X402, Gate: "g", Transaction: "sig"}
+	ad := &captureAdapter{protocol: X402, pmt: pmt}
+	c := x402Client(ad)
+
+	var paid bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paid = IsPaid(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("X-PAYMENT", "legacy-credential")
+	rec := httptest.NewRecorder()
+	c.RequireFunc(func(*http.Request) (Gate, error) {
+		return Gate{Amount: MustParseUSD("0.10")}, nil
+	})(next).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	if !paid {
+		t.Error("legacy X-PAYMENT request should be treated as paid")
+	}
+	if ad.seen == nil || ad.seen.PaymentSigLegacy != "legacy-credential" {
+		t.Errorf("PaymentSigLegacy not threaded: %+v", ad.seen)
+	}
+	if ad.seen.PaymentSig != "" {
+		t.Error("PaymentSig should be empty when only X-PAYMENT is present")
+	}
+}
+
+// TestPickAdapterThreadsBothHeaders proves the canonical Payment-Signature
+// and the legacy X-PAYMENT are both surfaced to the adapter so it can apply
+// its own precedence.
+func TestPickAdapterThreadsBothHeaders(t *testing.T) {
+	ad := &captureAdapter{protocol: X402, pmt: &Payment{Protocol: X402}}
+	c := x402Client(ad)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("Payment-Signature", "v2-cred")
+	r.Header.Set("X-PAYMENT", "v1-cred")
+	rec := httptest.NewRecorder()
+	c.RequireFunc(func(*http.Request) (Gate, error) {
+		return Gate{Amount: MustParseUSD("0.10")}, nil
+	})(next).ServeHTTP(rec, r)
+
+	if ad.seen.PaymentSig != "v2-cred" || ad.seen.PaymentSigLegacy != "v1-cred" {
+		t.Errorf("both headers should be threaded: %+v", ad.seen)
+	}
+}

--- a/go/protocols/x402/client/client.go
+++ b/go/protocols/x402/client/client.go
@@ -51,6 +51,32 @@ const (
 	paymentSignatureHeader = "Payment-Signature"
 	x402Version            = 2
 
+	// Legacy v1 wire names. A v1 server advertises its challenge either in
+	// the X-PAYMENT-REQUIRED header or as a 402 JSON body, and a v1 client
+	// posts its credential in the X-PAYMENT header. The default producer
+	// stays v2 (Payment-Signature); the v1 producer is opt-in and only
+	// emitted when the challenge itself declared v1. Mirrors the rust
+	// constants X402_V1_PAYMENT_HEADER / X402_V1_PAYMENT_REQUIRED_HEADER
+	// (constants.rs) and the v1 dual-read precedence (client/exact/payment.rs).
+	paymentRequiredHeaderLegacy = "X-PAYMENT-REQUIRED"
+	paymentHeaderLegacy         = "X-PAYMENT"
+	x402VersionLegacy           = 1
+
+	// exactScheme is the only x402 scheme; the v1 envelope carries it as a
+	// top-level sibling of network and payload.
+	exactScheme = "exact"
+
+	// Plain legacy SVM network slugs. The v1 wire uses these instead of
+	// the v2 CAIP-2 ids. Mirrors the rust v1_network_for_requirements
+	// mapping (client/exact/payment.rs).
+	legacyNetworkMainnet = "solana"
+	legacyNetworkDevnet  = "solana-devnet"
+
+	// solanaDevnetCAIP2 is the canonical devnet/localnet chain id offers
+	// normalize to, used by the v1 network mapping to recognize a
+	// devnet-family offer regardless of which slug it arrived as.
+	solanaDevnetCAIP2 = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
+
 	// Compute-budget values mirror the Rust client: a small fixed limit
 	// and a 1 microLamport priority price, both well under the server
 	// caps (maxComputeUnitLimit / maxComputeUnitPriceMicroLamports).
@@ -117,32 +143,57 @@ type challengeEnvelope struct {
 	Accepts     []x402.AcceptsEntry `json:"accepts"`
 }
 
-// ParseChallenge parses an x402 challenge from the `payment-required`
-// header and, failing that, the x402-express response body, then selects
-// one offer per the given preferences. Returns (nil, false) when no x402
-// offer is present or none matches the selection.
+// ParseChallenge parses an x402 challenge and selects one offer per the
+// given preferences. Returns (nil, false) when no x402 offer is present or
+// none matches the selection. It discards the declared wire version; use
+// [ParseChallengeVersioned] when the caller needs to emit the matching
+// producer.
 func ParseChallenge(h http.Header, body []byte, sel ChallengeSelection) (*x402.AcceptsEntry, bool) {
+	entry, _, ok := ParseChallengeVersioned(h, body, sel)
+	return entry, ok
+}
+
+// ParseChallengeVersioned parses an x402 challenge and reports both the
+// selected offer and the wire version the challenge declared, so the
+// client can emit the producer the server expects. The dual-read
+// precedence mirrors the rust spine (client/exact/payment.rs
+// parse_x402_challenge_with_selection): the canonical PAYMENT-REQUIRED
+// header first, then the legacy X-PAYMENT-REQUIRED header, then the 402
+// JSON body. The returned version is the envelope's declared x402Version
+// (defaulting to the canonical version when the field is absent), so the
+// transport can stay a v2 producer by default and only fall back to the
+// v1 producer when the server itself spoke v1.
+func ParseChallengeVersioned(h http.Header, body []byte, sel ChallengeSelection) (*x402.AcceptsEntry, int, bool) {
 	if raw := h.Get(paymentRequiredHeader); raw != "" {
 		if decoded, err := base64.StdEncoding.DecodeString(raw); err == nil {
-			if entry := selectFromJSON(decoded, sel); entry != nil {
-				return entry, true
+			if entry, version := selectFromJSON(decoded, sel); entry != nil {
+				return entry, version, true
 			}
 		}
 	}
-	if len(body) > 0 {
-		if entry := selectFromJSON(body, sel); entry != nil {
-			return entry, true
+	if raw := h.Get(paymentRequiredHeaderLegacy); raw != "" {
+		if entry, version := selectFromJSON([]byte(raw), sel); entry != nil {
+			return entry, version, true
 		}
 	}
-	return nil, false
+	if len(body) > 0 {
+		if entry, version := selectFromJSON(body, sel); entry != nil {
+			return entry, version, true
+		}
+	}
+	return nil, 0, false
 }
 
-func selectFromJSON(raw []byte, sel ChallengeSelection) *x402.AcceptsEntry {
+func selectFromJSON(raw []byte, sel ChallengeSelection) (*x402.AcceptsEntry, int) {
 	var env challengeEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
-		return nil
+		return nil, 0
 	}
-	return selectEntry(env.Accepts, sel)
+	version := env.X402Version
+	if version == 0 {
+		version = x402Version
+	}
+	return selectEntry(env.Accepts, sel), version
 }
 
 // selectEntry implements the Rust select_requirement logic: keep Solana
@@ -271,6 +322,56 @@ func BuildPaymentHeader(
 		return "", fmt.Errorf("x402 client: marshal credential: %w", err)
 	}
 	return base64.StdEncoding.EncodeToString(raw), nil
+}
+
+// BuildPaymentHeaderV1 builds and signs the transaction the selected offer
+// asks for and returns the base64 legacy `X-PAYMENT` credential envelope.
+// The v1 wire shape carries the scheme and a plain network slug as
+// top-level siblings of payload and commits to NO `accepted` object
+// (unlike v2, the server binds only scheme+network). This is opt-in: the
+// default producer stays v2 ([BuildPaymentHeader]); a client emits this
+// only when the server's challenge declared v1. Mirrors the rust
+// build_payment_header_v1 (client/exact/payment.rs).
+func BuildPaymentHeaderV1(
+	ctx context.Context,
+	signer solanatx.Signer,
+	rpc solanatx.RPCClient,
+	entry *x402.AcceptsEntry,
+) (string, error) {
+	if entry == nil {
+		return "", errors.New("x402 client: nil accept entry")
+	}
+	txBase64, err := buildTransaction(ctx, signer, rpc, entry)
+	if err != nil {
+		return "", err
+	}
+	credential := x402.Credential{
+		X402Version: x402VersionLegacy,
+		Scheme:      exactScheme,
+		Network:     v1NetworkForEntry(entry),
+		Payload:     x402.CredentialPayload{Transaction: txBase64},
+		// No Accepted: the v1 envelope binds only scheme+network.
+	}
+	raw, err := json.Marshal(credential)
+	if err != nil {
+		return "", fmt.Errorf("x402 client: marshal v1 credential: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw), nil
+}
+
+// v1NetworkForEntry maps an offer's network to the plain legacy SVM slug
+// the v1 wire uses: the devnet family (devnet/localnet, by cluster slug or
+// the shared devnet CAIP-2 id) maps to "solana-devnet" and everything else
+// maps to "solana". Mirrors the rust v1_network_for_requirements
+// (client/exact/payment.rs): only the devnet family is special-cased;
+// mainnet and testnet both collapse to the plain "solana" slug.
+func v1NetworkForEntry(entry *x402.AcceptsEntry) string {
+	switch entry.Network {
+	case "devnet", "solana-devnet", "localnet", solanaDevnetCAIP2:
+		return legacyNetworkDevnet
+	default:
+		return legacyNetworkMainnet
+	}
 }
 
 func buildTransaction(
@@ -457,18 +558,33 @@ func (t *PaymentTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	_ = resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
-	entry, ok := ParseChallenge(resp.Header, respBody, t.Selection)
+	entry, version, ok := ParseChallengeVersioned(resp.Header, respBody, t.Selection)
 	if !ok {
 		return resp, nil // not an x402 offer we can satisfy; hand back the 402.
-	}
-	header, err := BuildPaymentHeader(req.Context(), t.Signer, t.RPC, entry)
-	if err != nil {
-		return nil, err
 	}
 
 	retry := req.Clone(req.Context())
 	if bodyBytes != nil {
 		retry.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	// Emit the wire version the server declared: a v1 challenge gets the
+	// legacy X-PAYMENT producer, everything else stays on the canonical
+	// Payment-Signature producer (the default). Mirrors the rust client
+	// emitting the version the server's challenge declared while keeping
+	// v2 the default producer.
+	if version == x402VersionLegacy {
+		header, err := BuildPaymentHeaderV1(req.Context(), t.Signer, t.RPC, entry)
+		if err != nil {
+			return nil, err
+		}
+		retry.Header.Set(paymentHeaderLegacy, header)
+		return t.base().RoundTrip(retry)
+	}
+
+	header, err := BuildPaymentHeader(req.Context(), t.Signer, t.RPC, entry)
+	if err != nil {
+		return nil, err
 	}
 	retry.Header.Set(paymentSignatureHeader, header)
 	return t.base().RoundTrip(retry)

--- a/go/protocols/x402/client/client.go
+++ b/go/protocols/x402/client/client.go
@@ -312,10 +312,10 @@ func BuildPaymentHeader(
 	}
 	credential := x402.Credential{
 		X402Version: x402Version,
-		Scheme:      entry.Scheme,
-		Network:     entry.Network,
-		Payload:     x402.CredentialPayload{Transaction: txBase64},
-		Accepted:    entry,
+		// v2 omits top-level scheme/network (they ride in `accepted`),
+		// matching the rust spine; only the v1 producer sets them.
+		Payload:  x402.CredentialPayload{Transaction: txBase64},
+		Accepted: entry,
 	}
 	raw, err := json.Marshal(credential)
 	if err != nil {

--- a/go/protocols/x402/client/client_test.go
+++ b/go/protocols/x402/client/client_test.go
@@ -264,8 +264,13 @@ func decodeCredentialTx(t *testing.T, header string) *solana.Transaction {
 	if cred.X402Version != 2 {
 		t.Errorf("x402Version: got %d", cred.X402Version)
 	}
-	if !strings.EqualFold(cred.Scheme, "exact") {
-		t.Errorf("scheme: got %q", cred.Scheme)
+	// v2 omits top-level scheme/network (they ride in `accepted`), matching
+	// the rust spine which serializes them as None on v2.
+	if cred.Scheme != "" || cred.Network != "" {
+		t.Errorf("v2 must omit top-level scheme/network: got scheme=%q network=%q", cred.Scheme, cred.Network)
+	}
+	if cred.Accepted == nil || !strings.EqualFold(cred.Accepted.Scheme, "exact") {
+		t.Errorf("v2 scheme must ride in accepted: got %+v", cred.Accepted)
 	}
 	tx, err := solanatx.DecodeTransactionBase64(cred.Payload.Transaction)
 	if err != nil {

--- a/go/protocols/x402/client/v1_test.go
+++ b/go/protocols/x402/client/v1_test.go
@@ -1,0 +1,223 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/solana-foundation/pay-kit/go/internal/testutil"
+	x402 "github.com/solana-foundation/pay-kit/go/protocols/x402"
+)
+
+// decodeV1Credential decodes a legacy X-PAYMENT header into the typed
+// credential so the v1 wire shape can be asserted: x402Version=1, top-level
+// scheme + plain network slug, NO accepted object.
+func decodeV1Credential(t *testing.T, header string) x402.Credential {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	var cred x402.Credential
+	if err := json.Unmarshal(raw, &cred); err != nil {
+		t.Fatalf("unmarshal credential: %v", err)
+	}
+	return cred
+}
+
+func TestV1NetworkForEntry(t *testing.T) {
+	cases := []struct {
+		network string
+		want    string
+	}{
+		{"devnet", legacyNetworkDevnet},
+		{"solana-devnet", legacyNetworkDevnet},
+		{"localnet", legacyNetworkDevnet},
+		{devnetCAIP2, legacyNetworkDevnet},
+		{mainnetCAIP2, legacyNetworkMainnet},
+		{"mainnet-beta", legacyNetworkMainnet},
+		{"solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z", legacyNetworkMainnet}, // testnet collapses to "solana"
+		{"", legacyNetworkMainnet},
+	}
+	for _, c := range cases {
+		e := entry(testutil.NewPrivateKey().PublicKey().String(), "1", c.network)
+		if got := v1NetworkForEntry(&e); got != c.want {
+			t.Errorf("v1NetworkForEntry(%q): got %q want %q", c.network, got, c.want)
+		}
+	}
+}
+
+func TestBuildPaymentHeaderV1Devnet(t *testing.T) {
+	signer := testutil.NewPrivateKey()
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "1000", devnetCAIP2)
+
+	header, err := BuildPaymentHeaderV1(context.Background(), signer, testutil.NewFakeRPC(), &e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred := decodeV1Credential(t, header)
+	if cred.X402Version != x402VersionLegacy {
+		t.Errorf("x402Version: got %d want %d", cred.X402Version, x402VersionLegacy)
+	}
+	if cred.Scheme != exactScheme {
+		t.Errorf("scheme: got %q want %q", cred.Scheme, exactScheme)
+	}
+	if cred.Network != legacyNetworkDevnet {
+		t.Errorf("network: got %q want %q (plain slug, not CAIP-2)", cred.Network, legacyNetworkDevnet)
+	}
+	if cred.Accepted != nil {
+		t.Error("v1 envelope must not carry an accepted object")
+	}
+	if cred.Payload.Transaction == "" {
+		t.Error("v1 envelope missing transaction payload")
+	}
+}
+
+func TestBuildPaymentHeaderV1MainnetNetworkName(t *testing.T) {
+	signer := testutil.NewPrivateKey()
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "10000", mainnetCAIP2)
+
+	header, err := BuildPaymentHeaderV1(context.Background(), signer, testutil.NewFakeRPC(), &e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred := decodeV1Credential(t, header)
+	if cred.Network != legacyNetworkMainnet {
+		t.Errorf("network: got %q want %q", cred.Network, legacyNetworkMainnet)
+	}
+}
+
+func TestBuildPaymentHeaderV1NilEntry(t *testing.T) {
+	if _, err := BuildPaymentHeaderV1(context.Background(), testutil.NewPrivateKey(), testutil.NewFakeRPC(), nil); err == nil {
+		t.Fatal("expected error for nil entry")
+	}
+}
+
+func TestBuildPaymentHeaderV1BuildError(t *testing.T) {
+	signer := testutil.NewPrivateKey()
+	// A non-base58 recipient makes buildTransaction fail, so the v1
+	// producer must surface that error rather than emit a header.
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "1000", devnetCAIP2)
+	e.PayTo = "not-a-valid-base58-key"
+	if _, err := BuildPaymentHeaderV1(context.Background(), signer, testutil.NewFakeRPC(), &e); err == nil {
+		t.Fatal("expected build error for invalid recipient")
+	}
+}
+
+func TestParseChallengeVersionedV1Header(t *testing.T) {
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "1000", devnetCAIP2)
+	// A v1 challenge advertised in the legacy X-PAYMENT-REQUIRED header,
+	// carried as plain (un-base64'd) JSON, mirroring the rust dual-read.
+	body, _ := json.Marshal(challengeEnvelope{X402Version: x402VersionLegacy, Accepts: []x402.AcceptsEntry{e}})
+	h := http.Header{}
+	h.Set(paymentRequiredHeaderLegacy, string(body))
+
+	got, version, ok := ParseChallengeVersioned(h, nil, ChallengeSelection{})
+	if !ok {
+		t.Fatal("expected to parse a v1 challenge from the legacy header")
+	}
+	if version != x402VersionLegacy {
+		t.Errorf("version: got %d want %d", version, x402VersionLegacy)
+	}
+	if got == nil || got.Amount != "1000" {
+		t.Errorf("selected entry: got %+v", got)
+	}
+}
+
+func TestParseChallengeVersionedV1Body(t *testing.T) {
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "1000", devnetCAIP2)
+	body, _ := json.Marshal(challengeEnvelope{X402Version: x402VersionLegacy, Accepts: []x402.AcceptsEntry{e}})
+
+	_, version, ok := ParseChallengeVersioned(http.Header{}, body, ChallengeSelection{})
+	if !ok {
+		t.Fatal("expected to parse a v1 challenge from the 402 body")
+	}
+	if version != x402VersionLegacy {
+		t.Errorf("version: got %d want %d", version, x402VersionLegacy)
+	}
+}
+
+func TestParseChallengeVersionedV2HeaderWins(t *testing.T) {
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "1000", devnetCAIP2)
+	v2, _ := json.Marshal(challengeEnvelope{X402Version: x402Version, Accepts: []x402.AcceptsEntry{e}})
+	v1, _ := json.Marshal(challengeEnvelope{X402Version: x402VersionLegacy, Accepts: []x402.AcceptsEntry{e}})
+	h := http.Header{}
+	// Both headers present: the canonical v2 header takes precedence.
+	h.Set(paymentRequiredHeader, base64.StdEncoding.EncodeToString(v2))
+	h.Set(paymentRequiredHeaderLegacy, string(v1))
+
+	_, version, ok := ParseChallengeVersioned(h, nil, ChallengeSelection{})
+	if !ok {
+		t.Fatal("expected a challenge")
+	}
+	if version != x402Version {
+		t.Errorf("version: got %d want %d (v2 header must win)", version, x402Version)
+	}
+}
+
+func TestParseChallengeVersionedDefaultsToV2(t *testing.T) {
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "1000", mainnetCAIP2)
+	// Envelope without an explicit x402Version: defaults to the canonical
+	// version so the transport stays a v2 producer.
+	body, _ := json.Marshal(struct {
+		Accepts []x402.AcceptsEntry `json:"accepts"`
+	}{Accepts: []x402.AcceptsEntry{e}})
+
+	_, version, ok := ParseChallengeVersioned(http.Header{}, body, ChallengeSelection{})
+	if !ok {
+		t.Fatal("expected a challenge")
+	}
+	if version != x402Version {
+		t.Errorf("version: got %d want %d", version, x402Version)
+	}
+}
+
+// TestPaymentTransportSettlesV1Challenge proves the dual-read transport
+// emits the legacy X-PAYMENT producer (not Payment-Signature) when the
+// server's challenge declared v1.
+func TestPaymentTransportSettlesV1Challenge(t *testing.T) {
+	signer := testutil.NewPrivateKey()
+	e := entry(testutil.NewPrivateKey().PublicKey().String(), "100000", devnetCAIP2)
+	challenge, _ := json.Marshal(challengeEnvelope{X402Version: x402VersionLegacy, Accepts: []x402.AcceptsEntry{e}})
+
+	var sawV1, sawV2 string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cred := r.Header.Get(paymentHeaderLegacy); cred != "" {
+			sawV1 = cred
+			_, _ = io.WriteString(w, `{"ok":true}`)
+			return
+		}
+		if cred := r.Header.Get(paymentSignatureHeader); cred != "" {
+			sawV2 = cred
+			_, _ = io.WriteString(w, `{"ok":true}`)
+			return
+		}
+		// Advertise the v1 challenge as a 402 JSON body.
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write(challenge)
+	}))
+	defer srv.Close()
+
+	resp, err := NewClient(signer, testutil.NewFakeRPC()).Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	if sawV1 == "" {
+		t.Fatal("server never received an X-PAYMENT credential")
+	}
+	if sawV2 != "" {
+		t.Fatal("a v1 challenge must not produce a Payment-Signature credential")
+	}
+	cred := decodeV1Credential(t, sawV1)
+	if cred.X402Version != x402VersionLegacy || cred.Scheme != exactScheme || cred.Network != legacyNetworkDevnet {
+		t.Errorf("v1 credential shape wrong: %+v", cred)
+	}
+}

--- a/go/protocols/x402/v1_server_test.go
+++ b/go/protocols/x402/v1_server_test.go
@@ -1,0 +1,199 @@
+package x402
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/solana-foundation/pay-kit/go/paycore/signer"
+	"github.com/solana-foundation/pay-kit/go/paykit"
+)
+
+// Plain legacy SVM network slugs used to construct v1 credentials in these
+// tests. The server normalizes them via normalizeNetwork before the gate.
+const (
+	legacyNetworkMainnet = "solana"
+	legacyNetworkDevnet  = "solana-devnet"
+)
+
+// v1Credential re-wraps the transaction from a settle fixture into a legacy
+// v1 envelope (x402Version=1, top-level scheme + plain network slug, no
+// accepted object), returning the base64 X-PAYMENT header value.
+func v1Credential(t *testing.T, v2Sig, network string) string {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(v2Sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v2 Credential
+	if err := json.Unmarshal(raw, &v2); err != nil {
+		t.Fatal(err)
+	}
+	v1 := Credential{
+		X402Version: x402VersionLegacy,
+		Scheme:      exactScheme,
+		Network:     network,
+		Payload:     v2.Payload,
+	}
+	out, err := json.Marshal(v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(out)
+}
+
+// TestVerifyAndSettleV1HappyPath proves the server dual-accepts a legacy v1
+// envelope posted in the X-PAYMENT header (PaymentSigLegacy), settles it,
+// and echoes the settlement on the legacy X-PAYMENT-RESPONSE header.
+func TestVerifyAndSettleV1HappyPath(t *testing.T) {
+	fake := &fakeRPC{sig: solana.MustSignatureFromBase58(sampleSig), confirm: rpc.ConfirmationStatusConfirmed}
+	a, gate, v2Sig := settleFixture(t, fake)
+	// Localnet normalizes to the devnet CAIP-2, so the plain "solana-devnet"
+	// slug matches the route network.
+	v1Sig := v1Credential(t, v2Sig, legacyNetworkDevnet)
+
+	pmt, err := a.VerifyAndSettle(&paykit.AdapterRequest{Gate: gate, PaymentSigLegacy: v1Sig})
+	if err != nil {
+		t.Fatalf("expected v1 settle to succeed, got %v", err)
+	}
+	if pmt.SettlementHeaders[paymentResponseHeaderLegacy] == "" {
+		t.Error("v1 settle must emit the legacy x-payment-response header")
+	}
+	if pmt.SettlementHeaders[paymentResponseHeader] != "" {
+		t.Error("v1 settle must not emit the canonical payment-response header")
+	}
+	if pmt.SettlementHeaders[settlementHeader] != sampleSig {
+		t.Error("settlement signature header missing")
+	}
+	// The decoded v1 settlement body carries success + payer + network.
+	body, err := base64.StdEncoding.DecodeString(pmt.SettlementHeaders[paymentResponseHeaderLegacy])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resp SettlementResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success || resp.Payer == "" {
+		t.Errorf("v1 settlement response: %+v", resp)
+	}
+}
+
+// TestVerifyAndSettleV1PrefersV2Header proves that when both credentials are
+// present the canonical Payment-Signature wins (the legacy header is only a
+// fallback), matching the rust dual-read precedence.
+func TestVerifyAndSettleV1PrefersV2Header(t *testing.T) {
+	fake := &fakeRPC{sig: solana.MustSignatureFromBase58(sampleSig), confirm: rpc.ConfirmationStatusConfirmed}
+	a, gate, v2Sig := settleFixture(t, fake)
+	// A deliberately broken legacy credential: if the server fell back to
+	// it instead of preferring the v2 header, the settle would fail.
+	pmt, err := a.VerifyAndSettle(&paykit.AdapterRequest{
+		Gate:             gate,
+		PaymentSig:       v2Sig,
+		PaymentSigLegacy: "not-base64-and-would-fail",
+	})
+	if err != nil {
+		t.Fatalf("expected v2 header to win and settle, got %v", err)
+	}
+	if pmt.SettlementHeaders[paymentResponseHeader] == "" {
+		t.Error("v2 settle must emit the canonical payment-response header")
+	}
+}
+
+func TestVerifyAndSettleV1RejectsWrongScheme(t *testing.T) {
+	fake := &fakeRPC{sig: solana.MustSignatureFromBase58(sampleSig), confirm: rpc.ConfirmationStatusConfirmed}
+	a, gate, v2Sig := settleFixture(t, fake)
+
+	raw, _ := base64.StdEncoding.DecodeString(v2Sig)
+	var v2 Credential
+	_ = json.Unmarshal(raw, &v2)
+	bad := Credential{X402Version: x402VersionLegacy, Scheme: "not-exact", Network: legacyNetworkDevnet, Payload: v2.Payload}
+	badJSON, _ := json.Marshal(bad)
+
+	_, err := a.VerifyAndSettle(&paykit.AdapterRequest{
+		Gate:             gate,
+		PaymentSigLegacy: base64.StdEncoding.EncodeToString(badJSON),
+	})
+	if err == nil {
+		t.Fatal("expected scheme mismatch rejection")
+	}
+	var perr *paykit.PaymentError
+	if !errorsAs(err, &perr) || perr.Code != "charge_request_mismatch" {
+		t.Errorf("expected charge_request_mismatch, got %v", err)
+	}
+}
+
+func TestVerifyAndSettleV1RejectsWrongNetwork(t *testing.T) {
+	fake := &fakeRPC{sig: solana.MustSignatureFromBase58(sampleSig), confirm: rpc.ConfirmationStatusConfirmed}
+	a, gate, v2Sig := settleFixture(t, fake)
+	// "solana" normalizes to mainnet; the route is localnet (devnet).
+	v1Sig := v1Credential(t, v2Sig, legacyNetworkMainnet)
+
+	_, err := a.VerifyAndSettle(&paykit.AdapterRequest{Gate: gate, PaymentSigLegacy: v1Sig})
+	if err == nil {
+		t.Fatal("expected network mismatch rejection")
+	}
+	var perr *paykit.PaymentError
+	if !errorsAs(err, &perr) || perr.Code != "charge_request_mismatch" {
+		t.Errorf("expected charge_request_mismatch, got %v", err)
+	}
+}
+
+func TestVerifyAndSettleStillRejectsUnknownVersion(t *testing.T) {
+	a, err := New(cfgLocal())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A v1-shaped envelope (top-level scheme/network) carrying an unknown
+	// version must still be rejected: dual-accept does not widen the gate.
+	bad := Credential{X402Version: 9, Scheme: exactScheme, Network: legacyNetworkDevnet}
+	badJSON, _ := json.Marshal(bad)
+	g := paykit.Gate{Amount: paykit.MustParseUSD("0.10")}
+	_, err = a.VerifyAndSettle(&paykit.AdapterRequest{
+		Gate:             &g,
+		PaymentSigLegacy: base64.StdEncoding.EncodeToString(badJSON),
+	})
+	if err == nil {
+		t.Fatal("expected version_mismatch for unknown version")
+	}
+	var perr *paykit.PaymentError
+	if !errorsAs(err, &perr) || perr.Code != "version_mismatch" {
+		t.Errorf("expected version_mismatch, got %v", err)
+	}
+}
+
+func TestVerifyLegacyBindingDirect(t *testing.T) {
+	a, err := New(cfgLocal())
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := a.(*Adapter)
+	g := &paykit.Gate{Amount: paykit.MustParseUSD("0.10")}
+
+	if err := adapter.verifyLegacyBinding(g, &Credential{Scheme: exactScheme, Network: legacyNetworkDevnet}); err != nil {
+		t.Errorf("devnet slug against localnet route should bind: %v", err)
+	}
+	if err := adapter.verifyLegacyBinding(g, &Credential{Scheme: "bad", Network: legacyNetworkDevnet}); err == nil {
+		t.Error("non-exact scheme must be rejected")
+	}
+	if err := adapter.verifyLegacyBinding(g, &Credential{Scheme: exactScheme, Network: legacyNetworkMainnet}); err == nil {
+		t.Error("mainnet slug against devnet route must be rejected")
+	}
+}
+
+// cfgLocal builds a localnet adapter config for the envelope-level v1 tests
+// that never reach broadcast.
+func cfgLocal() paykit.Config {
+	return paykit.Config{
+		Network: paykit.SolanaLocalnet,
+		Accept:  []paykit.Protocol{paykit.X402},
+		Operator: paykit.Operator{
+			Signer:    signer.Demo(),
+			Recipient: signer.Demo().Pubkey(),
+		},
+		X402:                    paykit.X402Config{Scheme: "exact"},
+		RecentBlockhashProvider: func() (string, error) { return "BLOCKHASH-STUB-111111111111111111111111111", nil },
+	}
+}

--- a/go/protocols/x402/x402.go
+++ b/go/protocols/x402/x402.go
@@ -29,7 +29,29 @@ const (
 	paymentRequiredHeader = "payment-required"
 	paymentResponseHeader = "payment-response"
 	settlementHeader      = "x-payment-settlement-signature"
-	x402Version           = 2
+
+	// paymentResponseHeaderLegacy is the legacy v1 settlement-response
+	// header. The server writes the settlement under this name when the
+	// credential was a v1 X-PAYMENT envelope. Mirrors the rust
+	// X402_V1_PAYMENT_RESPONSE_HEADER (constants.rs).
+	paymentResponseHeaderLegacy = "x-payment-response"
+
+	x402Version = 2
+
+	// x402VersionLegacy is the legacy x402 wire version. The server
+	// dual-accepts it (a legacy client posts an X-PAYMENT header whose
+	// envelope carries x402Version=1 with top-level scheme+network and no
+	// `accepted` object), while still emitting the canonical version-2
+	// challenge by default. Mirrors the rust spine X402_VERSION_V1
+	// (rust/crates/x402/src/constants.rs) and the parse_payment_signature
+	// version dispatch (server/exact.rs).
+	x402VersionLegacy = 1
+
+	// exactScheme is the only scheme x402-exact speaks. The legacy v1
+	// envelope binds scheme+network at the top level, so the server
+	// rejects a v1 credential whose scheme is not "exact". Mirrors the
+	// rust EXACT_SCHEME check in the v1 arm (server/exact.rs).
+	exactScheme = "exact"
 
 	// stablecoinDecimals is the mint decimal count advertised in the
 	// challenge. Every stablecoin in the paycore table (USDC, USDT, USDG,
@@ -366,6 +388,7 @@ type SettlementResponse struct {
 	Transaction string `json:"transaction"`
 	Network     string `json:"network"`
 	Payer       string `json:"payer"`
+	ErrorReason string `json:"errorReason,omitempty"`
 }
 
 func (a *Adapter) AcceptsEntry(gate *paykit.Gate) paykit.AcceptsEntry {
@@ -429,7 +452,15 @@ func (a *Adapter) ChallengeHeaders(gate *paykit.Gate) map[string]string {
 
 func (a *Adapter) VerifyAndSettle(req *paykit.AdapterRequest) (*paykit.Payment, error) {
 	ctx := context.Background()
+	// Dual-accept: prefer the canonical Payment-Signature credential, then
+	// fall back to the legacy X-PAYMENT header so a v1 client is honoured
+	// without the server speaking two header names anywhere else. Mirrors
+	// the rust spine reading the v2 path first then the v1 envelope
+	// (server/exact.rs parse_payment_signature dispatch).
 	sig := req.PaymentSig
+	if sig == "" {
+		sig = req.PaymentSigLegacy
+	}
 	if sig == "" {
 		return nil, &paykit.PaymentError{Code: "payment_required", Err: paykit.ErrPaymentRequired, Gate: req.Gate}
 	}
@@ -441,22 +472,37 @@ func (a *Adapter) VerifyAndSettle(req *paykit.AdapterRequest) (*paykit.Payment, 
 	if err := json.Unmarshal(credBytes, &credential); err != nil {
 		return nil, &paykit.PaymentError{Code: "invalid_payload", Err: fmt.Errorf("decode credential: %w", err), Gate: req.Gate}
 	}
-	if credential.X402Version != x402Version {
-		return nil, &paykit.PaymentError{Code: "version_mismatch", Err: fmt.Errorf("unsupported x402Version %d", credential.X402Version), Gate: req.Gate}
-	}
 
-	// Echoed-accepted binding: when the credential carries an `accepted`
-	// object it is the requirements the client claims to be paying for.
-	// Compare it against the ROUTE's requirements (never the other way),
-	// so a credential that lies about its accepted offer is rejected
-	// before any transaction processing or settlement. Targeted field
-	// checks first, then a structural backstop over the canonical
-	// accepted shape. Mirrors Rust verify_envelope_payload
-	// (server/exact.rs:490-541).
-	if credential.Accepted != nil {
-		if err := a.verifyAcceptedBinding(req.Gate, credential.Accepted); err != nil {
+	// Version dispatch. The legacy v1 envelope commits only to the
+	// top-level scheme + network (no `accepted` object), so the server
+	// binds those two fields. The canonical v2 envelope echoes the full
+	// `accepted` offer, which is compared field-by-field against the
+	// route. A genuinely-unknown version is rejected; supporting v1 does
+	// NOT widen the gate. Mirrors the rust parse_payment_signature arms
+	// (server/exact.rs): v1 binds scheme+network, v2 binds accepted, any
+	// other version is "Unsupported x402 version". The downstream
+	// structural transfer verification is identical for both versions.
+	switch credential.X402Version {
+	case x402VersionLegacy:
+		if err := a.verifyLegacyBinding(req.Gate, &credential); err != nil {
 			return nil, &paykit.PaymentError{Code: "charge_request_mismatch", Err: err, Gate: req.Gate}
 		}
+	case x402Version:
+		// Echoed-accepted binding: when the credential carries an
+		// `accepted` object it is the requirements the client claims to
+		// be paying for. Compare it against the ROUTE's requirements
+		// (never the other way), so a credential that lies about its
+		// accepted offer is rejected before any transaction processing
+		// or settlement. Targeted field checks first, then a structural
+		// backstop over the canonical accepted shape. Mirrors Rust
+		// verify_envelope_payload (server/exact.rs:490-541).
+		if credential.Accepted != nil {
+			if err := a.verifyAcceptedBinding(req.Gate, credential.Accepted); err != nil {
+				return nil, &paykit.PaymentError{Code: "charge_request_mismatch", Err: err, Gate: req.Gate}
+			}
+		}
+	default:
+		return nil, &paykit.PaymentError{Code: "version_mismatch", Err: fmt.Errorf("unsupported x402 version %d", credential.X402Version), Gate: req.Gate}
 	}
 
 	txBase64 := credential.Payload.Transaction
@@ -534,11 +580,22 @@ func (a *Adapter) VerifyAndSettle(req *paykit.AdapterRequest) (*paykit.Payment, 
 		Success:     true,
 		Transaction: signature.String(),
 		Network:     a.cfg.Network.CAIP2(),
+		Payer:       tx.Message.AccountKeys[0].String(),
 	}
 	respRaw, _ := json.Marshal(respEnvelope)
 	headers := map[string]string{
-		paymentResponseHeader: base64.StdEncoding.EncodeToString(respRaw),
-		settlementHeader:      signature.String(),
+		settlementHeader: signature.String(),
+	}
+	// Echo the settlement on the header name matching the credential's
+	// wire version: a legacy v1 client posted X-PAYMENT and expects the
+	// X-PAYMENT-RESPONSE header, while the canonical client gets
+	// payment-response. Mirrors the rust v1/v2 response header split
+	// (constants.rs X402_V1_PAYMENT_RESPONSE_HEADER vs
+	// X402_V2_PAYMENT_RESPONSE_HEADER).
+	if credential.X402Version == x402VersionLegacy {
+		headers[paymentResponseHeaderLegacy] = base64.StdEncoding.EncodeToString(respRaw)
+	} else {
+		headers[paymentResponseHeader] = base64.StdEncoding.EncodeToString(respRaw)
 	}
 	return &paykit.Payment{
 		Protocol:          paykit.X402,
@@ -547,6 +604,26 @@ func (a *Adapter) VerifyAndSettle(req *paykit.AdapterRequest) (*paykit.Payment, 
 		SettlementHeaders: headers,
 		Raw:               sig,
 	}, nil
+}
+
+// verifyLegacyBinding validates the legacy v1 envelope, which carries no
+// echoed `accepted` offer: it commits only to the top-level scheme and
+// network. The scheme must be "exact" and the plain network slug must
+// normalize to this route's network. The structural transaction verifier
+// (verifyExactTransaction) still proves the transfer matches the route's
+// recipient/amount/mint downstream, so the binding here is intentionally
+// the same scheme+network check the rust v1 arm performs
+// (server/exact.rs parse_payment_signature v1 arm).
+func (a *Adapter) verifyLegacyBinding(gate *paykit.Gate, credential *Credential) error {
+	if credential.Scheme != exactScheme {
+		return fmt.Errorf("scheme mismatch: expected %s, got %q", exactScheme, credential.Scheme)
+	}
+	route := a.routeAccepts(gate)
+	got := normalizeNetwork(credential.Network)
+	if got != route.Network {
+		return fmt.Errorf("network mismatch: expected %s, got %s", route.Network, credential.Network)
+	}
+	return nil
 }
 
 // verifyAcceptedBinding rejects a credential whose echoed `accepted`

--- a/go/protocols/x402/x402.go
+++ b/go/protocols/x402/x402.go
@@ -364,11 +364,14 @@ func (e AcceptsEntry) AcceptsProtocol() paykit.Protocol { return paykit.X402 }
 // Credential is the typed x402 credential the client posts in the
 // payment-signature header (base64 of this JSON).
 type Credential struct {
-	X402Version int               `json:"x402Version"`
-	Scheme      string            `json:"scheme"`
-	Network     string            `json:"network"`
-	Payload     CredentialPayload `json:"payload"`
-	Accepted    *AcceptsEntry     `json:"accepted,omitempty"`
+	X402Version int `json:"x402Version"`
+	// Scheme/Network are top-level only on the legacy v1 envelope; the v2
+	// producer omits them (the offer rides in `accepted`), matching the rust
+	// spine which sets scheme/network to None on v2 (client/exact/payment.rs).
+	Scheme   string            `json:"scheme,omitempty"`
+	Network  string            `json:"network,omitempty"`
+	Payload  CredentialPayload `json:"payload"`
+	Accepted *AcceptsEntry     `json:"accepted,omitempty"`
 }
 
 // CredentialPayload carries the protocol-specific bits the client

--- a/harness/src/conformance/x402.ts
+++ b/harness/src/conformance/x402.ts
@@ -242,6 +242,16 @@ export function parseX402Challenge(
 
   const v1Header = find(X402_V1_PAYMENT_REQUIRED_HEADER);
   if (v1Header) {
+    // The rust spine parses X-PAYMENT-REQUIRED as RAW JSON
+    // (client/exact/payment.rs: serde_json::from_str on the header value),
+    // not base64. Accept both: raw JSON first (rust parity), then a base64
+    // envelope, so this oracle interoperates with either producer.
+    try {
+      const offer = parseV1ChallengeBody(v1Header);
+      if (offer) return offer;
+    } catch {
+      /* not raw JSON; try base64 */
+    }
     try {
       const decoded = Buffer.from(v1Header, "base64").toString("utf8");
       const offer = parseV1ChallengeBody(decoded);

--- a/harness/src/conformance/x402.ts
+++ b/harness/src/conformance/x402.ts
@@ -162,6 +162,103 @@ export function decodeEnvelopeShape(header: string): X402EnvelopeShape {
   return shape;
 }
 
+// A parsed offer selected from a v1/express 402 JSON body. Mirrors the
+// subset of rust `PaymentRequirements` the client commits to after
+// `parse_accepts_body` (client/exact/payment.rs:278-286): the legacy v1
+// challenge carries `accepts[]` with `maxAmountRequired`/`payTo`/`asset`.
+export type X402ParsedOffer = {
+  network: string;
+  amount: string;
+  asset: string;
+  payTo: string;
+};
+
+type V1ChallengeAccept = {
+  scheme?: string;
+  network?: string;
+  // v1 amount field; v2 spelling `amount` also accepted for robustness.
+  maxAmountRequired?: string;
+  amount?: string;
+  // v1 recipient field; legacy `recipient` also accepted.
+  payTo?: string;
+  recipient?: string;
+  // v1 asset field; legacy `currency` also accepted.
+  asset?: string;
+  currency?: string;
+};
+
+type V1ChallengeBody = {
+  x402Version?: number;
+  error?: string;
+  accepts?: V1ChallengeAccept[];
+};
+
+// Parse a v1 / x402-express 402 JSON BODY challenge into a selected offer.
+// Mirrors rust `parse_accepts_body` field fallbacks
+// (protocol/schemes/exact/types.rs:334-355): amount <- maxAmountRequired,
+// recipient <- payTo, currency <- asset. Picks the first Solana `accepts`
+// entry (the harness oracle uses single-offer v1 bodies). Returns
+// `undefined` when the body has no usable Solana offer. RPC-free.
+export function parseV1ChallengeBody(body: string): X402ParsedOffer | undefined {
+  let parsed: V1ChallengeBody;
+  try {
+    parsed = JSON.parse(body) as V1ChallengeBody;
+  } catch {
+    return undefined;
+  }
+  const accepts = parsed.accepts;
+  if (!Array.isArray(accepts) || accepts.length === 0) return undefined;
+  const offer = accepts[0];
+  const network = offer.network ?? "";
+  const amount = offer.maxAmountRequired ?? offer.amount ?? "";
+  const payTo = offer.payTo ?? offer.recipient ?? "";
+  const asset = offer.asset ?? offer.currency ?? "";
+  if (!network || !amount || !payTo || !asset) return undefined;
+  return { network, amount, asset, payTo };
+}
+
+// Parse an x402 challenge from response headers AND/OR body, in the rust
+// precedence order (client/exact/payment.rs:232-262): the v2
+// PAYMENT-REQUIRED header first, then the v1 X-PAYMENT-REQUIRED header,
+// then the v1/express body as the fallback. Returns the selected offer or
+// `undefined`. Header values are standard base64 of the challenge JSON.
+export function parseX402Challenge(
+  headers: Array<[string, string]>,
+  body: string | undefined,
+): X402ParsedOffer | undefined {
+  const find = (name: string): string | undefined =>
+    headers.find(([k]) => k.toLowerCase() === name.toLowerCase())?.[1];
+
+  const v2Header = find(X402_V2_PAYMENT_REQUIRED_HEADER);
+  if (v2Header) {
+    try {
+      const decoded = Buffer.from(v2Header, "base64").toString("utf8");
+      const offer = parseV1ChallengeBody(decoded);
+      if (offer) return offer;
+    } catch {
+      /* fall through to v1 header / body */
+    }
+  }
+
+  const v1Header = find(X402_V1_PAYMENT_REQUIRED_HEADER);
+  if (v1Header) {
+    try {
+      const decoded = Buffer.from(v1Header, "base64").toString("utf8");
+      const offer = parseV1ChallengeBody(decoded);
+      if (offer) return offer;
+    } catch {
+      /* fall through to body */
+    }
+  }
+
+  if (body) {
+    const offer = parseV1ChallengeBody(body);
+    if (offer) return offer;
+  }
+
+  return undefined;
+}
+
 export type X402ServerRoute = {
   network: string; // CAIP-2 or cluster slug; normalized via caip2NetworkForCluster
   recipient: string;

--- a/harness/test/x402-v1-exact.test.ts
+++ b/harness/test/x402-v1-exact.test.ts
@@ -1,0 +1,189 @@
+// Unit coverage for the legacy x402 EXACT v1 wire shape in the conformance
+// reference (src/conformance/x402.ts). These assert the v1 build/verify/
+// parse contract that the cross-SDK vectors (harness/vectors/x402-v1-*.json)
+// drive across every SDK runner, plus the body-challenge parse path that
+// the vector driver has no dedicated mode for.
+//
+// The contract is mirrored from the rust spine; see
+// docs/x402/exact-v1-spec.md for the per-rule file:line citations.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildPaymentHeaderV1,
+  buildPaymentHeaderV2,
+  decodeEnvelopeShape,
+  parseV1ChallengeBody,
+  parseX402Challenge,
+  v1NetworkForOffer,
+  verifyPaymentHeader,
+  SOLANA_DEVNET,
+  SOLANA_MAINNET,
+} from "../src/conformance/x402";
+import type { X402Offer } from "../src/conformance/schema";
+
+const devnetOffer: X402Offer = {
+  scheme: "exact",
+  network: SOLANA_DEVNET,
+  amount: "1000",
+  asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+  payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+  maxTimeoutSeconds: 60,
+  extra: { feePayer: "6AfzJJo1KfhNWKe56wa5EWszTNQ7B1W5Kfh5SY2JkRGQ" },
+};
+
+const mainnetOffer: X402Offer = {
+  scheme: "exact",
+  network: SOLANA_MAINNET,
+  amount: "10000",
+  asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+  maxTimeoutSeconds: 300,
+};
+
+describe("x402 v1 network-name mapping", () => {
+  it("maps devnet-family offers to the plain slug solana-devnet", () => {
+    expect(v1NetworkForOffer(devnetOffer)).toBe("solana-devnet");
+  });
+
+  it("maps everything else to the plain slug solana", () => {
+    expect(v1NetworkForOffer(mainnetOffer)).toBe("solana");
+  });
+});
+
+describe("x402 v1 client build (X-PAYMENT)", () => {
+  it("emits top-level scheme + plain network, no accepted", () => {
+    const header = buildPaymentHeaderV1(devnetOffer, "AA==");
+    const shape = decodeEnvelopeShape(header);
+    expect(shape.x402Version).toBe(1);
+    expect(shape.scheme).toBe("exact");
+    expect(shape.network).toBe("solana-devnet");
+    expect(shape.hasAccepted).toBe(false);
+    expect(shape.payloadHasTransaction).toBe(true);
+    // v1 must NOT carry CAIP-2 in the top-level network field.
+    expect(shape.network).not.toContain("solana:");
+  });
+
+  it("is standard (padded) base64, not base64url", () => {
+    const header = buildPaymentHeaderV1(devnetOffer, "AA==");
+    // standard base64 uses + and / and = padding; base64url uses - and _.
+    expect(header).not.toMatch(/[-_]/);
+    const roundTrip = Buffer.from(header, "base64").toString("utf8");
+    expect(JSON.parse(roundTrip).x402Version).toBe(1);
+  });
+});
+
+describe("x402 v1 server verify (dual-accept)", () => {
+  const devnetRoute = {
+    network: "devnet",
+    recipient: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+    currency: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    amount: "1000",
+  };
+
+  it("accepts a v1 X-PAYMENT against a matching-network route", () => {
+    const header = buildPaymentHeaderV1(devnetOffer, "AA==");
+    expect(verifyPaymentHeader(header, devnetRoute)).toEqual({ ok: true });
+  });
+
+  it("rejects a v1 credential signed for the wrong network", () => {
+    const header = buildPaymentHeaderV1(mainnetOffer, "AA==");
+    expect(() => verifyPaymentHeader(header, devnetRoute)).toThrow(
+      /Network mismatch/i,
+    );
+  });
+
+  it("rejects a genuinely-unknown version on the v1-shaped path", () => {
+    const env = {
+      x402Version: 9,
+      scheme: "exact",
+      network: "solana-devnet",
+      payload: { transaction: "AA==" },
+    };
+    const header = Buffer.from(JSON.stringify(env)).toString("base64");
+    expect(() => verifyPaymentHeader(header, devnetRoute)).toThrow(
+      /Unsupported x402 version/i,
+    );
+  });
+
+  it("still accepts a v2 PAYMENT-SIGNATURE on the same server (emit-v2-default peer)", () => {
+    const header = buildPaymentHeaderV2(devnetOffer, "AA==");
+    expect(verifyPaymentHeader(header, devnetRoute)).toEqual({ ok: true });
+  });
+});
+
+describe("x402 v1 client parses a 402 JSON-body challenge", () => {
+  // The legacy v1 challenge arrives as the HTTP 402 body with accepts[]
+  // and maxAmountRequired. Mirrors rust parse_accepts_body.
+  const v1Body = JSON.stringify({
+    x402Version: 1,
+    error: "PAYMENT-SIGNATURE header is required",
+    accepts: [
+      {
+        scheme: "exact",
+        network: "solana-devnet",
+        maxAmountRequired: "1000",
+        asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+        payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+        resource: "http://localhost:3402/x402/joke",
+        maxTimeoutSeconds: 60,
+        extra: { feePayer: "6AfzJJo1KfhNWKe56wa5EWszTNQ7B1W5Kfh5SY2JkRGQ" },
+      },
+    ],
+  });
+
+  it("reads maxAmountRequired/payTo/asset from accepts[]", () => {
+    const offer = parseV1ChallengeBody(v1Body);
+    expect(offer).toEqual({
+      network: "solana-devnet",
+      amount: "1000",
+      asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+    });
+  });
+
+  it("round-trips through the v1 builder: parsed body -> X-PAYMENT", () => {
+    const offer = parseV1ChallengeBody(v1Body);
+    expect(offer).toBeDefined();
+    if (!offer) return;
+    // Rebuild a v1 header from the parsed offer (network slug is already a
+    // plain v1 name here, which v1NetworkForOffer maps to itself).
+    const header = buildPaymentHeaderV1(
+      { ...offer, scheme: "exact" } as X402Offer,
+      "AA==",
+    );
+    const shape = decodeEnvelopeShape(header);
+    expect(shape.x402Version).toBe(1);
+    expect(shape.network).toBe("solana-devnet");
+  });
+
+  it("falls back to the v1 body only after the v2 header path", () => {
+    // No v2 header present -> body is consulted.
+    const fromBody = parseX402Challenge([], v1Body);
+    expect(fromBody?.amount).toBe("1000");
+
+    // A valid v2 PAYMENT-REQUIRED header wins over a v1 body.
+    const v2Body = JSON.stringify({
+      x402Version: 2,
+      accepts: [
+        {
+          scheme: "exact",
+          network: SOLANA_DEVNET,
+          amount: "777",
+          asset: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+          payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+        },
+      ],
+    });
+    const v2Header = Buffer.from(v2Body).toString("base64");
+    const fromHeader = parseX402Challenge(
+      [["PAYMENT-REQUIRED", v2Header]],
+      v1Body,
+    );
+    expect(fromHeader?.amount).toBe("777");
+  });
+
+  it("returns undefined for a body with no Solana offer", () => {
+    expect(parseV1ChallengeBody('{"accepts":[]}')).toBeUndefined();
+    expect(parseV1ChallengeBody("not json")).toBeUndefined();
+  });
+});

--- a/harness/vectors/x402-v1-build.json
+++ b/harness/vectors/x402-v1-build.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "x402-exact-v1-build-devnet",
+    "intent": "x402-exact",
+    "mode": "build-transaction",
+    "description": "Client builds a legacy v1 X-PAYMENT envelope from a devnet USDC offer. Asserts the v1 shape: x402Version=1, top-level scheme=\"exact\" and plain network slug \"solana-devnet\" (NOT CAIP-2), payloadHasTransaction=true, and NO accepted object (v1 commits only to scheme+network, unlike v2). Mirrors rust build_payment_header_v1 (client/exact/payment.rs:153-170) + v1_network_for_requirements (payment.rs:393-404).",
+    "input": {
+      "x402Version": 1,
+      "x402Offer": {
+        "scheme": "exact",
+        "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+        "amount": "1000",
+        "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+        "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+        "maxTimeoutSeconds": 60,
+        "extra": { "feePayer": "6AfzJJo1KfhNWKe56wa5EWszTNQ7B1W5Kfh5SY2JkRGQ" }
+      },
+      "x402PinnedTransaction": "AA=="
+    },
+    "expect": {
+      "outcome": "accept",
+      "x402EnvelopeShape": {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "solana-devnet",
+        "hasAccepted": false,
+        "payloadHasTransaction": true
+      }
+    }
+  },
+  {
+    "id": "x402-exact-v1-build-mainnet-network-name",
+    "intent": "x402-exact",
+    "mode": "build-transaction",
+    "description": "v1 SVM network-name mapping: a mainnet CAIP-2 offer produces the plain legacy slug \"solana\" (everything not devnet-family maps to \"solana\"). Confirms the producer emits a plain name, never the CAIP-2 string, on the top-level network field. Mirrors rust v1_network_for_requirements default arm (client/exact/payment.rs:402).",
+    "input": {
+      "x402Version": 1,
+      "x402Offer": {
+        "scheme": "exact",
+        "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "amount": "10000",
+        "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+        "maxTimeoutSeconds": 300
+      },
+      "x402PinnedTransaction": "AA=="
+    },
+    "expect": {
+      "outcome": "accept",
+      "x402EnvelopeShape": {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "solana",
+        "hasAccepted": false,
+        "payloadHasTransaction": true
+      }
+    }
+  },
+  {
+    "id": "x402-exact-v2-build-default-producer",
+    "intent": "x402-exact",
+    "mode": "build-transaction",
+    "description": "Default producer stays v2: with no version pinned, the client emits a v2 PAYMENT-SIGNATURE envelope (x402Version=2, accepted echoes the offer, NO top-level scheme/network). Guards that adding v1 support does not flip the default emitter. Mirrors rust build_payment_header (client/exact/payment.rs:132-150) being the default path.",
+    "input": {
+      "x402Offer": {
+        "scheme": "exact",
+        "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+        "amount": "1000",
+        "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+        "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+        "maxTimeoutSeconds": 300,
+        "extra": { "decimals": 6 }
+      },
+      "x402PinnedTransaction": "AA=="
+    },
+    "expect": {
+      "outcome": "accept",
+      "x402EnvelopeShape": {
+        "x402Version": 2,
+        "hasAccepted": true,
+        "payloadHasTransaction": true,
+        "acceptedScheme": "exact",
+        "acceptedNetwork": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+        "acceptedAsset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+        "acceptedPayTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+        "acceptedAmount": "1000"
+      }
+    }
+  }
+]

--- a/harness/vectors/x402-v1-verify.json
+++ b/harness/vectors/x402-v1-verify.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "x402-exact-v1-verify-accept-devnet",
+    "intent": "x402-exact",
+    "mode": "verify-transaction",
+    "description": "Server accepts a legacy v1 X-PAYMENT envelope (x402Version=1, top-level scheme=\"exact\" + plain network \"solana-devnet\", payload.transaction) against a devnet route. v1 has no accepted object: the server binds only scheme + network (normalized via caip2_network_for_cluster), then settles. Mirrors rust parse_payment_signature v1 arm (server/exact.rs:316-327). The decoded shape carries scheme/network and hasAccepted=false.",
+    "input": {
+      "x402PaymentHeader": "eyJ4NDAyVmVyc2lvbiI6MSwic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoic29sYW5hLWRldm5ldCIsInBheWxvYWQiOnsidHJhbnNhY3Rpb24iOiJBQT09In19",
+      "x402ServerNetwork": "devnet",
+      "x402ServerRecipient": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+      "x402ServerCurrency": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "x402ServerAmount": "1000"
+    },
+    "expect": {
+      "outcome": "accept",
+      "x402EnvelopeShape": {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "solana-devnet",
+        "hasAccepted": false,
+        "payloadHasTransaction": true
+      }
+    }
+  },
+  {
+    "id": "x402-exact-v1-verify-accept-mainnet",
+    "intent": "x402-exact",
+    "mode": "verify-transaction",
+    "description": "v1 SVM network-name mapping on the server side: a v1 credential with plain network \"solana\" verifies against a mainnet-beta route. The server normalizes \"solana\" -> mainnet CAIP-2 before the network gate, so the plain legacy slug is accepted. Mirrors caip2_network_for_cluster(\"solana\") (types.rs:33) in the v1 arm (server/exact.rs:321-326).",
+    "input": {
+      "x402PaymentHeader": "eyJ4NDAyVmVyc2lvbiI6MSwic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoic29sYW5hIiwicGF5bG9hZCI6eyJ0cmFuc2FjdGlvbiI6IkFBPT0ifX0=",
+      "x402ServerNetwork": "mainnet-beta",
+      "x402ServerRecipient": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+      "x402ServerCurrency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "x402ServerAmount": "10000"
+    },
+    "expect": {
+      "outcome": "accept",
+      "x402EnvelopeShape": {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "solana",
+        "hasAccepted": false,
+        "payloadHasTransaction": true
+      }
+    }
+  },
+  {
+    "id": "x402-exact-v1-verify-reject-unknown-version",
+    "intent": "x402-exact",
+    "mode": "verify-transaction",
+    "description": "Server still REJECTS a genuinely-unknown version even on the v1 dual-accept path: an envelope shaped like v1 (top-level scheme/network) but carrying x402Version=9 is neither v1 nor v2. Adding v1 support must not widen the version gate. Mirrors the catch-all arm in rust parse_payment_signature (server/exact.rs:342-346).",
+    "input": {
+      "x402PaymentHeader": "eyJ4NDAyVmVyc2lvbiI6OSwic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoic29sYW5hLWRldm5ldCIsInBheWxvYWQiOnsidHJhbnNhY3Rpb24iOiJBQT09In19",
+      "x402ServerNetwork": "devnet",
+      "x402ServerRecipient": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+      "x402ServerCurrency": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "x402ServerAmount": "1000"
+    },
+    "expect": {
+      "outcome": "reject",
+      "rejectCode": "unsupported-version",
+      "rejectReason": "x402Version 9 is neither v1 nor v2"
+    }
+  },
+  {
+    "id": "x402-exact-v1-verify-reject-wrong-network",
+    "intent": "x402-exact",
+    "mode": "verify-transaction",
+    "description": "Server rejects a v1 credential signed for the wrong network: a v1 envelope with plain network \"solana\" (mainnet) presented to a devnet route fails the v1 network gate (caip2_network_for_cluster(\"solana\") != devnet CAIP-2). Mirrors the network-mismatch branch of the v1 arm (server/exact.rs:322-326).",
+    "input": {
+      "x402PaymentHeader": "eyJ4NDAyVmVyc2lvbiI6MSwic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoic29sYW5hIiwicGF5bG9hZCI6eyJ0cmFuc2FjdGlvbiI6IkFBPT0ifX0=",
+      "x402ServerNetwork": "devnet",
+      "x402ServerRecipient": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+      "x402ServerCurrency": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "x402ServerAmount": "1000"
+    },
+    "expect": {
+      "outcome": "reject",
+      "rejectCode": "wrong-network",
+      "rejectReason": "v1 network solana normalizes to mainnet, route is devnet"
+    }
+  }
+]

--- a/lua/cmd/conformance/main.lua
+++ b/lua/cmd/conformance/main.lua
@@ -586,7 +586,21 @@ local function run_x402_verify(vector)
   end
 
   local version = env.x402Version
-  if version == 2 then
+  if version == 1 then
+    -- Legacy v1 dual-accept arm. The v1 envelope carries scheme + network
+    -- as top-level siblings of payload (no accepted object), so the server
+    -- binds only scheme + network and normalizes the plain SVM slug via
+    -- caip2_network_for_cluster before the network gate. Mirrors the rust
+    -- parse_payment_signature v1 arm (server/exact.rs:316-327): there is no
+    -- accepted-vs-route field comparison because v1 has no accepted object.
+    local scheme = env.scheme
+    if scheme ~= 'exact' then
+      error('invalid payload: v1 envelope scheme is not exact')
+    end
+    if caip2_network_for_cluster(env.network or '') ~= expected_caip2 then
+      error('wrong network: credential network does not match server')
+    end
+  elseif version == 2 then
     local accepted = env.accepted
     if type(accepted) ~= 'table' then
       error('invalid payload: v2 envelope missing accepted')

--- a/lua/pay_kit/protocols/x402/init.lua
+++ b/lua/pay_kit/protocols/x402/init.lua
@@ -38,10 +38,28 @@ Adapter.__index = Adapter
 
 -- --- constants ------------------------------------------------------
 
+-- Legacy and current protocol versions. We mirror the rust spine's
+-- X402_VERSION_V1 / X402_VERSION_V2 constant naming (constants.rs:10,13);
+-- per the no-version-suffix naming rule for NEW symbols, every wire shape
+-- introduced here is named by its structure, not by a v1/v2 suffix.
+local X402_VERSION_V1 = 1
 local X402_VERSION_V2 = 2
+
+-- v2 wire headers (canonical, lowercased for the OpenResty header table).
 local PAYMENT_REQUIRED_HEADER  = 'payment-required'
 local PAYMENT_SIGNATURE_HEADER = 'payment-signature'
 local PAYMENT_RESPONSE_HEADER  = 'payment-response'
+
+-- Legacy v1 wire headers (rust constants.rs:16-22). The v1 credential and
+-- settlement travel on the X-PAYMENT* header family; the credential header
+-- is X-PAYMENT (a standard-base64 envelope whose scheme and network sit as
+-- top-level siblings of payload, with no accepted), and the settlement is
+-- emitted on X-PAYMENT-RESPONSE. The v1 challenge-request header
+-- (X-PAYMENT-REQUIRED) is a producer concern: this server emits v2
+-- challenges by default, so it never reads or writes that header.
+local LEGACY_PAYMENT_HEADER          = 'x-payment'
+local LEGACY_PAYMENT_RESPONSE_HEADER = 'x-payment-response'
+
 local DEFAULT_FIXTURE_SETTLEMENT_HEADER = 'x-payment-settlement-signature'
 local DEFAULT_MAX_TIMEOUT_SECONDS = 60
 local DEFAULT_DECIMALS = 6
@@ -50,9 +68,47 @@ local TOKEN_PROGRAM_BASE58 = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 local CAIP2_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
 local CAIP2_DEVNET  = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1'
 
+-- Plain SVM network slugs the legacy v1 wire carries instead of CAIP-2.
+local LEGACY_NETWORK_SOLANA  = 'solana'
+local LEGACY_NETWORK_DEVNET  = 'solana-devnet'
+local LEGACY_NETWORK_TESTNET = 'solana-testnet'
+
 local function caip2_for(pay_kit_network)
   if pay_kit_network == 'solana_mainnet' then return CAIP2_MAINNET end
   return CAIP2_DEVNET                          -- devnet and localnet share devnet CAIP-2
+end
+
+-- Normalize any network identifier (CAIP-2 or plain legacy slug) to its
+-- CAIP-2 form so the v1 and v2 network gates share a comparison basis.
+-- Mirrors rust caip2_network_for_cluster (types.rs:31-39): plain
+-- "solana" / "mainnet" -> mainnet CAIP-2; "solana-devnet" / "devnet" /
+-- "localnet" -> devnet CAIP-2; the CAIP-2 forms map to themselves.
+local function caip2_network_for_cluster(network)
+  if type(network) ~= 'string' then return '' end
+  if network == LEGACY_NETWORK_SOLANA or network == 'mainnet'
+    or network == 'mainnet-beta' or network == CAIP2_MAINNET then
+    return CAIP2_MAINNET
+  end
+  if network == LEGACY_NETWORK_DEVNET or network == 'devnet'
+    or network == 'localnet' or network == CAIP2_DEVNET then
+    return CAIP2_DEVNET
+  end
+  return network
+end
+
+-- Map a pay-kit network to the plain SVM slug the legacy v1 settlement
+-- response carries. Mirrors rust v1_network_for_requirements
+-- (client/exact/payment.rs:393-404): devnet-family -> "solana-devnet",
+-- everything else -> "solana". (testnet stays available for completeness;
+-- the operator network only ever resolves to mainnet or devnet today.)
+local function legacy_network_slug(pay_kit_network)
+  if pay_kit_network == 'solana_devnet' or pay_kit_network == 'solana_localnet' then
+    return LEGACY_NETWORK_DEVNET
+  end
+  if pay_kit_network == 'solana_testnet' then
+    return LEGACY_NETWORK_TESTNET
+  end
+  return LEGACY_NETWORK_SOLANA
 end
 
 local function network_label(pay_kit_network)
@@ -153,20 +209,51 @@ end
 
 -- --- credential decoding -------------------------------------------
 
-local function decode_payment_signature(header_value)
+-- Decode a standard-base64 JSON credential envelope. The bytes are shared
+-- between the v1 X-PAYMENT and the v2 PAYMENT-SIGNATURE wires (rust decodes
+-- both via STANDARD base64, server/exact.rs:308); the version dispatch
+-- happens at the call site so each wire keeps its native shape.
+local function decode_envelope(header_value, label)
   if type(header_value) ~= 'string' or header_value == '' then
     return nil, errors.PAYMENT_REQUIRED
   end
   local decoded = base64_std.decode(header_value)
   if not decoded then
-    return nil, errors.INVALID_PROOF .. ': payment-signature base64 decode failed'
+    return nil, errors.INVALID_PROOF .. ': ' .. label .. ' base64 decode failed'
   end
   local envelope = cjson_safe.decode(decoded)
   if type(envelope) ~= 'table' then
-    return nil, errors.INVALID_PROOF .. ': payment-signature not a JSON object'
+    return nil, errors.INVALID_PROOF .. ': ' .. label .. ' not a JSON object'
   end
+  return envelope
+end
+
+-- Decode the v2 PAYMENT-SIGNATURE credential. v2 envelopes carry an
+-- `accepted` object and x402Version=2; the accepted-vs-offer identity match
+-- and the field comparison are run by the caller.
+local function decode_payment_signature(header_value)
+  local envelope, err = decode_envelope(header_value, 'payment-signature')
+  if err then return nil, err end
   if envelope.x402Version ~= X402_VERSION_V2 then
     return nil, errors.INVALID_PROOF .. ': unsupported x402Version'
+  end
+  return envelope
+end
+
+-- Decode a legacy v1 X-PAYMENT credential. The v1 envelope carries
+-- x402Version=1, scheme + network as top-level siblings of payload, and no
+-- accepted object (rust PaymentSignatureEnvelope, types.rs:587-608). The
+-- caller normalizes the plain network slug and runs the network gate; there
+-- is no accepted-vs-offer comparison because v1 has no accepted object
+-- (rust parse_payment_signature v1 arm, server/exact.rs:316-327).
+local function decode_legacy_payment(header_value)
+  local envelope, err = decode_envelope(header_value, 'x-payment')
+  if err then return nil, err end
+  if envelope.x402Version ~= X402_VERSION_V1 then
+    return nil, errors.INVALID_PROOF .. ': unsupported x402Version'
+  end
+  if envelope.scheme ~= 'exact' then
+    return nil, errors.INVALID_PROOF .. ': x-payment scheme is not exact'
   end
   return envelope
 end
@@ -226,10 +313,25 @@ function M.new(opts)
   }, Adapter)
 end
 
+-- Read the v2 credential header (PAYMENT-SIGNATURE) from a header table,
+-- tolerating the canonical-cased key OpenResty does not lowercase.
+local function read_payment_signature(headers)
+  return headers[PAYMENT_SIGNATURE_HEADER] or headers['PAYMENT-SIGNATURE']
+end
+
+-- Read the legacy v1 credential header (X-PAYMENT) from a header table.
+local function read_legacy_payment(headers)
+  return headers[LEGACY_PAYMENT_HEADER] or headers['X-PAYMENT']
+end
+
 function M.detect(headers)
   if type(headers) ~= 'table' then return false end
-  local sig = headers[PAYMENT_SIGNATURE_HEADER] or headers['PAYMENT-SIGNATURE']
-  return sig ~= nil and sig ~= ''
+  -- Dual-accept: the v2 PAYMENT-SIGNATURE wire is read first, then the
+  -- legacy v1 X-PAYMENT wire. A request carrying either credential is ours.
+  local sig = read_payment_signature(headers)
+  if sig ~= nil and sig ~= '' then return true end
+  local legacy = read_legacy_payment(headers)
+  return legacy ~= nil and legacy ~= ''
 end
 
 Adapter.detect = function(_, headers) return M.detect(headers) end
@@ -251,19 +353,52 @@ function Adapter:challenge_headers(gate, req)
   }
 end
 
+-- Resolve the inbound credential under the dual-accept rule: read the v2
+-- PAYMENT-SIGNATURE wire FIRST, then fall back to the legacy v1 X-PAYMENT
+-- wire. Returns (envelope, is_legacy, raw_header) or (nil, err). The server
+-- never rejects a v1 credential, but still rejects a genuinely-unknown
+-- version (the per-wire decoders gate x402Version to 1 / 2 respectively).
+-- Mirrors rust parse_payment_signature dispatch (server/exact.rs:316-346).
+local function resolve_credential(headers)
+  local v2_header = read_payment_signature(headers)
+  if type(v2_header) == 'string' and v2_header ~= '' then
+    local envelope, err = decode_payment_signature(v2_header)
+    if err then return nil, nil, nil, err end
+    return envelope, false, v2_header
+  end
+  local legacy_header = read_legacy_payment(headers)
+  if type(legacy_header) == 'string' and legacy_header ~= '' then
+    local envelope, err = decode_legacy_payment(legacy_header)
+    if err then return nil, nil, nil, err end
+    return envelope, true, legacy_header
+  end
+  return nil, nil, nil, errors.PAYMENT_REQUIRED
+end
+
 function Adapter:verify_and_settle(gate, req)
   local config = self._config_resolver()
   local headers = (req and req.headers) or {}
-  local credential, err = decode_payment_signature(
-    headers[PAYMENT_SIGNATURE_HEADER] or headers['PAYMENT-SIGNATURE']
-  )
+  local credential, is_legacy, raw_header, err = resolve_credential(headers)
   if err then return nil, err end
 
   local resource = (req and req.path) or '/'
   local offer = exact_requirement(config, gate, resource, gate:amount():primary_coin())
-  if not accepted_requirement_matches(credential.accepted, offer) then
-    return nil, errors.CHARGE_REQUEST_MISMATCH ..
-      ': accepted payment requirement does not match server challenge'
+
+  if is_legacy then
+    -- v1 binds only scheme + network (no accepted object). Normalize the
+    -- plain SVM slug and gate it against the server's CAIP-2, mirroring the
+    -- rust v1 arm (server/exact.rs:316-327). The facilitator MUST-checks
+    -- below are identical to v2 (both reach verify_transaction_shape).
+    if caip2_network_for_cluster(credential.network or '') ~= caip2_for(config.network) then
+      return nil, errors.WRONG_NETWORK ..
+        ': x-payment network does not match server challenge'
+    end
+  else
+    -- v2 binds the full accepted requirement against the server offer.
+    if not accepted_requirement_matches(credential.accepted, offer) then
+      return nil, errors.CHARGE_REQUEST_MISMATCH ..
+        ': accepted payment requirement does not match server challenge'
+    end
   end
 
   local payload = credential.payload
@@ -334,20 +469,34 @@ function Adapter:verify_and_settle(gate, req)
     return nil, errors.SIGNATURE_CONSUMED
   end
 
-  local response_body = cjson_safe.encode({
-    success     = true,
-    network     = offer.network,
-    transaction = signature,
-  })
+  -- Settlement response. v1 emits X-PAYMENT-RESPONSE carrying the plain SVM
+  -- network slug and the payer pubkey (rust v1 settlement shape
+  -- { success, transaction, network, payer }); v2 emits PAYMENT-RESPONSE
+  -- with the CAIP-2 network from the offer.
+  local settlement_headers = {
+    [DEFAULT_FIXTURE_SETTLEMENT_HEADER] = signature,
+  }
+  if is_legacy then
+    settlement_headers[LEGACY_PAYMENT_RESPONSE_HEADER] = cjson_safe.encode({
+      success     = true,
+      transaction = signature,
+      network     = credential.network or legacy_network_slug(config.network),
+      payer       = transfer and transfer.authority or nil,
+    })
+  else
+    settlement_headers[PAYMENT_RESPONSE_HEADER] = cjson_safe.encode({
+      success     = true,
+      network     = offer.network,
+      transaction = signature,
+    })
+  end
+
   return {
     protocol           = 'x402',
     scheme             = 'exact',
     transaction        = signature,
-    settlement_headers = {
-      [PAYMENT_RESPONSE_HEADER] = response_body,
-      [DEFAULT_FIXTURE_SETTLEMENT_HEADER] = signature,
-    },
-    raw                = headers[PAYMENT_SIGNATURE_HEADER] or headers['PAYMENT-SIGNATURE'],
+    settlement_headers = settlement_headers,
+    raw                = raw_header,
   }
 end
 
@@ -358,8 +507,14 @@ M._private = {
   exact_requirement            = exact_requirement,
   encode_payment_required      = encode_payment_required,
   decode_payment_signature     = decode_payment_signature,
+  decode_legacy_payment        = decode_legacy_payment,
+  resolve_credential           = resolve_credential,
   network_label                = network_label,
   caip2_for                    = caip2_for,
+  caip2_network_for_cluster    = caip2_network_for_cluster,
+  legacy_network_slug          = legacy_network_slug,
+  LEGACY_PAYMENT_HEADER          = LEGACY_PAYMENT_HEADER,
+  LEGACY_PAYMENT_RESPONSE_HEADER = LEGACY_PAYMENT_RESPONSE_HEADER,
 }
 
 return M

--- a/lua/pay_kit/protocols/x402/init.lua
+++ b/lua/pay_kit/protocols/x402/init.lua
@@ -353,24 +353,47 @@ function Adapter:challenge_headers(gate, req)
   }
 end
 
+-- Classify a decoded credential by its x402Version FIELD (not by which
+-- header carried it), mirroring rust parse_payment_signature which decodes
+-- once and matches on envelope.x402_version (server/exact.rs:315-347): v2 ->
+-- canonical, v1 -> legacy (scheme must be exact), anything else -> reject.
+-- Returns (is_legacy, err).
+local function classify_credential(envelope)
+  local version = envelope.x402Version
+  if version == X402_VERSION_V2 then
+    return false, nil
+  elseif version == X402_VERSION_V1 then
+    if envelope.scheme ~= 'exact' then
+      return nil, errors.INVALID_PROOF .. ': x-payment scheme is not exact'
+    end
+    return true, nil
+  end
+  return nil, errors.INVALID_PROOF .. ': unsupported x402Version'
+end
+
 -- Resolve the inbound credential under the dual-accept rule: read the v2
 -- PAYMENT-SIGNATURE wire FIRST, then fall back to the legacy v1 X-PAYMENT
--- wire. Returns (envelope, is_legacy, raw_header) or (nil, err). The server
--- never rejects a v1 credential, but still rejects a genuinely-unknown
--- version (the per-wire decoders gate x402Version to 1 / 2 respectively).
--- Mirrors rust parse_payment_signature dispatch (server/exact.rs:316-346).
+-- wire. Returns (envelope, is_legacy, raw_header) or (nil, err). Dispatch is
+-- CONTENT-BASED: whichever header carried the credential, it is decoded once
+-- and classified on its x402Version field (so a v1 envelope is honoured even
+-- if it arrived on PAYMENT-SIGNATURE, and a genuinely-unknown version is
+-- still rejected) -- matching rust parse_payment_signature (server/exact.rs:315-347).
 local function resolve_credential(headers)
   local v2_header = read_payment_signature(headers)
   if type(v2_header) == 'string' and v2_header ~= '' then
-    local envelope, err = decode_payment_signature(v2_header)
+    local envelope, err = decode_envelope(v2_header, 'payment-signature')
     if err then return nil, nil, nil, err end
-    return envelope, false, v2_header
+    local is_legacy, cerr = classify_credential(envelope)
+    if cerr then return nil, nil, nil, cerr end
+    return envelope, is_legacy, v2_header
   end
   local legacy_header = read_legacy_payment(headers)
   if type(legacy_header) == 'string' and legacy_header ~= '' then
-    local envelope, err = decode_legacy_payment(legacy_header)
+    local envelope, err = decode_envelope(legacy_header, 'x-payment')
     if err then return nil, nil, nil, err end
-    return envelope, true, legacy_header
+    local is_legacy, cerr = classify_credential(envelope)
+    if cerr then return nil, nil, nil, cerr end
+    return envelope, is_legacy, legacy_header
   end
   return nil, nil, nil, errors.PAYMENT_REQUIRED
 end

--- a/lua/pay_kit/protocols/x402/init.lua
+++ b/lua/pay_kit/protocols/x402/init.lua
@@ -67,6 +67,7 @@ local TOKEN_PROGRAM_BASE58 = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 
 local CAIP2_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
 local CAIP2_DEVNET  = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1'
+local CAIP2_TESTNET = 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z'
 
 -- Plain SVM network slugs the legacy v1 wire carries instead of CAIP-2.
 local LEGACY_NETWORK_SOLANA  = 'solana'
@@ -92,6 +93,10 @@ local function caip2_network_for_cluster(network)
   if network == LEGACY_NETWORK_DEVNET or network == 'devnet'
     or network == 'localnet' or network == CAIP2_DEVNET then
     return CAIP2_DEVNET
+  end
+  if network == LEGACY_NETWORK_TESTNET or network == 'testnet'
+    or network == CAIP2_TESTNET then
+    return CAIP2_TESTNET
   end
   return network
 end

--- a/lua/tests/pay_kit/schemes_x402_spec.lua
+++ b/lua/tests/pay_kit/schemes_x402_spec.lua
@@ -166,3 +166,142 @@ helper.test('verify_and_settle rejects unmatched accepted', function()
   local _, err = adapter:verify_and_settle(gate, {headers = headers, path = '/paid'})
   helper.assert_true(err and err:find('does not match', 1, true), err)
 end)
+
+-- --- legacy v1 dual-accept ------------------------------------------
+--
+-- The legacy v1 X-PAYMENT wire carries x402Version=1 with scheme + network
+-- as top-level siblings of payload and no accepted object. The server reads
+-- the v2 PAYMENT-SIGNATURE wire first, then falls back to v1; it binds only
+-- scheme + network for v1, normalizes the plain SVM slug, and still rejects
+-- a genuinely-unknown version. Mirrors rust parse_payment_signature
+-- (server/exact.rs:316-346).
+
+local function encode_legacy(body)
+  local base64 = require('pay_kit.util.base64_std')
+  return base64.encode(cjson.encode(body))
+end
+
+helper.test('detect: returns true for non-empty X-PAYMENT (legacy v1) header', function()
+  helper.assert_equal(x402.detect({['x-payment'] = 'abc'}), true)
+  helper.assert_equal(x402.detect({['X-PAYMENT'] = 'abc'}), true)
+end)
+
+helper.test('detect: false when only an empty X-PAYMENT header is present', function()
+  helper.assert_equal(x402.detect({['x-payment'] = ''}), false)
+end)
+
+helper.test('legacy_network_slug maps pay-kit network to plain SVM slug', function()
+  helper.assert_equal(x402._private.legacy_network_slug('solana_mainnet'), 'solana')
+  helper.assert_equal(x402._private.legacy_network_slug('solana_devnet'), 'solana-devnet')
+  helper.assert_equal(x402._private.legacy_network_slug('solana_localnet'), 'solana-devnet')
+  helper.assert_equal(x402._private.legacy_network_slug('solana_testnet'), 'solana-testnet')
+end)
+
+helper.test('caip2_network_for_cluster normalizes plain slugs to CAIP-2', function()
+  local p = x402._private
+  helper.assert_equal(p.caip2_network_for_cluster('solana'), p.caip2_for('solana_mainnet'))
+  helper.assert_equal(p.caip2_network_for_cluster('mainnet-beta'), p.caip2_for('solana_mainnet'))
+  helper.assert_equal(p.caip2_network_for_cluster('solana-devnet'), p.caip2_for('solana_devnet'))
+  helper.assert_equal(p.caip2_network_for_cluster('devnet'), p.caip2_for('solana_devnet'))
+  helper.assert_equal(p.caip2_network_for_cluster('localnet'), p.caip2_for('solana_devnet'))
+end)
+
+helper.test('decode_legacy_payment accepts a v1 envelope', function()
+  local env = assert(x402._private.decode_legacy_payment(encode_legacy({
+    x402Version = 1,
+    scheme      = 'exact',
+    network     = 'solana-devnet',
+    payload     = {transaction = 'AA=='},
+  })))
+  helper.assert_equal(env.x402Version, 1)
+  helper.assert_equal(env.scheme, 'exact')
+  helper.assert_equal(env.network, 'solana-devnet')
+end)
+
+helper.test('decode_legacy_payment rejects a non-v1 version', function()
+  local _, err = x402._private.decode_legacy_payment(encode_legacy({
+    x402Version = 2, scheme = 'exact', network = 'solana',
+  }))
+  helper.assert_true(err and err:find('unsupported x402Version', 1, true), err)
+end)
+
+helper.test('decode_legacy_payment rejects a non-exact scheme', function()
+  local _, err = x402._private.decode_legacy_payment(encode_legacy({
+    x402Version = 1, scheme = 'upto', network = 'solana',
+  }))
+  helper.assert_true(err and err:find('scheme is not exact', 1, true), err)
+end)
+
+helper.test('decode_legacy_payment rejects an empty header', function()
+  local _, err = x402._private.decode_legacy_payment('')
+  helper.assert_true(err and err:find('payment required', 1, true), err)
+end)
+
+helper.test('resolve_credential reads the v2 PAYMENT-SIGNATURE wire first', function()
+  local v2 = encode_legacy({x402Version = 2, accepted = {}, payload = {}})
+  local v1 = encode_legacy({x402Version = 1, scheme = 'exact', network = 'solana'})
+  local env, is_legacy = assert(x402._private.resolve_credential({
+    ['payment-signature'] = v2,
+    ['x-payment']         = v1,
+  }))
+  helper.assert_equal(env.x402Version, 2)
+  helper.assert_equal(is_legacy, false)
+end)
+
+helper.test('resolve_credential falls back to the v1 X-PAYMENT wire', function()
+  local v1 = encode_legacy({x402Version = 1, scheme = 'exact', network = 'solana-devnet',
+    payload = {transaction = 'AA=='}})
+  local env, is_legacy = assert(x402._private.resolve_credential({['x-payment'] = v1}))
+  helper.assert_equal(env.x402Version, 1)
+  helper.assert_equal(is_legacy, true)
+end)
+
+helper.test('resolve_credential rejects a genuinely-unknown version on the v1 wire', function()
+  local unknown = encode_legacy({x402Version = 9, scheme = 'exact', network = 'solana'})
+  local env, _, _, err = x402._private.resolve_credential({['x-payment'] = unknown})
+  helper.assert_true(env == nil)
+  helper.assert_true(err and err:find('unsupported x402Version', 1, true), err)
+end)
+
+helper.test('resolve_credential returns payment-required when no credential header is present', function()
+  local env, _, _, err = x402._private.resolve_credential({})
+  helper.assert_true(env == nil)
+  helper.assert_true(err and err:find('payment required', 1, true), err)
+end)
+
+helper.test('verify_and_settle rejects a v1 credential signed for the wrong network', function()
+  setup()  -- server configured for solana_devnet
+  local gate = make_gate('0.001')
+  local adapter = assert(x402.new({config_resolver = pay_kit.config}))
+  local base64 = require('pay_kit.util.base64_std')
+  -- v1 envelope with plain "solana" (mainnet) presented to a devnet route.
+  local v1 = base64.encode(cjson.encode({
+    x402Version = 1,
+    scheme      = 'exact',
+    network     = 'solana',
+    payload     = {transaction = base64.encode('placeholder')},
+  }))
+  local _, err = adapter:verify_and_settle(gate, {headers = {['x-payment'] = v1}, path = '/paid'})
+  helper.assert_true(err and err:find('wrong network', 1, true), err)
+end)
+
+helper.test('verify_and_settle passes a matching-network v1 credential past the network gate', function()
+  setup()  -- server configured for solana_devnet
+  local gate = make_gate('0.001')
+  local adapter = assert(x402.new({config_resolver = pay_kit.config}))
+  local base64 = require('pay_kit.util.base64_std')
+  -- v1 envelope with plain "solana-devnet" against a devnet route: the
+  -- network gate passes, so the failure must come from the missing payload
+  -- transaction proof, NOT a network/version mismatch. This pins that the
+  -- v1 arm binds scheme + network and then proceeds to the shared MUST-check
+  -- path identical to v2.
+  local v1 = base64.encode(cjson.encode({
+    x402Version = 1,
+    scheme      = 'exact',
+    network     = 'solana-devnet',
+    payload     = {},  -- no transaction: must fail AFTER the network gate
+  }))
+  local _, err = adapter:verify_and_settle(gate, {headers = {['x-payment'] = v1}, path = '/paid'})
+  helper.assert_true(err and err:find('payload missing transaction', 1, true), err)
+  helper.assert_true(not err:find('wrong network', 1, true), 'must pass the network gate')
+end)

--- a/php/conformance/runner.php
+++ b/php/conformance/runner.php
@@ -518,7 +518,9 @@ function build_fixture(ChargeRequest $request, array $signerSecretKey): string
 const X402_SOLANA_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 const X402_SOLANA_DEVNET  = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
 const X402_SOLANA_TESTNET = 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z';
+const X402_VERSION_V1     = 1;
 const X402_VERSION_V2     = 2;
+const X402_EXACT_SCHEME   = 'exact';
 
 /**
  * Normalize a legacy v1 network slug (or any cluster slug / CAIP-2 id) to its
@@ -651,9 +653,32 @@ function verify_x402_header(string $header, array $route): array
                 'Currency mismatch: expected ' . ($route['currency'] ?? '') . ", got $acceptedAsset",
             );
         }
+    } elseif ($version === X402_VERSION_V1) {
+        // v1 (legacy): no `accepted` object. The envelope commits only to a
+        // top-level scheme + plain network slug (siblings of `payload`). Bind
+        // scheme === "exact" and normalize the plain slug to a CAIP-2 chain id,
+        // gating it against the server route. Mirrors the PHP Adapter
+        // matchLegacyCredential + the rust v1 parse arm (server/exact.rs).
+        $scheme = $envelope['scheme'] ?? null;
+        if ($scheme !== X402_EXACT_SCHEME) {
+            throw new InvalidArgumentException(
+                'invalid payload: unsupported scheme ' . (is_scalar($scheme) ? (string) $scheme : 'unknown'),
+            );
+        }
+        $network = is_string($envelope['network'] ?? null) ? $envelope['network'] : '';
+        if ($network === '') {
+            throw new InvalidArgumentException('invalid payload: v1 envelope missing network');
+        }
+        $normalized = x402_caip2_for_cluster($network);
+        if ($normalized !== $expectedNetwork) {
+            throw new InvalidArgumentException(
+                "Network mismatch: expected $expectedNetwork, got $network",
+            );
+        }
     } else {
         // Genuinely-unknown versions are rejected (rust exact.rs / Adapter
-        // unsupported_x402_version arm).
+        // unsupported_x402_version arm). Adding v1 support must not widen the
+        // version gate.
         throw new InvalidArgumentException(
             'unsupported x402 version: ' . (is_scalar($version) ? (string) $version : 'unknown'),
         );

--- a/php/src/Protocols/X402/Adapter.php
+++ b/php/src/Protocols/X402/Adapter.php
@@ -324,12 +324,17 @@ final class Adapter
             'payer'       => $payload['transactionHash'] ?? '',
         ], JSON_THROW_ON_ERROR));
 
+        // v1 credentials get the legacy X-PAYMENT-RESPONSE receipt header; v2
+        // uses PAYMENT-RESPONSE (rust X402_V1_PAYMENT_RESPONSE_HEADER,
+        // constants.rs:22; matches go/lua/ruby/swift).
+        $responseHeader = ($version === self::X402_VERSION_V1) ? 'x-payment-response' : 'payment-response';
+
         return new Payment(
             protocol: Protocol::X402,
             transaction: $sig,
             gateName: null,
             settlementHeaders: [
-                'payment-response'                => $responseEnvelope,
+                $responseHeader                   => $responseEnvelope,
                 'x-payment-settlement-signature'  => $sig,
             ],
             raw: $header,

--- a/php/src/Protocols/X402/Adapter.php
+++ b/php/src/Protocols/X402/Adapter.php
@@ -34,9 +34,28 @@ use Throwable;
 final class Adapter
 {
     private const PAYMENT_SIGNATURE_HEADER = 'payment-signature';
+    // Legacy x402 client payment header (coinbase/x402 SVM). v1 carries the
+    // credential here instead of PAYMENT-SIGNATURE; the server reads the v2
+    // header first, then falls back to this one. Mirrors the rust spine
+    // constants X402_V1_PAYMENT_HEADER / X402_V2_PAYMENT_HEADER.
+    private const PAYMENT_LEGACY_HEADER    = 'x-payment';
+    // x402 protocol versions. X402_VERSION is the version this server EMITS by
+    // default (the canonical current wire); X402_VERSION_V1 is the legacy wire
+    // this server still ACCEPTS on the dual-accept read path. Mirrors the rust
+    // X402_VERSION_V1 / X402_VERSION_V2 constants.
     private const X402_VERSION             = 2;
+    private const X402_VERSION_V1          = 1;
     private const TOKEN_PROGRAM            = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+    private const EXACT_SCHEME             = 'exact';
     private const REPLAY_KEY_PREFIX        = 'x402-svm-exact:consumed:';
+
+    // Canonical CAIP-2 chain identifiers (match Network::caip2() + the rust
+    // spine types.rs). Used to normalize a legacy v1 plain network slug
+    // ("solana", "solana-devnet", "solana-testnet") to the chain id the route
+    // is pinned to, so the v1 network gate compares apples to apples.
+    private const CAIP2_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+    private const CAIP2_DEVNET  = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+    private const CAIP2_TESTNET = 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z';
 
     /** @var \Closure():?string|null */
     private $recentBlockhashProvider = null;
@@ -188,54 +207,47 @@ final class Adapter
         if ($signer === null) {
             throw new InvalidProofException('pay_kit: x402 requires operator.signer');
         }
+        // Dual-accept read: the canonical (current) credential rides the
+        // PAYMENT-SIGNATURE header; the legacy credential rides X-PAYMENT.
+        // Read the canonical header first, then fall back to the legacy one,
+        // mirroring the rust spine's read precedence. A server NEVER rejects a
+        // well-formed legacy credential just because it arrived on X-PAYMENT.
         $header = $request->getHeaderLine('Payment-Signature');
         if ($header === '') {
             $header = $request->getHeaderLine('PAYMENT-SIGNATURE');
         }
         if ($header === '') {
+            $header = $request->getHeaderLine('X-Payment');
+        }
+        if ($header === '') {
+            $header = $request->getHeaderLine('X-PAYMENT');
+        }
+        if ($header === '') {
             throw new InvalidProofException('pay_kit: payment required');
         }
 
-        // Decode credential.
-        $decoded = base64_decode($header, true);
-        if ($decoded === false) {
-            throw new InvalidProofException('invalid_exact_svm_payload_signature_base64');
-        }
-        try {
-            $envelope = json_decode($decoded, true, flags: JSON_THROW_ON_ERROR);
-        } catch (Throwable) {
-            throw new InvalidProofException('invalid_exact_svm_payload_signature_json');
-        }
-        if (!is_array($envelope) || ($envelope['x402Version'] ?? null) !== self::X402_VERSION) {
+        $envelope = $this->decodeCredential($header);
+        $offer    = $this->acceptsEntry($gate, $request);
+
+        // Version dispatch. The canonical wire commits to a full `accepted`
+        // requirement object (identity-key matched below); the legacy wire
+        // commits only to a top-level scheme + plain network slug, which the
+        // server normalizes and gates against its route. Adding legacy support
+        // must NOT widen the version gate: a genuinely-unknown version is still
+        // rejected. Mirrors rust parse_payment_signature (server/exact.rs).
+        $version = $envelope['x402Version'] ?? null;
+        if ($version === self::X402_VERSION) {
+            $this->matchCanonicalCredential($envelope, $offer);
+        } elseif ($version === self::X402_VERSION_V1) {
+            $this->matchLegacyCredential($envelope);
+        } else {
             throw new InvalidProofException('unsupported_x402_version');
         }
-        $accepted = $envelope['accepted'] ?? null;
-        $payload  = $envelope['payload']  ?? null;
-        if (!is_array($accepted) || !is_array($payload)) {
+
+        $payload = $envelope['payload'] ?? null;
+        if (!is_array($payload)) {
             throw new InvalidProofException('invalid_exact_svm_payload_envelope');
         }
-
-        // Identity-key match (cross-SDK PR #138 alignment).
-        $offer = $this->acceptsEntry($gate, $request);
-        foreach (['scheme', 'network', 'asset', 'payTo'] as $key) {
-            if (($accepted[$key] ?? null) !== ($offer[$key] ?? null)) {
-                throw new InvalidProofException(
-                    'pay_kit: charge_request_mismatch: '
-                    . 'accepted payment requirement does not match server challenge',
-                );
-            }
-        }
-        $offerExtra    = $offer['extra']    ?? [];
-        $acceptedExtra = $accepted['extra'] ?? [];
-        foreach (['feePayer', 'tokenProgram', 'memo'] as $key) {
-            if (array_key_exists($key, $offerExtra)
-                && ($acceptedExtra[$key] ?? null) !== $offerExtra[$key]) {
-                throw new InvalidProofException(
-                    'pay_kit: charge_request_mismatch (extra.' . $key . ')',
-                );
-            }
-        }
-
         $txBase64 = is_string($payload['transaction'] ?? null) ? $payload['transaction'] : '';
         if ($txBase64 === '') {
             throw new InvalidProofException('invalid_exact_svm_payload_missing_transaction');
@@ -301,10 +313,14 @@ final class Adapter
             );
         }
 
+        // Echo the network the credential committed to in the settlement
+        // response: the canonical wire's `accepted.network` (CAIP-2) or the
+        // legacy wire's top-level plain network slug, falling back to the
+        // route's CAIP-2 id. Mirrors the rust v1/v2 settlement-response shape.
         $responseEnvelope = base64_encode(json_encode([
             'success'     => true,
             'transaction' => $sig,
-            'network'     => $accepted['network'] ?? $this->caip2(),
+            'network'     => $this->settlementNetwork($envelope),
             'payer'       => $payload['transactionHash'] ?? '',
         ], JSON_THROW_ON_ERROR));
 
@@ -350,5 +366,138 @@ final class Adapter
     private function caip2(): string
     {
         return $this->config->network->caip2();
+    }
+
+    /**
+     * Decode a base64(JSON) x402 credential header into its envelope array.
+     * Standard (padded) base64, matching the rust producer's STANDARD engine.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeCredential(string $header): array
+    {
+        $decoded = base64_decode($header, true);
+        if ($decoded === false) {
+            throw new InvalidProofException('invalid_exact_svm_payload_signature_base64');
+        }
+        try {
+            $envelope = json_decode($decoded, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            throw new InvalidProofException('invalid_exact_svm_payload_signature_json');
+        }
+        if (!is_array($envelope)) {
+            throw new InvalidProofException('invalid_exact_svm_payload_envelope');
+        }
+        return $envelope;
+    }
+
+    /**
+     * Validate a canonical (current-wire) credential against the server offer.
+     *
+     * The credential echoes the full `accepted` requirement it claims to be
+     * paying for; we identity-key match it against the route's offer
+     * (scheme/network/asset/payTo + extra.feePayer/tokenProgram/memo) so a
+     * credential that lies about its requirement is rejected before settlement.
+     * Mirrors the rust v2 arm + cross-SDK PR #138 alignment.
+     *
+     * @param array<string, mixed> $envelope
+     * @param array<string, mixed> $offer
+     */
+    private function matchCanonicalCredential(array $envelope, array $offer): void
+    {
+        $accepted = $envelope['accepted'] ?? null;
+        if (!is_array($accepted)) {
+            throw new InvalidProofException('invalid_exact_svm_payload_envelope');
+        }
+        foreach (['scheme', 'network', 'asset', 'payTo'] as $key) {
+            if (($accepted[$key] ?? null) !== ($offer[$key] ?? null)) {
+                throw new InvalidProofException(
+                    'pay_kit: charge_request_mismatch: '
+                    . 'accepted payment requirement does not match server challenge',
+                );
+            }
+        }
+        $offerExtra    = $offer['extra']    ?? [];
+        $acceptedExtra = $accepted['extra'] ?? [];
+        foreach (['feePayer', 'tokenProgram', 'memo'] as $key) {
+            if (array_key_exists($key, $offerExtra)
+                && ($acceptedExtra[$key] ?? null) !== $offerExtra[$key]) {
+                throw new InvalidProofException(
+                    'pay_kit: charge_request_mismatch (extra.' . $key . ')',
+                );
+            }
+        }
+    }
+
+    /**
+     * Validate a legacy-wire credential.
+     *
+     * The legacy wire carries no `accepted` object: it commits only to a
+     * top-level scheme + plain network slug (siblings of `payload`). The
+     * server binds scheme === "exact" and normalizes the plain slug to a
+     * CAIP-2 chain id, gating it against the route's pinned network. The inner
+     * transaction is then checked against the server-built offer with the
+     * IDENTICAL MUST-checks (compute budget, transferChecked, fee-payer,
+     * memo) the canonical path runs. Mirrors the rust v1 arm
+     * (server/exact.rs parse_payment_signature + find_matching_requirement).
+     *
+     * @param array<string, mixed> $envelope
+     */
+    private function matchLegacyCredential(array $envelope): void
+    {
+        $scheme = $envelope['scheme'] ?? null;
+        if ($scheme !== self::EXACT_SCHEME) {
+            throw new InvalidProofException(
+                'pay_kit: charge_request_mismatch: unsupported scheme '
+                . (is_scalar($scheme) ? (string) $scheme : 'unknown'),
+            );
+        }
+        $network = $envelope['network'] ?? null;
+        if (!is_string($network) || $network === '') {
+            throw new InvalidProofException('invalid_exact_svm_payload_envelope');
+        }
+        $normalized = self::caip2ForCluster($network);
+        $expected   = $this->caip2();
+        if ($normalized !== $expected) {
+            throw new InvalidProofException(
+                "Network mismatch: expected $expected, got $network",
+            );
+        }
+    }
+
+    /**
+     * Pick the network to echo in the settlement response: the canonical
+     * wire's `accepted.network` (CAIP-2) or the legacy wire's top-level plain
+     * network slug, falling back to the route's CAIP-2 id.
+     *
+     * @param array<string, mixed> $envelope
+     */
+    private function settlementNetwork(array $envelope): string
+    {
+        $accepted = $envelope['accepted'] ?? null;
+        if (is_array($accepted) && is_string($accepted['network'] ?? null) && $accepted['network'] !== '') {
+            return $accepted['network'];
+        }
+        if (is_string($envelope['network'] ?? null) && $envelope['network'] !== '') {
+            return $envelope['network'];
+        }
+        return $this->caip2();
+    }
+
+    /**
+     * Normalize a legacy v1 plain network slug (or any cluster slug / CAIP-2
+     * id) to its canonical CAIP-2 chain identifier. Mirrors the rust spine
+     * `caip2_network_for_cluster`: localnet collapses to the devnet CAIP-2 id
+     * by convention (Surfpool clones mainnet state but reuses devnet genesis).
+     */
+    private static function caip2ForCluster(string $cluster): string
+    {
+        return match ($cluster) {
+            self::CAIP2_MAINNET, 'solana', 'mainnet', 'mainnet-beta' => self::CAIP2_MAINNET,
+            self::CAIP2_TESTNET, 'testnet', 'solana-testnet'         => self::CAIP2_TESTNET,
+            'devnet', 'localnet'                                     => self::CAIP2_DEVNET,
+            self::CAIP2_DEVNET, 'solana-devnet'                      => self::CAIP2_DEVNET,
+            default                                                  => self::CAIP2_MAINNET,
+        };
     }
 }

--- a/php/tests/Conformance/X402LegacyVectorTest.php
+++ b/php/tests/Conformance/X402LegacyVectorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Conformance;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Drives the cross-SDK x402 legacy-wire (v1) conformance vectors through the
+ * PHP conformance runner (conformance/runner.php) over its real stdin/stdout
+ * ABI, the same way the TypeScript harness driver does. PHP is a SERVER-only
+ * SDK, so:
+ *
+ *   - verify-transaction vectors run the envelope verify (version dispatch +
+ *     scheme + network gate) and assert accept (with x402EnvelopeShape) or
+ *     reject (with rejectCode), matching the vector's expectation.
+ *   - build-transaction vectors are client-side and SKIP for PHP
+ *     (outcome === "unsupported-mode").
+ *
+ * This pins the PHP server's legacy-wire support to the shared vectors so the
+ * cross-SDK contract fails loudly here if the runner or Adapter dispatch drifts
+ * from the rust spine.
+ */
+final class X402LegacyVectorTest extends TestCase
+{
+    private const RUNNER = __DIR__ . '/../../conformance/runner.php';
+    private const VECTORS = __DIR__ . '/../../../harness/vectors';
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runVector(array $vector): array
+    {
+        $process = proc_open(
+            [PHP_BINARY, self::RUNNER],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+        if (!is_resource($process)) {
+            throw new RuntimeException('failed to spawn php conformance runner');
+        }
+        fwrite($pipes[0], json_encode($vector, JSON_THROW_ON_ERROR));
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $code = proc_close($process);
+        if ($code !== 0) {
+            throw new RuntimeException("runner exited $code: $stderr");
+        }
+        $decoded = json_decode(trim((string) $stdout), true, flags: JSON_THROW_ON_ERROR);
+        if (!is_array($decoded)) {
+            throw new RuntimeException('runner emitted non-object: ' . $stdout);
+        }
+        return $decoded;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadVectors(string $file): array
+    {
+        $raw = file_get_contents(self::VECTORS . '/' . $file);
+        if ($raw === false) {
+            throw new RuntimeException("missing vector file: $file");
+        }
+        $decoded = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        return $decoded;
+    }
+
+    public function testLegacyVerifyVectorsConform(): void
+    {
+        $vectors = $this->loadVectors('x402-v1-verify.json');
+        self::assertNotEmpty($vectors, 'expected x402 v1 verify vectors');
+
+        foreach ($vectors as $vector) {
+            $expect = $vector['expect'] ?? [];
+            $result = $this->runVector($vector);
+            $id = $vector['id'] ?? '?';
+
+            self::assertSame(
+                $expect['outcome'] ?? null,
+                $result['outcome'] ?? null,
+                "outcome mismatch for $id: " . json_encode($result),
+            );
+
+            if (($expect['outcome'] ?? null) === 'accept') {
+                self::assertArrayHasKey('x402EnvelopeShape', $result, "missing shape for $id");
+                foreach (($expect['x402EnvelopeShape'] ?? []) as $key => $value) {
+                    self::assertSame(
+                        $value,
+                        $result['x402EnvelopeShape'][$key] ?? null,
+                        "shape.$key mismatch for $id",
+                    );
+                }
+            }
+
+            if (($expect['outcome'] ?? null) === 'reject') {
+                self::assertSame(
+                    $expect['rejectCode'] ?? null,
+                    $result['rejectCode'] ?? null,
+                    "rejectCode mismatch for $id: " . json_encode($result),
+                );
+            }
+        }
+    }
+
+    public function testLegacyBuildVectorsAreSkippedForServerOnlySdk(): void
+    {
+        // PHP ships no client-side x402 envelope builder; the harness driver
+        // SKIPs build vectors for PHP (outcome === "unsupported-mode").
+        $vectors = $this->loadVectors('x402-v1-build.json');
+        self::assertNotEmpty($vectors, 'expected x402 v1 build vectors');
+
+        foreach ($vectors as $vector) {
+            $result = $this->runVector($vector);
+            self::assertSame(
+                'unsupported-mode',
+                $result['outcome'] ?? null,
+                'build vector ' . ($vector['id'] ?? '?') . ' should be unsupported for server-only PHP',
+            );
+        }
+    }
+}

--- a/php/tests/Protocols/X402/LegacyWireTest.php
+++ b/php/tests/Protocols/X402/LegacyWireTest.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PayKit\Config;
+use PayKit\Exception\InvalidProofException;
+use PayKit\Gate;
+use PayKit\Operator;
+use PayKit\PayCore\Network;
+use PayKit\Price;
+use PayKit\Protocols\X402\Adapter;
+use PayKit\Signer;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionMethod;
+
+/**
+ * Coverage for the x402 legacy-wire (coinbase/x402 v1) dual-accept path on
+ * the PHP server adapter. The legacy credential rides the X-PAYMENT header
+ * with a top-level scheme + plain network slug (siblings of payload) and NO
+ * `accepted` object; the server normalizes the slug to a CAIP-2 chain id and
+ * gates it against the route, then runs the IDENTICAL transaction MUST-checks
+ * the canonical path runs. Mirrors the rust spine v1 arm
+ * (server/exact.rs parse_payment_signature + find_matching_requirement).
+ *
+ * Assembling a fully-valid signed Solana wire transaction at PHPUnit level is
+ * impractical (the structural verifier + cosign + broadcast run after the
+ * envelope dispatch), so the credential-validation primitives are exercised
+ * directly via reflection, and the dispatch/reject paths through
+ * verifyAndSettle which throw before any broadcast.
+ */
+final class LegacyWireTest extends TestCase
+{
+    private function makeAdapter(Network $network = Network::SolanaDevnet): Adapter
+    {
+        $config = new Config(
+            network: $network,
+            operator: new Operator(
+                recipient: Signer::generate()->pubkey(),
+                signer:    Signer::generate(),
+                feePayer:  true,
+            ),
+            preflight: false,
+        );
+        return new Adapter($config, recentBlockhashProvider: fn () => null);
+    }
+
+    private function makeGate(): Gate
+    {
+        return new Gate(amount: Price::usd('0.10'));
+    }
+
+    private function request(): ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest('GET', '/paid');
+    }
+
+    /**
+     * Build a base64(JSON) legacy x402 credential header. Standard (padded)
+     * base64, matching the rust producer's STANDARD engine.
+     *
+     * @param array<string, mixed> $envelope
+     */
+    private function legacyHeader(array $envelope): string
+    {
+        return base64_encode(json_encode($envelope, JSON_THROW_ON_ERROR));
+    }
+
+    private function invoke(Adapter $adapter, string $method, mixed ...$args): mixed
+    {
+        $ref = new ReflectionMethod(Adapter::class, $method);
+        $ref->setAccessible(true);
+        return $ref->invoke($adapter, ...$args);
+    }
+
+    // ── caip2ForCluster: legacy plain-slug -> CAIP-2 normalization ──────────
+
+    public function testCaip2ForClusterMapsPlainSlugs(): void
+    {
+        $adapter = $this->makeAdapter();
+        $mainnet = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+        $devnet  = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+        $testnet = 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z';
+
+        self::assertSame($mainnet, $this->invoke($adapter, 'caip2ForCluster', 'solana'));
+        self::assertSame($mainnet, $this->invoke($adapter, 'caip2ForCluster', 'mainnet-beta'));
+        self::assertSame($devnet, $this->invoke($adapter, 'caip2ForCluster', 'solana-devnet'));
+        self::assertSame($devnet, $this->invoke($adapter, 'caip2ForCluster', 'devnet'));
+        self::assertSame($devnet, $this->invoke($adapter, 'caip2ForCluster', 'localnet'));
+        self::assertSame($testnet, $this->invoke($adapter, 'caip2ForCluster', 'solana-testnet'));
+        self::assertSame($testnet, $this->invoke($adapter, 'caip2ForCluster', 'testnet'));
+        // CAIP-2 ids pass through unchanged.
+        self::assertSame($mainnet, $this->invoke($adapter, 'caip2ForCluster', $mainnet));
+        self::assertSame($devnet, $this->invoke($adapter, 'caip2ForCluster', $devnet));
+        // Unknown slugs default to mainnet, mirroring the rust spine.
+        self::assertSame($mainnet, $this->invoke($adapter, 'caip2ForCluster', 'whatever'));
+    }
+
+    // ── matchLegacyCredential: scheme + network gate ───────────────────────
+
+    public function testMatchLegacyCredentialAcceptsDevnetSlug(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $this->invoke($adapter, 'matchLegacyCredential', [
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+            'network'     => 'solana-devnet',
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        // No exception means the scheme + network gate passed.
+        $this->addToAssertionCount(1);
+    }
+
+    public function testMatchLegacyCredentialAcceptsPlainSolanaOnMainnet(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaMainnet);
+        $this->invoke($adapter, 'matchLegacyCredential', [
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+            'network'     => 'solana',
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testMatchLegacyCredentialRejectsWrongScheme(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/unsupported scheme/');
+        $this->invoke($adapter, 'matchLegacyCredential', [
+            'x402Version' => 1,
+            'scheme'      => 'upto',
+            'network'     => 'solana-devnet',
+        ]);
+    }
+
+    public function testMatchLegacyCredentialRejectsMissingNetwork(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $this->expectException(InvalidProofException::class);
+        $this->invoke($adapter, 'matchLegacyCredential', [
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+        ]);
+    }
+
+    public function testMatchLegacyCredentialRejectsWrongNetwork(): void
+    {
+        // Plain "solana" normalizes to mainnet; the route is devnet.
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/Network mismatch/');
+        $this->invoke($adapter, 'matchLegacyCredential', [
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+            'network'     => 'solana',
+        ]);
+    }
+
+    // ── settlementNetwork: per-wire network echo ───────────────────────────
+
+    public function testSettlementNetworkEchoesLegacyPlainSlug(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $network = $this->invoke($adapter, 'settlementNetwork', [
+            'x402Version' => 1,
+            'network'     => 'solana-devnet',
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        self::assertSame('solana-devnet', $network);
+    }
+
+    public function testSettlementNetworkEchoesCanonicalAcceptedNetwork(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $caip2 = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+        $network = $this->invoke($adapter, 'settlementNetwork', [
+            'x402Version' => 2,
+            'accepted'    => ['network' => $caip2],
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        self::assertSame($caip2, $network);
+    }
+
+    public function testSettlementNetworkFallsBackToRouteCaip2(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $network = $this->invoke($adapter, 'settlementNetwork', [
+            'x402Version' => 2,
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        self::assertSame('solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1', $network);
+    }
+
+    // ── decodeCredential: base64(JSON) decode guards ───────────────────────
+
+    public function testDecodeCredentialRejectsBadBase64(): void
+    {
+        $adapter = $this->makeAdapter();
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/base64/');
+        $this->invoke($adapter, 'decodeCredential', '@@@not-base64@@@');
+    }
+
+    public function testDecodeCredentialRejectsNonJson(): void
+    {
+        $adapter = $this->makeAdapter();
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/json/');
+        $this->invoke($adapter, 'decodeCredential', base64_encode('not json at all'));
+    }
+
+    public function testDecodeCredentialAcceptsObjectAndScalarValues(): void
+    {
+        // A JSON object decodes to a PHP array (the only credential shape we
+        // accept). A JSON array also decodes to a PHP array but carries no
+        // x402Version, so it is rejected downstream by the version gate, not
+        // here — decodeCredential only guards that the payload decodes at all.
+        $adapter = $this->makeAdapter();
+        $decoded = $this->invoke(
+            $adapter,
+            'decodeCredential',
+            base64_encode(json_encode(['x402Version' => 1]) ?: '{}'),
+        );
+        self::assertSame(['x402Version' => 1], $decoded);
+    }
+
+    public function testVerifyAndSettleRejectsBareJsonArrayCredential(): void
+    {
+        // A JSON array decodes but has no x402Version; the version gate rejects
+        // it as an unsupported version rather than letting it through.
+        $adapter = $this->makeAdapter();
+        $header = base64_encode(json_encode([1, 2, 3]) ?: '[]');
+        $req = $this->request()->withHeader('X-PAYMENT', $header);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/unsupported_x402_version/');
+        $adapter->verifyAndSettle($this->makeGate(), $req);
+    }
+
+    // ── verifyAndSettle: dual-accept read + version dispatch ───────────────
+
+    public function testVerifyAndSettleReadsLegacyXPaymentHeader(): void
+    {
+        // A well-formed legacy credential on X-PAYMENT must NOT be rejected at
+        // the dispatch/gate; it advances past version + scheme + network and
+        // fails only on the missing transaction proof (the "AA==" tx here is
+        // empty-ish but present, so it reaches the structural verifier path).
+        // We assert it does NOT trip "payment required" or "unsupported
+        // version" — i.e. the X-PAYMENT fallback fired and v1 was accepted by
+        // the gate.
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $header = $this->legacyHeader([
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+            'network'     => 'solana-devnet',
+            'payload'     => [], // no transaction -> trips missing-transaction
+        ]);
+        $req = $this->request()->withHeader('X-PAYMENT', $header);
+        try {
+            $adapter->verifyAndSettle($this->makeGate(), $req);
+            self::fail('expected an InvalidProofException');
+        } catch (InvalidProofException $e) {
+            self::assertStringContainsString('missing_transaction', $e->getMessage());
+        }
+    }
+
+    public function testVerifyAndSettleRejectsLegacyWrongNetwork(): void
+    {
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $header = $this->legacyHeader([
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+            'network'     => 'solana', // mainnet slug on a devnet route
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        $req = $this->request()->withHeader('X-PAYMENT', $header);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/Network mismatch/');
+        $adapter->verifyAndSettle($this->makeGate(), $req);
+    }
+
+    public function testVerifyAndSettleStillRejectsUnknownVersionOnLegacyHeader(): void
+    {
+        // Adding legacy support must NOT widen the version gate: a credential
+        // shaped like v1 (top-level scheme/network) but carrying an unknown
+        // version is still rejected.
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $header = $this->legacyHeader([
+            'x402Version' => 9,
+            'scheme'      => 'exact',
+            'network'     => 'solana-devnet',
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        $req = $this->request()->withHeader('X-PAYMENT', $header);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/unsupported_x402_version/');
+        $adapter->verifyAndSettle($this->makeGate(), $req);
+    }
+
+    public function testVerifyAndSettleCanonicalHeaderTakesPrecedenceOverLegacy(): void
+    {
+        // When both headers are present the canonical PAYMENT-SIGNATURE wins.
+        // We send a canonical credential with a mismatched accepted (so it
+        // trips the canonical identity-key check) AND a legacy credential that
+        // would otherwise pass; the canonical-path error proves precedence.
+        $adapter = $this->makeAdapter(Network::SolanaDevnet);
+        $canonical = $this->legacyHeader([
+            'x402Version' => 2,
+            'accepted'    => ['scheme' => 'exact', 'network' => 'solana:WRONG', 'asset' => 'X', 'payTo' => 'Y'],
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        $legacy = $this->legacyHeader([
+            'x402Version' => 1,
+            'scheme'      => 'exact',
+            'network'     => 'solana-devnet',
+            'payload'     => ['transaction' => 'AA=='],
+        ]);
+        $req = $this->request()
+            ->withHeader('Payment-Signature', $canonical)
+            ->withHeader('X-PAYMENT', $legacy);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessageMatches('/charge_request_mismatch/');
+        $adapter->verifyAndSettle($this->makeGate(), $req);
+    }
+}

--- a/python/conformance_runner.py
+++ b/python/conformance_runner.py
@@ -50,8 +50,14 @@ from pay_kit.protocols.mpp.server._verify import _verify_local_transaction_inten
 from pay_kit.protocols.x402.client.exact.payment import (
     _caip2_for_selection,
     build_payment_header,
+    build_payment_header_legacy,
 )
-from pay_kit.protocols.x402.exact.verify import X402_VERSION
+from pay_kit.protocols.x402.exact.legacy import caip2_for_network
+from pay_kit.protocols.x402.exact.verify import (
+    EXACT_SCHEME,
+    X402_VERSION_V1,
+    X402_VERSION_V2,
+)
 from pay_kit.signer import LocalSigner
 
 DEFAULT_NETWORK = "mainnet"
@@ -409,13 +415,14 @@ def _decode_envelope_shape(header_b64: str) -> dict[str, Any]:
 
 
 async def _x402_build_header(vector: dict[str, Any]) -> str:
-    """Drive the real pay_kit x402 client to build a v2 PAYMENT-SIGNATURE header.
+    """Drive the real pay_kit x402 client to build a payment header.
 
     The offer is the vector's ``x402Offer``. An ephemeral signer + pinned
     blockhash + pinned memo nonce keep the build deterministic and RPC-free;
     the resulting transaction is real but its bytes are not asserted (the
-    envelope shape is the oracle). Only the canonical v2 wire is built here;
-    the legacy v1 builder ships in a separate change.
+    envelope shape is the oracle). The default producer stays the canonical (v2)
+    ``PAYMENT-SIGNATURE`` wire; when the vector pins ``x402Version: 1`` the
+    runner drives the legacy ``X-PAYMENT`` producer instead.
     """
     inp = vector.get("input") or {}
     offer = inp.get("x402Offer")
@@ -423,7 +430,8 @@ async def _x402_build_header(vector: dict[str, Any]) -> str:
         raise ValueError("x402 build vector is missing input.x402Offer")
 
     signer = LocalSigner.generate()
-    return await build_payment_header(
+    builder = build_payment_header_legacy if inp.get("x402Version") == X402_VERSION_V1 else build_payment_header
+    return await builder(
         signer,
         OfflineRPC(),
         offer,
@@ -459,7 +467,7 @@ def _x402_verify(vector: dict[str, Any]) -> dict[str, Any]:
     expected_network = _caip2_for_selection(inp.get("x402ServerNetwork") or DEFAULT_NETWORK)
     version = env.get("x402Version")
 
-    if version == X402_VERSION:
+    if version == X402_VERSION_V2:
         accepted = env.get("accepted")
         if not isinstance(accepted, dict):
             raise ValueError("invalid payload: v2 envelope missing accepted")
@@ -477,6 +485,15 @@ def _x402_verify(vector: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(
                 f"Currency mismatch: expected {inp.get('x402ServerCurrency')}, got {accepted.get('asset')}"
             )
+    elif version == X402_VERSION_V1:
+        # Legacy arm: no ``accepted`` object. Bind only scheme + the plain
+        # network slug (normalized to CAIP-2) against the route. Mirrors the v1
+        # arm of rust parse_payment_signature (server/exact.rs:316-327).
+        if env.get("scheme") != EXACT_SCHEME:
+            raise ValueError(f"invalid payload: legacy scheme {env.get('scheme')!r} is not exact")
+        network_slug = env.get("network") or ""
+        if caip2_for_network(network_slug) != expected_network:
+            raise ValueError(f"Network mismatch: expected {expected_network}, got {network_slug}")
     else:
         raise ValueError(f"invalid payload: Unsupported x402 version: {version}")
 

--- a/python/src/pay_kit/protocols/x402/__init__.py
+++ b/python/src/pay_kit/protocols/x402/__init__.py
@@ -56,6 +56,10 @@ __all__ = ["X402Adapter", "ExactVerifier", "X402_VERSION"]
 
 _SETTLEMENT_HEADER = "x-payment-settlement-signature"
 _RESPONSE_HEADER = "payment-response"
+# Legacy v1 clients read the settlement receipt under X-PAYMENT-RESPONSE; the
+# server must echo it there when it accepted a v1 credential (rust
+# X402_V1_PAYMENT_RESPONSE_HEADER, constants.rs:22).
+_RESPONSE_HEADER_LEGACY = "x-payment-response"
 _REPLAY_PREFIX = "x402-svm-exact:consumed:"
 
 
@@ -266,12 +270,16 @@ class X402Adapter:
             "ascii"
         )
 
+        # v1 credentials get the legacy X-PAYMENT-RESPONSE receipt header; v2
+        # uses PAYMENT-RESPONSE. Mirrors the rust v1/v2 settlement-response
+        # split (constants.rs:22/31) and the go/lua/ruby/swift behavior.
+        response_header = _RESPONSE_HEADER_LEGACY if version == X402_VERSION_V1 else _RESPONSE_HEADER
         return Payment(
             protocol=Protocol.X402,
             transaction=signature,
             gate_name=gate.name,
             settlement_headers={
-                _RESPONSE_HEADER: response_envelope,
+                response_header: response_envelope,
                 _SETTLEMENT_HEADER: signature,
             },
             raw=header,

--- a/python/src/pay_kit/protocols/x402/__init__.py
+++ b/python/src/pay_kit/protocols/x402/__init__.py
@@ -28,6 +28,10 @@ from pay_kit._paycore.rpc import SolanaRpc
 from pay_kit._paycore.store import MemoryStore, Store
 from pay_kit.errors import ConfigurationError, InvalidProofError
 from pay_kit.payment import Payment
+from pay_kit.protocols.x402.exact.legacy import (
+    X402_LEGACY_PAYMENT_HEADER,
+    caip2_for_network,
+)
 from pay_kit.protocols.x402.exact.types import (
     X402AcceptsEntry,
     X402Challenge,
@@ -35,7 +39,13 @@ from pay_kit.protocols.x402.exact.types import (
     X402PayloadField,
     X402ResponseEnvelope,
 )
-from pay_kit.protocols.x402.exact.verify import X402_VERSION, ExactVerifier
+from pay_kit.protocols.x402.exact.verify import (
+    EXACT_SCHEME,
+    X402_VERSION,
+    X402_VERSION_V1,
+    X402_VERSION_V2,
+    ExactVerifier,
+)
 
 if TYPE_CHECKING:
     from pay_kit.config import Config
@@ -134,7 +144,14 @@ class X402Adapter:
         if signer is None:
             raise InvalidProofError("pay_kit: x402 requires operator.signer", code="payment_invalid")
 
+        # Dual-accept: read the canonical (v2) ``Payment-Signature`` header
+        # FIRST, then fall back to the legacy ``X-PAYMENT`` header. Mirrors rust
+        # ``parse_payment_signature`` being driven from both header names
+        # (server/exact.rs) and the dual-accept rule: a v2 server must NOT reject
+        # a legacy credential, but still rejects genuinely-unknown versions.
         header = _payment_signature_header(request)
+        if not header:
+            header = _legacy_payment_header(request)
         if not header:
             raise InvalidProofError("pay_kit: payment required", code="payment_required")
 
@@ -158,51 +175,23 @@ class X402Adapter:
         # The envelope is attacker-controlled; it is validated field-by-field
         # below, then narrowed to the typed wire shape for the rest of the flow.
         envelope_map = cast("dict[str, object]", envelope)
-        if envelope_map.get("x402Version") != X402_VERSION:
-            raise InvalidProofError("unsupported_x402_version", code="unsupported_x402_version")
-        accepted_raw = envelope_map.get("accepted")
-        payload_raw = envelope_map.get("payload")
-        if not isinstance(accepted_raw, dict) or not isinstance(payload_raw, dict):
-            raise InvalidProofError(
-                "invalid_exact_svm_payload_envelope",
-                code="invalid_exact_svm_payload_envelope",
-            )
-        accepted = cast("dict[str, object]", accepted_raw)
-        payload = cast("X402PayloadField", payload_raw)
+        version = envelope_map.get("x402Version")
 
-        # Tier-2 identity-key match: the credential's accepted requirement must
-        # match the server's freshly built offer for this route. x402 has no
-        # HMAC-bound challenge id, so the offer is the source of truth and the
-        # credential's `accepted` is never trusted for the route's parameters
-        # (mirrors rust verify_pinned_fields + the targeted deepEqual gate).
+        # The server's freshly built offer for this route is the source of truth
+        # for the route's parameters in BOTH wire shapes; the credential is never
+        # trusted for them. The structural verifier and every facilitator
+        # MUST-check below run against this offer identically for v1 and v2.
         offer = self.accepts_entry(gate, request)
         offer_map = cast("dict[str, object]", offer)
-        for key in ("scheme", "network", "asset", "payTo"):
-            if accepted.get(key) != offer_map.get(key):
-                raise InvalidProofError(
-                    "pay_kit: charge_request_mismatch: accepted payment requirement does not match server challenge",
-                    code="charge_request_mismatch",
-                )
-        # Reject if EITHER the exact `amount` or the `maxAmountRequired`
-        # ceiling drifts from the server offer. The previous AND only tripped
-        # when both diverged, so one-sided drift (e.g. amount tampered while
-        # maxAmountRequired left intact) silently passed.
-        if accepted.get("amount") != offer_map.get("amount") or accepted.get(
-            "maxAmountRequired"
-        ) != offer_map.get("maxAmountRequired"):
-            raise InvalidProofError(
-                "pay_kit: charge_request_mismatch (amount)",
-                code="charge_request_mismatch",
-            )
-        offer_extra = cast("dict[str, object]", offer_map.get("extra") or {})
-        accepted_extra_raw = accepted.get("extra")
-        accepted_extra = cast("dict[str, object]", accepted_extra_raw if isinstance(accepted_extra_raw, dict) else {})
-        for key in ("feePayer", "tokenProgram", "memo"):
-            if key in offer_extra and accepted_extra.get(key) != offer_extra[key]:
-                raise InvalidProofError(
-                    f"pay_kit: charge_request_mismatch (extra.{key})",
-                    code="charge_request_mismatch",
-                )
+
+        if version == X402_VERSION_V2:
+            accepted, payload = self._bind_canonical(envelope_map, offer_map)
+        elif version == X402_VERSION_V1:
+            accepted, payload = self._bind_legacy(envelope_map, offer_map)
+        else:
+            # A genuinely-unknown version is rejected on the dual-accept path,
+            # exactly like the catch-all arm in rust ``parse_payment_signature``.
+            raise InvalidProofError("unsupported_x402_version", code="unsupported_x402_version")
 
         tx_base64 = payload.get("transaction")
         if not isinstance(tx_base64, str) or tx_base64 == "":
@@ -287,6 +276,94 @@ class X402Adapter:
             },
             raw=header,
         )
+
+    def _bind_canonical(
+        self,
+        envelope: dict[str, object],
+        offer: dict[str, object],
+    ) -> tuple[dict[str, object], X402PayloadField]:
+        """Bind a canonical (v2) credential to the route's offer.
+
+        The v2 envelope carries an ``accepted`` requirement the client echoed
+        back; it is matched field-by-field against the server's freshly built
+        offer (x402 has no HMAC-bound challenge id, so the offer is the source
+        of truth). Mirrors the v2 arm of rust ``parse_payment_signature`` plus
+        ``verify_pinned_fields`` (server/exact.rs:328-341).
+        """
+        accepted_raw = envelope.get("accepted")
+        payload_raw = envelope.get("payload")
+        if not isinstance(accepted_raw, dict) or not isinstance(payload_raw, dict):
+            raise InvalidProofError(
+                "invalid_exact_svm_payload_envelope",
+                code="invalid_exact_svm_payload_envelope",
+            )
+        accepted = cast("dict[str, object]", accepted_raw)
+        # Tier-2 identity-key match: scheme/network/asset/payTo must match.
+        for key in ("scheme", "network", "asset", "payTo"):
+            if accepted.get(key) != offer.get(key):
+                raise InvalidProofError(
+                    "pay_kit: charge_request_mismatch: accepted payment requirement does not match server challenge",
+                    code="charge_request_mismatch",
+                )
+        # Reject if EITHER the exact ``amount`` or the ``maxAmountRequired``
+        # ceiling drifts from the server offer.
+        if accepted.get("amount") != offer.get("amount") or accepted.get("maxAmountRequired") != offer.get(
+            "maxAmountRequired"
+        ):
+            raise InvalidProofError(
+                "pay_kit: charge_request_mismatch (amount)",
+                code="charge_request_mismatch",
+            )
+        offer_extra = cast("dict[str, object]", offer.get("extra") or {})
+        accepted_extra_raw = accepted.get("extra")
+        accepted_extra = cast("dict[str, object]", accepted_extra_raw if isinstance(accepted_extra_raw, dict) else {})
+        for key in ("feePayer", "tokenProgram", "memo"):
+            if key in offer_extra and accepted_extra.get(key) != offer_extra[key]:
+                raise InvalidProofError(
+                    f"pay_kit: charge_request_mismatch (extra.{key})",
+                    code="charge_request_mismatch",
+                )
+        return accepted, cast("X402PayloadField", payload_raw)
+
+    def _bind_legacy(
+        self,
+        envelope: dict[str, object],
+        offer: dict[str, object],
+    ) -> tuple[dict[str, object], X402PayloadField]:
+        """Bind a legacy (x402Version=1) credential to the route's offer.
+
+        The legacy envelope has NO ``accepted`` object: it commits only to
+        ``scheme`` + a plain ``network`` slug at the top level. The server binds
+        exactly those two fields (scheme must be ``exact``; the plain network
+        slug, normalized via ``caip2_for_network``, must match the route's CAIP-2
+        network), then runs the IDENTICAL structural verifier and facilitator
+        MUST-checks against the route's offer as the v2 path. Mirrors the v1 arm
+        of rust ``parse_payment_signature`` (server/exact.rs:316-327).
+        """
+        scheme = envelope.get("scheme")
+        if scheme != EXACT_SCHEME:
+            raise InvalidProofError(
+                "invalid_exact_svm_payload_scheme",
+                code="invalid_exact_svm_payload_scheme",
+            )
+        network = envelope.get("network")
+        network_slug = network if isinstance(network, str) else ""
+        expected = self._caip2()
+        if caip2_for_network(network_slug) != expected:
+            raise InvalidProofError(
+                f"Network mismatch: expected {expected}, got {network_slug}",
+                code="charge_request_mismatch",
+            )
+        payload_raw = envelope.get("payload")
+        if not isinstance(payload_raw, dict):
+            raise InvalidProofError(
+                "invalid_exact_svm_payload_envelope",
+                code="invalid_exact_svm_payload_envelope",
+            )
+        # The legacy wire carries no ``accepted`` body, so the response receipt
+        # reports the route's CAIP-2 network rather than echoing the credential.
+        synthetic_accepted: dict[str, object] = {"network": expected}
+        return synthetic_accepted, cast("X402PayloadField", payload_raw)
 
     def _fetch_recent_blockhash(self) -> str | None:
         if self._recent_blockhash_provider is not None:
@@ -430,5 +507,30 @@ def _payment_signature_header(request: Any) -> str:
         if isinstance(raw_headers, dict):
             for key, header_value in cast("dict[object, object]", raw_headers).items():
                 if isinstance(key, str) and key.lower() == "payment-signature" and header_value:
+                    return str(header_value)
+    return ""
+
+
+def _legacy_payment_header(request: Any) -> str:
+    """Read the legacy ``X-PAYMENT`` header across framework request shapes.
+
+    The legacy x402 credential travels in ``X-PAYMENT`` (rust
+    ``X402_V1_PAYMENT_HEADER``), not ``Payment-Signature``. Read it only after
+    the canonical (v2) header is absent so the v2 path stays the default.
+    """
+    target = X402_LEGACY_PAYMENT_HEADER.lower()
+    headers = getattr(request, "headers", None)
+    if headers is not None:
+        getter = getattr(headers, "get", None)
+        if callable(getter):
+            for name in (target, X402_LEGACY_PAYMENT_HEADER, X402_LEGACY_PAYMENT_HEADER.upper()):
+                value: object = getter(name)
+                if value:
+                    return str(value)
+    if isinstance(request, dict):
+        raw_headers = cast("dict[str, object]", request).get("headers")
+        if isinstance(raw_headers, dict):
+            for key, header_value in cast("dict[object, object]", raw_headers).items():
+                if isinstance(key, str) and key.lower() == target and header_value:
                     return str(header_value)
     return ""

--- a/python/src/pay_kit/protocols/x402/client/exact/__init__.py
+++ b/python/src/pay_kit/protocols/x402/client/exact/__init__.py
@@ -6,6 +6,7 @@ from pay_kit.protocols.x402.client.exact.payment import (
     ChallengeSelection,
     build_payment,
     build_payment_header,
+    build_payment_header_legacy,
     parse_x402_challenge,
 )
 from pay_kit.protocols.x402.client.exact.transport import (
@@ -20,6 +21,7 @@ __all__ = [
     "parse_x402_challenge",
     "build_payment",
     "build_payment_header",
+    "build_payment_header_legacy",
     "PaymentTransport",
     "X402Client",
     "x402_async_client",

--- a/python/src/pay_kit/protocols/x402/client/exact/payment.py
+++ b/python/src/pay_kit/protocols/x402/client/exact/payment.py
@@ -146,11 +146,26 @@ def parse_x402_challenge(
     cheapest ``amount``. Returns ``None`` when no supported offer matches.
     Mirrors rust ``parse_x402_challenge_with_selection``.
     """
+    offer, _version = parse_x402_challenge_with_version(headers, body, selection)
+    return offer
+
+
+def parse_x402_challenge_with_version(
+    headers: Mapping[str, str],
+    body: str | None,
+    selection: ChallengeSelection,
+) -> tuple[X402AcceptsEntry | None, int]:
+    """Like :func:`parse_x402_challenge`, but also surfaces the DECLARED wire
+    version of the challenge the offer came from, so the transport can emit the
+    matching producer (v1 ``X-PAYMENT`` vs v2 ``PAYMENT-SIGNATURE``). Mirrors the
+    go ``ParseChallengeVersioned`` / swift ``parseX402ChallengeWithVersion``.
+    Returns ``(None, X402_VERSION)`` when no supported offer matches.
+    """
     header_value = _lookup_header(headers, "payment-required")
     if header_value:
-        offer = _select_from_header(header_value, selection)
+        offer, version = _select_from_header(header_value, selection)
         if offer is not None:
-            return offer
+            return offer, version
 
     # Legacy precedence after the canonical (v2) header: the ``X-PAYMENT-REQUIRED``
     # header carries the legacy challenge as a plain (not base64) JSON object, the
@@ -159,19 +174,19 @@ def parse_x402_challenge(
     # (rust/crates/x402/src/client/exact/payment.rs:246-253).
     legacy_header = _lookup_header(headers, X402_LEGACY_PAYMENT_REQUIRED_HEADER)
     if legacy_header:
-        offer = _select_from_body(legacy_header, selection)
+        offer, version = _select_from_body(legacy_header, selection)
         if offer is not None:
-            return offer
+            return offer, version
 
     # Final fallback: the legacy 402 JSON body ``{"accepts": [...]}`` with plain
     # SVM network slugs and ``maxAmountRequired``. Mirrors rust ``parse_accepts_
     # body`` (payment.rs:255-259).
     if body is not None:
-        offer = _select_from_body(body, selection)
+        offer, version = _select_from_body(body, selection)
         if offer is not None:
-            return offer
+            return offer, version
 
-    return None
+    return None, X402_VERSION
 
 
 def _lookup_header(headers: Mapping[str, str], name: str) -> str | None:
@@ -182,34 +197,36 @@ def _lookup_header(headers: Mapping[str, str], name: str) -> str | None:
     return None
 
 
-def _select_from_header(header_value: str, selection: ChallengeSelection) -> X402AcceptsEntry | None:
+def _select_from_header(header_value: str, selection: ChallengeSelection) -> tuple[X402AcceptsEntry | None, int]:
     try:
         decoded = base64.b64decode(header_value, validate=True)
         envelope = json.loads(decoded)
     except Exception:  # noqa: BLE001 - any decode failure means "no challenge here"
-        return None
+        return None, X402_VERSION
     return _select_from_envelope(envelope, selection)
 
 
-def _select_from_body(body: str, selection: ChallengeSelection) -> X402AcceptsEntry | None:
+def _select_from_body(body: str, selection: ChallengeSelection) -> tuple[X402AcceptsEntry | None, int]:
     try:
         envelope = json.loads(body)
     except Exception:  # noqa: BLE001
-        return None
+        return None, X402_VERSION
     return _select_from_envelope(envelope, selection)
 
 
-def _select_from_envelope(envelope: object, selection: ChallengeSelection) -> X402AcceptsEntry | None:
+def _select_from_envelope(envelope: object, selection: ChallengeSelection) -> tuple[X402AcceptsEntry | None, int]:
     if not isinstance(envelope, dict):
-        return None
+        return None, X402_VERSION
     envelope_dict = cast("dict[str, object]", envelope)
+    raw_version = envelope_dict.get("x402Version")
+    version = raw_version if isinstance(raw_version, int) else X402_VERSION
     accepts_raw = envelope_dict.get("accepts")
     if not isinstance(accepts_raw, list):
-        return None
+        return None, version
     entries = cast("list[object]", accepts_raw)
     accepts = [cast("dict[str, object]", entry) for entry in entries if isinstance(entry, dict)]
     _attach_envelope_resource(envelope_dict, accepts)
-    return _select_requirement(accepts, selection)
+    return _select_requirement(accepts, selection), version
 
 
 #: Private (non-wire) key under which the envelope-level v2 ``resource`` info is

--- a/python/src/pay_kit/protocols/x402/client/exact/payment.py
+++ b/python/src/pay_kit/protocols/x402/client/exact/payment.py
@@ -33,8 +33,21 @@ from pay_kit._paycore.solana import (
     default_token_program_for_currency,
     is_native_sol,
 )
+from pay_kit.protocols.x402.exact.legacy import (
+    SOLANA_DEVNET_NAME,
+    SOLANA_NETWORK_NAME,
+    SOLANA_TESTNET_NAME,
+    X402_LEGACY_PAYMENT_REQUIRED_HEADER,
+    caip2_for_network,
+    legacy_network_for_caip2,
+)
 from pay_kit.protocols.x402.exact.types import X402AcceptsEntry, X402Envelope, X402PayloadField
-from pay_kit.protocols.x402.exact.verify import COMPUTE_BUDGET_PROGRAM, X402_VERSION
+from pay_kit.protocols.x402.exact.verify import (
+    COMPUTE_BUDGET_PROGRAM,
+    EXACT_SCHEME,
+    X402_VERSION,
+    X402_VERSION_V1,
+)
 
 if TYPE_CHECKING:
     from pay_kit.signer import LocalSigner
@@ -44,6 +57,7 @@ __all__ = [
     "parse_x402_challenge",
     "build_payment",
     "build_payment_header",
+    "build_payment_header_legacy",
 ]
 
 #: ComputeBudget SetComputeUnitLimit (disc 2, u32 LE). Matches the rust spine
@@ -138,6 +152,20 @@ def parse_x402_challenge(
         if offer is not None:
             return offer
 
+    # Legacy precedence after the canonical (v2) header: the ``X-PAYMENT-REQUIRED``
+    # header carries the legacy challenge as a plain (not base64) JSON object, the
+    # same shape the 402 body carries. Mirrors rust ``parse_x402_challenge_with_
+    # selection`` reading ``X402_V1_PAYMENT_REQUIRED_HEADER`` before the body
+    # (rust/crates/x402/src/client/exact/payment.rs:246-253).
+    legacy_header = _lookup_header(headers, X402_LEGACY_PAYMENT_REQUIRED_HEADER)
+    if legacy_header:
+        offer = _select_from_body(legacy_header, selection)
+        if offer is not None:
+            return offer
+
+    # Final fallback: the legacy 402 JSON body ``{"accepts": [...]}`` with plain
+    # SVM network slugs and ``maxAmountRequired``. Mirrors rust ``parse_accepts_
+    # body`` (payment.rs:255-259).
     if body is not None:
         offer = _select_from_body(body, selection)
         if offer is not None:
@@ -231,6 +259,11 @@ def _attach_envelope_resource(
         accept.setdefault(_RESOURCE_INFO_KEY, info)
 
 
+#: Plain legacy SVM network slugs accepted on the challenge-parse path
+#: alongside the canonical CAIP-2 ids.
+_LEGACY_NETWORK_NAMES = frozenset({SOLANA_NETWORK_NAME, SOLANA_DEVNET_NAME, SOLANA_TESTNET_NAME})
+
+
 def _is_solana_exact(offer: dict[str, object]) -> bool:
     scheme = offer.get("scheme")
     protocol = offer.get("protocol")
@@ -239,7 +272,23 @@ def _is_solana_exact(offer: dict[str, object]) -> bool:
     # accept the offer when it is absent but reject an explicit non-x402 value.
     if protocol is not None and protocol != "x402":
         return False
-    return scheme == "exact" and isinstance(network, str) and network in _SOLANA_CAIP2
+    if scheme != "exact" or not isinstance(network, str):
+        return False
+    # Canonical (v2) offers carry a CAIP-2 network; legacy offers carry a plain
+    # SVM slug. Accept both so the client can pay a legacy 402 challenge.
+    return network in _SOLANA_CAIP2 or network in _LEGACY_NETWORK_NAMES
+
+
+def _offer_network_caip2(offer: dict[str, object]) -> str | None:
+    """Normalize an offer's network (CAIP-2 or plain slug) to a CAIP-2 id."""
+    network = offer.get("network")
+    if not isinstance(network, str):
+        return None
+    if network in _SOLANA_CAIP2:
+        return network
+    if network in _LEGACY_NETWORK_NAMES:
+        return caip2_for_network(network)
+    return None
 
 
 def _amount_of(offer: dict[str, object]) -> int:
@@ -274,7 +323,9 @@ def _select_requirement(
     label = _mints_label_for_caip2(preferred)
 
     solana = [offer for offer in accepts if _is_solana_exact(offer)]
-    on_preferred = [offer for offer in solana if offer.get("network") == preferred]
+    # Compare on the normalized CAIP-2 network so a legacy offer naming
+    # ``solana``/``solana-devnet`` matches the preferred CAIP-2 selection.
+    on_preferred = [offer for offer in solana if _offer_network_caip2(offer) == preferred]
 
     if selection.currencies is not None:
         for wanted in selection.currencies:
@@ -576,3 +627,47 @@ async def build_payment_header(
     )
     payload = json.dumps(envelope, separators=(",", ":")).encode("utf-8")
     return base64.b64encode(payload).decode("ascii")
+
+
+async def build_payment_header_legacy(
+    signer: LocalSigner,
+    rpc: Any,
+    requirement: X402AcceptsEntry,
+    *,
+    recent_blockhash_provider: Callable[[], Awaitable[str] | str] | None = None,
+    memo_nonce: Callable[[], str] | None = None,
+) -> str:
+    """Build the legacy standard-base64 ``X-PAYMENT`` header value.
+
+    The legacy wire is a SEPARATE shape from the canonical (v2) producer: the
+    envelope is ``{x402Version: 1, scheme: "exact", network: <plain slug>,
+    payload: {transaction}}`` with ``scheme`` and ``network`` as TOP-LEVEL
+    siblings of ``payload`` and NO ``accepted`` object. The plain network slug
+    (``solana`` / ``solana-devnet``) is derived from the offer's network via
+    :func:`legacy_network_for_caip2`. Mirrors rust ``build_payment_header_v1``
+    (rust/crates/x402/src/client/exact/payment.rs:153-170).
+
+    The canonical (v2) producer (:func:`build_payment_header`) stays the
+    default; emit this legacy shape only when the server's challenge declared
+    the legacy version.
+    """
+    envelope = await build_payment(
+        signer,
+        rpc,
+        requirement,
+        recent_blockhash_provider=recent_blockhash_provider,
+        memo_nonce=memo_nonce,
+    )
+    # The legacy envelope commits only to scheme + plain network, not an
+    # ``accepted`` body. Reuse the signed transaction from the canonical build
+    # and re-wrap it in the legacy top-level shape.
+    payload_field = cast("dict[str, object]", envelope).get("payload")
+    network_caip2 = _str_field(cast("dict[str, object]", requirement), "network")
+    legacy_envelope: dict[str, object] = {
+        "x402Version": X402_VERSION_V1,
+        "scheme": EXACT_SCHEME,
+        "network": legacy_network_for_caip2(network_caip2),
+        "payload": payload_field,
+    }
+    encoded = json.dumps(legacy_envelope, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(encoded).decode("ascii")

--- a/python/src/pay_kit/protocols/x402/client/exact/transport.py
+++ b/python/src/pay_kit/protocols/x402/client/exact/transport.py
@@ -19,8 +19,11 @@ import httpx
 from pay_kit.protocols.x402.client.exact.payment import (
     ChallengeSelection,
     build_payment_header,
-    parse_x402_challenge,
+    build_payment_header_legacy,
+    parse_x402_challenge_with_version,
 )
+from pay_kit.protocols.x402.exact.legacy import X402_LEGACY_PAYMENT_HEADER
+from pay_kit.protocols.x402.exact.verify import X402_VERSION_V1
 
 if TYPE_CHECKING:
     from pay_kit.signer import LocalSigner
@@ -70,12 +73,20 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         except Exception:  # noqa: BLE001 - a non-decodable body just means "header only"
             body = None
 
-        requirement = parse_x402_challenge(dict(response.headers), body, self._selection)
+        requirement, version = parse_x402_challenge_with_version(
+            dict(response.headers), body, self._selection
+        )
         if requirement is None:
             return response
 
+        # Emit the producer matching the challenge's declared version: a v1
+        # challenge gets the legacy X-PAYMENT credential, v2 (the default) gets
+        # PAYMENT-SIGNATURE. Mirrors the go/swift transports.
+        is_legacy = version == X402_VERSION_V1
+        builder = build_payment_header_legacy if is_legacy else build_payment_header
+        credential_header = X402_LEGACY_PAYMENT_HEADER if is_legacy else PAYMENT_SIGNATURE_HEADER
         try:
-            header_value = await build_payment_header(
+            header_value = await builder(
                 self._signer,
                 self._rpc,
                 requirement,
@@ -86,7 +97,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
             return response
 
         headers = dict(request.headers)
-        headers[PAYMENT_SIGNATURE_HEADER] = header_value
+        headers[credential_header] = header_value
         retry_request = httpx.Request(
             method=request.method,
             url=request.url,

--- a/python/src/pay_kit/protocols/x402/exact/legacy.py
+++ b/python/src/pay_kit/protocols/x402/exact/legacy.py
@@ -1,0 +1,89 @@
+"""Legacy x402 ``exact`` wire helpers: plain SVM network names + headers.
+
+The legacy x402 wire (``X-PAYMENT`` / ``X-PAYMENT-REQUIRED`` /
+``X-PAYMENT-RESPONSE``) names networks with PLAIN SVM slugs
+(``solana`` / ``solana-devnet`` / ``solana-testnet``) rather than the CAIP-2
+identifiers the canonical (v2) wire uses. This module mirrors the rust spine
+constants and the two mappings the legacy producer/parser rely on:
+
+* :func:`legacy_network_for_caip2` mirrors rust ``v1_network_for_requirements``
+  (``rust/crates/x402/src/client/exact/payment.rs:393-404``): devnet-family ->
+  ``solana-devnet``, everything else -> ``solana``.
+* :func:`caip2_for_network` mirrors rust ``caip2_network_for_cluster``
+  (``rust/crates/x402/src/protocol/schemes/exact/types.rs:30-39``): normalize a
+  plain slug (or a CAIP-2 string) to the canonical CAIP-2 identifier the network
+  gate compares against.
+
+The legacy wire is a SEPARATE parallel shape from the canonical (v2) wire; there
+is no conversion helper between the two. Each is built/parsed natively.
+"""
+
+from __future__ import annotations
+
+from pay_kit._paycore.network import SOLANA_DEVNET_CAIP2, SOLANA_MAINNET_CAIP2
+
+__all__ = [
+    "X402_LEGACY_PAYMENT_HEADER",
+    "X402_LEGACY_PAYMENT_REQUIRED_HEADER",
+    "X402_LEGACY_PAYMENT_RESPONSE_HEADER",
+    "SOLANA_NETWORK_NAME",
+    "SOLANA_DEVNET_NAME",
+    "SOLANA_TESTNET_NAME",
+    "legacy_network_for_caip2",
+    "caip2_for_network",
+]
+
+#: Solana testnet CAIP-2 (rust ``SOLANA_TESTNET``, types.rs:18). Not advertised
+#: by the pay_kit server but accepted on the gate so a testnet legacy credential
+#: normalizes correctly.
+SOLANA_TESTNET_CAIP2 = "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
+
+#: Legacy client payment header (rust ``X402_V1_PAYMENT_HEADER``, constants.rs:16).
+X402_LEGACY_PAYMENT_HEADER = "X-PAYMENT"
+#: Legacy payment-required header (rust ``X402_V1_PAYMENT_REQUIRED_HEADER``,
+#: constants.rs:19). pay_kit follows the rust spine: a legacy challenge MAY ship
+#: in this header and the client reads it before the 402 JSON body.
+X402_LEGACY_PAYMENT_REQUIRED_HEADER = "X-PAYMENT-REQUIRED"
+#: Legacy settlement response header (rust ``X402_V1_PAYMENT_RESPONSE_HEADER``,
+#: constants.rs:22).
+X402_LEGACY_PAYMENT_RESPONSE_HEADER = "X-PAYMENT-RESPONSE"
+
+#: Plain SVM network names (rust ``SOLANA_NETWORK`` + the devnet/testnet slugs).
+SOLANA_NETWORK_NAME = "solana"
+SOLANA_DEVNET_NAME = "solana-devnet"
+SOLANA_TESTNET_NAME = "solana-testnet"
+
+#: Devnet-family CAIP-2 ids that map to the ``solana-devnet`` legacy slug.
+_DEVNET_CAIP2 = frozenset({SOLANA_DEVNET_CAIP2})
+
+
+def legacy_network_for_caip2(network: str | None) -> str:
+    """Map an offer's network (CAIP-2 or plain slug) to a legacy SVM slug.
+
+    Mirrors rust ``v1_network_for_requirements`` (payment.rs:393-404): the
+    devnet family (``devnet`` / ``solana-devnet`` / devnet CAIP-2) maps to
+    ``solana-devnet``; everything else maps to ``solana``.
+    """
+    if network is None:
+        return SOLANA_NETWORK_NAME
+    candidate = network.strip()
+    if candidate in _DEVNET_CAIP2 or candidate in {"devnet", "solana-devnet", "localnet"}:
+        return SOLANA_DEVNET_NAME
+    return SOLANA_NETWORK_NAME
+
+
+def caip2_for_network(network: str | None) -> str:
+    """Normalize a plain slug (or CAIP-2) to the canonical CAIP-2 identifier.
+
+    Mirrors rust ``caip2_network_for_cluster`` (types.rs:30-39): testnet and
+    devnet families resolve to their CAIP-2 ids; everything else (including the
+    bare ``solana`` slug and ``mainnet``/``mainnet-beta``) resolves to mainnet.
+    """
+    if network is None:
+        return SOLANA_MAINNET_CAIP2
+    candidate = network.strip()
+    if candidate in {SOLANA_TESTNET_CAIP2, "testnet", SOLANA_TESTNET_NAME}:
+        return SOLANA_TESTNET_CAIP2
+    if candidate in {SOLANA_DEVNET_CAIP2, "devnet", SOLANA_DEVNET_NAME, "localnet"}:
+        return SOLANA_DEVNET_CAIP2
+    return SOLANA_MAINNET_CAIP2

--- a/python/src/pay_kit/protocols/x402/exact/verify.py
+++ b/python/src/pay_kit/protocols/x402/exact/verify.py
@@ -18,7 +18,10 @@ from pay_kit.errors import InvalidProofError
 
 __all__ = [
     "ExactVerifier",
+    "EXACT_SCHEME",
     "X402_VERSION",
+    "X402_VERSION_V1",
+    "X402_VERSION_V2",
     "COMPUTE_BUDGET_PROGRAM",
     "MEMO_PROGRAM",
     "LIGHTHOUSE_PROGRAM",
@@ -26,8 +29,19 @@ __all__ = [
     "MAX_COMPUTE_UNIT_PRICE",
 ]
 
-#: x402 protocol version emitted in challenges and required on credentials.
-X402_VERSION = 2
+#: x402 ``exact`` scheme identifier (rust ``EXACT_SCHEME``, types.rs:6).
+EXACT_SCHEME = "exact"
+
+#: Legacy x402 protocol version. Mirrors the rust spine constant
+#: ``X402_VERSION_V1`` (rust/crates/x402/src/constants.rs:10).
+X402_VERSION_V1 = 1
+#: Canonical x402 protocol version used by current payments. Mirrors the rust
+#: spine ``X402_VERSION_V2`` (constants.rs:13).
+X402_VERSION_V2 = 2
+#: Default x402 protocol version emitted in challenges and required on the
+#: canonical credential path. Aliases the canonical (v2) version so existing
+#: call sites keep emitting/expecting the default producer's wire.
+X402_VERSION = X402_VERSION_V2
 
 #: ComputeBudget program id (instruction[0]/[1] guard).
 COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111"

--- a/python/tests/test_pk_x402_client.py
+++ b/python/tests/test_pk_x402_client.py
@@ -794,6 +794,50 @@ async def test_transport_sends_payment_signature_header(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_transport_sends_x_payment_header_for_v1_challenge(monkeypatch):
+    # A v1 challenge (x402Version:1 body) must make the transport emit the legacy
+    # X-PAYMENT credential, not v2 PAYMENT-SIGNATURE. Regression for the gap where
+    # the transport always built the v2 producer regardless of declared version.
+    import pay_kit.protocols.x402.client.exact.transport as tmod
+
+    async def fake_v1(*_a, **_k):
+        return "V1-CRED"
+
+    async def fake_v2(*_a, **_k):
+        return "V2-CRED"
+
+    monkeypatch.setattr(tmod, "build_payment_header_legacy", fake_v1)
+    monkeypatch.setattr(tmod, "build_payment_header", fake_v2)
+
+    v1_body = json.dumps({"x402Version": 1, "accepts": [_offer(network="solana-devnet")]})
+    seen_headers: list[dict[str, str]] = []
+
+    async def app(scope, receive, send):
+        headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers", [])}
+        seen_headers.append(headers)
+        if "x-payment" in headers or "payment-signature" in headers:
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"{}"})
+            return
+        await send(
+            {"type": "http.response.start", "status": 402, "headers": [(b"content-type", b"application/json")]}
+        )
+        await send({"type": "http.response.body", "body": v1_body.encode()})
+
+    signer = Signer.generate()
+    inner = httpx.ASGITransport(app=app)
+    transport = PaymentTransport(signer, None, network="devnet", base_transport=inner)
+    async with httpx.AsyncClient(transport=transport, base_url="http://server") as client:
+        resp = await client.get("/protected")
+
+    assert resp.status_code == 200
+    assert len(seen_headers) == 2
+    # The retry carries the legacy X-PAYMENT credential, NOT v2 Payment-Signature.
+    assert seen_headers[1].get("x-payment") == "V1-CRED"
+    assert "payment-signature" not in seen_headers[1]
+
+
+@pytest.mark.asyncio
 async def test_transport_passes_through_non_402(monkeypatch):
     async def ok_app(scope, receive, send):
         await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})

--- a/python/tests/test_pk_x402_legacy.py
+++ b/python/tests/test_pk_x402_legacy.py
@@ -1,0 +1,407 @@
+"""Legacy x402 ``exact`` wire coverage (x402Version=1).
+
+Covers the three new surfaces that ship the legacy wire alongside the canonical
+(v2) one, mirroring the rust spine v1 arms:
+
+* :mod:`pay_kit.protocols.x402.exact.legacy` plain-SVM-name mappings.
+* the client legacy producer ``build_payment_header_legacy`` (top-level
+  scheme/network, no ``accepted``) and the legacy challenge-parse fallbacks
+  (``X-PAYMENT-REQUIRED`` header + 402 ``accepts[]`` body with plain slugs).
+* the server dual-accept path in ``X402Adapter.verify_and_settle``: it reads
+  the canonical header first then falls back to ``X-PAYMENT``; it MUST accept a
+  legacy credential, still reject a genuinely-unknown version, and still emit a
+  v2 challenge by default.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import struct
+
+import pytest
+from solders.hash import Hash
+from solders.instruction import AccountMeta, Instruction
+from solders.keypair import Keypair
+from solders.message import MessageV0
+from solders.pubkey import Pubkey
+
+import pay_kit.protocols.x402 as xmod
+from pay_kit import Gate as GateCls
+from pay_kit import (
+    LocalSigner,
+    MemoryStore,
+    Operator,
+    Price,
+    Protocol,
+    Stablecoin,
+    configure,
+)
+from pay_kit._paycore.mints import derive_ata, resolve, token_program_for
+from pay_kit._paycore.network import SOLANA_DEVNET_CAIP2, SOLANA_MAINNET_CAIP2
+from pay_kit.config import reset
+from pay_kit.errors import InvalidProofError
+from pay_kit.protocols.x402 import X402Adapter
+from pay_kit.protocols.x402.client.exact import (
+    ChallengeSelection,
+    build_payment_header_legacy,
+    parse_x402_challenge,
+)
+from pay_kit.protocols.x402.exact.legacy import (
+    SOLANA_DEVNET_NAME,
+    SOLANA_NETWORK_NAME,
+    X402_LEGACY_PAYMENT_HEADER,
+    X402_LEGACY_PAYMENT_REQUIRED_HEADER,
+    caip2_for_network,
+    legacy_network_for_caip2,
+)
+from pay_kit.protocols.x402.exact.verify import (
+    COMPUTE_BUDGET_PROGRAM,
+    EXACT_SCHEME,
+    MEMO_PROGRAM,
+    X402_VERSION_V1,
+    X402_VERSION_V2,
+)
+
+BH = "4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs"
+_MINT_DEVNET = resolve("USDC", "devnet")
+assert _MINT_DEVNET is not None
+MINT_DEVNET: str = _MINT_DEVNET
+TP_DEVNET = token_program_for("USDC", "devnet")
+
+
+# ── legacy.py network mappings ──────────────────────────────────────────────
+
+
+def test_legacy_network_for_caip2_devnet_family():
+    assert legacy_network_for_caip2(SOLANA_DEVNET_CAIP2) == SOLANA_DEVNET_NAME
+    assert legacy_network_for_caip2("devnet") == SOLANA_DEVNET_NAME
+    assert legacy_network_for_caip2("solana-devnet") == SOLANA_DEVNET_NAME
+    assert legacy_network_for_caip2("localnet") == SOLANA_DEVNET_NAME
+
+
+def test_legacy_network_for_caip2_defaults_to_solana():
+    assert legacy_network_for_caip2(SOLANA_MAINNET_CAIP2) == SOLANA_NETWORK_NAME
+    assert legacy_network_for_caip2("mainnet") == SOLANA_NETWORK_NAME
+    assert legacy_network_for_caip2(None) == SOLANA_NETWORK_NAME
+
+
+def test_caip2_for_network_normalizes_plain_slugs():
+    assert caip2_for_network("solana") == SOLANA_MAINNET_CAIP2
+    assert caip2_for_network("mainnet-beta") == SOLANA_MAINNET_CAIP2
+    assert caip2_for_network("solana-devnet") == SOLANA_DEVNET_CAIP2
+    assert caip2_for_network("devnet") == SOLANA_DEVNET_CAIP2
+    assert caip2_for_network("localnet") == SOLANA_DEVNET_CAIP2
+    assert caip2_for_network(None) == SOLANA_MAINNET_CAIP2
+    # testnet round-trips through its own CAIP-2 id, not mainnet.
+    assert caip2_for_network("solana-testnet").startswith("solana:")
+    assert caip2_for_network("solana-testnet") != SOLANA_MAINNET_CAIP2
+
+
+def test_caip2_for_network_passthrough_caip2():
+    assert caip2_for_network(SOLANA_DEVNET_CAIP2) == SOLANA_DEVNET_CAIP2
+    assert caip2_for_network(SOLANA_MAINNET_CAIP2) == SOLANA_MAINNET_CAIP2
+
+
+# ── client legacy producer ──────────────────────────────────────────────────
+
+
+def _devnet_offer(amount: str = "1000") -> dict:
+    feepayer = str(Keypair().pubkey())
+    return {
+        "protocol": "x402",
+        "scheme": "exact",
+        "network": SOLANA_DEVNET_CAIP2,
+        "asset": MINT_DEVNET,
+        "amount": amount,
+        "maxAmountRequired": amount,
+        "payTo": str(Keypair().pubkey()),
+        "maxTimeoutSeconds": 60,
+        "extra": {"feePayer": feepayer, "decimals": 6, "tokenProgram": TP_DEVNET, "memo": "/r"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_legacy_producer_emits_top_level_scheme_and_plain_network():
+    signer = LocalSigner.generate()
+    offer = _devnet_offer()
+    header = await build_payment_header_legacy(
+        signer,
+        rpc=None,
+        requirement=offer,  # type: ignore[arg-type]
+        recent_blockhash_provider=lambda: BH,
+        memo_nonce=lambda: "00112233445566778899aabbccddeeff",
+    )
+    env = json.loads(base64.b64decode(header, validate=True))
+    assert env["x402Version"] == X402_VERSION_V1
+    # scheme + network are TOP-LEVEL siblings of payload; NO accepted object.
+    assert env["scheme"] == EXACT_SCHEME
+    assert env["network"] == SOLANA_DEVNET_NAME
+    assert "accepted" not in env
+    assert isinstance(env["payload"]["transaction"], str) and env["payload"]["transaction"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_producer_maps_mainnet_to_plain_solana():
+    signer = LocalSigner.generate()
+    mint_mainnet = resolve("USDC", "mainnet")
+    offer = {
+        "protocol": "x402",
+        "scheme": "exact",
+        "network": SOLANA_MAINNET_CAIP2,
+        "asset": mint_mainnet,
+        "amount": "10000",
+        "maxAmountRequired": "10000",
+        "payTo": str(Keypair().pubkey()),
+        "maxTimeoutSeconds": 60,
+        "extra": {
+            "feePayer": str(Keypair().pubkey()),
+            "decimals": 6,
+            "tokenProgram": token_program_for("USDC", "mainnet"),
+            "memo": "/r",
+        },
+    }
+    header = await build_payment_header_legacy(
+        signer,
+        rpc=None,
+        requirement=offer,  # type: ignore[arg-type]
+        recent_blockhash_provider=lambda: BH,
+        memo_nonce=lambda: "00112233445566778899aabbccddeeff",
+    )
+    env = json.loads(base64.b64decode(header, validate=True))
+    assert env["network"] == SOLANA_NETWORK_NAME
+
+
+# ── client legacy challenge parsing ─────────────────────────────────────────
+
+
+def test_parse_challenge_from_legacy_payment_required_header():
+    offer = _devnet_offer()
+    # Legacy challenge body shape with a plain network slug + maxAmountRequired.
+    legacy_offer = dict(offer)
+    legacy_offer["network"] = SOLANA_DEVNET_NAME
+    body = json.dumps({"accepts": [legacy_offer]})
+    headers = {X402_LEGACY_PAYMENT_REQUIRED_HEADER: body}
+    parsed = parse_x402_challenge(headers, None, ChallengeSelection(network="devnet"))
+    assert parsed is not None
+    assert parsed["network"] == SOLANA_DEVNET_NAME
+    assert parsed["asset"] == MINT_DEVNET
+
+
+def test_parse_challenge_from_legacy_402_body_plain_network():
+    offer = _devnet_offer()
+    legacy_offer = dict(offer)
+    legacy_offer["network"] = SOLANA_DEVNET_NAME
+    body = json.dumps({"accepts": [legacy_offer]})
+    parsed = parse_x402_challenge({}, body, ChallengeSelection(network="devnet"))
+    assert parsed is not None
+    assert parsed["network"] == SOLANA_DEVNET_NAME
+
+
+def test_parse_challenge_canonical_header_wins_over_body():
+    # When both a canonical (v2) header and a legacy body are present, the v2
+    # header takes precedence (rust precedence order).
+    v2_offer = _devnet_offer()
+    v2_body = {"x402Version": X402_VERSION_V2, "accepts": [v2_offer]}
+    v2_header = base64.b64encode(json.dumps(v2_body).encode()).decode()
+    legacy_offer = dict(_devnet_offer(amount="9999"))
+    legacy_offer["network"] = SOLANA_DEVNET_NAME
+    legacy_body = json.dumps({"accepts": [legacy_offer]})
+    parsed = parse_x402_challenge(
+        {"payment-required": v2_header},
+        legacy_body,
+        ChallengeSelection(network="devnet"),
+    )
+    assert parsed is not None
+    # The v2 header offer (amount 1000) wins, not the legacy body (9999).
+    assert parsed["amount"] == "1000"
+
+
+# ── server dual-accept ──────────────────────────────────────────────────────
+
+
+class _FakeRpc:
+    def __init__(self, *_a, signature="SIG-legacy", **_k):
+        self._signature = signature
+        self.confirm_calls = 0
+        self.aclose_calls = 0
+
+    async def send_raw_transaction(self, _raw):
+        class _Resp:
+            value = self._signature
+
+        return _Resp()
+
+    async def await_confirmation(self, _sig, *_a, **_k):
+        self.confirm_calls += 1
+        return None
+
+    async def aclose(self):
+        self.aclose_calls += 1
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    reset()
+    monkeypatch.setenv("PAY_KIT_DISABLE_PREFLIGHT", "1")
+    yield
+    reset()
+
+
+def _devnet_adapter(monkeypatch, signature="SIG-legacy"):
+    op_kp = Keypair()
+    op = Operator(signer=LocalSigner.from_keypair(op_kp), recipient=str(Keypair().pubkey()))
+    cfg = configure(
+        network="solana_devnet",
+        preflight=False,
+        accept=(Protocol.X402,),
+        operator=op,
+        stablecoins=(Stablecoin.USDC,),
+        rpc_url="http://127.0.0.1:8899",
+    )
+    gate = GateCls.build(
+        name="report",
+        amount=Price.usd("0.001", Stablecoin.USDC),
+        default_pay_to=cfg.effective_recipient(),
+        accept=(Protocol.X402,),
+    )
+    adapter = X402Adapter(cfg, replay_store=MemoryStore())
+
+    def _factory(*_a, **_k):
+        return _FakeRpc(signature=signature)
+
+    monkeypatch.setattr(xmod, "SolanaRpc", _factory)
+    return adapter, gate, op_kp
+
+
+def _legacy_envelope(adapter, gate, op_kp, *, network=SOLANA_DEVNET_NAME, version=X402_VERSION_V1, scheme=EXACT_SCHEME):
+    offer = adapter.accepts_entry(gate, {"path": "/report"})
+    amt = int(offer["amount"])
+    authority = Keypair()
+    dest = derive_ata(offer["payTo"], MINT_DEVNET, TP_DEVNET)
+    src = derive_ata(str(authority.pubkey()), MINT_DEVNET, TP_DEVNET)
+    cl = Instruction(Pubkey.from_string(COMPUTE_BUDGET_PROGRAM), bytes([2]) + struct.pack("<I", 200_000), [])
+    cp = Instruction(Pubkey.from_string(COMPUTE_BUDGET_PROGRAM), bytes([3]) + struct.pack("<Q", 1_000), [])
+    data = bytes([12]) + struct.pack("<Q", amt) + bytes([6])
+    metas = [
+        AccountMeta(Pubkey.from_string(src), False, True),
+        AccountMeta(Pubkey.from_string(MINT_DEVNET), False, False),
+        AccountMeta(Pubkey.from_string(dest), False, True),
+        AccountMeta(authority.pubkey(), True, False),
+    ]
+    transfer = Instruction(Pubkey.from_string(TP_DEVNET), data, metas)
+    memo = Instruction(Pubkey.from_string(MEMO_PROGRAM), offer["extra"]["memo"].encode(), [])
+    msg = MessageV0.try_compile(op_kp.pubkey(), [cl, cp, transfer, memo], [], Hash.from_string(BH))
+    num = int(msg.header.num_required_signatures)
+    wire = bytearray()
+    wire.append(num)
+    wire.extend(bytes(64) * num)
+    wire.extend(bytes(msg))
+    tx_b64 = base64.b64encode(bytes(wire)).decode()
+    # Legacy envelope: top-level scheme + plain network, NO accepted object.
+    envelope: dict = {
+        "x402Version": version,
+        "scheme": scheme,
+        "network": network,
+        "payload": {"transaction": tx_b64},
+    }
+    return base64.b64encode(json.dumps(envelope).encode()).decode()
+
+
+class _LegacyReq:
+    """Carries the credential ONLY in the legacy ``X-PAYMENT`` header."""
+
+    def __init__(self, header, path="/report"):
+        self.headers = {X402_LEGACY_PAYMENT_HEADER.lower(): header}
+        self.path = path
+
+
+@pytest.mark.asyncio
+async def test_server_accepts_legacy_x_payment_header(monkeypatch):
+    adapter, gate, op_kp = _devnet_adapter(monkeypatch, signature="SIG-legacy-ok")
+    header = _legacy_envelope(adapter, gate, op_kp)
+    payment = await adapter.verify_and_settle(gate, _LegacyReq(header))
+    assert payment.protocol is Protocol.X402
+    assert payment.transaction == "SIG-legacy-ok"
+    # The response receipt reports the route's CAIP-2 network for a legacy cred.
+    resp = json.loads(base64.b64decode(payment.settlement_headers["payment-response"]))
+    assert resp["network"] == SOLANA_DEVNET_CAIP2
+
+
+@pytest.mark.asyncio
+async def test_server_accepts_legacy_header_from_dict_request(monkeypatch):
+    # The legacy reader's dict-request fallback (case-insensitive header key).
+    adapter, gate, op_kp = _devnet_adapter(monkeypatch, signature="SIG-dict")
+    header = _legacy_envelope(adapter, gate, op_kp)
+    req = {"path": "/report", "headers": {"X-Payment": header}}
+    payment = await adapter.verify_and_settle(gate, req)
+    assert payment.transaction == "SIG-dict"
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_unknown_version_on_dual_accept(monkeypatch):
+    adapter, gate, op_kp = _devnet_adapter(monkeypatch)
+    header = _legacy_envelope(adapter, gate, op_kp, version=9)
+    with pytest.raises(InvalidProofError) as exc:
+        await adapter.verify_and_settle(gate, _LegacyReq(header))
+    assert exc.value.code == "unsupported_x402_version"
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_legacy_wrong_network(monkeypatch):
+    adapter, gate, op_kp = _devnet_adapter(monkeypatch)
+    # Plain "solana" normalizes to mainnet, route is devnet -> mismatch.
+    header = _legacy_envelope(adapter, gate, op_kp, network=SOLANA_NETWORK_NAME)
+    with pytest.raises(InvalidProofError) as exc:
+        await adapter.verify_and_settle(gate, _LegacyReq(header))
+    assert exc.value.code == "charge_request_mismatch"
+    assert "Network mismatch" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_legacy_non_exact_scheme(monkeypatch):
+    adapter, gate, op_kp = _devnet_adapter(monkeypatch)
+    header = _legacy_envelope(adapter, gate, op_kp, scheme="upto")
+    with pytest.raises(InvalidProofError) as exc:
+        await adapter.verify_and_settle(gate, _LegacyReq(header))
+    assert exc.value.code == "invalid_exact_svm_payload_scheme"
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_legacy_missing_payload(monkeypatch):
+    adapter, gate, op_kp = _devnet_adapter(monkeypatch)
+    envelope = {"x402Version": X402_VERSION_V1, "scheme": EXACT_SCHEME, "network": SOLANA_DEVNET_NAME}
+    header = base64.b64encode(json.dumps(envelope).encode()).decode()
+    with pytest.raises(InvalidProofError) as exc:
+        await adapter.verify_and_settle(gate, _LegacyReq(header))
+    assert exc.value.code == "invalid_exact_svm_payload_envelope"
+
+
+@pytest.mark.asyncio
+async def test_server_still_emits_v2_challenge_by_default(monkeypatch):
+    # Adding the legacy path must NOT flip the default challenge producer.
+    adapter, gate, _ = _devnet_adapter(monkeypatch)
+    headers = adapter.challenge_headers(gate, {"path": "/report"})
+    assert "payment-required" in headers
+    challenge = json.loads(base64.b64decode(headers["payment-required"]))
+    assert challenge["x402Version"] == X402_VERSION_V2
+    assert challenge["accepts"][0]["network"] == SOLANA_DEVNET_CAIP2
+
+
+@pytest.mark.asyncio
+async def test_server_prefers_canonical_header_over_legacy(monkeypatch):
+    # When BOTH headers are present, the canonical (v2) one is read first.
+    from pay_kit.protocols.x402 import _legacy_payment_header, _payment_signature_header
+
+    class _BothReq:
+        def __init__(self, v2_header, legacy_header):
+            self.headers = {
+                "payment-signature": v2_header,
+                X402_LEGACY_PAYMENT_HEADER.lower(): legacy_header,
+            }
+            self.path = "/report"
+
+    req = _BothReq("V2VALUE", "LEGACYVALUE")
+    assert _payment_signature_header(req) == "V2VALUE"
+    assert _legacy_payment_header(req) == "LEGACYVALUE"

--- a/python/tests/test_pk_x402_legacy.py
+++ b/python/tests/test_pk_x402_legacy.py
@@ -324,8 +324,10 @@ async def test_server_accepts_legacy_x_payment_header(monkeypatch):
     payment = await adapter.verify_and_settle(gate, _LegacyReq(header))
     assert payment.protocol is Protocol.X402
     assert payment.transaction == "SIG-legacy-ok"
-    # The response receipt reports the route's CAIP-2 network for a legacy cred.
-    resp = json.loads(base64.b64decode(payment.settlement_headers["payment-response"]))
+    # A v1 credential gets the legacy X-PAYMENT-RESPONSE receipt header, NOT the
+    # v2 payment-response (rust X402_V1_PAYMENT_RESPONSE_HEADER, constants.rs:22).
+    assert "payment-response" not in payment.settlement_headers
+    resp = json.loads(base64.b64decode(payment.settlement_headers["x-payment-response"]))
     assert resp["network"] == SOLANA_DEVNET_CAIP2
 
 

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
-    puma (7.2.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -139,7 +139,7 @@ CHECKSUMS
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (7.2.1) sha256=d7bf0e9cabd532e0d401e142cd94e3ac531e993610e2d80e6fbf9c26961414b0
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac

--- a/ruby/exe/conformance
+++ b/ruby/exe/conformance
@@ -382,21 +382,18 @@ module X402
   SOLANA_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
   SOLANA_TESTNET = "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
 
+  VERSION_V1 = 1
   VERSION_V2 = 2
 
-  # Map a cluster/network identifier to its CAIP-2 form. Mirrors
-  # caip2_network_for_cluster.
+  EXACT_SCHEME = "exact"
+
+  # Map a cluster/network identifier to its CAIP-2 form. Delegates to the
+  # SDK's shared normalizer (PayCore::Solana::Caip2.for_cluster) so the
+  # legacy v1 plain slugs ("solana", "solana-devnet", "solana-testnet") and
+  # the CAIP-2 forms resolve identically here and in the production server.
+  # Mirrors the Rust spine caip2_network_for_cluster.
   def self.caip2_network_for_cluster(cluster)
-    case cluster
-    when SOLANA_MAINNET, SOLANA_NETWORK, "mainnet", "mainnet-beta"
-      SOLANA_MAINNET
-    when SOLANA_TESTNET, "testnet", "solana-testnet"
-      SOLANA_TESTNET
-    when "devnet", "localnet", SOLANA_DEVNET, "solana-devnet"
-      SOLANA_DEVNET
-    else
-      SOLANA_MAINNET
-    end
+    PayCore::Solana::Caip2.for_cluster(cluster)
   end
 
   # Decode a base64(JSON) envelope header into the conformance shape oracle.
@@ -463,6 +460,20 @@ module X402
       end
       if accepted["asset"].to_s != route.fetch("currency").to_s
         raise "Currency mismatch: expected #{route.fetch("currency")}, got #{accepted["asset"]}"
+      end
+    elsif version == VERSION_V1
+      # Legacy v1 envelope: top-level scheme + plain network, no `accepted`.
+      # Bind scheme + network only (mirrors rust parse_payment_signature v1
+      # arm, server/exact.rs:316-327); the amount/recipient/currency live on
+      # the signed transaction the envelope oracle does not inspect.
+      scheme = env["scheme"].to_s
+      unless scheme == EXACT_SCHEME
+        raise "invalid payload type: #{scheme.inspect}"
+      end
+
+      credential_network = caip2_network_for_cluster(env["network"])
+      if credential_network != expected_network
+        raise "Network mismatch: expected #{expected_network}, got #{env["network"]}"
       end
     else
       raise "invalid payload: Unsupported x402 version: #{version}"

--- a/ruby/lib/pay_core/solana/caip2.rb
+++ b/ruby/lib/pay_core/solana/caip2.rb
@@ -12,6 +12,14 @@ module PayCore
       DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
       TESTNET = "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
 
+      # Legacy plain SVM network slugs used on the x402 EXACT v1 wire, where
+      # networks are referenced by name rather than CAIP-2 ID. Mirrors the
+      # Rust spine `SOLANA_NETWORK`/`SOLANA_DEVNET`/`SOLANA_TESTNET` literals
+      # (rust/crates/x402/src/constants.rs:4 + protocol/schemes/exact/types.rs).
+      LEGACY_MAINNET = "solana"
+      LEGACY_DEVNET = "solana-devnet"
+      LEGACY_TESTNET = "solana-testnet"
+
       ALL = {
         "mainnet" => MAINNET,
         "devnet" => DEVNET,
@@ -26,6 +34,26 @@ module PayCore
         return network if network.to_s.start_with?("solana:")
 
         ALL[network.to_s] || network
+      end
+
+      # Normalize ANY cluster/network identifier to its canonical CAIP-2 ID,
+      # including the legacy plain SVM slugs the x402 v1 wire uses
+      # (`solana`, `solana-devnet`, `solana-testnet`) and the friendly
+      # cluster names. Mirrors the Rust spine `caip2_network_for_cluster`
+      # (rust/crates/x402/src/protocol/schemes/exact/types.rs:31-39) so the
+      # v1 network gate compares apples to apples against a CAIP-2 route
+      # network. Unknown identifiers fall back to mainnet, matching rust.
+      def for_cluster(cluster)
+        case cluster.to_s
+        when MAINNET, LEGACY_MAINNET, "mainnet", "mainnet-beta"
+          MAINNET
+        when TESTNET, LEGACY_TESTNET, "testnet"
+          TESTNET
+        when DEVNET, LEGACY_DEVNET, "devnet", "localnet"
+          DEVNET
+        else
+          MAINNET
+        end
       end
     end
   end

--- a/ruby/lib/pay_kit/protocols/x402.rb
+++ b/ruby/lib/pay_kit/protocols/x402.rb
@@ -70,7 +70,7 @@ module PayKit
           scheme: :exact,
           transaction: signature,
           settlement_headers: {
-            ::PayKit::Protocols::X402::Constants::PAYMENT_RESPONSE_HEADER => payment_response,
+            ::PayKit::Protocols::X402::Server::Exact.settlement_response_header(payment_header) => payment_response,
             exact_config.settlement_header => signature
           },
           raw: payment_header

--- a/ruby/lib/pay_kit/protocols/x402/server/exact.rb
+++ b/ruby/lib/pay_kit/protocols/x402/server/exact.rb
@@ -396,6 +396,23 @@ module PayKit::Protocols::X402
         #
         # Mirrors MPP `server/charge.rs:535-556` and the spine ordering
         # at `rust/crates/x402/src/bin/interop_server.rs:316-324`.
+        # Pick the settlement-response header for a credential by its wire
+        # version: a v1 `X-PAYMENT` credential gets the legacy
+        # `X-PAYMENT-RESPONSE` receipt header, a v2 credential gets
+        # `PAYMENT-RESPONSE`. Mirrors the rust split (constants.rs:22/31) and
+        # go/python/php/lua/swift. Falls back to the v2 header if the version
+        # cannot be read (the credential was already verified by settle).
+        def settlement_response_header(payment_header)
+          decoded = Types.decode_payment_signature(payment_header)
+          if decoded["x402Version"] == Constants::X402_VERSION_V1
+            Constants::X402_V1_PAYMENT_RESPONSE_HEADER
+          else
+            Constants::PAYMENT_RESPONSE_HEADER
+          end
+        rescue
+          Constants::PAYMENT_RESPONSE_HEADER
+        end
+
         def settle_exact_payment(config, payment_header, resource: nil)
           decoded = Types.decode_payment_signature(payment_header)
           requirements = exact_requirements(config, resource: resource)
@@ -605,7 +622,7 @@ module PayKit::Protocols::X402
                 200,
                 {
                   config.settlement_header => settlement,
-                  PAYMENT_RESPONSE_HEADER => payment_response
+                  settlement_response_header(payment_signature) => payment_response
                 },
                 {
                   ok: true,

--- a/ruby/lib/pay_kit/protocols/x402/server/exact.rb
+++ b/ruby/lib/pay_kit/protocols/x402/server/exact.rb
@@ -309,6 +309,80 @@ module PayKit::Protocols::X402
           "x402-svm-exact:consumed:#{signature}"
         end
 
+        # Resolve which offered requirement an inbound credential settles
+        # against, dispatching on the wire version. Mirrors the Rust spine
+        # version gate in `parse_payment_signature` plus the per-version
+        # match in `find_matching_requirement`
+        # (rust/crates/x402/src/server/exact.rs:315-346, 406-451):
+        #
+        #   - v2 (`x402Version == 2`): require an `accepted` object, bind it
+        #     to one offered requirement by the canonical identity tuple
+        #     (and enforce the resource-memo binding so a payment built for
+        #     one route cannot be replayed against another).
+        #   - v1 (`x402Version == 1`): require top-level `scheme == "exact"`
+        #     and a plain network that normalizes (via
+        #     `Caip2.for_cluster`) to the route's CAIP-2 network. v1 carries
+        #     no per-option `accepted`, so every offered option is on the
+        #     same scheme + network; settle against the first.
+        #   - any other version: reject. Adding v1 MUST NOT widen the gate
+        #     to silently accept a wire contract the server cannot read.
+        def select_settlement_requirement(config, decoded, requirements, resource: nil)
+          case decoded["x402Version"]
+          when Constants::X402_VERSION_V2
+            select_v2_requirement(requirements, decoded, resource: resource)
+          when Constants::X402_VERSION_V1
+            select_v1_requirement(config, requirements, decoded)
+          else
+            raise "unsupported x402Version: #{decoded["x402Version"]}"
+          end
+        end
+
+        def select_v2_requirement(requirements, decoded, resource: nil)
+          accepted = decoded["accepted"]
+          if resource.is_a?(String) && !resource.empty? && accepted.is_a?(Hash)
+            accepted_memo = accepted.dig("extra", "memo")
+            unless accepted_memo == resource
+              raise "invalid_exact_svm_payload_resource_mismatch"
+            end
+          end
+
+          requirement = if accepted.is_a?(Hash)
+            requirements.find { |candidate| payment_requirement_matches?(accepted, candidate) }
+          end
+          unless requirement
+            # Mirrors Go reference (go/cmd/interop-server/main.go:856).
+            raise "No matching payment requirements: accepted payment requirement does not match server challenge"
+          end
+
+          requirement
+        end
+
+        # Bind a legacy v1 credential to a route requirement. v1 commits to
+        # a scheme + plain network only — there is no `accepted` to match
+        # field-by-field — so this enforces scheme + network and then picks
+        # the first offered option, exactly like the Rust spine v1 arm of
+        # `find_matching_requirement` (server/exact.rs:438-446). The network
+        # is normalized through `Caip2.for_cluster` before the comparison so
+        # the plain v1 slug ("solana", "solana-devnet") is matched against
+        # the route's CAIP-2 network.
+        def select_v1_requirement(config, requirements, decoded)
+          scheme = decoded["scheme"]
+          unless scheme == Constants::EXACT_SCHEME
+            raise "invalid payload type: #{scheme.inspect}"
+          end
+
+          expected_network = ::PayCore::Solana::Caip2.for_cluster(config.network)
+          credential_network = ::PayCore::Solana::Caip2.for_cluster(decoded["network"])
+          if credential_network != expected_network
+            raise "Network mismatch: expected #{expected_network}, got #{decoded["network"]}"
+          end
+
+          requirement = requirements.first
+          raise "at least one payment option is required" unless requirement
+
+          requirement
+        end
+
         # ---- L8 settlement: verify + broadcast + confirm + record ----
         #
         # Order MUST be:
@@ -325,23 +399,16 @@ module PayKit::Protocols::X402
         def settle_exact_payment(config, payment_header, resource: nil)
           decoded = Types.decode_payment_signature(payment_header)
           requirements = exact_requirements(config, resource: resource)
-          raise "unsupported x402Version: #{decoded["x402Version"]}" unless decoded["x402Version"] == Constants::X402_VERSION_V2
 
-          accepted = decoded["accepted"]
-          if resource.is_a?(String) && !resource.empty? && accepted.is_a?(Hash)
-            accepted_memo = accepted.dig("extra", "memo")
-            unless accepted_memo == resource
-              raise "invalid_exact_svm_payload_resource_mismatch"
-            end
-          end
-
-          requirement = if accepted.is_a?(Hash)
-            requirements.find { |candidate| payment_requirement_matches?(accepted, candidate) }
-          end
-          unless requirement
-            # Mirrors Go reference (go/cmd/interop-server/main.go:856).
-            raise "No matching payment requirements: accepted payment requirement does not match server challenge"
-          end
+          # Dual-accept version dispatch. The server reads the v2
+          # `accepted`-bearing envelope first and falls back to the legacy
+          # v1 envelope (top-level scheme + plain network, no `accepted`),
+          # rejecting any genuinely-unknown version. Mirrors the Rust spine
+          # `parse_payment_signature` + `find_matching_requirement`
+          # (rust/crates/x402/src/server/exact.rs:315-346, 406-451). The
+          # facilitator MUST-checks after this gate are identical for both
+          # versions — both reach the same Verifier + settlement tail.
+          requirement = select_settlement_requirement(config, decoded, requirements, resource: resource)
 
           payload = decoded["payload"]
           unless payload.is_a?(Hash) && payload["transaction"].is_a?(String)
@@ -514,7 +581,17 @@ module PayKit::Protocols::X402
               {error: "payment_required"}
             ]
           when config.resource_path
+            # Dual-accept at the HTTP layer: read the v2 `PAYMENT-SIGNATURE`
+            # header first, then fall back to the legacy v1 `X-PAYMENT`
+            # header. The server still emits v2 challenges by default
+            # (see `exact_challenge`), but it must honour either credential
+            # shape on the way in. Mirrors the client dual-read precedence
+            # in the Rust spine (client/exact/payment.rs:232-262), inverted
+            # for the server.
             payment_signature = header_value(headers, Constants::PAYMENT_SIGNATURE_HEADER)
+            if payment_signature.nil? || payment_signature.empty?
+              payment_signature = header_value(headers, Constants::X402_V1_PAYMENT_HEADER)
+            end
             return payment_required_response(config, resource: path) if payment_signature.nil? || payment_signature.empty?
 
             begin

--- a/ruby/test/pay_core/caip2_test.rb
+++ b/ruby/test/pay_core/caip2_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# CAIP-2 network-identifier helper tests for the Ruby SDK. Covers the
+# `for_cluster` normalizer added for x402 EXACT v1, which maps the legacy
+# plain SVM slugs ("solana", "solana-devnet", "solana-testnet") and the
+# friendly cluster names to canonical CAIP-2 IDs. Mirrors the Rust spine
+# `caip2_network_for_cluster`
+# (rust/crates/x402/src/protocol/schemes/exact/types.rs:31-39).
+require_relative "../test_helper"
+
+class Caip2Test < Minitest::Test
+  include RubyMppTestHelpers
+
+  Caip2 = ::PayCore::Solana::Caip2
+
+  def test_resolve_passes_through_caip2_and_maps_friendly_names
+    assert_equal Caip2::DEVNET, Caip2.resolve("devnet")
+    assert_equal Caip2::MAINNET, Caip2.resolve("mainnet")
+    assert_equal Caip2::TESTNET, Caip2.resolve("testnet")
+    assert_equal Caip2::DEVNET, Caip2.resolve(Caip2::DEVNET)
+    # Unknown names pass through unchanged (legacy behaviour).
+    assert_equal "solana-devnet", Caip2.resolve("solana-devnet")
+  end
+
+  def test_for_cluster_normalizes_legacy_v1_slugs
+    assert_equal Caip2::MAINNET, Caip2.for_cluster("solana")
+    assert_equal Caip2::DEVNET, Caip2.for_cluster("solana-devnet")
+    assert_equal Caip2::TESTNET, Caip2.for_cluster("solana-testnet")
+  end
+
+  def test_for_cluster_normalizes_friendly_and_caip2_forms
+    assert_equal Caip2::MAINNET, Caip2.for_cluster("mainnet")
+    assert_equal Caip2::MAINNET, Caip2.for_cluster("mainnet-beta")
+    assert_equal Caip2::DEVNET, Caip2.for_cluster("devnet")
+    assert_equal Caip2::DEVNET, Caip2.for_cluster("localnet")
+    assert_equal Caip2::TESTNET, Caip2.for_cluster("testnet")
+
+    assert_equal Caip2::MAINNET, Caip2.for_cluster(Caip2::MAINNET)
+    assert_equal Caip2::DEVNET, Caip2.for_cluster(Caip2::DEVNET)
+    assert_equal Caip2::TESTNET, Caip2.for_cluster(Caip2::TESTNET)
+  end
+
+  def test_for_cluster_falls_back_to_mainnet_for_unknown
+    # Matches the Rust spine catch-all arm (types.rs:38).
+    assert_equal Caip2::MAINNET, Caip2.for_cluster("not-a-network")
+    assert_equal Caip2::MAINNET, Caip2.for_cluster(nil)
+  end
+end

--- a/ruby/test/pay_kit/protocols/x402/server_exact_test.rb
+++ b/ruby/test/pay_kit/protocols/x402/server_exact_test.rb
@@ -103,6 +103,129 @@ class X402ServerExactTest < Minitest::Test
     refute_equal "\x00".b * 64, signed_transaction.byteslice(65, 64)
   end
 
+  # ---- Legacy x402 v1 dual-accept (server reads v1 X-PAYMENT) ----------
+  #
+  # The server emits v2 challenges by default but must still settle a
+  # legacy v1 credential: top-level scheme + plain network, no `accepted`
+  # object. Mirrors the Rust spine v1 arm of `parse_payment_signature` +
+  # `find_matching_requirement` (server/exact.rs:316-327, 438-446).
+
+  def test_settlement_accepts_v1_envelope_devnet
+    sent = []
+    state = build_state(sender: ->(_state, transaction) {
+      sent << transaction
+      "ruby-v1-settlement-signature"
+    })
+    payment_header = build_v1_payment_header(state, network: "solana-devnet")
+
+    settlement = PayKit::Protocols::X402::Server::Exact.settle_exact_payment(state, payment_header)
+
+    assert_equal "ruby-v1-settlement-signature", settlement
+    # Fee payer (index 0) signature was applied before sending, identical to
+    # the v2 settlement tail.
+    refute_equal "\x00".b * 64, sent.fetch(0).byteslice(1, 64)
+  end
+
+  def test_settlement_v1_runs_identical_facilitator_checks_as_v2
+    # The MUST-checks after the version gate are shared: a v1 credential
+    # whose transfer amount drifts from the route is rejected by the same
+    # Verifier the v2 path uses, before broadcast.
+    sent = []
+    state = build_state(sender: ->(_state, transaction) {
+      sent << transaction
+      "should-not-reach"
+    })
+    header = build_v1_payment_header(state, network: "solana-devnet")
+    tampered = mutate_payment_transaction(header, resign: true) do |transaction|
+      replace_transfer_amount(transaction, 999_999)
+    end
+
+    assert_raises(RuntimeError) do
+      PayKit::Protocols::X402::Server::Exact.settle_exact_payment(state, tampered)
+    end
+    assert_empty sent, "tampered v1 transfer must be rejected before broadcast"
+  end
+
+  def test_settlement_rejects_v1_wrong_network
+    state = build_state
+    # Route is devnet (NETWORK); a v1 credential claiming mainnet "solana"
+    # normalizes to a different CAIP-2 and fails the v1 network gate.
+    payment_header = build_v1_payment_header(state, network: "solana")
+
+    error = assert_raises(RuntimeError) do
+      PayKit::Protocols::X402::Server::Exact.settle_exact_payment(state, payment_header)
+    end
+
+    assert_match(/Network mismatch/, error.message)
+  end
+
+  def test_settlement_rejects_v1_non_exact_scheme
+    state = build_state
+    header = build_v1_payment_header(state, network: "solana-devnet")
+    envelope = JSON.parse(Base64.decode64(header))
+    envelope["scheme"] = "upto"
+    tampered = Base64.strict_encode64(JSON.generate(envelope))
+
+    error = assert_raises(RuntimeError) do
+      PayKit::Protocols::X402::Server::Exact.settle_exact_payment(state, tampered)
+    end
+
+    assert_match(/invalid payload type/, error.message)
+  end
+
+  def test_settlement_rejects_genuinely_unknown_version
+    # Adding v1 must NOT widen the gate: an envelope shaped like v1 but
+    # carrying an unknown version is still rejected.
+    state = build_state
+    header = build_v1_payment_header(state, network: "solana-devnet")
+    envelope = JSON.parse(Base64.decode64(header))
+    envelope["x402Version"] = 9
+    tampered = Base64.strict_encode64(JSON.generate(envelope))
+
+    error = assert_raises(RuntimeError) do
+      PayKit::Protocols::X402::Server::Exact.settle_exact_payment(state, tampered)
+    end
+
+    assert_equal "unsupported x402Version: 9", error.message
+  end
+
+  def test_protected_route_accepts_v1_x_payment_header
+    # HTTP-layer dual-accept: a v1 client presents the credential in the
+    # legacy `X-PAYMENT` header (not `PAYMENT-SIGNATURE`). The server reads
+    # v2 first, falls back to v1, and settles.
+    state = build_state(sender: ->(_state, _transaction) { "v1-http-settlement" })
+    payment_header = build_v1_payment_header(state, network: "solana-devnet", resource: "/protected")
+
+    status, headers, body = PayKit::Protocols::X402::Server::Exact.response_for(
+      "/protected",
+      {"x-payment" => payment_header},
+      state
+    )
+
+    assert_equal 200, status
+    assert_equal "v1-http-settlement", headers.fetch("x-fixture-settlement")
+    assert_equal true, body.fetch(:paid)
+  end
+
+  def test_protected_route_prefers_v2_header_over_v1
+    # When both headers are present the v2 `PAYMENT-SIGNATURE` path wins,
+    # matching the documented dual-accept precedence.
+    state = build_state(sender: ->(_state, _transaction) { "v2-wins" })
+    v2_header = build_payment_header(state, resource: "/protected")
+    # A v1 header that would fail the network gate; if it were read the
+    # request would 402 instead of settling.
+    v1_header = build_v1_payment_header(state, network: "solana", resource: "/protected")
+
+    status, _headers, body = PayKit::Protocols::X402::Server::Exact.response_for(
+      "/protected",
+      {"PAYMENT-SIGNATURE" => v2_header, "X-PAYMENT" => v1_header},
+      state
+    )
+
+    assert_equal 200, status
+    assert_equal true, body.fetch(:paid)
+  end
+
   def test_settlement_rejects_accepted_requirement_drift
     state = build_state
     envelope = JSON.parse(Base64.decode64(build_payment_header(state)))
@@ -992,6 +1115,15 @@ class X402ServerExactTest < Minitest::Test
       client_secret_key: JSON.generate(secret(1)),
       recent_blockhash: BLOCKHASH,
       resource: {"type" => "http", "uri" => resource || "/protected"}
+    )
+  end
+
+  def build_v1_payment_header(state, network:, resource: nil)
+    X402ExactClientFixture.build_v1_exact_payment_signature(
+      requirement: PayKit::Protocols::X402::Server::Exact.exact_requirement(state, resource: resource),
+      client_secret_key: JSON.generate(secret(1)),
+      recent_blockhash: BLOCKHASH,
+      network: network
     )
   end
 

--- a/ruby/test/pay_kit/protocols/x402/server_exact_test.rb
+++ b/ruby/test/pay_kit/protocols/x402/server_exact_test.rb
@@ -205,6 +205,27 @@ class X402ServerExactTest < Minitest::Test
     assert_equal 200, status
     assert_equal "v1-http-settlement", headers.fetch("x-fixture-settlement")
     assert_equal true, body.fetch(:paid)
+    # A v1 credential gets the legacy X-PAYMENT-RESPONSE receipt header, not
+    # the v2 PAYMENT-RESPONSE (rust X402_V1_PAYMENT_RESPONSE_HEADER).
+    assert headers.key?(PayKit::Protocols::X402::Constants::X402_V1_PAYMENT_RESPONSE_HEADER),
+      "expected v1 settlement under X-PAYMENT-RESPONSE, got: #{headers.keys.inspect}"
+    refute headers.key?(PayKit::Protocols::X402::Constants::PAYMENT_RESPONSE_HEADER),
+      "v1 response must not use the v2 PAYMENT-RESPONSE header"
+  end
+
+  def test_protected_route_v2_uses_payment_response_header
+    # Symmetry with the v1 case: a v2 credential settles under PAYMENT-RESPONSE.
+    state = build_state(sender: ->(_state, _transaction) { "v2-http-settlement" })
+    payment_header = build_payment_header(state, resource: "/protected")
+
+    _status, headers, _body = PayKit::Protocols::X402::Server::Exact.response_for(
+      "/protected",
+      {"PAYMENT-SIGNATURE" => payment_header},
+      state
+    )
+
+    assert headers.key?(PayKit::Protocols::X402::Constants::PAYMENT_RESPONSE_HEADER)
+    refute headers.key?(PayKit::Protocols::X402::Constants::X402_V1_PAYMENT_RESPONSE_HEADER)
   end
 
   def test_protected_route_prefers_v2_header_over_v1

--- a/ruby/test/support/x402_exact_client_fixture.rb
+++ b/ruby/test/support/x402_exact_client_fixture.rb
@@ -40,6 +40,30 @@ module X402ExactClientFixture
     Base64.strict_encode64(JSON.generate(envelope))
   end
 
+  # Build a legacy v1 x402 payment envelope. Mirrors the spine
+  # `build_payment_header_v1` shape (client/exact/payment.rs:153-170):
+  # `x402Version=1`, top-level `scheme` + plain `network` siblings of
+  # `payload`, and NO `accepted` object. `network` is the legacy plain
+  # SVM slug (e.g. "solana-devnet"), not CAIP-2.
+  def build_v1_exact_payment_signature(requirement:, client_secret_key:, recent_blockhash:, network:)
+    raise ArgumentError, "only exact payment requirements can be signed" unless requirement["scheme"] == "exact"
+
+    private_key = Exact.private_key_from_json(client_secret_key)
+    transaction = build_transaction(
+      requirement: requirement,
+      private_key: private_key,
+      recent_blockhash: recent_blockhash
+    )
+    envelope = {
+      x402Version: Constants::X402_VERSION_V1,
+      scheme: Constants::EXACT_SCHEME,
+      network: network,
+      payload: {transaction: Base64.strict_encode64(transaction)}
+    }
+
+    Base64.strict_encode64(JSON.generate(envelope))
+  end
+
   def build_transaction(requirement:, private_key:, recent_blockhash:)
     signer = private_key.raw_public_key
     fee_payer = Exact.base58_decode(Exact.string_extra(requirement, "feePayer"))

--- a/swift/Sources/SolanaPayKit/PayCore/Network.swift
+++ b/swift/Sources/SolanaPayKit/PayCore/Network.swift
@@ -47,4 +47,51 @@ public enum SolanaNetwork {
         default: return "mainnet"
         }
     }
+
+    // MARK: - Legacy plain SVM network slugs
+
+    /// Legacy mainnet slug. Mirrors rust `SOLANA_NETWORK` (constants.rs:4).
+    public static let legacyMainnet = "solana"
+    /// Legacy devnet slug.
+    public static let legacyDevnet = "solana-devnet"
+    /// Legacy testnet slug.
+    public static let legacyTestnet = "solana-testnet"
+
+    /// Map an offer's network (CAIP-2 id or cluster slug) to the legacy
+    /// plain SVM slug used by the legacy `X-PAYMENT` envelope.
+    ///
+    /// Mirrors rust `v1_network_for_requirements`
+    /// (client/exact/payment.rs:393-404): devnet-family maps to
+    /// `"solana-devnet"`, everything else (including mainnet and testnet)
+    /// maps to `"solana"`.
+    public static func legacySlug(for network: String) -> String {
+        switch network {
+        case devnet, legacyDevnet:
+            return legacyDevnet
+        default:
+            switch network.lowercased() {
+            case "devnet", "solana-devnet":
+                return legacyDevnet
+            default:
+                return legacyMainnet
+            }
+        }
+    }
+
+    /// True when the string is a recognized Solana network — a CAIP-2 id or
+    /// a legacy plain slug. Mirrors the rust selection filter, which keeps an
+    /// offer whose network normalizes to a known Solana cluster
+    /// (`cluster_for_caip2_network`, client/exact/payment.rs:312) so legacy
+    /// challenge bodies carrying plain slugs are eligible for selection.
+    public static func isSolanaNetwork(_ network: String) -> Bool {
+        if network == mainnet || network == devnet || network == testnet { return true }
+        switch network.lowercased() {
+        case "mainnet", "mainnet-beta", "solana",
+             "devnet", "solana-devnet",
+             "testnet", "solana-testnet":
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/swift/Sources/SolanaPayKit/protocols/x402/client/exact/Payment.swift
+++ b/swift/Sources/SolanaPayKit/protocols/x402/client/exact/Payment.swift
@@ -17,6 +17,25 @@ let X402DefaultDecimals: UInt8 = 6
 
 // MARK: - Challenge parsing
 
+/// A selected x402 offer together with the protocol version the server's
+/// challenge declared. The version drives which payment shape the client
+/// emits in reply: legacy `X-PAYMENT` when the challenge declared `1`,
+/// otherwise the canonical `PAYMENT-SIGNATURE`.
+public struct X402ParsedChallenge: Sendable {
+    /// The selected offer to pay.
+    public let offer: X402AcceptsEntry
+    /// The `x402Version` the challenge declared, or `nil` when the source
+    /// (e.g. a bare express body) carried no version. A `nil` or non-1
+    /// version keeps the canonical producer; only an explicit `1` selects
+    /// the legacy producer.
+    public let declaredVersion: Int?
+
+    public init(offer: X402AcceptsEntry, declaredVersion: Int?) {
+        self.offer = offer
+        self.declaredVersion = declaredVersion
+    }
+}
+
 /// Parse an x402 challenge from response headers and/or body, applying the
 /// client's network + currency-preference selection.
 ///
@@ -31,18 +50,50 @@ public func parseX402Challenge(
     body: String?,
     selection: X402ChallengeSelection = X402ChallengeSelection()
 ) -> X402AcceptsEntry? {
-    if let headerValue = headers.first(where: { $0.name.lowercased() == "payment-required" })?.value,
-       let offer = _selectFromHeader(headerValue, selection: selection) {
-        return offer
+    parseX402ChallengeWithVersion(headers: headers, body: body, selection: selection)?.offer
+}
+
+/// Parse an x402 challenge and surface the version it declared.
+///
+/// Source precedence mirrors the rust client
+/// (client/exact/payment.rs:232-262):
+/// 1. canonical `PAYMENT-REQUIRED` header (standard-base64 JSON);
+/// 2. legacy `X-PAYMENT-REQUIRED` header (standard-base64 JSON);
+/// 3. the 402 JSON body (`{ "accepts": [...] }`), legacy/express fallback.
+///
+/// The legacy header and body carry plain SVM network slugs and
+/// `maxAmountRequired`; both are handled natively by the same selection +
+/// `effective*` accessors. Returns `nil` when no supported Solana exact
+/// offer matches.
+public func parseX402ChallengeWithVersion(
+    headers: [(name: String, value: String)],
+    body: String?,
+    selection: X402ChallengeSelection = X402ChallengeSelection()
+) -> X402ParsedChallenge? {
+    func header(_ name: String) -> String? {
+        headers.first { $0.name.lowercased() == name.lowercased() }?.value
+    }
+
+    if let value = header(X402PaymentRequiredHeaderName),
+       let parsed = _selectFromHeader(value, selection: selection) {
+        return parsed
+    }
+
+    if let value = header(X402LegacyPaymentRequiredHeader),
+       let parsed = _selectFromHeader(value, selection: selection) {
+        return parsed
     }
 
     if let body = body,
-       let offer = _selectFromBody(body, selection: selection) {
-        return offer
+       let parsed = _selectFromBody(body, selection: selection) {
+        return parsed
     }
 
     return nil
 }
+
+/// Canonical v2 server challenge header name (lower-cased compare).
+let X402PaymentRequiredHeaderName = "PAYMENT-REQUIRED"
 
 // MARK: - Payment header building
 
@@ -88,6 +139,78 @@ public func buildX402PaymentHeader(
         accepted: offer,
         payload: payload
     )
+    return try _encodePaymentEnvelope(envelope)
+}
+
+/// Build the standard-base64 legacy `X-PAYMENT` header value for an x402
+/// exact offer.
+///
+/// The legacy envelope is `{ x402Version: 1, scheme: "exact",
+/// network: <plain SVM slug>, payload: { transaction } }` — `scheme` and
+/// `network` are top-level siblings of `payload` and there is NO `accepted`
+/// object (the legacy wire binds only scheme + network, unlike the canonical
+/// shape). The network is the plain slug (`solana` / `solana-devnet`), never
+/// the CAIP-2 id. Mirrors rust `build_payment_header_v1`
+/// (client/exact/payment.rs:153-170) + `v1_network_for_requirements`
+/// (payment.rs:393-404).
+///
+/// The transaction is built identically to the canonical path (same
+/// compute-budget + transfer + memo instructions); only the envelope shape
+/// differs. The output is standard base64 (not base64url).
+public func buildX402LegacyPaymentHeader(
+    signer: any SolanaSigner,
+    rpc: RpcClient,
+    offer: X402AcceptsEntry,
+    nonceGenerator: (() -> Data)? = nil
+) async throws -> String {
+    let payload = try await _buildPaymentPayload(
+        signer: signer, rpc: rpc, offer: offer, nonceGenerator: nonceGenerator
+    )
+    let envelope = X402PaymentSignatureEnvelope(
+        x402Version: X402VersionLegacy,
+        scheme: "exact",
+        network: SolanaNetwork.legacySlug(for: offer.network),
+        accepted: nil,
+        payload: payload
+    )
+    return try _encodePaymentEnvelope(envelope)
+}
+
+/// Build the payment header for the version the server's challenge declared.
+///
+/// Dispatches to the legacy `X-PAYMENT` producer when `x402Version == 1`,
+/// otherwise to the canonical `PAYMENT-SIGNATURE` producer. The canonical
+/// shape stays the default (`nil` / any non-1 version), so adding legacy
+/// support does not flip the default emitter. Mirrors the rust client, where
+/// the default producer is `build_payment_header` (v2) and `build_payment_
+/// header_v1` is emitted only for legacy peers.
+///
+/// - Returns: the base64 header value and the header name to set it under
+///   (`X-PAYMENT` for legacy, `PAYMENT-SIGNATURE` otherwise).
+public func buildX402PaymentForChallenge(
+    signer: any SolanaSigner,
+    rpc: RpcClient,
+    offer: X402AcceptsEntry,
+    declaredVersion: Int?,
+    nonceGenerator: (() -> Data)? = nil
+) async throws -> (headerName: String, value: String) {
+    if declaredVersion == X402VersionLegacy {
+        let value = try await buildX402LegacyPaymentHeader(
+            signer: signer, rpc: rpc, offer: offer, nonceGenerator: nonceGenerator
+        )
+        return (X402LegacyPaymentHeader, value)
+    }
+    let value = try await buildX402PaymentHeader(
+        signer: signer, rpc: rpc, offer: offer, nonceGenerator: nonceGenerator
+    )
+    return (X402PaymentHeader, value)
+}
+
+/// Encode a payment envelope to a standard-base64 header value.
+///
+/// Sorted keys for deterministic output. Standard base64 (padded), matching
+/// the rust producer's `general_purpose::STANDARD` engine — NOT base64url.
+private func _encodePaymentEnvelope(_ envelope: X402PaymentSignatureEnvelope) throws -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
     let json = try encoder.encode(envelope)
@@ -131,7 +254,11 @@ private func _buildPaymentPayload(
     instructions.append(Instructions.computeBudgetSetUnitLimit(units: X402ComputeUnitLimit))
     instructions.append(Instructions.computeBudgetSetUnitPrice(microLamports: X402ComputeUnitPrice))
 
-    let clusterLabel = SolanaNetwork.clusterLabel(for: offer.network)
+    // Normalize the offer's network (CAIP-2 id or legacy plain slug) to its
+    // canonical CAIP-2 form first, so legacy offers carrying `solana-devnet`
+    // resolve to the correct cluster mints rather than falling through to
+    // mainnet.
+    let clusterLabel = SolanaNetwork.clusterLabel(for: SolanaNetwork.caip2(for: offer.network))
     let mintAddress = Mints.resolveMint(currency: assetStr, cluster: clusterLabel)
 
     if let mintStr = mintAddress {
@@ -269,21 +396,23 @@ private func _appendX402Memo(
 private func _selectFromHeader(
     _ headerValue: String,
     selection: X402ChallengeSelection
-) -> X402AcceptsEntry? {
+) -> X402ParsedChallenge? {
     guard let data = Data(base64Encoded: headerValue),
-          let envelope = try? JSONDecoder().decode(X402PaymentRequiredEnvelope.self, from: data)
+          let envelope = try? JSONDecoder().decode(X402PaymentRequiredEnvelope.self, from: data),
+          let offer = _selectRequirement(from: envelope.accepts, selection: selection)
     else { return nil }
-    return _selectRequirement(from: envelope.accepts, selection: selection)
+    return X402ParsedChallenge(offer: offer, declaredVersion: envelope.x402Version)
 }
 
 private func _selectFromBody(
     _ body: String,
     selection: X402ChallengeSelection
-) -> X402AcceptsEntry? {
+) -> X402ParsedChallenge? {
     guard let data = body.data(using: .utf8),
-          let envelope = try? JSONDecoder().decode(X402PaymentRequiredEnvelope.self, from: data)
+          let envelope = try? JSONDecoder().decode(X402PaymentRequiredEnvelope.self, from: data),
+          let offer = _selectRequirement(from: envelope.accepts, selection: selection)
     else { return nil }
-    return _selectRequirement(from: envelope.accepts, selection: selection)
+    return X402ParsedChallenge(offer: offer, declaredVersion: envelope.x402Version)
 }
 
 private func _selectRequirement(
@@ -294,7 +423,12 @@ private func _selectRequirement(
     let clusterLabel = SolanaNetwork.clusterLabel(for: preferredNetwork)
 
     let solana = accepts.filter { _isSolanaExact($0) }
-    let onPreferred = solana.filter { $0.network == preferredNetwork }
+    // Normalize each offer's network (CAIP-2 id or legacy plain slug) to its
+    // CAIP-2 form before comparing against the preferred network, so legacy
+    // 402-body offers (`solana-devnet` etc.) match the same way v2 offers do.
+    // Mirrors rust `network_matches`, which normalizes the offer's
+    // network/cluster through `caip2_network_for_cluster`.
+    let onPreferred = solana.filter { SolanaNetwork.caip2(for: $0.network) == preferredNetwork }
 
     if let currencies = selection.currencies {
         for wanted in currencies {
@@ -316,9 +450,11 @@ private func _isSolanaExact(_ offer: X402AcceptsEntry) -> Bool {
     // Require an explicit `scheme == "exact"` (python parity): offers
     // without a scheme, or with a different scheme, are not eligible.
     guard offer.scheme == "exact" else { return false }
-    return offer.network == SolanaNetwork.mainnet
-        || offer.network == SolanaNetwork.devnet
-        || offer.network == SolanaNetwork.testnet
+    // Accept both CAIP-2 ids (v2 challenges) and legacy plain SVM slugs
+    // (`solana` / `solana-devnet` / `solana-testnet`, carried by legacy 402
+    // bodies). Mirrors the rust selection filter, which keeps any offer
+    // whose network normalizes to a known Solana cluster.
+    return SolanaNetwork.isSolanaNetwork(offer.network)
 }
 
 private func _effectiveAmountOf(_ offer: X402AcceptsEntry) -> UInt64 {

--- a/swift/Sources/SolanaPayKit/protocols/x402/client/exact/Payment.swift
+++ b/swift/Sources/SolanaPayKit/protocols/x402/client/exact/Payment.swift
@@ -58,7 +58,8 @@ public func parseX402Challenge(
 /// Source precedence mirrors the rust client
 /// (client/exact/payment.rs:232-262):
 /// 1. canonical `PAYMENT-REQUIRED` header (standard-base64 JSON);
-/// 2. legacy `X-PAYMENT-REQUIRED` header (standard-base64 JSON);
+/// 2. legacy `X-PAYMENT-REQUIRED` header (RAW JSON per the rust spine; a
+///    base64 envelope is also accepted for robustness);
 /// 3. the 402 JSON body (`{ "accepts": [...] }`), legacy/express fallback.
 ///
 /// The legacy header and body carry plain SVM network slugs and
@@ -79,8 +80,13 @@ public func parseX402ChallengeWithVersion(
         return parsed
     }
 
+    // The rust spine parses X-PAYMENT-REQUIRED as RAW JSON
+    // (client/exact/payment.rs: serde_json::from_str on the header value),
+    // not base64. Accept a base64 envelope first, then fall back to raw JSON
+    // (rust parity), so we interoperate with either producer.
     if let value = header(X402LegacyPaymentRequiredHeader),
-       let parsed = _selectFromHeader(value, selection: selection) {
+       let parsed = _selectFromHeader(value, selection: selection)
+        ?? _selectFromBody(value, selection: selection) {
         return parsed
     }
 

--- a/swift/Sources/SolanaPayKit/protocols/x402/client/exact/Transport.swift
+++ b/swift/Sources/SolanaPayKit/protocols/x402/client/exact/Transport.swift
@@ -34,7 +34,7 @@ public struct X402Interceptor: PayKit.PaymentInterceptor {
     ) async throws -> PayKit.RetryResult {
         let rawHeaders = Self.allHeaders(from: response)
         let bodyStr = String(decoding: body, as: UTF8.self)
-        guard let offer = parseX402Challenge(
+        guard let challenge = parseX402ChallengeWithVersion(
             headers: rawHeaders,
             body: bodyStr,
             selection: selection
@@ -44,13 +44,18 @@ public struct X402Interceptor: PayKit.PaymentInterceptor {
             )
         }
 
-        let paymentHeader = try await buildX402PaymentHeader(
-            signer: signer, rpc: rpc, offer: offer
+        // Emit the version the server's challenge declared: legacy `X-PAYMENT`
+        // when it declared v1, otherwise the canonical `PAYMENT-SIGNATURE`.
+        let payment = try await buildX402PaymentForChallenge(
+            signer: signer,
+            rpc: rpc,
+            offer: challenge.offer,
+            declaredVersion: challenge.declaredVersion
         )
 
         var retry = request
-        retry.setValue(paymentHeader, forHTTPHeaderField: "Payment-Signature")
-        return .retry(request: retry, paymentSent: paymentHeader)
+        retry.setValue(payment.value, forHTTPHeaderField: payment.headerName)
+        return .retry(request: retry, paymentSent: payment.value)
     }
 
     // MARK: - Private helpers

--- a/swift/Sources/SolanaPayKit/protocols/x402/exact/Types.swift
+++ b/swift/Sources/SolanaPayKit/protocols/x402/exact/Types.swift
@@ -5,6 +5,24 @@ import Foundation
 /// x402 protocol version constant emitted in the `Payment-Signature` envelope.
 public let X402Version: Int = 2
 
+/// Legacy x402 protocol version (v1). Mirrors the rust spine constant
+/// `X402_VERSION_V1` (constants.rs:10). The default producer stays
+/// `X402Version` (v2); this is emitted only when the server's challenge
+/// declared the legacy version.
+public let X402VersionLegacy: Int = 1
+
+/// Legacy client payment header carrying the base64 legacy envelope.
+/// Mirrors rust `X402_V1_PAYMENT_HEADER` (constants.rs:16).
+public let X402LegacyPaymentHeader: String = "X-PAYMENT"
+
+/// Legacy server challenge header. Mirrors rust
+/// `X402_V1_PAYMENT_REQUIRED_HEADER` (constants.rs:19).
+public let X402LegacyPaymentRequiredHeader: String = "X-PAYMENT-REQUIRED"
+
+/// Canonical v2 payment header. Mirrors rust `X402_V2_PAYMENT_HEADER`
+/// (constants.rs:25).
+public let X402PaymentHeader: String = "PAYMENT-SIGNATURE"
+
 /// One entry in the `accepts` array of a `PAYMENT-REQUIRED` challenge.
 ///
 /// The x402 pay_kit server stamps `extra.recentBlockhash`,
@@ -283,28 +301,50 @@ public struct X402PaymentPayload: Codable, Sendable {
     }
 }
 
-/// The `Payment-Signature` header value (base64 of this JSON).
+/// The client payment header value (base64 of this JSON).
 ///
-/// Mirrors the rust `PaymentSignatureEnvelope`:
-/// `{ x402Version, accepted, payload }`.
+/// Mirrors the rust `PaymentSignatureEnvelope` (types.rs:587-608), a single
+/// type covering both wire shapes:
+/// - Canonical (v2): `{ x402Version: 2, accepted, payload }`, carried in the
+///   `PAYMENT-SIGNATURE` header. `scheme`/`network` are `nil` and omitted.
+/// - Legacy (v1): `{ x402Version: 1, scheme, network, payload }`, carried in
+///   the `X-PAYMENT` header. `accepted` is `nil` and omitted; `scheme` and
+///   `network` (a plain SVM slug) are top-level siblings of `payload`.
+///
+/// `scheme`/`network`/`accepted` are skipped when `nil`, matching the rust
+/// `skip_serializing_if = "Option::is_none"` on each field.
 public struct X402PaymentSignatureEnvelope: Codable, Sendable {
     public let x402Version: Int
+    /// Top-level scheme (legacy v1 only; `nil` and omitted for v2).
+    public let scheme: String?
+    /// Top-level plain SVM network slug (legacy v1 only; `nil` for v2).
+    public let network: String?
     public let accepted: X402AcceptsEntry?
     public let payload: X402PaymentPayload
 
-    public init(x402Version: Int, accepted: X402AcceptsEntry?, payload: X402PaymentPayload) {
+    public init(
+        x402Version: Int,
+        scheme: String? = nil,
+        network: String? = nil,
+        accepted: X402AcceptsEntry?,
+        payload: X402PaymentPayload
+    ) {
         self.x402Version = x402Version
+        self.scheme = scheme
+        self.network = network
         self.accepted = accepted
         self.payload = payload
     }
 
     private enum CodingKeys: String, CodingKey {
-        case x402Version, accepted, payload
+        case x402Version, scheme, network, accepted, payload
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         x402Version = try container.decode(Int.self, forKey: .x402Version)
+        scheme = try container.decodeIfPresent(String.self, forKey: .scheme)
+        network = try container.decodeIfPresent(String.self, forKey: .network)
         accepted = try container.decodeIfPresent(X402AcceptsEntry.self, forKey: .accepted)
         payload = try container.decode(X402PaymentPayload.self, forKey: .payload)
     }
@@ -312,11 +352,15 @@ public struct X402PaymentSignatureEnvelope: Codable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(x402Version, forKey: .x402Version)
+        // Legacy v1 siblings; omitted (and thus absent on v2) when nil.
+        try container.encodeIfPresent(scheme, forKey: .scheme)
+        try container.encodeIfPresent(network, forKey: .network)
         // Echo the offered requirement verbatim when we captured it on the
         // wire (preserves maxTimeoutSeconds / resource / server extras the
         // typed entry does not model); fall back to the typed encoding for
         // in-code entries. Mirrors the rust client's `to_accepted_value`,
-        // which returns the original parsed object unchanged.
+        // which returns the original parsed object unchanged. The legacy v1
+        // envelope omits `accepted` entirely (it binds only scheme+network).
         if let raw = accepted?.raw {
             try container.encode(raw, forKey: .accepted)
         } else {

--- a/swift/Tests/SolanaPayKitTests/X402LegacyExactTests.swift
+++ b/swift/Tests/SolanaPayKitTests/X402LegacyExactTests.swift
@@ -1,0 +1,453 @@
+import Foundation
+import Testing
+@testable import SolanaPayKit
+
+// MARK: - Legacy x402 exact (v1) wire support
+//
+// Swift implements the x402 CLIENT side, so it covers the conformance
+// `build-transaction` mode: parse a legacy 402 challenge, build the legacy
+// `X-PAYMENT` envelope, and keep the canonical `PAYMENT-SIGNATURE` as the
+// default producer. The shared conformance vectors at
+// `harness/vectors/x402-v1-build.json` are driven directly through the swift
+// builder below; the `verify-transaction` vectors are server-side and are
+// out of scope for the client SDK.
+//
+// Mirrors rust `build_payment_header_v1` (client/exact/payment.rs:153-170),
+// `v1_network_for_requirements` (payment.rs:393-404), and the default
+// producer `build_payment_header` (payment.rs:132-150).
+
+private struct LegacyFixtures {
+    static func makeSigner() throws -> MemorySigner {
+        try MemorySigner(secretKey: Data(repeating: 0x01, count: 32))
+    }
+
+    static func makeRpc() -> RpcClient {
+        RpcClient(endpoint: URL(string: "http://localhost:8899")!)
+    }
+
+    static let knownBlockhash = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi"
+}
+
+// MARK: - Shared conformance vector driver (client build side)
+
+/// Decoded `expect.x402EnvelopeShape` of a build-transaction vector.
+private struct ExpectedEnvelopeShape: Decodable {
+    let x402Version: Int
+    let scheme: String?
+    let network: String?
+    let hasAccepted: Bool
+    let payloadHasTransaction: Bool
+    let acceptedScheme: String?
+    let acceptedNetwork: String?
+    let acceptedAsset: String?
+    let acceptedPayTo: String?
+    let acceptedAmount: String?
+}
+
+private struct BuildVector: Decodable {
+    struct Expect: Decodable {
+        let outcome: String
+        let x402EnvelopeShape: ExpectedEnvelopeShape
+    }
+    struct Input: Decodable {
+        let x402Version: Int?
+        let x402Offer: VectorOffer
+    }
+    struct VectorOffer: Decodable {
+        let scheme: String?
+        let network: String
+        let amount: String?
+        let maxAmountRequired: String?
+        let asset: String?
+        let payTo: String?
+        let maxTimeoutSeconds: Int?
+        let extra: [String: JSONValue]?
+    }
+    let id: String
+    let mode: String
+    let input: Input
+    let expect: Expect
+}
+
+@Suite("x402 legacy exact conformance vectors (build side)")
+struct X402LegacyBuildVectorTests {
+    /// Load the shared build-transaction vectors from the harness corpus so
+    /// the swift client is exercised by the same fixtures as the other SDKs.
+    private static func loadVectors() throws -> [BuildVector] {
+        let here = URL(fileURLWithPath: #filePath)
+        let vectorURL = here
+            .deletingLastPathComponent() // SolanaPayKitTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // swift
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent("harness/vectors/x402-v1-build.json")
+        let data = try Data(contentsOf: vectorURL)
+        return try JSONDecoder().decode([BuildVector].self, from: data)
+    }
+
+    @Test
+    func everyBuildVectorMatchesEnvelopeShape() async throws {
+        let vectors = try Self.loadVectors()
+        #expect(vectors.count == 3)
+
+        for vector in vectors {
+            #expect(vector.mode == "build-transaction", "\(vector.id)")
+            #expect(vector.expect.outcome == "accept", "\(vector.id)")
+
+            let v = vector.input.x402Offer
+            let offer = X402AcceptsEntry(
+                scheme: v.scheme,
+                network: v.network,
+                amount: v.amount,
+                maxAmountRequired: v.maxAmountRequired,
+                asset: v.asset,
+                payTo: v.payTo,
+                recipient: nil,
+                extra: _withBlockhash(v.extra),
+                maxTimeoutSeconds: v.maxTimeoutSeconds
+            )
+
+            // Emit the version the vector's challenge declared (nil -> default v2).
+            let payment = try await buildX402PaymentForChallenge(
+                signer: try LegacyFixtures.makeSigner(),
+                rpc: LegacyFixtures.makeRpc(),
+                offer: offer,
+                declaredVersion: vector.input.x402Version,
+                nonceGenerator: { Data(repeating: 0xAB, count: 16) }
+            )
+
+            // Header name follows the declared version.
+            let expectedHeader = vector.input.x402Version == X402VersionLegacy
+                ? X402LegacyPaymentHeader
+                : X402PaymentHeader
+            #expect(payment.headerName == expectedHeader, "\(vector.id) header")
+
+            let shape = try _decodeShape(payment.value)
+            let want = vector.expect.x402EnvelopeShape
+
+            #expect(shape["x402Version"] as? Int == want.x402Version, "\(vector.id) version")
+            #expect((shape["accepted"] != nil) == want.hasAccepted, "\(vector.id) hasAccepted")
+
+            let payload = shape["payload"] as? [String: Any]
+            let tx = payload?["transaction"] as? String
+            #expect((tx?.isEmpty == false) == want.payloadHasTransaction, "\(vector.id) tx")
+
+            if let wantScheme = want.scheme {
+                #expect(shape["scheme"] as? String == wantScheme, "\(vector.id) scheme")
+            }
+            if let wantNetwork = want.network {
+                #expect(shape["network"] as? String == wantNetwork, "\(vector.id) network")
+            }
+
+            // Canonical (v2) shape carries an `accepted` and NO top-level
+            // scheme/network; the legacy (v1) shape is the inverse.
+            if want.hasAccepted {
+                #expect(shape["scheme"] == nil, "\(vector.id) v2 no top-level scheme")
+                #expect(shape["network"] == nil, "\(vector.id) v2 no top-level network")
+            }
+
+            // v2 vectors assert the echoed accepted fields.
+            if want.hasAccepted, let accepted = shape["accepted"] as? [String: Any] {
+                if let s = want.acceptedScheme {
+                    #expect(accepted["scheme"] as? String == s, "\(vector.id) acceptedScheme")
+                }
+                if let n = want.acceptedNetwork {
+                    #expect(accepted["network"] as? String == n, "\(vector.id) acceptedNetwork")
+                }
+                if let a = want.acceptedAsset {
+                    #expect(accepted["asset"] as? String == a, "\(vector.id) acceptedAsset")
+                }
+                if let p = want.acceptedPayTo {
+                    #expect(accepted["payTo"] as? String == p, "\(vector.id) acceptedPayTo")
+                }
+                if let amt = want.acceptedAmount {
+                    #expect(accepted["amount"] as? String == amt, "\(vector.id) acceptedAmount")
+                }
+            }
+        }
+    }
+
+    /// Offers built from the vector corpus pin no blockhash, so add a known
+    /// one to keep the builder offline (no RPC round-trip in unit tests).
+    private func _withBlockhash(_ extra: [String: JSONValue]?) -> [String: JSONValue] {
+        var merged = extra ?? [:]
+        if merged["recentBlockhash"] == nil {
+            merged["recentBlockhash"] = .string(LegacyFixtures.knownBlockhash)
+        }
+        return merged
+    }
+
+    private func _decodeShape(_ header: String) throws -> [String: Any] {
+        guard let data = Data(base64Encoded: header) else {
+            throw MppError.invalidTransaction("header is not standard base64")
+        }
+        return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    }
+}
+
+// MARK: - Legacy producer unit tests
+
+@Suite("x402 legacy producer")
+struct X402LegacyProducerTests {
+    static func devnetOffer() -> X402AcceptsEntry {
+        let extra: [String: JSONValue] = [
+            "recentBlockhash": .string(LegacyFixtures.knownBlockhash),
+            "decimals": .int(6),
+        ]
+        return X402AcceptsEntry(
+            scheme: "exact",
+            network: SolanaNetwork.devnet,
+            amount: "1000",
+            maxAmountRequired: nil,
+            asset: Mints.usdcDevnet,
+            payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+            recipient: nil,
+            extra: extra,
+            maxTimeoutSeconds: 60
+        )
+    }
+
+    private func decode(_ header: String) throws -> [String: Any] {
+        let data = Data(base64Encoded: header)!
+        return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    }
+
+    @Test
+    func legacyEnvelopeHasTopLevelSchemeNetworkAndNoAccepted() async throws {
+        let header = try await buildX402LegacyPaymentHeader(
+            signer: try LegacyFixtures.makeSigner(),
+            rpc: LegacyFixtures.makeRpc(),
+            offer: Self.devnetOffer()
+        )
+        let env = try decode(header)
+        #expect(env["x402Version"] as? Int == 1)
+        #expect(env["scheme"] as? String == "exact")
+        #expect(env["network"] as? String == "solana-devnet")  // plain slug, not CAIP-2
+        #expect(env["accepted"] == nil)  // legacy binds only scheme + network
+        let payload = env["payload"] as? [String: Any]
+        #expect((payload?["transaction"] as? String)?.isEmpty == false)
+    }
+
+    @Test
+    func legacyHeaderIsStandardBase64NotUrlSafe() async throws {
+        // A standard-base64 string round-trips through Data(base64Encoded:);
+        // url-safe ('-'/'_') would not. Use a SOL offer (no ATA dependency).
+        let extra: [String: JSONValue] = ["recentBlockhash": .string(LegacyFixtures.knownBlockhash)]
+        let offer = X402AcceptsEntry(
+            scheme: "exact", network: SolanaNetwork.mainnet,
+            amount: "1000", maxAmountRequired: nil,
+            asset: "SOL", payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+            recipient: nil, extra: extra
+        )
+        let header = try await buildX402LegacyPaymentHeader(
+            signer: try LegacyFixtures.makeSigner(), rpc: LegacyFixtures.makeRpc(), offer: offer
+        )
+        #expect(Data(base64Encoded: header) != nil)
+        #expect(!header.contains("-"))
+        #expect(!header.contains("_"))
+    }
+
+    @Test
+    func legacyNetworkSlugMaps() async throws {
+        // mainnet CAIP-2 -> "solana"
+        let mainnet = X402AcceptsEntry(
+            scheme: "exact", network: SolanaNetwork.mainnet,
+            amount: "1000", maxAmountRequired: nil,
+            asset: "SOL", payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+            recipient: nil,
+            extra: ["recentBlockhash": .string(LegacyFixtures.knownBlockhash)]
+        )
+        let mainnetHeader = try await buildX402LegacyPaymentHeader(
+            signer: try LegacyFixtures.makeSigner(), rpc: LegacyFixtures.makeRpc(), offer: mainnet
+        )
+        #expect(try decode(mainnetHeader)["network"] as? String == "solana")
+
+        // testnet collapses to "solana" on the producer side (rust parity).
+        let testnet = X402AcceptsEntry(
+            scheme: "exact", network: SolanaNetwork.testnet,
+            amount: "1000", maxAmountRequired: nil,
+            asset: "SOL", payTo: "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+            recipient: nil,
+            extra: ["recentBlockhash": .string(LegacyFixtures.knownBlockhash)]
+        )
+        let testnetHeader = try await buildX402LegacyPaymentHeader(
+            signer: try LegacyFixtures.makeSigner(), rpc: LegacyFixtures.makeRpc(), offer: testnet
+        )
+        #expect(try decode(testnetHeader)["network"] as? String == "solana")
+    }
+
+    @Test
+    func challengeDispatcherKeepsCanonicalAsDefault() async throws {
+        let offer = Self.devnetOffer()
+        // nil declared version -> canonical PAYMENT-SIGNATURE, x402Version 2.
+        let canonical = try await buildX402PaymentForChallenge(
+            signer: try LegacyFixtures.makeSigner(), rpc: LegacyFixtures.makeRpc(),
+            offer: offer, declaredVersion: nil
+        )
+        #expect(canonical.headerName == X402PaymentHeader)
+        #expect(try decode(canonical.value)["x402Version"] as? Int == 2)
+        #expect(try decode(canonical.value)["accepted"] != nil)
+        #expect(try decode(canonical.value)["scheme"] == nil)
+
+        // declared version 2 -> still canonical.
+        let v2 = try await buildX402PaymentForChallenge(
+            signer: try LegacyFixtures.makeSigner(), rpc: LegacyFixtures.makeRpc(),
+            offer: offer, declaredVersion: 2
+        )
+        #expect(v2.headerName == X402PaymentHeader)
+
+        // declared version 1 -> legacy X-PAYMENT.
+        let legacy = try await buildX402PaymentForChallenge(
+            signer: try LegacyFixtures.makeSigner(), rpc: LegacyFixtures.makeRpc(),
+            offer: offer, declaredVersion: 1
+        )
+        #expect(legacy.headerName == X402LegacyPaymentHeader)
+        #expect(try decode(legacy.value)["x402Version"] as? Int == 1)
+    }
+}
+
+// MARK: - Legacy challenge parse (dual-read) unit tests
+
+@Suite("x402 legacy challenge parse")
+struct X402LegacyChallengeParseTests {
+    @Test
+    func parsesLegacyBodyWithPlainNetworkAndMaxAmountRequired() throws {
+        // Legacy 402 body: plain network slug + maxAmountRequired + x402Version 1.
+        let body = """
+        {
+            "x402Version": 1,
+            "error": "X-PAYMENT header is required",
+            "accepts": [{
+                "scheme": "exact",
+                "network": "solana-devnet",
+                "maxAmountRequired": "1000",
+                "asset": "\(Mints.usdcDevnet)",
+                "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+                "maxTimeoutSeconds": 60
+            }]
+        }
+        """
+        let parsed = parseX402ChallengeWithVersion(headers: [], body: body)
+        #expect(parsed != nil)
+        #expect(parsed?.declaredVersion == 1)
+        #expect(parsed?.offer.network == "solana-devnet")
+        #expect(parsed?.offer.effectiveAmount == "1000")
+        #expect(parsed?.offer.effectiveAsset == Mints.usdcDevnet)
+    }
+
+    @Test
+    func legacyBodyWithPlainNetworkSelectsOnPreferredCluster() throws {
+        // The plain `solana-devnet` slug must normalize to the devnet CAIP-2
+        // when matched against a devnet preference.
+        let body = """
+        {
+            "x402Version": 1,
+            "accepts": [{
+                "scheme": "exact",
+                "network": "solana-devnet",
+                "maxAmountRequired": "1000",
+                "asset": "\(Mints.usdcDevnet)",
+                "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY"
+            }]
+        }
+        """
+        let selection = X402ChallengeSelection(network: "devnet", currencies: ["USDC"])
+        let parsed = parseX402ChallengeWithVersion(headers: [], body: body, selection: selection)
+        #expect(parsed?.offer.asset == Mints.usdcDevnet)
+    }
+
+    @Test
+    func readsCanonicalHeaderBeforeLegacyHeaderBeforeBody() throws {
+        let net = SolanaNetwork.devnet
+        // Canonical PAYMENT-REQUIRED header (v2) wins over everything.
+        let canonicalEnv = "{\"x402Version\":2,\"accepts\":[{\"scheme\":\"exact\",\"network\":\"\(net)\",\"amount\":\"100\",\"asset\":\"SOL\",\"payTo\":\"from-canonical\"}]}"
+        let legacyEnv = "{\"x402Version\":1,\"accepts\":[{\"scheme\":\"exact\",\"network\":\"solana-devnet\",\"maxAmountRequired\":\"200\",\"asset\":\"SOL\",\"payTo\":\"from-legacy-header\"}]}"
+        let body = "{\"x402Version\":1,\"accepts\":[{\"scheme\":\"exact\",\"network\":\"solana-devnet\",\"maxAmountRequired\":\"300\",\"asset\":\"SOL\",\"payTo\":\"from-body\"}]}"
+
+        let headers = [
+            (name: "PAYMENT-REQUIRED", value: Data(canonicalEnv.utf8).base64EncodedString()),
+            (name: "X-PAYMENT-REQUIRED", value: Data(legacyEnv.utf8).base64EncodedString()),
+        ]
+        let viaCanonical = parseX402ChallengeWithVersion(headers: headers, body: body)
+        #expect(viaCanonical?.offer.effectivePayTo == "from-canonical")
+        #expect(viaCanonical?.declaredVersion == 2)
+
+        // Without the canonical header, the legacy X-PAYMENT-REQUIRED header
+        // wins over the body.
+        let legacyHeaders = [
+            (name: "X-PAYMENT-REQUIRED", value: Data(legacyEnv.utf8).base64EncodedString()),
+        ]
+        let viaLegacyHeader = parseX402ChallengeWithVersion(headers: legacyHeaders, body: body)
+        #expect(viaLegacyHeader?.offer.effectivePayTo == "from-legacy-header")
+        #expect(viaLegacyHeader?.declaredVersion == 1)
+
+        // With no headers, the body is the fallback.
+        let viaBody = parseX402ChallengeWithVersion(headers: [], body: body)
+        #expect(viaBody?.offer.effectivePayTo == "from-body")
+        #expect(viaBody?.declaredVersion == 1)
+    }
+
+    @Test
+    func roundTripsLegacyChallengeIntoLegacyPayment() async throws {
+        // End-to-end client flow: parse a legacy body, then emit the version
+        // it declared. The reply must be the legacy X-PAYMENT envelope.
+        let body = """
+        {
+            "x402Version": 1,
+            "accepts": [{
+                "scheme": "exact",
+                "network": "solana-devnet",
+                "maxAmountRequired": "1000",
+                "asset": "\(Mints.usdcDevnet)",
+                "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+                "extra": { "recentBlockhash": "\(LegacyFixtures.knownBlockhash)", "decimals": 6 }
+            }]
+        }
+        """
+        let parsed = parseX402ChallengeWithVersion(headers: [], body: body)
+        #expect(parsed?.declaredVersion == 1)
+
+        let payment = try await buildX402PaymentForChallenge(
+            signer: try LegacyFixtures.makeSigner(),
+            rpc: LegacyFixtures.makeRpc(),
+            offer: parsed!.offer,
+            declaredVersion: parsed!.declaredVersion
+        )
+        #expect(payment.headerName == X402LegacyPaymentHeader)
+        let env = try JSONSerialization.jsonObject(
+            with: Data(base64Encoded: payment.value)!
+        ) as! [String: Any]
+        #expect(env["x402Version"] as? Int == 1)
+        #expect(env["network"] as? String == "solana-devnet")
+        #expect(env["accepted"] == nil)
+    }
+}
+
+// MARK: - Legacy network slug mapping unit tests
+
+@Suite("SolanaNetwork legacy slugs")
+struct SolanaNetworkLegacySlugTests {
+    @Test
+    func legacySlugMapping() {
+        #expect(SolanaNetwork.legacySlug(for: SolanaNetwork.mainnet) == "solana")
+        #expect(SolanaNetwork.legacySlug(for: SolanaNetwork.devnet) == "solana-devnet")
+        #expect(SolanaNetwork.legacySlug(for: SolanaNetwork.testnet) == "solana")  // collapses
+        #expect(SolanaNetwork.legacySlug(for: "devnet") == "solana-devnet")
+        #expect(SolanaNetwork.legacySlug(for: "solana-devnet") == "solana-devnet")
+        #expect(SolanaNetwork.legacySlug(for: "mainnet") == "solana")
+        #expect(SolanaNetwork.legacySlug(for: "solana") == "solana")
+    }
+
+    @Test
+    func isSolanaNetworkRecognizesCaip2AndPlainSlugs() {
+        #expect(SolanaNetwork.isSolanaNetwork(SolanaNetwork.mainnet))
+        #expect(SolanaNetwork.isSolanaNetwork(SolanaNetwork.devnet))
+        #expect(SolanaNetwork.isSolanaNetwork(SolanaNetwork.testnet))
+        #expect(SolanaNetwork.isSolanaNetwork("solana"))
+        #expect(SolanaNetwork.isSolanaNetwork("solana-devnet"))
+        #expect(SolanaNetwork.isSolanaNetwork("solana-testnet"))
+        #expect(SolanaNetwork.isSolanaNetwork("mainnet-beta"))
+        #expect(!SolanaNetwork.isSolanaNetwork("ethereum:1"))
+        #expect(!SolanaNetwork.isSolanaNetwork("base"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds **x402 `exact` v1 (legacy) wire support** to the non-Rust pay-kit SDKs that have an x402 surface — **go, python, ruby, php, lua, swift** — mirroring the Rust spine (`rust/crates/x402`), which already accepts both v1 and v2. Before this, every non-Rust SDK was x402-**v2-only** and rejected the legacy v1 shape, so a legacy `X-PAYMENT` client could not interoperate with a pay-kit server.

The change is **additive and backward-safe**: servers now *also* accept v1, still **reject genuinely-unknown versions**, and **still emit v2 by default**; clients gain a v1 parser (as a fallback) and an opt-in v1 producer, with v2 staying the default producer.

## What v1 is (and how it differs from v2)

| | v1 (legacy) | v2 (canonical, default) |
|---|---|---|
| request header | `X-PAYMENT` | `PAYMENT-SIGNATURE` |
| challenge | `X-PAYMENT-REQUIRED` header **or** 402 JSON body | `PAYMENT-REQUIRED` header |
| version | `x402Version: 1` | `x402Version: 2` |
| payload shape | top-level `scheme` + `network` + `payload`, **no `accepted`** | `accepted` object |
| amount field | `maxAmountRequired` (string) | `amount` |
| SVM network | plain `solana` / `solana-devnet` / `solana-testnet` | CAIP-2 (`solana:5eykt4…`) |
| base64 | **standard (padded)** | standard |

The facilitator MUST-checks (compute budget, `transferChecked` shape, fee-payer ≠ authority, amount, memo) are **identical** for v1 and v2 — v1 reuses the exact same verifier, so it does not weaken verification.

> **Spec note (rust is the source of truth):** the coinbase x402 spec describes the v1 challenge as a 402 JSON body only, but the pay-kit Rust spine also defines and reads an `X-PAYMENT-REQUIRED` header (`constants.rs:19`, read before the body). pay-kit follows Rust: support **both** the header and the body (body as fallback). Documented in `docs/x402/exact-v1-spec.md`.

## Per-role coverage

- **client + server:** go, python
- **server only (dual-accept):** ruby, php, lua
- **client only (parse + opt-in producer):** swift

TypeScript and Kotlin are intentionally out of scope (TS is addressed via the `mppx` path; Kotlin stacks on its own open x402 PR).

## Conformance

x402 has **no upstream v1 vector corpus**, so the vectors here are authored from the Rust behavior + the spec's real base64 examples, added to the harness:
- `harness/vectors/x402-v1-build.json` (v1 build devnet, v1 network-name mapping, v2-default-producer guard)
- `harness/vectors/x402-v1-verify.json` (v1 accept devnet, v1 accept mainnet plain-slug, reject-unknown-version, reject-wrong-network)
- the self-contained TS reference (`harness/src/conformance/x402.ts`) gained a v1 challenge-body parser with the Rust precedence (v2 header → v1 header → v1 body).

The cross-SDK conformance matrix is green for all six SDKs over the v1 vectors plus the existing x402 v2 + MPP-protocol matrices. Each SDK also passes its full CI-equivalent **including the coverage gate** (go 91.7%, python 92.98%, php 92.09%, lua 90.37%, ruby + swift green).

## How to review

24 commits, grouped for review: one **spec + vectors** foundation commit (`docs(x402): establish legacy v1 exact contract…`), then **per-language** `feat` + `test` commits behind a per-language merge commit. Start with `docs/x402/exact-v1-spec.md` (the contract + the v1↔v2 diff + per-rule Rust citations), then read one language section at a time.

**Risk / blast radius:** additive only. No change to the v2 path, the Rust crate, MPP charge/session/subscription, or the x402 extensions work. The only shared surface touched is the harness (vectors + the TS reference parser).

## Verification

- Consolidated conformance matrix: green (v1 + v2 + protocol); the only local failures were surfpool-localnet e2e replay flakes in **MPP charge** cells (which v1 does not touch) — these run against a fresh validator in CI.
- An independent adversarial review (rust-parity + security + cross-SDK) returned **MERGEABLE, no high-severity issues**; it confirmed standard (non-url-safe) base64, no `accepted` in any v1 producer, plain network slugs, a `{1,2}`-only version gate that rejects all others, and the **identical facilitator MUST-checks** on the v1 path. Two parity nits it raised were fixed in this PR: the go v2 producer no longer leaks top-level `scheme`/`network` (now omitted, matching rust), and the lua server now dispatches on the decoded `x402Version` field rather than the header.
- **Known limitation (negligible):** on a `localnet` offer the v1 network slug resolves to `solana-devnet` in swift/the harness vs `solana` in rust (rust maps by cluster; the offer's CAIP-2 cannot distinguish localnet from devnet). Localnet-only, no production impact.
- All commits SSH-signed.

## Reviewer notes (conventions + an open naming question)

This PR was cross-checked against the recurring review conventions from prior pay-kit PRs. It already follows them: v1 slots into the existing `protocols/x402` layer in each SDK (no new ad-hoc path); the layered `pay-kit → {mpp, x402} → PayCore` boundaries hold and **no protocol imports another**; ruby/php/lua stay **server-only**; all interop adapters live under `harness/` (none in shipped libs); every language ships a README and meets its coverage gate; harness dirs follow `<lang>-<role>`. One small cross-SDK parity gap surfaced in review was fixed here (lua testnet-slug normalization in `caip2_network_for_cluster`).

**Open question for the maintainer — v1/v2 naming.** This PR uses `v1`/`v2` in a few identifiers (`BuildPaymentHeaderV1`, `X402_V1_*` / `X402_LEGACY_*` header constants, a python `exact/legacy.py` module, `select_v1_requirement`/`select_v2_requirement`). These mirror the **rust spine's own names** (`build_payment_header_v1`, `X402_VERSION_V1`, `X402_V1_PAYMENT_REQUIRED_HEADER`) and the on-wire `x402Version: 1` protocol field — i.e. they name the two on-wire x402 protocol versions, not internal pay-kit versioning. That collides with the "name wire shapes by structure, not by version" convention. Line-by-line rust parity argues for keeping the rust names; happy to (a) keep as-is for parity, (b) rename the `legacy.py` module to a structural name, or (c) align symbols to a structural scheme — your call.
