### PR TITLE
fix(go): repair playground x402 routing

### DIFF
--- a/go/examples/playground-api/README.md
+++ b/go/examples/playground-api/README.md
@@ -5,17 +5,20 @@ the HTTP API behind the [pay-kit playground](../../../playground/). It serves
 the same endpoints with the same payment gating semantics against the Solana
 Payment Sandbox (a hosted test validator, no real funds):
 
-- **Charges**: `solana.charge` endpoints (stock quote, marketplace purchase
-  with multi-recipient splits, fortune payment link) gated through the Go
+- **Charges**: TS-style quote and joke endpoints, legacy stock/weather and
+  marketplace endpoints, and the fortune payment link gated through the Go
   `paykit` umbrella client, plus a faucet that funds wallets through surfpool
-  cheatcodes.
-- **Sessions**: the in-process Go session method gating `/sessions/stream`
-  (pay-per-chunk SSE) and `/sessions/compute` (pay-per-call), with real
+  cheatcodes. `/api/v1/quote/:symbol` and `/api/v1/fortune` advertise both
+  x402 exact and MPP charge.
+- **Sessions**: the in-process Go session method gating `/api/v1/stream`
+  (pay-per-chunk SSE, also served at `/sessions/stream`) and
+  `/sessions/compute` (pay-per-call), with real
   payment-channel opens (server-completed fee-payer signature), voucher
   metering through the `/__402/session/*` side channel, and on-chain
   settlement via the idle-close watchdog.
-- **x402**: two `exact`-scheme demo routes plus the embedded facilitator
-  endpoints.
+- **x402**: the TS-style `/api/v1/summarize` usage endpoint, two legacy
+  `exact`-scheme demo routes, one legacy `upto` route, plus the embedded
+  facilitator endpoints.
 - `/openapi.json`: the endpoint catalog and wallet/network metadata the web
   app renders from `x-payment-info.offers[]`.
 - `/api/v1/config`: a legacy JSON catalog kept for direct smoke tests and
@@ -77,13 +80,18 @@ when the binary runs outside the repository checkout, and the standard
 | GET | `/api/v1/docs`, `/api/v1/docs/:lang/tree`, `/api/v1/docs/:lang/file` | free |
 | GET | `/api/v1/faucet/status` | free |
 | POST | `/api/v1/faucet/airdrop` | free |
+| GET | `/api/v1/quote/:symbol` | x402 exact or MPP charge 0.01 USDC |
+| GET | `/api/v1/joke` | MPP charge 0.01 USDC |
+| POST | `/api/v1/summarize` | x402 upto, cap 0.10 USDC |
+| GET | `/api/v1/stream` | session, cap 1.00 USDC, 0.0001 USDC/chunk |
+| POST | `/api/v1/stream` | session voucher commits |
 | GET | `/api/v1/stocks/quote/:symbol` | charge 0.01 USDC |
 | GET | `/api/v1/stocks/search?q=` | charge 0.01 USDC |
 | GET | `/api/v1/stocks/history/:symbol` | charge 0.05 USDC |
 | GET | `/api/v1/weather/:city` | charge 0.01 USDC |
 | GET | `/api/v1/marketplace/products` | free |
 | GET | `/api/v1/marketplace/buy/:productId?referrer=` | charge with splits |
-| GET | `/api/v1/fortune` | charge 0.01 USDC, HTML payment link |
+| GET | `/api/v1/fortune` | x402 exact or MPP charge 0.01 USDC, HTML payment link |
 | GET | `/api/v1/premium/feed` | 501 stub (see below) |
 | GET | `/sessions/stream` | session, cap 1.00 USDC, 0.0001 USDC/chunk |
 | POST | `/sessions/stream` | session voucher commits |
@@ -94,6 +102,7 @@ when the binary runs outside the repository checkout, and the standard
 | GET | `/facilitator/supported` | free |
 | POST | `/facilitator/verify`, `/facilitator/settle` | free |
 | GET | `/x402/joke`, `/x402/fact` | x402 exact, $0.001 |
+| GET | `/x402/usage` | x402 upto, cap 1.00 USDC |
 
 As in the TypeScript example, `/openapi.json` is the discovery endpoint the
 playground app reads.
@@ -111,10 +120,16 @@ faithful behavior is served and listed here:
    The endpoint catalog omits the subscription entry, which is exactly how
    the TypeScript server behaves when its plan bootstrap fails, so the
    playground UI renders its graceful empty state.
-2. **x402 gating is self-hosted**: the TypeScript routes are gated by
+2. **Fortune keeps the HTML payment link**: `/api/v1/fortune` advertises
+   the same dual x402/MPP fixed charge as the TypeScript server for API
+   clients. Browser HTML and service-worker requests still use the
+   protocol-layer MPP server so the payment-link E2E keeps exercising the
+   hosted pay.sh-style challenge page.
+3. **x402 gating is self-hosted**: the TypeScript routes are gated by
    `x402-express` POSTing to the embedded facilitator; the Go x402 adapter
-   only implements self-hosted mode, so `/x402/joke` and `/x402/fact` verify
-   and settle in-process with the operator signer. The
+   only implements self-hosted mode, so `/api/v1/summarize`, `/x402/joke`,
+   `/x402/fact`, and `/x402/usage` verify and settle in-process with the
+   operator signer. The
    `/facilitator/supported|verify|settle` endpoints are still served with
    the same response shapes for external x402 clients. The challenge
    advertises the configured `NETWORK` instead of the TypeScript example's

--- a/go/examples/playground-api/charges.go
+++ b/go/examples/playground-api/charges.go
@@ -1,10 +1,8 @@
 package main
 
-// Charge-gated endpoints: stock data, weather, a marketplace purchase with
-// multi-recipient splits (all gated through the paykit umbrella client), and
-// the fortune payment link served straight from the protocol-layer MPP
-// server with the HTML challenge page enabled. The 402 challenge fires
-// before any upstream fetch.
+// Charge-gated endpoints: TS-reference playground routes, stock data,
+// weather, a marketplace purchase with multi-recipient splits, and the
+// fortune payment link. The 402 challenge fires before any upstream fetch.
 
 import (
 	"fmt"
@@ -109,7 +107,7 @@ func displayUSD(p paykit.Price) string {
 
 // registerCharges mounts every charge-gated endpoint plus the free
 // marketplace catalog.
-func registerCharges(mux *http.ServeMux, a *app, client *paykit.Client) error {
+func registerCharges(mux *http.ServeMux, a *app, client *paykit.Client, dualClient *paykit.Client) error {
 	platform := a.recipient
 
 	// logged surfaces the settlement signature once a gated handler runs.
@@ -131,6 +129,38 @@ func registerCharges(mux *http.ServeMux, a *app, client *paykit.Client) error {
 			}, nil
 		}
 	}
+
+	// TS-reference fixed charge: clean path, dual-protocol challenge.
+	mux.Handle("GET /api/v1/quote/{symbol}",
+		dualClient.RequireFunc(staticGate("0.01", "quote", func(r *http.Request) string {
+			return "Stock quote: " + r.PathValue("symbol")
+		}))(logged(func(w http.ResponseWriter, r *http.Request) {
+			symbol := strings.ToUpper(r.PathValue("symbol"))
+			via := ""
+			if payment, ok := paykit.PaymentFrom(r.Context()); ok {
+				via = string(payment.Protocol)
+			}
+			price := 100
+			if symbol != "" {
+				price += int(symbol[0]) % 50
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"price":  price,
+				"symbol": symbol,
+				"via":    via,
+			})
+		})))
+
+	mux.Handle("GET /api/v1/joke",
+		client.Require(paykit.Gate{
+			Amount: paykit.MustParseUSD("0.01"),
+			Name:   "joke",
+			Desc:   "A programmer joke",
+		})(logged(func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, http.StatusOK, map[string]string{
+				"joke": jokes[rand.Intn(len(jokes))],
+			})
+		})))
 
 	// Stocks, backed by the same Yahoo Finance endpoints (and response
 	// shapes) as the yahoo-finance2 package the TypeScript server uses.
