### PR TITLE
fix(typescript): premium feed route crashes the playground API

### DIFF
--- a/typescript/examples/playground-api/modules/subscriptions.ts
+++ b/typescript/examples/playground-api/modules/subscriptions.ts
@@ -58,15 +58,7 @@ export function registerSubscriptions(app: Express, opts: RegisterOptions): void
   })
 
   app.get('/api/v1/premium/feed', async (req: Request, res: ExpressResponse) => {
-    const result = await (mppx as unknown as {
-      charge: (params: { amount: string; currency: string; description: string }) => (
-        request: globalThis.Request,
-      ) => Promise<{
-        status: number
-        challenge?: globalThis.Response
-        withReceipt: (r: globalThis.Response) => globalThis.Response
-      }>
-    }).charge({
+    const result = await mppx.subscription({
       amount: plan.amount,
       currency: plan.currency,
       description: plan.description,


### PR DESCRIPTION
## Problem

An unauthenticated `GET /api/v1/premium/feed` kills the whole playground API process:

```
TypeError: mppx.charge is not a function
    at modules/subscriptions.ts:69
```

The route casts the `Mppx` instance through `as unknown as { charge: ... }` and calls `.charge()`. The instance only carries handlers for its registered methods, and this module registers `solana.subscription(...)` only, so there is no `.charge` at runtime. The cast hid the mismatch from the type checker, and in Express 4 the rejected async handler escalates to an unhandled rejection that exits the Node process. Any visitor opening the playground subscriptions page takes the whole API down with it.

## Fix

Call the handler that is actually registered:

```ts
const result = await mppx.subscription({
  amount: plan.amount,
  currency: plan.currency,
  description: plan.description,
})(toWebRequest(req))
```

One call site, nine lines of cast deleted.

## Verified

- Before: the first unauthenticated request to `/api/v1/premium/feed` crashes the server (reproduced repeatedly while testing the playground against the Go port of this API).
- After: the route returns a proper 402 subscription challenge (`WWW-Authenticate: Payment ... intent=subscription`) and the process stays up; the rest of the playground is unaffected.

## Note on the paid path

With the route reaching real verification for the first time, paying the challenge from the playground UI currently fails downstream: the `settleActivation` simulation is rejected by the delegation program with custom error 105 (`InvalidTokenProgram`; `De1eg...` fails after 275 CU). That looks like a separate program/SDK account mismatch on the hosted sandbox rather than a route bug, so this PR does not attempt to address it; happy to file details separately if useful.
