### PR TITLE
fix(playground): standardize RPC env and post-rename demo/tooling fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -214,7 +214,7 @@ jobs:
           GOCACHE: /tmp/go-build-cache
           PORT: "3002"
           NETWORK: localnet
-          RPC_URL: http://localhost:8899
+          PAY_KIT_RPC_URL: http://localhost:8899
           MPP_SECRET_KEY: playground-ci-secret-padding-0123456789
         run: go run ./examples/playground-api &
       - name: Wait for playground server

--- a/go/examples/playground-api/README.md
+++ b/go/examples/playground-api/README.md
@@ -61,7 +61,7 @@ Same table as the TypeScript example:
 |----------|---------|---------|
 | `PORT` | `3000` | Listen port |
 | `NETWORK` | `localnet` | Solana network tag for MPP / x402 challenges |
-| `RPC_URL` | `https://402.surfnet.dev:8899` | Surfpool RPC endpoint (hosted sandbox by default) |
+| `PAY_KIT_RPC_URL` | `https://402.surfnet.dev:8899` | Surfpool RPC endpoint (hosted sandbox by default) |
 | `RECIPIENT` | (auto-generated) | Solana address that receives payments |
 | `FEE_PAYER_KEY` | (auto-generated) | Base58 fee-payer keypair (server signs as fee payer) |
 | `MPP_SECRET_KEY` | (random per-boot) | MPP secret key for challenge HMAC |

--- a/go/examples/playground-api/main.go
+++ b/go/examples/playground-api/main.go
@@ -7,7 +7,7 @@
 //	cd go
 //	go run ./examples/playground-api
 //
-// Environment: PORT, NETWORK, RPC_URL, RECIPIENT, FEE_PAYER_KEY,
+// Environment: PORT, NETWORK, PAY_KIT_RPC_URL, RECIPIENT, FEE_PAYER_KEY,
 // MPP_SECRET_KEY. See README.md for the full table.
 package main
 