@@ -246,10 +276,20 @@ func registerCharges(mux *http.ServeMux, a *app, client *paykit.Client) error {
 			})
 		}))))
 
-	// Fortune: a charge payment link with the interactive HTML challenge
-	// page. Stays on the protocol layer directly (server.Mpp with HTML
-	// enabled) because the paykit dispatcher renders the cross-SDK JSON
-	// challenge body; dropping down a layer is the intended escape hatch.
+	fortuneJSON := dualClient.Require(paykit.Gate{
+		Amount: paykit.MustParseUSD("0.01"),
+		Name:   "fortune",
+		Desc:   "A fortune cookie",
+	})(logged(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{
+			"fortune": fortunes[rand.Intn(len(fortunes))],
+		})
+	}))
+
+	// Fortune's API surface follows the TypeScript server (dual x402 exact
+	// or MPP charge). Browser payment-link requests still drop to the
+	// protocol-layer MPP server so the HTML challenge and service worker flow
+	// remain available for the payment-link E2E.
 	fortuneMpp, err := server.New(server.Config{
 		Recipient:      a.recipient,
 		Currency:       paycore.USDCMainnetMint,
@@ -278,7 +318,11 @@ func registerCharges(mux *http.ServeMux, a *app, client *paykit.Client) error {
 		if server.IsServiceWorkerRequest(r) {
 			w.Header().Set("Service-Worker-Allowed", "/")
 		}
-		fortuneHandler.ServeHTTP(w, r)
+		if server.IsServiceWorkerRequest(r) || server.AcceptsHTML(r) {
+			fortuneHandler.ServeHTTP(w, r)
+			return
+		}
+		fortuneJSON.ServeHTTP(w, r)
 	})
 
 	return nil

--- a/go/examples/playground-api/discovery.go
+++ b/go/examples/playground-api/discovery.go
@@ -57,26 +57,44 @@ func buildOpenAPIDoc(a *app) openAPIDoc {
 			"version": "1.0.0",
 		},
 		Paths: map[string]map[string]openAPIOperation{
-			"/api/v1/stocks/quote/{symbol}": {
-				"get": pricedOperation("Stock quote", openAPIOffer{
-					Amount:      "10000",
-					Description: "0.01 USDC",
-					Intent:      "charge",
-					Method:      "mpp",
-					Scheme:      "charge",
-				}, a),
-			},
-			"/api/v1/stocks/history/{symbol}": {
-				"get": pricedOperation("Stock history", openAPIOffer{
-					Amount:      "50000",
-					Description: "0.05 USDC",
-					Intent:      "charge",
-					Method:      "mpp",
-					Scheme:      "charge",
+			"/api/v1/quote/{symbol}": {
+				"get": pricedOperationMany("Stock quote", []openAPIOffer{
+					{
+						Amount:      "10000",
+						Description: "0.01 USDC",
+						Intent:      "charge",
+						Method:      "x402",
+						Scheme:      "exact",
+					},
+					{
+						Amount:      "10000",
+						Description: "0.01 USDC",
+						Intent:      "charge",
+						Method:      "mpp",
+						Scheme:      "charge",
+					},
 				}, a),
 			},
 			"/api/v1/fortune": {
-				"get": pricedOperation("Fortune cookie", openAPIOffer{
+				"get": pricedOperationMany("Fortune cookie", []openAPIOffer{
+					{
+						Amount:      "10000",
+						Description: "0.01 USDC",
+						Intent:      "charge",
+						Method:      "x402",
+						Scheme:      "exact",
+					},
+					{
+						Amount:      "10000",
+						Description: "0.01 USDC",
+						Intent:      "charge",
+						Method:      "mpp",
+						Scheme:      "charge",
+					},
+				}, a),
+			},
+			"/api/v1/joke": {
+				"get": pricedOperation("A programmer joke", openAPIOffer{
 					Amount:      "10000",
 					Description: "0.01 USDC",
 					Intent:      "charge",
@@ -84,8 +102,17 @@ func buildOpenAPIDoc(a *app) openAPIDoc {
 					Scheme:      "charge",
 				}, a),
 			},
-			"/sessions/stream": {
-				"get": pricedOperation("Metered stream", openAPIOffer{
+			"/api/v1/summarize": {
+				"post": pricedOperation("Summarize text, billed per token", openAPIOffer{
+					Amount:      "100000",
+					Description: "up to 0.10 USDC",
+					Intent:      "charge",
+					Method:      "x402",
+					Scheme:      "upto",
+				}, a),
+			},
+			"/api/v1/stream": {
+				"get": pricedOperation("Metered token stream", openAPIOffer{
 					Amount:      "1000000",
 					Description: "up to 1.00 USDC",
 					Intent:      "session",
@@ -94,48 +121,29 @@ func buildOpenAPIDoc(a *app) openAPIDoc {
 					UnitPrice:   "100",
 				}, a),
 			},
-			"/sessions/compute": {
-				"post": pricedOperation("Pay-per-call compute", openAPIOffer{
-					Amount:      "500000",
-					Description: "up to 0.50 USDC",
-					Intent:      "session",
-					Method:      "mpp",
-					Scheme:      "session",
-					UnitPrice:   "5000",
-				}, a),
-			},
-			"/x402/joke": {
-				"get": pricedOperation("x402 joke", openAPIOffer{
-					Amount:      "1000",
-					Description: "0.001 USDC",
-					Intent:      "charge",
-					Method:      "x402",
-					Scheme:      "exact",
-				}, a),
-			},
-			"/x402/fact": {
-				"get": pricedOperation("x402 fact", openAPIOffer{
-					Amount:      "1000",
-					Description: "0.001 USDC",
-					Intent:      "charge",
-					Method:      "x402",
-					Scheme:      "exact",
-				}, a),
-			},
-			"/x402/usage": {
-				"get": pricedOperation("Usage-metered endpoint", openAPIOffer{
-					Amount:      "1000000",
-					Description: "up to 1.00 USDC",
-					Intent:      "charge",
-					Method:      "x402",
-					Scheme:      "upto",
-				}, a),
-			},
 		},
 	}
 }
 
 func pricedOperation(summary string, offer openAPIOffer, a *app) openAPIOperation {
+	return pricedOperationMany(summary, []openAPIOffer{offer}, a)
+}
+
+func pricedOperationMany(summary string, offers []openAPIOffer, a *app) openAPIOperation {
+	for i := range offers {
+		offers[i] = withPaymentContext(offers[i], a)
+	}
+	return openAPIOperation{
+		Responses: map[string]openAPIResponse{
+			"200": {Description: "Successful response"},
+			"402": {Description: "Payment Required"},
+		},
+		Summary:      summary,
+		XPaymentInfo: openAPIPaymentInfo{Offers: offers},
+	}
+}
+
+func withPaymentContext(offer openAPIOffer, a *app) openAPIOffer {
 	offer.Currency = "USDC"
 	offer.FeePayer = a.feePayer.PublicKey().String()
 	offer.Network = a.network
@@ -143,12 +151,5 @@ func pricedOperation(summary string, offer openAPIOffer, a *app) openAPIOperatio
 		offer.Network = network.CAIP2()
 	}
 	offer.PayTo = a.recipient
-	return openAPIOperation{
-		Responses: map[string]openAPIResponse{
-			"200": {Description: "Successful response"},
-			"402": {Description: "Payment Required"},
-		},
-		Summary:      summary,
-		XPaymentInfo: openAPIPaymentInfo{Offers: []openAPIOffer{offer}},
-	}
+	return offer
 }

--- a/go/examples/playground-api/main.go
+++ b/go/examples/playground-api/main.go
@@ -133,7 +133,11 @@ func newApp(a *app) (http.Handler, func(), error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("charges paykit client: %w", err)
 	}
-	if err := registerCharges(mux, a, chargesClient); err != nil {
+	dualChargeClient, err := newDualChargeClient(a)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dual charge paykit client: %w", err)
+	}
+	if err := registerCharges(mux, a, chargesClient, dualChargeClient); err != nil {
 		return nil, nil, fmt.Errorf("charges module: %w", err)
 	}
 
@@ -157,6 +161,26 @@ func newApp(a *app) (http.Handler, func(), error) {
 // newChargesClient builds the paykit client gating the charge endpoints.
 // MPP is the only accepted protocol.
 func newChargesClient(a *app) (*paykit.Client, error) {
+	return newPaymentClient(a, []paykit.Protocol{paykit.MPP}, "")
+}
+
+// newDualChargeClient builds the TS-reference style fixed-price client.
+// The client advertises x402 exact and MPP charge, letting the browser pick.
+func newDualChargeClient(a *app) (*paykit.Client, error) {
+	return newPaymentClient(a, []paykit.Protocol{paykit.X402, paykit.MPP}, "exact")
+}
+
+// newX402ExactClient builds the x402 exact client used by legacy routes.
+func newX402ExactClient(a *app) (*paykit.Client, error) {
+	return newPaymentClient(a, []paykit.Protocol{paykit.X402}, "exact")
+}
+
+// newX402UsageClient builds the x402 upto client used by usage routes.
+func newX402UsageClient(a *app) (*paykit.Client, error) {
+	return newPaymentClient(a, []paykit.Protocol{paykit.X402}, "upto")
+}
+
+func newPaymentClient(a *app, accept []paykit.Protocol, x402Scheme string) (*paykit.Client, error) {
 	network, err := paykit.ParseNetwork(a.network)
 	if err != nil {
 		return nil, err
@@ -168,7 +192,7 @@ func newChargesClient(a *app) (*paykit.Client, error) {
 	return paykit.New(paykit.Config{
 		Network: network,
 		RPCURL:  a.rpcURL,
-		Accept:  []paykit.Protocol{paykit.MPP},
+		Accept:  accept,
 		Operator: paykit.Operator{
 			Recipient: paykit.Address(a.recipient),
 			Signer:    operatorSigner,
@@ -177,6 +201,9 @@ func newChargesClient(a *app) (*paykit.Client, error) {
 		MPP: paykit.MPPConfig{
 			Realm:                  "PayKit Playground",
 			ChallengeBindingSecret: []byte(a.secretKey),
+		},
+		X402: paykit.X402Config{
+			Scheme: x402Scheme,
 		},
 	})
 }
@@ -284,53 +311,57 @@ type endpointInfo struct {
 
 // buildEndpointList builds the /api/v1/config endpoint catalog. The
 // subscription entry is omitted because the Go SDK has no subscription
-// server method (see README.md); the stocks-search / stocks-history /
-// weather / fortune / x402 routes stay live server-side but are not
+// server method (see README.md); the legacy stocks-search / stocks-history /
+// weather / marketplace / x402 routes stay live server-side but are not
 // advertised in the nav.
 func buildEndpointList() []endpointInfo {
 	return []endpointInfo{
 		{
-			ID:          "stocks-quote",
+			ID:          "quote",
 			Primitive:   "charge",
 			Method:      "GET",
-			Path:        "/api/v1/stocks/quote/:symbol",
+			Path:        "/api/v1/quote/:symbol",
 			Title:       "Stock quote",
-			Description: "Real-time price for a single ticker.",
+			Description: "Dual x402 exact or MPP charge.",
 			Cost:        "0.01 USDC",
-			Params:      []endpointParam{{Name: "symbol", Default: "AAPL"}},
+			Params:      []endpointParam{{Name: "symbol", Default: "SPCX"}},
 		},
 		{
-			ID:          "marketplace-buy",
+			ID:          "fortune",
 			Primitive:   "charge",
 			Method:      "GET",
-			Path:        "/api/v1/marketplace/buy/:productId",
-			Title:       "Marketplace purchase",
-			Description: "Multi-recipient split (seller + platform + referral).",
-			Cost:        "varies",
-			Params: []endpointParam{
-				{Name: "productId", Default: "sol-hoodie"},
-				{Name: "referrer", Default: ""},
-			},
+			Path:        "/api/v1/fortune",
+			Title:       "Fortune cookie",
+			Description: "Dual x402 exact or MPP charge, with HTML payment link support.",
+			Cost:        "0.01 USDC",
+		},
+		{
+			ID:          "joke",
+			Primitive:   "charge",
+			Method:      "GET",
+			Path:        "/api/v1/joke",
+			Title:       "A programmer joke",
+			Description: "MPP charge.",
+			Cost:        "0.01 USDC",
+		},
+		{
+			ID:          "summarize",
+			Primitive:   "x402",
+			Method:      "POST",
+			Path:        "/api/v1/summarize",
+			Title:       "Summarize text, billed per token",
+			Description: "x402 upto usage.",
+			Cost:        "up to 0.10 USDC",
 		},
 		{
 			ID:          "sessions-stream",
 			Primitive:   "session",
 			Method:      "GET",
-			Path:        "/sessions/stream",
-			Title:       "Metered stream",
+			Path:        "/api/v1/stream",
+			Title:       "Metered token stream",
 			Description: "Pay-per-chunk SSE delivery via session vouchers.",
 			Cost:        "0.0001 USDC / chunk",
 			UnitPrice:   "100",
-		},
-		{
-			ID:          "sessions-compute",
-			Primitive:   "session",
-			Method:      "POST",
-			Path:        "/sessions/compute",
-			Title:       "Pay-per-call compute",
-			Description: "Voucher-billed inference; cap 0.50 USDC per session.",
-			Cost:        "0.005 USDC / call",
-			UnitPrice:   "5000",
 		},
 	}
 }
@@ -342,7 +373,8 @@ func corsMiddleware(next http.Handler) http.Handler {
 		header := w.Header()
 		header.Set("Access-Control-Allow-Origin", "*")
 		header.Set("Access-Control-Expose-Headers",
-			"www-authenticate, payment-receipt, x-payment-required, x-payment-response")
+			"www-authenticate, payment-required, payment-response, payment-receipt, "+
+				"x-payment-required, x-payment-response, x-payment-settlement-signature")
 		if r.Method == http.MethodOptions {
 			header.Set("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE")
 			if requested := r.Header.Get("Access-Control-Request-Headers"); requested != "" {

--- a/go/examples/playground-api/main_test.go
+++ b/go/examples/playground-api/main_test.go
@@ -176,13 +176,16 @@ func TestPlaygroundEndpoints(t *testing.T) {
 		for _, e := range config.Endpoints {
 			ids[e.ID] = e
 		}
-		for _, want := range []string{"stocks-quote", "marketplace-buy", "sessions-stream", "sessions-compute"} {
+		for _, want := range []string{"quote", "fortune", "joke", "summarize", "sessions-stream"} {
 			if _, ok := ids[want]; !ok {
 				t.Fatalf("catalog missing %q: %s", want, body)
 			}
 		}
-		if ids["sessions-stream"].UnitPrice != "100" || ids["sessions-compute"].UnitPrice != "5000" {
-			t.Fatalf("unit prices = %q / %q", ids["sessions-stream"].UnitPrice, ids["sessions-compute"].UnitPrice)
+		if ids["sessions-stream"].Path != "/api/v1/stream" || ids["sessions-stream"].UnitPrice != "100" {
+			t.Fatalf("stream catalog = %+v", ids["sessions-stream"])
+		}
+		if ids["quote"].Path != "/api/v1/quote/:symbol" || ids["summarize"].Primitive != "x402" {
+			t.Fatalf("catalog = %+v / %+v", ids["quote"], ids["summarize"])
 		}
 		if _, ok := ids["premium-feed"]; ok {
 			t.Fatal("catalog must omit the subscription entry (no Go subscription method)")
@@ -199,36 +202,55 @@ func TestPlaygroundEndpoints(t *testing.T) {
 		if doc.OpenAPI != "3.1.0" {
 			t.Fatalf("openapi = %q", doc.OpenAPI)
 		}
-		quote := doc.Paths["/api/v1/stocks/quote/{symbol}"]["get"]
-		if quote.Summary != "Stock quote" || len(quote.XPaymentInfo.Offers) != 1 {
+		quote := doc.Paths["/api/v1/quote/{symbol}"]["get"]
+		if quote.Summary != "Stock quote" || len(quote.XPaymentInfo.Offers) != 2 {
 			t.Fatalf("quote operation = %+v", quote)
 		}
 		if quote.Responses["200"].Description == "" || quote.Responses["402"].Description == "" {
 			t.Fatalf("quote responses = %+v", quote.Responses)
 		}
-		offer := quote.XPaymentInfo.Offers[0]
-		if offer.Method != "mpp" || offer.Intent != "charge" ||
-			offer.PayTo != a.recipient || offer.Network != paykit.SolanaLocalnet.CAIP2() ||
-			offer.FeePayer != a.feePayer.PublicKey().String() {
-			t.Fatalf("quote offer = %+v", offer)
+		quoteMethods := map[string]openAPIOffer{}
+		for _, offer := range quote.XPaymentInfo.Offers {
+			quoteMethods[offer.Method] = offer
 		}
-		fortune := doc.Paths["/api/v1/fortune"]["get"].XPaymentInfo.Offers[0]
-		if fortune.Amount != "10000" || fortune.Scheme != "charge" {
-			t.Fatalf("fortune offer = %+v", fortune)
+		for _, method := range []string{"x402", "mpp"} {
+			offer, ok := quoteMethods[method]
+			if !ok || offer.Intent != "charge" ||
+				offer.PayTo != a.recipient || offer.Network != paykit.SolanaLocalnet.CAIP2() ||
+				offer.FeePayer != a.feePayer.PublicKey().String() {
+				t.Fatalf("quote %s offer = %+v", method, offer)
+			}
 		}
-		stream := doc.Paths["/sessions/stream"]["get"].XPaymentInfo.Offers[0]
+		if quoteMethods["x402"].Scheme != "exact" || quoteMethods["mpp"].Scheme != "charge" {
+			t.Fatalf("quote offers = %+v", quote.XPaymentInfo.Offers)
+		}
+		fortuneMethods := map[string]openAPIOffer{}
+		for _, offer := range doc.Paths["/api/v1/fortune"]["get"].XPaymentInfo.Offers {
+			fortuneMethods[offer.Method] = offer
+		}
+		if fortuneMethods["x402"].Scheme != "exact" || fortuneMethods["x402"].Amount != "10000" ||
+			fortuneMethods["mpp"].Scheme != "charge" || fortuneMethods["mpp"].Amount != "10000" {
+			t.Fatalf("fortune offers = %+v", doc.Paths["/api/v1/fortune"]["get"].XPaymentInfo.Offers)
+		}
+		joke := doc.Paths["/api/v1/joke"]["get"].XPaymentInfo.Offers[0]
+		if joke.Amount != "10000" || joke.Method != "mpp" || joke.Scheme != "charge" {
+			t.Fatalf("joke offer = %+v", joke)
+		}
+		stream := doc.Paths["/api/v1/stream"]["get"].XPaymentInfo.Offers[0]
 		if stream.Intent != "session" || stream.UnitPrice != "100" {
 			t.Fatalf("stream offer = %+v", stream)
 		}
-		usage := doc.Paths["/x402/usage"]["get"].XPaymentInfo.Offers[0]
-		if usage.Method != "x402" || usage.Intent != "charge" || usage.Scheme != "upto" {
-			t.Fatalf("usage offer = %+v", usage)
+		summarize := doc.Paths["/api/v1/summarize"]["post"].XPaymentInfo.Offers[0]
+		if summarize.Method != "x402" || summarize.Intent != "charge" ||
+			summarize.Scheme != "upto" || summarize.Amount != "100000" {
+			t.Fatalf("summarize offer = %+v", summarize)
 		}
 	})
 
 	t.Run("charge endpoints issue MPP challenges", func(t *testing.T) {
 		for _, path := range []string{
 			"/api/v1/stocks/quote/AAPL",
+			"/api/v1/joke",
 			"/api/v1/stocks/search?q=apple",
 			"/api/v1/stocks/history/AAPL",
 			"/api/v1/weather/tokyo",
@@ -255,6 +277,30 @@ func TestPlaygroundEndpoints(t *testing.T) {
 		}
 	})
 
+	t.Run("fixed TS-reference endpoints issue dual protocol challenges", func(t *testing.T) {
+		for _, path := range []string{"/api/v1/quote/SPCX", "/api/v1/fortune"} {
+			response, body := doRequest(t, http.MethodGet, base+path, "", nil)
+			if response.StatusCode != http.StatusPaymentRequired {
+				t.Fatalf("%s status = %d: %s", path, response.StatusCode, body)
+			}
+			var challenge struct {
+				Error   string `json:"error"`
+				Accepts []struct {
+					Protocol string `json:"protocol"`
+					Scheme   string `json:"scheme"`
+				} `json:"accepts"`
+			}
+			decodeBody(t, body, &challenge)
+			seen := map[string]string{}
+			for _, accept := range challenge.Accepts {
+				seen[accept.Protocol] = accept.Scheme
+			}
+			if challenge.Error != "payment_required" || seen["x402"] != "exact" || seen["mpp"] != "charge" {
+				t.Fatalf("%s challenge = %s", path, body)
+			}
+		}
+	})
+
 	t.Run("pre-gate validation runs before payment", func(t *testing.T) {
 		for path, wantStatus := range map[string]int{
 			"/api/v1/weather/atlantis":          http.StatusNotFound,
@@ -266,6 +312,17 @@ func TestPlaygroundEndpoints(t *testing.T) {
 			if response.StatusCode != wantStatus {
 				t.Fatalf("%s status = %d, want %d: %s", path, response.StatusCode, wantStatus, body)
 			}
+		}
+	})
+
+	t.Run("summarize body validation runs before payment", func(t *testing.T) {
+		response, body := doRequest(t, http.MethodPost, base+"/api/v1/summarize",
+			strings.Repeat("x", summarizeMaxBodyBytes+1), nil)
+		if response.StatusCode != http.StatusRequestEntityTooLarge || !strings.Contains(body, "body-too-large") {
+			t.Fatalf("status = %d body = %s", response.StatusCode, body)
+		}
+		if response.Header.Get("Payment-Required") != "" || response.Header.Get("WWW-Authenticate") != "" {
+			t.Fatalf("body validation should run before payment headers: %+v", response.Header)
 		}
 	})
 
@@ -308,17 +365,21 @@ func TestPlaygroundEndpoints(t *testing.T) {
 	})
 
 	t.Run("sessions issue session challenges", func(t *testing.T) {
-		for method, path := range map[string]string{
-			http.MethodGet:  "/sessions/stream",
-			http.MethodPost: "/sessions/compute",
+		for _, route := range []struct {
+			method string
+			path   string
+		}{
+			{method: http.MethodGet, path: "/sessions/stream"},
+			{method: http.MethodGet, path: "/api/v1/stream"},
+			{method: http.MethodPost, path: "/sessions/compute"},
 		} {
-			response, body := doRequest(t, method, base+path, "", nil)
+			response, body := doRequest(t, route.method, base+route.path, "", nil)
 			if response.StatusCode != http.StatusPaymentRequired {
-				t.Fatalf("%s %s status = %d: %s", method, path, response.StatusCode, body)
+				t.Fatalf("%s %s status = %d: %s", route.method, route.path, response.StatusCode, body)
 			}
 			wwwAuth := response.Header.Get("WWW-Authenticate")
 			if !strings.Contains(wwwAuth, "intent=\"session\"") {
-				t.Fatalf("%s WWW-Authenticate = %q", path, wwwAuth)
+				t.Fatalf("%s WWW-Authenticate = %q", route.path, wwwAuth)
 			}
 		}
 	})
@@ -412,6 +473,32 @@ func TestPlaygroundEndpoints(t *testing.T) {
 		}
 	})
 
+	t.Run("x402 usage routes issue upto challenges", func(t *testing.T) {
+		for method, path := range map[string]string{
+			http.MethodPost: "/api/v1/summarize",
+			http.MethodGet:  "/x402/usage",
+		} {
+			response, body := doRequest(t, method, base+path, "hello world", nil)
+			if response.StatusCode != http.StatusPaymentRequired {
+				t.Fatalf("%s %s status = %d: %s", method, path, response.StatusCode, body)
+			}
+			var challenge struct {
+				Error   string `json:"error"`
+				Accepts []struct {
+					Protocol string `json:"protocol"`
+					Scheme   string `json:"scheme"`
+				} `json:"accepts"`
+			}
+			decodeBody(t, body, &challenge)
+			if challenge.Error != "payment_required" ||
+				len(challenge.Accepts) != 1 ||
+				challenge.Accepts[0].Protocol != "x402" ||
+				challenge.Accepts[0].Scheme != "upto" {
+				t.Fatalf("%s %s challenge = %s", method, path, body)
+			}
+		}
+	})
+
 	t.Run("docs", func(t *testing.T) {
 		response, body := doRequest(t, http.MethodGet, base+"/api/v1/docs", "", nil)
 		if response.StatusCode != http.StatusOK || !strings.Contains(body, `"go":false`) {
@@ -440,7 +527,15 @@ func TestPlaygroundEndpoints(t *testing.T) {
 	t.Run("CORS exposes the payment headers", func(t *testing.T) {
 		response, _ := doRequest(t, http.MethodGet, base+"/api/v1/health", "", nil)
 		exposed := response.Header.Get("Access-Control-Expose-Headers")
-		for _, header := range []string{"www-authenticate", "payment-receipt", "x-payment-required", "x-payment-response"} {
+		for _, header := range []string{
+			"www-authenticate",
+			"payment-required",
+			"payment-response",
+			"payment-receipt",
+			"x-payment-required",
+			"x-payment-response",
+			"x-payment-settlement-signature",
+		} {
 			if !strings.Contains(exposed, header) {
 				t.Fatalf("expose headers = %q missing %q", exposed, header)
 			}
@@ -468,4 +563,16 @@ func TestPlaygroundEndpoints(t *testing.T) {
 			t.Fatalf("status = %d body = %s", response.StatusCode, body)
 		}
 	})
+}
+
+func TestSummarizeUsageClampsBilling(t *testing.T) {
+	billed, tokens := summarizeUsage(4, 100_000)
+	if billed != 100 || tokens != 1 {
+		t.Fatalf("small usage = %d/%d, want 100/1", billed, tokens)
+	}
+
+	billed, tokens = summarizeUsage(10_000_000, 100_000)
+	if billed != 100_000 || tokens <= 1 {
+		t.Fatalf("large usage = %d/%d, want clamped billed units", billed, tokens)
+	}
 }

--- a/go/examples/playground-api/sessions.go
+++ b/go/examples/playground-api/sessions.go
@@ -32,7 +32,9 @@ var tokenChunks = []string{
 //
 // Routes:
 //   - GET  /sessions/stream: pay-per-chunk SSE, cap 1.00 USDC, 0.0001 USDC/chunk
+//   - GET  /api/v1/stream: TS-reference alias for /sessions/stream
 //   - POST /sessions/stream: voucher commits for the stream endpoint
+//   - POST /api/v1/stream: TS-reference alias for voucher commits
 //   - POST /sessions/compute: pay-per-call compute, cap 0.50 USDC, 0.005 USDC/call
 //     (also accepts voucher commits)
 //   - POST /__402/session/deliveries: SessionFetch-style delivery reservation
@@ -91,8 +93,7 @@ func registerSessions(mux *http.ServeMux, a *app) (func(), error) {
 		return server.SessionChallengeOptions{Cap: "500000", Description: "Voucher-billed inference call"}, nil
 	})
 
-	// GET /sessions/stream: stream tokens as SSE; each chunk costs 0.0001 USDC.
-	mux.Handle("GET /sessions/stream", streamGate(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	streamHandler := streamGate(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		stream := server.NewMeteredStream(w)
 		w.WriteHeader(http.StatusOK)
 		for _, chunk := range tokenChunks {
@@ -102,14 +103,21 @@ func registerSessions(mux *http.ServeMux, a *app) (func(), error) {
 			time.Sleep(80 * time.Millisecond)
 		}
 		_ = stream.WriteDone()
-	})))
+	}))
+	// GET /sessions/stream and /api/v1/stream: stream tokens as SSE; each
+	// chunk costs 0.0001 USDC.
+	mux.Handle("GET /sessions/stream", streamHandler)
+	mux.Handle("GET /api/v1/stream", streamHandler)
 
-	// POST /sessions/stream: voucher commits arrive on the URL the session
-	// was opened against, with the signed voucher in the Authorization
-	// credential. The middleware's verify path applies it; the body is an ack.
-	mux.Handle("POST /sessions/stream", streamGate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	streamCommitHandler := streamGate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, commitAck(r))
-	})))
+	}))
+	// POST /sessions/stream and /api/v1/stream: voucher commits arrive on
+	// the URL the session was opened against, with the signed voucher in the
+	// Authorization credential. The middleware's verify path applies it; the
+	// body is an ack.
+	mux.Handle("POST /sessions/stream", streamCommitHandler)
+	mux.Handle("POST /api/v1/stream", streamCommitHandler)
 
 	// POST /sessions/compute: pay-per-call compute; the same handler also
 	// accepts voucher commits (a deliveryId in the body discriminates).

--- a/go/examples/playground-api/x402.go
+++ b/go/examples/playground-api/x402.go
@@ -9,12 +9,20 @@ package main
 // shapes for external x402 clients. See README.md.
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
 
-	"github.com/solana-foundation/pay-kit/go/paycore/signer"
 	"github.com/solana-foundation/pay-kit/go/paykit"
+)
+
+const (
+	summarizeMaxBodyBytes       = 1 << 20
+	summarizePricePerTokenUnits = 100
 )
 
 // jokes is the canned joke pool.
@@ -113,26 +121,13 @@ func registerX402(mux *http.ServeMux, a *app) error {
 		writeJSON(w, http.StatusOK, map[string]any{"success": true, "transaction": signature})
 	})
 
-	// x402-gated routes: a dedicated x402-only paykit client, self-hosted
+	// x402-gated routes: dedicated x402-only paykit clients, self-hosted
 	// verification + settlement against the configured RPC.
-	network, err := paykit.ParseNetwork(a.network)
+	exactClient, err := newX402ExactClient(a)
 	if err != nil {
 		return err
 	}
-	operatorSigner, err := signer.FromBase58(a.feePayer.String())
-	if err != nil {
-		return err
-	}
-	client, err := paykit.New(paykit.Config{
-		Network: network,
-		RPCURL:  a.rpcURL,
-		Accept:  []paykit.Protocol{paykit.X402},
-		Operator: paykit.Operator{
-			Recipient: paykit.Address(a.recipient),
-			Signer:    operatorSigner,
-			FeePayer:  true,
-		},
-	})
+	usageClient, err := newX402UsageClient(a)
 	if err != nil {
 		return err
 	}
@@ -142,7 +137,7 @@ func registerX402(mux *http.ServeMux, a *app) error {
 		Name:   "x402Joke",
 		Desc:   "A random programmer joke",
 	}
-	mux.Handle("GET /x402/joke", client.Require(jokeGate)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	mux.Handle("GET /x402/joke", exactClient.Require(jokeGate)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{
 			"joke":   jokes[rand.Intn(len(jokes))],
 			"source": "x402",
@@ -154,12 +149,39 @@ func registerX402(mux *http.ServeMux, a *app) error {
 		Name:   "x402Fact",
 		Desc:   "A random fun fact",
 	}
-	mux.Handle("GET /x402/fact", client.Require(factGate)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	mux.Handle("GET /x402/fact", exactClient.Require(factGate)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{
 			"fact":   facts[rand.Intn(len(facts))],
 			"source": "x402",
 		})
 	})))
+
+	summarizeGate := paykit.Gate{
+		Amount: paykit.MustParseUSD("0.10"),
+		Name:   "summarize",
+		Desc:   "Summarize text, billed per token",
+		Kind:   paykit.GateUsage,
+	}
+	summarizeHandler := usageClient.RequireUsage(summarizeGate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		charge, ok := paykit.ChargeFrom(r.Context())
+		if !ok {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "no charge meter"})
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid-body")
+			return
+		}
+		billedBaseUnits, tokens := summarizeUsage(len(body), charge.MaxBaseUnits())
+		charge.Charge(billedBaseUnits)
+		writeJSON(w, http.StatusOK, map[string]string{
+			"billedBaseUnits": strconv.FormatUint(billedBaseUnits, 10),
+			"summarizedBytes": strconv.FormatUint(uint64(len(body)), 10),
+			"tokens":          strconv.FormatUint(tokens, 10),
+		})
+	}))
+	mux.Handle("POST /api/v1/summarize", bufferRequestBody(summarizeMaxBodyBytes, summarizeHandler))
 
 	// Usage-gated route: the client opens a payment channel depositing
 	// the authorized ceiling; the handler meters the response and the
@@ -170,7 +192,7 @@ func registerX402(mux *http.ServeMux, a *app) error {
 		Desc:   "Usage-metered endpoint",
 		Kind:   paykit.GateUsage,
 	}
-	mux.Handle("GET /x402/usage", client.RequireUsage(usageGate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("GET /x402/usage", usageClient.RequireUsage(usageGate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		charge, ok := paykit.ChargeFrom(r.Context())
 		if !ok {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "no charge meter"})
@@ -188,4 +210,36 @@ func registerX402(mux *http.ServeMux, a *app) error {
 	})))
 
 	return nil
+}
+
+func summarizeUsage(bodyLen int, maxBaseUnits uint64) (uint64, uint64) {
+	tokens := uint64(bodyLen / 4)
+	if tokens < 1 {
+		tokens = 1
+	}
+	billedBaseUnits := tokens * summarizePricePerTokenUnits
+	if billedBaseUnits > maxBaseUnits {
+		billedBaseUnits = maxBaseUnits
+	}
+	return billedBaseUnits, tokens
+}
+
+func bufferRequestBody(maxBytes int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBytes))
+		if err != nil {
+			status := http.StatusBadRequest
+			code := "invalid-body"
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				status = http.StatusRequestEntityTooLarge
+				code = "body-too-large"
+			}
+			writeJSONError(w, status, code)
+			return
+		}
+		_ = r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		next.ServeHTTP(w, r)
+	})
 }

--- a/go/paykit/adapters/x402/exact.go
+++ b/go/paykit/adapters/x402/exact.go
@@ -199,7 +199,10 @@ func (a *Adapter) VerifyAndSettle(req *paykit.AdapterRequest) (*paykit.Payment, 
 		}
 		return nil, &paykit.PaymentError{Code: code, Err: err, Gate: req.Gate}
 	}
-	replayKey := tx.Signatures[0].String()
+	replayKey, err := transactionReplayKey(tx)
+	if err != nil {
+		return nil, &paykit.PaymentError{Code: "invalid_payload", Err: err, Gate: req.Gate}
+	}
 	if _, loaded := a.replay.LoadOrStore(replayKey, struct{}{}); loaded {
 		return nil, &paykit.PaymentError{Code: "signature_consumed", Err: errors.New("replay rejected"), Gate: req.Gate}
 	}
@@ -249,6 +252,15 @@ func (a *Adapter) VerifyAndSettle(req *paykit.AdapterRequest) (*paykit.Payment, 
 		SettlementHeaders: headers,
 		Raw:               sig,
 	}, nil
+}
+
+func transactionReplayKey(tx *solana.Transaction) (string, error) {
+	for _, sig := range tx.Signatures {
+		if !sig.IsZero() {
+			return sig.String(), nil
+		}
+	}
+	return "", errors.New("transaction carries no non-zero signer signature")
 }
 
 func (a *Adapter) verifyLegacyBinding(gate *paykit.Gate, credential *proto.Credential) error {

--- a/go/paykit/adapters/x402/verify_test.go
+++ b/go/paykit/adapters/x402/verify_test.go
@@ -339,7 +339,7 @@ func settleFixture(t *testing.T, fake *fakeRPC) (*Adapter, *paykit.Gate, string)
 				{ProgramIDIndex: 6, Accounts: []uint16{1, 2, 3, 4}, Data: transferData},
 			},
 		},
-		Signatures: []solana.Signature{{}},
+		Signatures: []solana.Signature{{}, solana.MustSignatureFromBase58(sampleClientSig)},
 	}
 	wire, err := tx.MarshalBinary()
 	if err != nil {
@@ -430,6 +430,26 @@ func TestVerifyAndSettleReplayRejected(t *testing.T) {
 	}
 }
 
+func TestTransactionReplayKeySkipsSponsoredFeePayerSlot(t *testing.T) {
+	clientSig := solana.MustSignatureFromBase58(sampleClientSig)
+	tx := &solana.Transaction{Signatures: []solana.Signature{{}, clientSig}}
+	key, err := transactionReplayKey(tx)
+	if err != nil {
+		t.Fatalf("transactionReplayKey: %v", err)
+	}
+	if key != sampleClientSig {
+		t.Fatalf("replay key = %s, want %s", key, sampleClientSig)
+	}
+}
+
+func TestTransactionReplayKeyRejectsUnsignedTransaction(t *testing.T) {
+	tx := &solana.Transaction{Signatures: []solana.Signature{{}}}
+	_, err := transactionReplayKey(tx)
+	if err == nil {
+		t.Fatal("expected unsigned transaction to be rejected")
+	}
+}
+
 func TestVerifyAndSettleRejectsTransactionThatDoesNotPayGate(t *testing.T) {
 	// Operator recipient != fixture payTo, so the destination ATA
 	// mismatch is caught BEFORE any broadcast.
@@ -461,6 +481,7 @@ func TestVerifyAndSettleRejectsTransactionThatDoesNotPayGate(t *testing.T) {
 }
 
 const sampleSig = "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"
+const sampleClientSig = "3APVUYY2Qcq9WwPSciQ1xicshQcsXJWhgD1x5YEMNnNnKtpaAJtRhDVMWcvePosamk3JfSKpBM8qt5ZkAQgRNSzo"
 
 func TestRecentBlockhashUsesProviderThenRPC(t *testing.T) {
 	// Provider wins when set.

--- a/go/protocols/x402/upto.go
+++ b/go/protocols/x402/upto.go
@@ -390,6 +390,14 @@ func ParseUptoPaymentSignature(header string) (UptoSignatureEnvelope, error) {
 	if err := json.Unmarshal(decoded, &envelope); err != nil {
 		return UptoSignatureEnvelope{}, fmt.Errorf("invalid 402 response: %w", err)
 	}
+	if envelope.Scheme == "" && len(envelope.Accepted) > 0 {
+		var accepted UptoRequirements
+		if err := json.Unmarshal(envelope.Accepted, &accepted); err != nil {
+			return UptoSignatureEnvelope{}, fmt.Errorf("invalid accepted requirements: %w", err)
+		}
+		envelope.Scheme = accepted.Scheme
+		envelope.Network = accepted.Network
+	}
 	if envelope.Scheme != UptoScheme {
 		return UptoSignatureEnvelope{}, fmt.Errorf("invalid payload type: %s", envelope.Scheme)
 	}

--- a/go/protocols/x402/upto_test.go
+++ b/go/protocols/x402/upto_test.go
@@ -264,6 +264,30 @@ func TestParseUptoPaymentSignatureValid(t *testing.T) {
 	}
 }
 
+func TestParseUptoPaymentSignatureAcceptsUpstreamV2Envelope(t *testing.T) {
+	accepted, err := uptoRequirements().AcceptedValue()
+	if err != nil {
+		t.Fatalf("AcceptedValue: %v", err)
+	}
+	envelope := UptoSignatureEnvelope{
+		X402Version: X402Version,
+		Accepted:    accepted,
+		Payload:     uptoPayload(),
+	}
+	raw, _ := json.Marshal(envelope)
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	parsed, err := ParseUptoPaymentSignature(encoded)
+	if err != nil {
+		t.Fatalf("ParseUptoPaymentSignature: %v", err)
+	}
+	if parsed.Scheme != UptoScheme {
+		t.Fatalf("scheme = %q, want %q", parsed.Scheme, UptoScheme)
+	}
+	if parsed.Network != uptoRequirements().Network {
+		t.Fatalf("network = %q, want %q", parsed.Network, uptoRequirements().Network)
+	}
+}
+
 func TestParseUptoPaymentSignatureRejectsWrongScheme(t *testing.T) {
 	envelope := UptoSignatureEnvelope{X402Version: X402Version, Scheme: "exact", Payload: uptoPayload()}
 	raw, _ := json.Marshal(envelope)

--- a/playground/app/src/lib/flow.ts
+++ b/playground/app/src/lib/flow.ts
@@ -102,6 +102,22 @@ function receiptReference(receiptB64: string | undefined): string | null {
   }
 }
 
+/** Pull the settle tx signature out of an x402 Payment-Response header. */
+function x402SettlementReference(headers: Record<string, string>): string | null {
+  const value = headers['payment-response'] ?? headers['x-payment-response']
+  if (!value) return null
+  try {
+    const json = JSON.parse(atob(value.replace(/-/g, '+').replace(/_/g, '/'))) as {
+      reference?: unknown
+      transaction?: unknown
+    }
+    const signature = json.transaction ?? json.reference
+    return typeof signature === 'string' && signature.length > 0 ? signature : null
+  } catch {
+    return null
+  }
+}
+
 async function pollSessionReceipt(channelId: string, timeoutMs = 10_000): Promise<string | null> {
   const deadline = performance.now() + timeoutMs
   while (performance.now() < deadline) {
@@ -290,11 +306,11 @@ export async function* payAndFetch(url: string, opts: Options = {}): AsyncGenera
           }
         }
 
-        // With server-side broadcast the client never emits paying/paid —
-        // the settle signature only comes back in the Payment-Receipt
-        // header. Surface it so the Broadcast / Settled steps complete.
+        // With server-side broadcast the client never emits paying/paid -
+        // the settle signature only comes back in settlement response headers.
+        // Surface it so the Broadcast / Settled steps complete.
         if (response.ok && !sawPaid) {
-          const signature = receiptReference(headers['payment-receipt'])
+          const signature = receiptReference(headers['payment-receipt']) ?? x402SettlementReference(headers)
           if (signature) {
             yield { type: 'paying' }
             yield { type: 'paid', signature }

--- a/playground/app/vite.config.ts
+++ b/playground/app/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     proxy: {
       '/openapi.json': target,
       '/api': target, // priced routes (/api/v1/*) + meta (health, faucet, docs)
+      '^/x402/': target, // legacy x402 demo API routes kept for compatibility
       '/sessions': target, // session receipt poll
       '/__402': target, // session delivery side-channel
     },


### PR DESCRIPTION
## Summary

- Proxy legacy `/x402/*` API routes from the playground Vite dev server to the Go API without stealing the `/x402?ep=...` SPA route.
- Align the visible Go playground catalog with TS-style endpoints: dual `/api/v1/quote/{symbol}` and `/api/v1/fortune`, MPP `/api/v1/joke`, x402 upto `/api/v1/summarize`, and `/api/v1/stream` session alias.
- Keep the `/api/v1/fortune` HTML payment-link flow for browser and service-worker requests while API clients get the dual x402 exact or MPP charge JSON route.
- Split Go x402 exact and upto clients so usage routes use the x402 upto adapter.
- Accept the upstream x402 v2 `PAYMENT-SIGNATURE` envelope shape for `x402/upto` by hydrating scheme/network from `accepted`.
- Surface x402 settlement signatures in the playground flow from `payment-response` / `x-payment-response`, not only MPP `payment-receipt`.
- Pre-read and cap summarize request bodies before opening usage payment channels, then clamp reported billing to the authorized ceiling.
- Fix x402 exact replay tracking for operator-sponsored transactions by keying replay on the first non-zero signer signature instead of the blank fee-payer slot.

## Verification

- `go test ./examples/playground-api`
- `go test ./protocols/x402 ./paykit/adapters/x402 ./examples/playground-api`
- `go test ./paykit ./paykit/adapters/x402 ./paykit/adapters/mpp ./examples/playground-api`
- `go test ./paykit/adapters/x402 ./examples/playground-api ./paykit ./protocols/x402`
- `go test ./...`
- `golangci-lint run --timeout=5m`
- `corepack pnpm install --frozen-lockfile` in `playground/`
- `corepack pnpm install --frozen-lockfile` in `typescript/`
- `corepack pnpm --filter @solana/mpp --filter @solana/pay-kit build`
- `corepack pnpm install --force --frozen-lockfile` in `playground/` after building local file dependencies
- `corepack pnpm --filter paykit-playground-app build`
- Live smoke with Go API on `:3321` and Vite on `:5173`:
  - `/x402/fact` through Vite returns `402` with `x402/exact`, not SPA HTML.
  - `/x402?ep=POST-api-v1-summarize` through Vite serves the SPA.
  - `/api/v1/summarize` through Vite returns `402` with `x402/upto`.
  - Oversized `/api/v1/summarize` through Vite returns `413 body-too-large` with no payment headers.
  - `/api/v1/quote/SPCX` through Vite returns `402` with `x402/exact, mpp/charge`.
  - `/api/v1/fortune` through Vite returns `402` with `x402/exact, mpp/charge`.
  - `/api/v1/fortune` with `Accept: text/html` returns the MPP HTML challenge.
  - `/api/v1/fortune?__mpp_worker` returns JavaScript with `Service-Worker-Allowed: /`.
  - `/api/v1/stream` through Vite returns `402` with `intent="session"`.
  - `/openapi.json` advertises `/api/v1/fortune`, `/api/v1/joke`, `/api/v1/quote/{symbol}`, `/api/v1/stream`, `/api/v1/summarize`.
- Real TS client x402 exact on-chain smoke against the Go `/api/v1/fortune` route:
  - Two fresh faucet-funded payers settled back-to-back after the replay fix.
  - Settlement signatures: `4CMUz1kz2qKbNjFBDdrt6yQbhmVY8Wjgq5w5P3egD4q1SoqSz2dkqA6cV9NnoGTUzcyT8dsGx3TxfaZCinKBDS9w`, `4ACp14WjciChyS7eecqGi9sFAhmWeUpYK94bjmJgeV1sgdmJzjYo4fNqvQCEKXsPLwqW32QATyruCVbUvma3b3d6`.
  - Both responses returned `200` with `x-payment-settlement-signature` and the protected fortune JSON body.
- Real TS client x402 upto on-chain smoke against the Go `/api/v1/summarize` route:
  - Faucet-funded generated payer `Hx5g3a6PkibuEjLvqpA2MuGaP6fEKGxdbStWzAqGdiez`.
  - `client.fetch("/api/v1/summarize", ..., "x402")` returned `200`.
  - Response included `payment-response` and `x-payment-settlement-signature`.
  - Settlement signature: `4z74u2EPJ8YNrjX1fNxzcYoBJHnF1JRHvNR3qQWhf3ybvaCvU7YhTEqcmx4akSrE5amA3nRcT541VUBsnoBZRv3e`.

## Known caveat

- `go vet ./...` still fails on `go/protocols/programs/paymentchannels/instructions.go`, which is explicitly marked Codama autogenerated and says not to edit manually. The same generated-code warning is reached even when vetting touched packages that import the generated client.
