### PR TITLE
fix(mpp/ts): enforce 32-byte HMAC secret floor at the @solana/mpp boundary (audit #24)

### DIFF
--- a/typescript/packages/mpp/src/__tests__/cross-route-replay.test.ts
+++ b/typescript/packages/mpp/src/__tests__/cross-route-replay.test.ts
@@ -19,7 +19,8 @@ import { Mppx } from 'mppx/server';
 import { charge } from '../server/Charge.js';
 
 const RECIPIENT = '9xAXssX9j7vuK99c7cFwqbixzL3bFrzPy9PUhCtDPAYJ';
-const SECRET_KEY = 'cross-route-replay-test-secret';
+// >= 32 bytes (audit #24 secret-key floor enforced by the secret guard).
+const SECRET_KEY = 'cross-route-replay-test-secret-32-bytes';
 const REALM = 'api.example.com';
 
 function makeHandler() {

--- a/typescript/packages/mpp/src/__tests__/integration.test.ts
+++ b/typescript/packages/mpp/src/__tests__/integration.test.ts
@@ -261,7 +261,7 @@ test('e2e: fee payer mode — server co-signs and pays fees', async () => {
     const feePayerSigner = await generateKeyPairSigner();
     await client.airdrop(feePayerSigner.address, lamports(10_000_000_000n));
 
-    const secretKey = 'test-secret-key-feepayer';
+    const secretKey = 'test-secret-key-feepayer-padded-32b';
 
     const feePayerMppx = ServerMppx.create({
         secretKey,
@@ -358,7 +358,7 @@ test('e2e: USDC charge via pull mode with fee payer', async () => {
     await fundUsdc(clientSigner.address, 100_000_000); // 100 USDC
     await fundUsdc(recipientSigner.address, 0);
 
-    const secretKey = 'test-secret-key-usdc';
+    const secretKey = 'test-secret-key-usdc-padded-to-32bytes';
 
     const usdcMppx = ServerMppx.create({
         secretKey,
@@ -428,7 +428,7 @@ test('e2e: USDC charge with splits (platform fee)', async () => {
     await fundUsdc(recipientSigner.address, 0);
     await fundUsdc(platformSigner.address, 0);
 
-    const secretKey = 'test-secret-key-splits';
+    const secretKey = 'test-secret-key-splits-padded-32bytes';
     const splits = [{ recipient: platformSigner.address, amount: '5000', memo: 'platform fee' }];
 
     const splitsMppx = ServerMppx.create({
@@ -493,7 +493,7 @@ test('e2e: native SOL charge with splits', async () => {
     const platformSigner = await generateKeyPairSigner();
     const referrerSigner = await generateKeyPairSigner();
 
-    const secretKey = 'test-secret-key-sol-splits';
+    const secretKey = 'test-secret-key-sol-splits-padded-32b';
     // Split amounts must be >= rent-exempt minimum (~890_880 lamports)
     // because the recipient accounts are freshly generated keypairs that
     // don't yet exist on-chain, and Solana refuses to create system

--- a/typescript/packages/mpp/src/__tests__/secret-guard.test.ts
+++ b/typescript/packages/mpp/src/__tests__/secret-guard.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Audit #24: the @solana/mpp boundary rejects a weak HMAC secret key before any
+ * challenge is signed. mppx@0.5.x accepts any non-empty secret, so the floor is
+ * enforced here in the `Mppx.create` wrapper (see server/secret-guard.ts).
+ */
+import { afterEach, expect, test } from 'vitest';
+import { charge } from '../server/Charge.js';
+import { MIN_SECRET_KEY_BYTES, Mppx } from '../server/secret-guard.js';
+
+const RECIPIENT = '9xAXssX9j7vuK99c7cFwqbixzL3bFrzPy9PUhCtDPAYJ';
+const methods = () => [charge({ recipient: RECIPIENT, network: 'devnet', rpcUrl: 'https://mock-rpc' })];
+
+// A 'a'.repeat(N) string is N UTF-8 bytes, so length maps directly to byte count.
+const strong = 'a'.repeat(MIN_SECRET_KEY_BYTES);
+const tooShort = 'a'.repeat(MIN_SECRET_KEY_BYTES - 1);
+
+afterEach(() => {
+    delete process.env.MPP_SECRET_KEY;
+});
+
+test('rejects an explicit secret key shorter than the floor', () => {
+    expect(() => Mppx.create({ methods: methods(), secretKey: tooShort })).toThrow(/at least 32 bytes/);
+});
+
+test('accepts an explicit secret key at the floor', () => {
+    delete process.env.MPP_SECRET_KEY;
+    expect(() => Mppx.create({ methods: methods(), secretKey: strong })).not.toThrow();
+});
+
+test('rejects a short MPP_SECRET_KEY from the environment', () => {
+    process.env.MPP_SECRET_KEY = tooShort;
+    expect(() => Mppx.create({ methods: methods() })).toThrow(/at least 32 bytes/);
+});
+
+test('accepts a strong MPP_SECRET_KEY from the environment', () => {
+    process.env.MPP_SECRET_KEY = strong;
+    expect(() => Mppx.create({ methods: methods() })).not.toThrow();
+});

--- a/typescript/packages/mpp/src/server/index.ts
+++ b/typescript/packages/mpp/src/server/index.ts
@@ -12,5 +12,8 @@ export {
     type SessionStore,
 } from './session/store.js';
 export { subscription } from './Subscription.js';
-// Re-export Mppx so consumers can do: import { Mppx, solana } from '@solana/mpp/server'
-export { Mppx, Expires, Store } from 'mppx/server';
+// Re-export Mppx so consumers can do: import { Mppx, solana } from '@solana/mpp/server'.
+// Mppx comes from the secret-strength guard (audit #24): a weak HMAC secret is
+// rejected at `Mppx.create` before any challenge is signed.
+export { Expires, Store } from 'mppx/server';
+export { MIN_SECRET_KEY_BYTES, Mppx } from './secret-guard.js';

--- a/typescript/packages/mpp/src/server/secret-guard.ts
+++ b/typescript/packages/mpp/src/server/secret-guard.ts
@@ -1,0 +1,62 @@
+// Defensive secret-key strength guard for the MPP server (audit #24).
+//
+// pay-kit's TypeScript SDK delegates HMAC-bound challenge issuance/verification
+// to `mppx` via `Mppx.create({ secretKey })`. mppx@0.5.x only rejects an empty
+// secret (`if (!secretKey) throw`), so a weak key such as `"key"` is accepted as
+// the HMAC-SHA256 key that binds challenge IDs — an attacker who guesses or
+// brute-forces a low-entropy key can forge challenges. Per NIST SP 800-107 the
+// HMAC-SHA256 key should be at least the hash output size (32 bytes).
+//
+// Until a length floor lands upstream in mppx, we gate at OUR `@solana/mpp`
+// boundary, mirroring `challenge-guard.ts`: this module re-exports the `Mppx`
+// namespace with `create` wrapped so a short secret is rejected before any
+// challenge is signed. We do NOT fork or vendor mppx, and we touch only the
+// secret-strength gate, never the signing or settlement path.
+
+import { Mppx as MppxBase } from 'mppx/server';
+
+/**
+ * Minimum accepted MPP HMAC secret-key length in bytes (audit #24).
+ *
+ * 32 bytes matches the HMAC-SHA256 output size (NIST SP 800-107). Generate a
+ * conforming key with `openssl rand -base64 32`.
+ */
+export const MIN_SECRET_KEY_BYTES = 32;
+
+function assertStrongSecret(config: Parameters<typeof MppxBase.create>[0]): void {
+    // Mirror mppx's own resolution order: explicit `secretKey`, else the
+    // `MPP_SECRET_KEY` environment variable. When neither is set we stay silent
+    // and let mppx raise its own "secret key required" error, so we own only the
+    // strength check and never change the missing-secret behavior.
+    const secret = config.secretKey ?? process.env.MPP_SECRET_KEY;
+    if (secret === undefined) return;
+
+    const byteLength = new TextEncoder().encode(secret).length;
+    if (byteLength < MIN_SECRET_KEY_BYTES) {
+        throw new Error(
+            `MPP secret key must be at least ${MIN_SECRET_KEY_BYTES} bytes (got ${byteLength}); ` +
+                'generate one with `openssl rand -base64 32`',
+        );
+    }
+}
+
+/**
+ * `Mppx.create` with the audit #24 secret-strength gate applied. Identical to
+ * `mppx`'s `Mppx.create` except a secret shorter than {@link MIN_SECRET_KEY_BYTES}
+ * bytes (whether passed explicitly or via `MPP_SECRET_KEY`) is rejected.
+ */
+export const create: typeof MppxBase.create = (config => {
+    assertStrongSecret(config);
+    return MppxBase.create(config);
+}) as typeof MppxBase.create;
+
+/**
+ * The `Mppx` namespace as exposed by `@solana/mpp/server`: the upstream `mppx`
+ * surface with the secret-strength gate applied to `create`. Use this instead
+ * of importing `Mppx` directly from `mppx` so a weak HMAC secret is rejected at
+ * server construction.
+ */
+export const Mppx: typeof MppxBase = {
+    ...MppxBase,
+    create,
+};

--- a/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
@@ -11,7 +11,7 @@ const PLATFORM = 'CXG3Pq3DwZb1HVckhPQbVxiwoNGM3jNGYvC2BSdkj1pK';
 
 async function setup() {
     const config = await configure({
-        mpp: { challengeBindingSecret: 'adapter-test-secret', realm: 'Adapter test' },
+        mpp: { challengeBindingSecret: 'adapter-test-secret-padded-to-32b', realm: 'Adapter test' },
         operator: { recipient: SELLER, signer: await Signer.generate() },
     });
     return { adapter: createMppAdapter(config), config };


### PR DESCRIPTION
## What

Follow-up to #169. The cross-language audit routed the `mppx`-owned findings (#1/#24/#15/#9) to an upstream report rather than fixing them in-repo. This closes **#24** (weak HMAC secret key) at pay-kit's own boundary as defense-in-depth, without forking or vendoring `mppx`.

`mppx@0.5.x` accepts any non-empty `secretKey` as the HMAC-SHA256 key that binds challenge IDs, so a weak key (e.g. `"key"`) lets an attacker forge challenges. Per NIST SP 800-107 the HMAC-SHA256 key should be at least the hash output size (32 bytes).

## How

`server/secret-guard.ts` wraps `Mppx.create` and rejects a resolved secret shorter than 32 bytes, checking both the explicit `secretKey` and the `MPP_SECRET_KEY` env path. When no secret is set at all it stays silent and defers to mppx's own error, so it owns only the strength check. This mirrors the existing `challenge-guard.ts` boundary pattern and touches only the secret-strength gate, never signing or settlement.

`server/index.ts` now re-exports the guarded `Mppx` so `import { Mppx } from '@solana/mpp/server'` gets the floor automatically.

## Notes

- The authoritative fix belongs upstream in `mppx` (alongside #1/#15/#9); this is the pay-kit-side guard until that lands.
- Bumps test secrets that were under the new floor (cross-route unit, integration, pay-kit adapter).

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean
- Full TS suite: 467 passed (4 new guard tests covering explicit/env, short/at-floor)
- The full-suite run surfaced that pay-kit's adapter production path now enforces the floor too (intended)

Based on the #169 branch; will retarget to main once #169 merges.