@@ -36,7 +36,7 @@ import (
 // app carries the boot configuration shared by every module.
 type app struct {
 	network string // raw NETWORK tag: localnet | devnet | mainnet
-	// rpcURL is the Solana JSON-RPC endpoint (RPC_URL env var; defaults to
+	// rpcURL is the Solana JSON-RPC endpoint (PAY_KIT_RPC_URL env var; defaults to
 	// the hosted Solana Payment Sandbox).
 	rpcURL string
 	// recipient is the base58 address paid by the charge endpoints
@@ -59,9 +59,9 @@ func main() {
 	network := envOr("NETWORK", "localnet")
 	// Default to the hosted Solana Payment Sandbox so the playground works
 	// zero-config: it has the payment-channels program preloaded and supports
-	// the surfnet cheatcodes used by the faucet. Override RPC_URL to point at
-	// a local surfpool when you need offline iteration.
-	rpcURL := envOr("RPC_URL", "https://402.surfnet.dev:8899")
+	// the surfnet cheatcodes used by the faucet. Override PAY_KIT_RPC_URL to
+	// point at a local surfpool when you need offline iteration.
+	rpcURL := envOr("PAY_KIT_RPC_URL", "https://402.surfnet.dev:8899")
 	secretKey := os.Getenv("MPP_SECRET_KEY")
 	if secretKey == "" {
 		secretKey = randomHexSecret()

--- a/playground/README.md
+++ b/playground/README.md
@@ -96,7 +96,7 @@ request-builder layout.
 | `PAYKIT_PLAYGROUND_API_URL` | (unset) | Use an already-running playground API at this URL; `pnpm dev` then launches only the web app and proxies to it |
 | `PORT` | `3000` | Express listen port |
 | `NETWORK` | `localnet` | Solana network tag for MPP / x402 challenges |
-| `RPC_URL` | `https://402.surfnet.dev:8899` | Surfpool RPC endpoint (hosted sandbox by default) |
+| `PAY_KIT_RPC_URL` | `https://402.surfnet.dev:8899` | Surfpool RPC endpoint (hosted sandbox by default) |
 | `RECIPIENT` | (auto-generated) | Solana address that receives payments |
 | `FEE_PAYER_KEY` | (auto-generated) | Base58 fee-payer keypair (server signs as fee payer) |
 | `MPP_SECRET_KEY` | (random per-boot) | MPP secret key for challenge HMAC |

--- a/playground/app/src/components/EndpointWorkbench.tsx
+++ b/playground/app/src/components/EndpointWorkbench.tsx
@@ -230,6 +230,13 @@ export function EndpointWorkbench({
   )
 }
 
+// Sample request body for POST endpoints. The x402 `upto` summarize gate bills
+// per byte, so sending a non-empty body is what makes the demo show real
+// usage-based metering instead of always settling the 1-token minimum.
+const SAMPLE_POST_BODY =
+  'Summarize this passage. The x402 upto scheme authorizes a ceiling, meters the request by the byte, ' +
+  'settles only what is actually spent on-chain, and refunds the rest of the deposit.'
+
 async function* runFlow(
   endpoint: Endpoint,
   url: string,
@@ -238,11 +245,15 @@ async function* runFlow(
   protocol?: 'mpp' | 'x402',
 ): AsyncGenerator<FlowProgress> {
   void paramValues
+  const init: RequestInit =
+    endpoint.method === 'POST'
+      ? { method: 'POST', body: SAMPLE_POST_BODY, headers: { 'content-type': 'text/plain' } }
+      : { method: endpoint.method }
   for await (const step of payAndFetch(url, {
     primitive,
     protocol,
     unitPrice: endpoint.unitPrice,
-    init: { method: endpoint.method },
+    init,
   })) {
     yield step
   }

--- a/playground/app/src/lib/flow.ts
+++ b/playground/app/src/lib/flow.ts
@@ -129,7 +129,7 @@ async function pollSessionReceipt(channelId: string, timeoutMs = 10_000): Promis
   while (performance.now() < deadline) {
     try {
       const res = await nativeFetch(
-        `/__402/payment-channels/receipt/${encodeURIComponent(channelId)}`,
+        `/sessions/receipt/${encodeURIComponent(channelId)}`,
       )
       if (res.ok) {
         const body = (await res.json()) as { settledSignature: string | null; finalized: boolean }

--- a/playground/app/vite.config.ts
+++ b/playground/app/vite.config.ts
@@ -29,7 +29,9 @@ export default defineConfig({
       '/api': target, // priced routes (/api/v1/*) + meta (health, faucet, docs)
       '^/x402/': target, // legacy x402 demo API routes kept for compatibility
       '/__402': target, // session side-channels: delivery reserve + settle-receipt poll
-      '/sessions': target, // session settle-receipt poll (/sessions/receipt/:channelId)
+      // Regex with the trailing slash so the SPA's own /sessions page still
+      // renders on refresh/deep-link; only the receipt poll hits the API.
+      '^/sessions/': target, // session settle-receipt poll (/sessions/receipt/:channelId)
     },
   },
 })

--- a/playground/app/vite.config.ts
+++ b/playground/app/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       '/api': target, // priced routes (/api/v1/*) + meta (health, faucet, docs)
       '^/x402/': target, // legacy x402 demo API routes kept for compatibility
       '/__402': target, // session side-channels: delivery reserve + settle-receipt poll
+      '/sessions': target, // session settle-receipt poll (/sessions/receipt/:channelId)
     },
   },
 })

--- a/python/Justfile
+++ b/python/Justfile
@@ -25,7 +25,7 @@ typecheck:
 
 # Run tests with the 90% line-coverage gate.
 test-cover:
-    pytest --cov=pay_kit --cov-report=term-missing --cov-fail-under=90 --ignore=tests/test_server_html.py
+    pytest --cov=solana_pay_kit --cov-report=term-missing --cov-fail-under=90 --ignore=tests/test_server_html.py
 
 # Run all local Python gates.
 check: lint typecheck test-cover

--- a/python/examples/playground_api/app.py
+++ b/python/examples/playground_api/app.py
@@ -50,7 +50,8 @@ from .sandbox import fund_sandbox, fund_usdc, register_faucet
 solana_pay_kit.configure(
     network=os.getenv("PAY_KIT_NETWORK", "solana_localnet"),
     # Point at a specific Solana RPC (e.g. a local surfnet) when set; otherwise
-    # the network default is used. Mirrors the TS playground's RPC_URL knob.
+    # the network default is used. The TS, Go, and Ruby playgrounds read the
+    # same PAY_KIT_RPC_URL knob.
     rpc_url=os.getenv("PAY_KIT_RPC_URL") or None,
 )
 

--- a/typescript/examples/playground-api/README.md
+++ b/typescript/examples/playground-api/README.md
@@ -63,7 +63,7 @@ a faucet (`/api/v1/faucet/airdrop`) using sandbox cheatcodes — see
 |----------|---------|---------|
 | `PORT` | `3000` | Express listen port |
 | `NETWORK` | `localnet` | Solana network for the payment challenges |
-| `RPC_URL` | `https://402.surfnet.dev:8899` | RPC endpoint (hosted sandbox by default) |
+| `PAY_KIT_RPC_URL` | `https://402.surfnet.dev:8899` | RPC endpoint (hosted sandbox by default) |
 | `RECIPIENT` | (operator address) | Address that receives payments |
 | `FEE_PAYER_KEY` | (auto-generated) | Base58 operator keypair — fee-pays + signs settlement |
 | `MPP_SECRET_KEY` | (random per-boot) | HMAC secret binding MPP challenges |

--- a/typescript/examples/playground-api/index.ts
+++ b/typescript/examples/playground-api/index.ts
@@ -29,7 +29,7 @@ import { registerDocs } from './docs.js'
 import { bootstrapPlan, fundSandbox, fundUsdc, registerFaucet } from './sandbox.js'
 
 const NETWORK = (process.env.NETWORK ?? 'localnet') as 'devnet' | 'localnet' | 'mainnet'
-const RPC_URL = process.env.RPC_URL ?? 'https://402.surfnet.dev:8899'
+const RPC_URL = process.env.PAY_KIT_RPC_URL ?? 'https://402.surfnet.dev:8899'
 const PORT = parseInt(process.env.PORT || '3000', 10)
 const SECRET_KEY = process.env.MPP_SECRET_KEY ?? crypto.randomBytes(32).toString('hex')
 


### PR DESCRIPTION
## What

Cross-language playground fixes, grouped because they all surfaced while getting the playground demo working end to end.

### 1. Standardize the RPC override on `PAY_KIT_RPC_URL`
Python and Ruby read `PAY_KIT_RPC_URL`; TS and Go read the bare `RPC_URL`. A generic `RPC_URL` set for another service could silently redirect the backend's RPC and settle on a different fork. Move the TS and Go backends (and the Go CI step) onto the namespaced `PAY_KIT_RPC_URL` so every backend reads one knob. Per @lgalabru's review.

### 2. Restore the session receipt route (post-#193 leftover)
`flow.ts` polled `/__402/payment-channels/receipt/:id`, but both servers serve `/sessions/receipt/:id` and the Vite proxy only forwarded `/__402`, so the session demo never surfaced its on-chain settle signature. Point the client back at `/sessions/receipt` and add the `/sessions` proxy entry.

### 3. Send a metered POST body so the upto demo shows real billing
The endpoint workbench sent no request body, so the x402 `upto` summarize gate always metered 0 bytes (`summarizedBytes: 0`) and settled the 1-token minimum, making `upto` look like a flat charge. Send a sample text body for POST endpoints (summarize is the only one), so the demo shows per-byte usage-based billing.

### 4. Fix the Python coverage target (post-#193 leftover)
`python/Justfile` ran `pytest --cov=pay_kit` after the package was renamed to `solana_pay_kit`, measuring 0% and tripping the 90% gate. Point it at `solana_pay_kit`.

## Test
Go playground builds; Python tests green; the rest verified against the running playground.


## Read order
1. `typescript/examples/playground-api/index.ts`, the env rename at the reference implementation
2. `go/examples/playground-api/main.go`, same rename mirrored in Go
3. `.github/workflows/go.yml`, CI boot env renamed in lockstep
4. the two playground-api READMEs, env tables following the code
5. `playground/app/src/lib/flow.ts`, receipt poll repointed to the live `/sessions/receipt/:channelId` route
6. `playground/app/vite.config.ts`, the dev proxy enabling that poll (scoped to `^/sessions/`)
7. `playground/app/src/components/EndpointWorkbench.tsx`, sample POST body so the summarize demo meters real bytes
8. `python/Justfile`, coverage target renamed to the actual `solana_pay_kit` package

## Generated vs handwritten
No generated files; ~30 handwritten changed lines across 10 files, all reviewable in one pass.

## Reviewer note
Everything cross-checks against all three playground server implementations, and the response shape of the receipt route (`{settledSignature, finalized}`) was verified in TS, Go, and Python. The one place that bit us was the vite proxy: a bare `/sessions` prefix shadowed the SPA's own Sessions page on refresh; fixed in 050ca12b by scoping to `^/sessions/`.

## Fable 5 self-review
The env rename and receipt-route fix are done properly, CI updated in the same commit. But the first cut shipped a proxy rule that broke refresh on the very page whose poll it fixes, despite the `^/x402/` precedent on the adjacent line: a copy-the-pattern miss, caught in re-check and fixed (050ca12b) along with the last stale `RPC_URL` row in `playground/README.md`. `SAMPLE_POST_BODY` quietly assumes every POST endpoint wants prose; true today across all three APIs, worth gating on the endpoint id if a JSON POST endpoint ever lands.
