### PR TITLE
ci: shared setup-harness composite action

### DIFF
--- a/.github/actions/setup-harness/action.yml
+++ b/.github/actions/setup-harness/action.yml
@@ -1,0 +1,81 @@
+name: Setup PayKit harness
+description: >-
+  Shared setup for the cross-language PayKit harness jobs: pnpm + Node, build
+  @solana/mpp, (optionally) build the Rust harness adapter binaries, install the
+  harness, and typecheck it. Each language workflow adds only its own toolchain,
+  adapter build, and smoke run on top of this.
+
+inputs:
+  cargo-bins:
+    description: >-
+      Space-separated "pkg:bin[,bin...]" specs of Rust harness adapters to build,
+      e.g. "solana-mpp:harness_client solana-x402:harness_client" or
+      "solana-mpp:harness_client,harness_server". Empty (default) skips Rust
+      setup entirely (for languages that only test against the TypeScript spine).
+    required: false
+    default: ""
+  cargo-cache-key:
+    description: Language id used to namespace the cargo cache key.
+    required: false
+    default: harness
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v5
+      with:
+        package_json_file: package.json
+    - uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: pnpm
+        cache-dependency-path: typescript/pnpm-lock.yaml
+
+    - name: Install TypeScript workspace
+      working-directory: typescript
+      shell: bash
+      run: pnpm install --frozen-lockfile
+    - name: Build @solana/mpp
+      working-directory: typescript
+      shell: bash
+      run: pnpm --filter @solana/mpp build
+
+    - name: Set up Rust toolchain
+      if: inputs.cargo-bins != ''
+      uses: dtolnay/rust-toolchain@stable
+    - name: Cache cargo registry + target
+      if: inputs.cargo-bins != ''
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          rust/target
+        key: ${{ runner.os }}-cargo-${{ inputs.cargo-cache-key }}-harness-${{ hashFiles('rust/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-${{ inputs.cargo-cache-key }}-harness-
+    - name: Build Rust harness adapters
+      if: inputs.cargo-bins != ''
+      working-directory: rust
+      shell: bash
+      env:
+        CARGO_BINS: ${{ inputs.cargo-bins }}
+      run: |
+        set -euo pipefail
+        for spec in $CARGO_BINS; do
+          pkg="${spec%%:*}"
+          bins="${spec#*:}"
+          args=()
+          IFS=',' read -ra parts <<< "$bins"
+          for b in "${parts[@]}"; do args+=(--bin "$b"); done
+          echo "cargo build -p $pkg ${args[*]}"
+          cargo build -p "$pkg" "${args[@]}"
+        done
+
+    - name: Install harness
+      working-directory: harness
+      shell: bash
+      run: pnpm install --frozen-lockfile
+    - name: Typecheck harness
+      working-directory: harness
+      shell: bash
+      run: pnpm typecheck

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -87,41 +87,10 @@ jobs:
         with:
           go-version-file: go/go.mod
           cache-dependency-path: go/go.sum
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v5
+      - uses: ./.github/actions/setup-harness
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            rust/target
-          key: ${{ runner.os }}-cargo-go-harness-${{ hashFiles('rust/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-go-harness-
-      - uses: pnpm/action-setup@v5
-        with:
-          package_json_file: package.json
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: typescript/pnpm-lock.yaml
-      - name: Install TypeScript workspace
-        working-directory: typescript
-        run: pnpm install --frozen-lockfile
-      - name: Build TypeScript package
-        working-directory: typescript
-        run: pnpm --filter @solana/mpp build
-      - name: Build Rust harness client
-        working-directory: rust
-        run: cargo build -p solana-mpp --bin harness_client
-      - name: Build Rust x402 harness client
-        working-directory: rust
-        run: cargo build -p solana-x402 --bin harness_client
-      - name: Install harness
-        working-directory: harness
-        run: pnpm install --frozen-lockfile
-      - name: Typecheck harness
-        working-directory: harness
-        run: pnpm typecheck
+          cargo-bins: "solana-mpp:harness_client solana-x402:harness_client"
+          cargo-cache-key: go
       - name: Build Go paykit harness server
         working-directory: harness/go-server
         run: go build -o paykit-server .


### PR DESCRIPTION
## What
Factors the duplicated harness CI setup (pnpm+node → build @solana/mpp → build Rust harness adapters → install + typecheck harness) into a single composite action `.github/actions/setup-harness`, and adopts it in `go.yml` first.

## Why
Every language harness job (go/python/ruby/lua/swift/kotlin/php + the TS job in ci.yml) repeats the same ~9 setup steps. A single harness change currently fans out into N divergent edits (and broke 8 jobs at once recently). One composite action removes the duplication.

## Rollout
- This PR: composite action + `go.yml` (proving slice, validates the local-action path + cargo-bins parsing in real CI).
- Follow-up: convert python/ruby/lua/swift/kotlin/php + ci.yml's TS harness job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)