### PR TITLE
chore(pay-kit): code-quality review fixes

### DIFF
--- a/typescript/packages/pay-kit/src/__tests__/buffered-settle.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/buffered-settle.test.ts
@@ -116,7 +116,6 @@ describe('express usage gate settle-after-response', () => {
         const response = await fetch(`${base}/summarize`, { headers: { [CREDENTIAL_HEADER]: 'present' } });
 
         expect(response.status).toBe(200);
-        expect(response.status).not.toBe(402);
         expect(response.headers.get('x-payment-response')).toBeNull();
         const body = (await response.json()) as { hasMeter: boolean; ok: boolean };
         expect(body).toEqual({ hasMeter: true, ok: true });

--- a/typescript/packages/pay-kit/src/__tests__/buffered-settle.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/buffered-settle.test.ts
@@ -1,0 +1,140 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Price } from '../price.js';
+
+const CREDENTIAL_HEADER = 'x-fake-credential';
+
+type SettleResult = { amount: string; settlementHeaders: Record<string, string>; transaction: string };
+
+// The settle behavior is swapped per test through this holder, captured by the
+// mocked `X402Upto.settle` below.
+const settleControl: { impl: () => Promise<SettleResult> } = {
+    impl: () => Promise.reject(new Error('settle not configured')),
+};
+
+vi.mock('../adapters/x402-upto.js', async () => {
+    const actual = await vi.importActual<typeof import('../adapters/x402-upto.js')>('../adapters/x402-upto.js');
+    class FakeX402Upto {
+        detect(request: Request): boolean {
+            return request.headers.has(CREDENTIAL_HEADER);
+        }
+        accepts(price: Price): readonly Record<string, unknown>[] {
+            return [
+                {
+                    amount: price.baseUnits().toString(),
+                    asset: 'mint',
+                    maxTimeoutSeconds: 300,
+                    network: 'solana:test',
+                    payTo: 'PayTo',
+                    scheme: 'upto',
+                },
+            ];
+        }
+        challengeHeaders(): Promise<Readonly<Record<string, string>>> {
+            return Promise.resolve({});
+        }
+        verifyOpen(_request: Request, price: Price): Promise<Record<string, unknown>> {
+            return Promise.resolve({
+                maxBaseUnits: price.baseUnits(),
+                payer: 'Payer',
+                payload: { payload: { channelId: 'chan-1' } },
+                requirements: { amount: price.baseUnits().toString(), asset: 'mint', scheme: 'upto' },
+            });
+        }
+        settle(): Promise<SettleResult> {
+            return settleControl.impl();
+        }
+    }
+    return { ...actual, X402Upto: FakeX402Upto };
+});
+
+const { createPayKit } = await import('../paykit.js');
+const { usage } = await import('../pricing.js');
+const { usd } = await import('../price.js');
+
+async function startServer(): Promise<{ base: string; server: Server }> {
+    const pay = await createPayKit({
+        accept: ['x402'],
+        mpp: { challengeBindingSecret: 's' },
+        network: 'solana_localnet',
+        pricing: { summarize: usage(usd('1.00')) },
+    });
+    const middleware = pay.express('summarize');
+    const server = createServer((req, res) => {
+        void middleware(req, res, error => {
+            if (error) {
+                res.writeHead(500);
+                res.end(String(error));
+                return;
+            }
+            const meter = pay.charge(req);
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ hasMeter: meter !== undefined, ok: true }));
+        });
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    return { base: `http://127.0.0.1:${(server.address() as AddressInfo).port}`, server };
+}
+
+describe('express usage gate settle-after-response', () => {
+    let server: Server;
+    let base: string;
+
+    beforeEach(async () => {
+        ({ base, server } = await startServer());
+    });
+
+    afterEach(async () => {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+        vi.restoreAllMocks();
+    });
+
+    it('serves the handler body with settlement headers when settle succeeds', async () => {
+        settleControl.impl = () =>
+            Promise.resolve({
+                amount: '0',
+                settlementHeaders: { 'x-payment-response': 'SETTLED' },
+                transaction: 'Tx',
+            });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const response = await fetch(`${base}/summarize`, { headers: { [CREDENTIAL_HEADER]: 'present' } });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('x-payment-response')).toBe('SETTLED');
+        const body = (await response.json()) as { hasMeter: boolean; ok: boolean };
+        expect(body).toEqual({ hasMeter: true, ok: true });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('fails open: serves the handler body without settlement headers when settle fails', async () => {
+        settleControl.impl = () => Promise.reject(new Error('rpc down'));
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const response = await fetch(`${base}/summarize`, { headers: { [CREDENTIAL_HEADER]: 'present' } });
+
+        expect(response.status).toBe(200);
+        expect(response.status).not.toBe(402);
+        expect(response.headers.get('x-payment-response')).toBeNull();
+        const body = (await response.json()) as { hasMeter: boolean; ok: boolean };
+        expect(body).toEqual({ hasMeter: true, ok: true });
+        expect(warn).toHaveBeenCalled();
+    });
+
+    it('exposes the Charge meter to the handler on the usage path', async () => {
+        settleControl.impl = () => Promise.resolve({ amount: '0', settlementHeaders: {}, transaction: 'Tx' });
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const response = await fetch(`${base}/summarize`, { headers: { [CREDENTIAL_HEADER]: 'present' } });
+
+        const body = (await response.json()) as { hasMeter: boolean };
+        expect(body.hasMeter).toBe(true);
+    });
+
+    it('challenges an unpaid request with a 402', async () => {
+        const response = await fetch(`${base}/summarize`);
+        expect(response.status).toBe(402);
+    });
+});

--- a/typescript/packages/pay-kit/src/__tests__/client.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/client.test.ts
@@ -1,0 +1,65 @@
+import { generateKeyPairSigner, type KeyPairSigner } from '@solana/kit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `createPayKitClient` binds `globalThis.fetch` into a module-level `nativeFetch`
+// when its module first loads, so the stub must be installed before that import
+// is evaluated — `vi.hoisted` runs ahead of the static imports below.
+const { mockFetch } = vi.hoisted(() => {
+    const mockFetch = vi.fn<typeof fetch>();
+    globalThis.fetch = mockFetch;
+    return { mockFetch };
+});
+
+import { createPayKitClient } from '../client/index.js';
+import { ConfigurationError } from '../errors.js';
+
+const RPC_URL = 'http://127.0.0.1:8899';
+
+function response(status: number, headers: Record<string, string> = {}): Response {
+    return new Response(null, { headers, status });
+}
+
+describe('createPayKitClient', () => {
+    let signer: KeyPairSigner;
+
+    beforeEach(async () => {
+        signer = await generateKeyPairSigner();
+        mockFetch.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('passes a non-402 response through untouched without attempting payment', async () => {
+        const ok = response(200);
+        mockFetch.mockResolvedValue(ok);
+
+        const client = await createPayKitClient({ accept: ['x402', 'mpp'], rpcUrl: RPC_URL, signer });
+        const result = await client.fetch('http://api.test/joke');
+
+        expect(result).toBe(ok);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a session intent with ConfigurationError before any signing', async () => {
+        mockFetch.mockResolvedValue(response(402, { 'www-authenticate': 'Payment intent="session"' }));
+
+        const client = await createPayKitClient({ accept: ['mpp'], rpcUrl: RPC_URL, signer });
+
+        await expect(client.fetch('http://api.test/stream')).rejects.toBeInstanceOf(ConfigurationError);
+        await expect(client.fetch('http://api.test/stream')).rejects.toThrow(/session client/i);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns the probe unchanged when no accepted protocol matches the challenge headers', async () => {
+        const challenge = response(402);
+        mockFetch.mockResolvedValue(challenge);
+
+        const client = await createPayKitClient({ accept: ['x402'], rpcUrl: RPC_URL, signer });
+        const result = await client.fetch('http://api.test/joke');
+
+        expect(result).toBe(challenge);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/typescript/packages/pay-kit/src/adapters/mpp-session.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp-session.ts
@@ -14,7 +14,7 @@ import { createSolanaRpc } from '@solana/kit';
 import { resolveStablecoinMint } from '@solana/mpp';
 import { createMemorySessionStore, Mppx, session } from '@solana/mpp/server';
 
-import { resolveCoinAndMint } from '../coin.js';
+import { requireMint, resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { ConfigurationError } from '../errors.js';
 import type { Gate } from '../gate.js';
@@ -61,12 +61,8 @@ export function createSessionEngine(config: PayKitConfig, gate: Gate): SessionEn
         );
     }
     const network = toSolanaNetwork(config.network);
-    const { mint } = resolveCoinAndMint(
-        gate.amount,
-        config.stablecoins,
-        coin => resolveStablecoinMint(coin, network),
-        config.network,
-    );
+    const coin = resolveCoin(gate.amount, config.stablecoins);
+    const mint = requireMint(coin, resolveStablecoinMint(coin, network), config.network);
 
     const signer = config.operator.signer.signer;
     const store = createMemorySessionStore();

--- a/typescript/packages/pay-kit/src/adapters/mpp-session.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp-session.ts
@@ -14,7 +14,7 @@ import { createSolanaRpc } from '@solana/kit';
 import { resolveStablecoinMint } from '@solana/mpp';
 import { createMemorySessionStore, Mppx, session } from '@solana/mpp/server';
 
-import { resolveCoin } from '../coin.js';
+import { resolveCoinAndMint } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { ConfigurationError } from '../errors.js';
 import type { Gate } from '../gate.js';
@@ -61,9 +61,12 @@ export function createSessionEngine(config: PayKitConfig, gate: Gate): SessionEn
         );
     }
     const network = toSolanaNetwork(config.network);
-    const coin = resolveCoin(gate.amount, config.stablecoins);
-    const mint = resolveStablecoinMint(coin, network);
-    if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${config.network}.`);
+    const { mint } = resolveCoinAndMint(
+        gate.amount,
+        config.stablecoins,
+        coin => resolveStablecoinMint(coin, network),
+        config.network,
+    );
 
     const signer = config.operator.signer.signer;
     const store = createMemorySessionStore();

--- a/typescript/packages/pay-kit/src/adapters/mpp-session.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp-session.ts
@@ -14,6 +14,7 @@ import { createSolanaRpc } from '@solana/kit';
 import { resolveStablecoinMint } from '@solana/mpp';
 import { createMemorySessionStore, Mppx, session } from '@solana/mpp/server';
 
+import { resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { ConfigurationError } from '../errors.js';
 import type { Gate } from '../gate.js';
@@ -60,7 +61,7 @@ export function createSessionEngine(config: PayKitConfig, gate: Gate): SessionEn
         );
     }
     const network = toSolanaNetwork(config.network);
-    const coin = gate.amount.primaryCoin() ?? config.stablecoins[0] ?? 'USDC';
+    const coin = resolveCoin(gate.amount, config.stablecoins);
     const mint = resolveStablecoinMint(coin, network);
     if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${config.network}.`);
 

--- a/typescript/packages/pay-kit/src/adapters/mpp.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp.ts
@@ -4,7 +4,7 @@ import { Receipt } from 'mppx';
 
 import type { ProtocolAdapter } from '../adapter.js';
 import type { AcceptsEntry } from '../challenge.js';
-import { resolveCoinAndMint } from '../coin.js';
+import { requireMint, resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { InvalidProofError } from '../errors.js';
 import type { Gate } from '../gate.js';
@@ -52,17 +52,9 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
     const network = toSolanaNetwork(config.network);
     const handlers = new Map<string, ChargeHandler>();
 
-    function coinFor(gate: Gate): { coin: string; mint: string } {
-        return resolveCoinAndMint(
-            gate.amount,
-            config.stablecoins,
-            coin => resolveStablecoinMint(coin, network),
-            config.network,
-        );
-    }
-
     function handlerFor(gate: Gate): ChargeHandler {
-        const { mint } = coinFor(gate);
+        const coin = resolveCoin(gate.amount, config.stablecoins);
+        const mint = requireMint(coin, resolveStablecoinMint(coin, network), config.network);
         const splits = splitsFor(gate);
         // Key on every field a built handler captures, so gates differing only
         // in amount, description, or externalId get distinct handlers.
@@ -145,7 +137,7 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
 
     return {
         acceptsEntry(gate: Gate): Promise<AcceptsEntry> {
-            const { coin } = coinFor(gate);
+            const coin = resolveCoin(gate.amount, config.stablecoins);
             const splits = splitsFor(gate);
             return Promise.resolve({
                 amount: totalAmount(gate).toString(),

--- a/typescript/packages/pay-kit/src/adapters/mpp.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp.ts
@@ -4,9 +4,9 @@ import { Receipt } from 'mppx';
 
 import type { ProtocolAdapter } from '../adapter.js';
 import type { AcceptsEntry } from '../challenge.js';
-import { resolveCoin } from '../coin.js';
+import { resolveCoinAndMint } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
-import { ConfigurationError, InvalidProofError } from '../errors.js';
+import { InvalidProofError } from '../errors.js';
 import type { Gate } from '../gate.js';
 import type { Payment } from '../payment.js';
 import { caip2, toSolanaNetwork } from '../protocol.js';
@@ -53,10 +53,12 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
     const handlers = new Map<string, ChargeHandler>();
 
     function coinFor(gate: Gate): { coin: string; mint: string } {
-        const coin = resolveCoin(gate.amount, config.stablecoins);
-        const mint = resolveStablecoinMint(coin, network);
-        if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${config.network}.`);
-        return { coin, mint };
+        return resolveCoinAndMint(
+            gate.amount,
+            config.stablecoins,
+            coin => resolveStablecoinMint(coin, network),
+            config.network,
+        );
     }
 
     function handlerFor(gate: Gate): ChargeHandler {

--- a/typescript/packages/pay-kit/src/adapters/mpp.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp.ts
@@ -4,6 +4,7 @@ import { Receipt } from 'mppx';
 
 import type { ProtocolAdapter } from '../adapter.js';
 import type { AcceptsEntry } from '../challenge.js';
+import { resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { ConfigurationError, InvalidProofError } from '../errors.js';
 import type { Gate } from '../gate.js';
@@ -52,7 +53,7 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
     const handlers = new Map<string, ChargeHandler>();
 
     function coinFor(gate: Gate): { coin: string; mint: string } {
-        const coin = gate.amount.primaryCoin() ?? config.stablecoins[0] ?? 'USDC';
+        const coin = resolveCoin(gate.amount, config.stablecoins);
         const mint = resolveStablecoinMint(coin, network);
         if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${config.network}.`);
         return { coin, mint };
@@ -61,7 +62,18 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
     function handlerFor(gate: Gate): ChargeHandler {
         const { mint } = coinFor(gate);
         const splits = splitsFor(gate);
-        const key = JSON.stringify([gate.kind, gate.payTo, mint, splits, gate.subscription ?? null]);
+        // Key on every field a built handler captures, so gates differing only
+        // in amount, description, or externalId get distinct handlers.
+        const key = JSON.stringify([
+            gate.kind,
+            gate.payTo,
+            mint,
+            splits,
+            gate.subscription ?? null,
+            totalAmount(gate).toString(),
+            gate.description ?? null,
+            gate.externalId ?? null,
+        ]);
         let handler = handlers.get(key);
         if (!handler) {
             const signer = config.operator.feePayer ? { signer: config.operator.signer.signer } : {};

--- a/typescript/packages/pay-kit/src/adapters/x402-shared.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402-shared.ts
@@ -1,0 +1,9 @@
+/** The x402 payment credential header, read from either accepted name. */
+export function x402PaymentHeader(request: Request): string | undefined {
+    return request.headers.get('x-payment') ?? request.headers.get('payment-signature') ?? undefined;
+}
+
+/** The message of an Error-like value, or `undefined`. */
+export function errorMessage(error: unknown): string | undefined {
+    return error instanceof Error ? error.message : undefined;
+}

--- a/typescript/packages/pay-kit/src/adapters/x402-upto.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402-upto.ts
@@ -15,10 +15,12 @@ import type { Network, PaymentPayload, PaymentRequired, PaymentRequirements } fr
 import { getStablecoinTokenProgram, resolveStablecoinMint } from '@x402/svm';
 import { UptoSvmScheme as UptoSvmFacilitator } from '@x402/svm/upto/facilitator';
 
+import { requireMint, resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
-import { ConfigurationError, InvalidProofError } from '../errors.js';
+import { InvalidProofError } from '../errors.js';
 import type { Price } from '../price.js';
 import { caip2 } from '../protocol.js';
+import { errorMessage, x402PaymentHeader } from './x402-shared.js';
 
 /** Settlement-response header mirrored by the x402 SDK family. */
 const PAYMENT_RESPONSE_HEADER = 'x-payment-response';
@@ -111,7 +113,7 @@ export class X402Upto {
 
     /** Whether `request` carries an x402 payment credential. */
     detect(request: Request): boolean {
-        return this.#paymentHeader(request) !== undefined;
+        return x402PaymentHeader(request) !== undefined;
     }
 
     /** The 402 challenge headers for a route capped at `maxPrice`. */
@@ -136,7 +138,7 @@ export class X402Upto {
      * @throws {InvalidProofError} when the authorization fails verification.
      */
     async verifyOpen(request: Request, maxPrice: Price): Promise<UptoVerified> {
-        const header = this.#paymentHeader(request);
+        const header = x402PaymentHeader(request);
         if (!header) throw new InvalidProofError('missing_x402_payment_header');
 
         let payload: PaymentPayload;
@@ -225,9 +227,8 @@ export class X402Upto {
     }
 
     #requirements(maxPrice: Price): PaymentRequirements {
-        const coin = maxPrice.primaryCoin() ?? this.#stablecoins[0] ?? 'USDC';
-        const mint = resolveStablecoinMint(coin, this.#network);
-        if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${this.#network}.`);
+        const coin = resolveCoin(maxPrice, this.#stablecoins);
+        const mint = requireMint(coin, resolveStablecoinMint(coin, this.#network), this.#network);
         return {
             amount: maxPrice.baseUnits().toString(),
             asset: mint,
@@ -263,10 +264,6 @@ export class X402Upto {
             return base;
         }
     }
-
-    #paymentHeader(request: Request): string | undefined {
-        return request.headers.get('x-payment') ?? request.headers.get('payment-signature') ?? undefined;
-    }
 }
 
 type UptoPaymentChannelPayload = {
@@ -292,8 +289,4 @@ function tokenProgramFor(requirements: PaymentRequirements): string {
     const fromExtra = requirements.extra?.tokenProgram;
     if (typeof fromExtra === 'string') return fromExtra;
     return getStablecoinTokenProgram(requirements.asset, requirements.network);
-}
-
-function errorMessage(error: unknown): string | undefined {
-    return error instanceof Error ? error.message : undefined;
 }

--- a/typescript/packages/pay-kit/src/adapters/x402.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402.ts
@@ -11,11 +11,13 @@ import { ExactSvmScheme as ExactSvmFacilitator } from '@x402/svm/exact/facilitat
 
 import type { ProtocolAdapter } from '../adapter.js';
 import type { AcceptsEntry } from '../challenge.js';
+import { resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { ConfigurationError, InvalidProofError } from '../errors.js';
 import type { Gate } from '../gate.js';
 import type { Payment } from '../payment.js';
 import { caip2 } from '../protocol.js';
+import { errorMessage, x402PaymentHeader } from './x402-shared.js';
 
 /** x402 v2 protocol version advertised in the challenge envelope. */
 const X402_VERSION = 2;
@@ -47,7 +49,7 @@ export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
     );
 
     function mintFor(gate: Gate): string {
-        const coin = gate.amount.primaryCoin() ?? config.stablecoins[0] ?? 'USDC';
+        const coin = resolveCoin(gate.amount, config.stablecoins);
         const mint = resolveStablecoinMint(coin, network);
         if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${config.network}.`);
         return mint;
@@ -64,10 +66,6 @@ export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
             payTo: gate.payTo,
             scheme: 'exact',
         };
-    }
-
-    function paymentHeader(request: Request): string | undefined {
-        return request.headers.get('x-payment') ?? request.headers.get('payment-signature') ?? undefined;
     }
 
     /**
@@ -109,14 +107,14 @@ export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
         },
 
         detect(request: Request): boolean {
-            return paymentHeader(request) !== undefined;
+            return x402PaymentHeader(request) !== undefined;
         },
 
         protocol: 'x402',
         scheme: 'exact',
 
         async verifyAndSettle(gate: Gate, request: Request): Promise<Payment> {
-            const header = paymentHeader(request);
+            const header = x402PaymentHeader(request);
             if (!header) throw new InvalidProofError('missing_x402_payment_header');
 
             let payload: PaymentPayload;
@@ -148,8 +146,4 @@ export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
             };
         },
     };
-}
-
-function errorMessage(error: unknown): string | undefined {
-    return error instanceof Error ? error.message : undefined;
 }

--- a/typescript/packages/pay-kit/src/adapters/x402.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402.ts
@@ -11,9 +11,9 @@ import { ExactSvmScheme as ExactSvmFacilitator } from '@x402/svm/exact/facilitat
 
 import type { ProtocolAdapter } from '../adapter.js';
 import type { AcceptsEntry } from '../challenge.js';
-import { resolveCoin } from '../coin.js';
+import { resolveCoinAndMint } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
-import { ConfigurationError, InvalidProofError } from '../errors.js';
+import { InvalidProofError } from '../errors.js';
 import type { Gate } from '../gate.js';
 import type { Payment } from '../payment.js';
 import { caip2 } from '../protocol.js';
@@ -49,10 +49,12 @@ export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
     );
 
     function mintFor(gate: Gate): string {
-        const coin = resolveCoin(gate.amount, config.stablecoins);
-        const mint = resolveStablecoinMint(coin, network);
-        if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${config.network}.`);
-        return mint;
+        return resolveCoinAndMint(
+            gate.amount,
+            config.stablecoins,
+            coin => resolveStablecoinMint(coin, network),
+            config.network,
+        ).mint;
     }
 
     /** The route's pinned requirements — the credential is bound to this exact amount. */

--- a/typescript/packages/pay-kit/src/adapters/x402.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402.ts
@@ -11,7 +11,7 @@ import { ExactSvmScheme as ExactSvmFacilitator } from '@x402/svm/exact/facilitat
 
 import type { ProtocolAdapter } from '../adapter.js';
 import type { AcceptsEntry } from '../challenge.js';
-import { resolveCoinAndMint } from '../coin.js';
+import { requireMint, resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
 import { InvalidProofError } from '../errors.js';
 import type { Gate } from '../gate.js';
@@ -49,12 +49,8 @@ export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
     );
 
     function mintFor(gate: Gate): string {
-        return resolveCoinAndMint(
-            gate.amount,
-            config.stablecoins,
-            coin => resolveStablecoinMint(coin, network),
-            config.network,
-        ).mint;
+        const coin = resolveCoin(gate.amount, config.stablecoins);
+        return requireMint(coin, resolveStablecoinMint(coin, network), config.network);
     }
 
     /** The route's pinned requirements — the credential is bound to this exact amount. */

--- a/typescript/packages/pay-kit/src/coin.ts
+++ b/typescript/packages/pay-kit/src/coin.ts
@@ -10,20 +10,14 @@ export function resolveCoin(amount: Price, stablecoins: readonly string[]): stri
 }
 
 /**
- * The settlement coin for a price together with its on-chain mint.
+ * Assert that a coin resolved to a mint on the target network.
  *
- * @param toMint - Maps a coin symbol to its mint address on the target network.
+ * @param coin - The settlement coin symbol.
+ * @param mint - The mint resolved for the coin, if any.
  * @param network - Network label used in the error message.
- * @throws {ConfigurationError} when the resolved coin has no mint on the network.
+ * @throws {ConfigurationError} when the coin has no mint on the network.
  */
-export function resolveCoinAndMint<TMint>(
-    amount: Price,
-    stablecoins: readonly string[],
-    toMint: (coin: string) => TMint | null | undefined,
-    network: string,
-): { coin: string; mint: TMint } {
-    const coin = resolveCoin(amount, stablecoins);
-    const mint = toMint(coin);
+export function requireMint(coin: string, mint: string | undefined, network: string): string {
     if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${network}.`);
-    return { coin, mint };
+    return mint;
 }

--- a/typescript/packages/pay-kit/src/coin.ts
+++ b/typescript/packages/pay-kit/src/coin.ts
@@ -1,0 +1,9 @@
+import type { Price } from './price.js';
+
+/**
+ * The settlement coin for a price: its explicit first preference, else the
+ * first configured stablecoin, else USDC.
+ */
+export function resolveCoin(amount: Price, stablecoins: readonly string[]): string {
+    return amount.primaryCoin() ?? stablecoins[0] ?? 'USDC';
+}

--- a/typescript/packages/pay-kit/src/coin.ts
+++ b/typescript/packages/pay-kit/src/coin.ts
@@ -1,3 +1,4 @@
+import { ConfigurationError } from './errors.js';
 import type { Price } from './price.js';
 
 /**
@@ -6,4 +7,23 @@ import type { Price } from './price.js';
  */
 export function resolveCoin(amount: Price, stablecoins: readonly string[]): string {
     return amount.primaryCoin() ?? stablecoins[0] ?? 'USDC';
+}
+
+/**
+ * The settlement coin for a price together with its on-chain mint.
+ *
+ * @param toMint - Maps a coin symbol to its mint address on the target network.
+ * @param network - Network label used in the error message.
+ * @throws {ConfigurationError} when the resolved coin has no mint on the network.
+ */
+export function resolveCoinAndMint<TMint>(
+    amount: Price,
+    stablecoins: readonly string[],
+    toMint: (coin: string) => TMint | null | undefined,
+    network: string,
+): { coin: string; mint: TMint } {
+    const coin = resolveCoin(amount, stablecoins);
+    const mint = toMint(coin);
+    if (!mint) throw new ConfigurationError(`No ${coin} mint known for ${network}.`);
+    return { coin, mint };
 }

--- a/typescript/packages/pay-kit/src/paykit.ts
+++ b/typescript/packages/pay-kit/src/paykit.ts
@@ -4,6 +4,7 @@ import { createSessionEngine, type SessionEngine } from './adapters/mpp-session.
 import { createX402ExactAdapter } from './adapters/x402.js';
 import { Charge, X402Upto } from './adapters/x402-upto.js';
 import type { AcceptsEntry, Challenge } from './challenge.js';
+import { resolveCoin } from './coin.js';
 import { configure, type ConfigureParams, type PayKitConfig } from './config.js';
 import { ConfigurationError, InvalidProofError } from './errors.js';
 import { type ExpressRoutesApp, GATE_METADATA, introspectExpressRoutes } from './express-routes.js';
@@ -161,7 +162,14 @@ export type PayKit<P extends PricingDef = PricingDef> = {
     readonly paid: (request: object, gate?: GateName<P>) => boolean;
     /** The verified payment on `request`, if any. */
     readonly payment: (request: object) => Payment | undefined;
-    /** Verify-or-deny: settles a credential (or opens a usage channel) or produces the 402 challenge. */
+    /**
+     * Verify-or-deny: settles a credential (or opens a usage channel) or
+     * produces the 402 challenge. For a `usage` gate the returned
+     * {@link PaymentGranted} holds an in-flight channel reservation released
+     * only when its `settle` (or `withSettlement`) runs; a caller driving
+     * `requirePayment` directly must call one of them, as the framework
+     * wrappers do.
+     */
     readonly requirePayment: (request: Request, gate: GateRef<P>) => Promise<RequirePaymentResult>;
     /** The side-channel + receipt handlers for a `session` gate, for the app to mount. */
     readonly sessionRoutes: (gate: Gate | GateName<P>) => SessionRouteHandlers;
@@ -483,7 +491,7 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
     }
 
     /** Settlement coin for a gate (its explicit preference, else the config default). */
-    const coinFor = (gate: Gate): string => gate.amount.primaryCoin() ?? config.stablecoins[0] ?? 'USDC';
+    const coinFor = (gate: Gate): string => resolveCoin(gate.amount, config.stablecoins);
 
     /**
      * The discovery `intent` for a gate kind. `subscription` and `session` are
@@ -618,12 +626,17 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
                     // 0, so this refunds). Best-effort; re-throw the original error.
                     try {
                         await result.settle();
-                    } catch {
-                        /* swallow settle failure; the handler error is what matters */
+                    } catch (settleError) {
+                        logSettleFailure(settleError);
                     }
                     throw error;
                 }
-                return await result.withSettlement(response);
+                try {
+                    return await result.withSettlement(response);
+                } catch (settleError) {
+                    logSettleFailure(settleError);
+                    return response;
+                }
             };
         },
 
@@ -643,8 +656,8 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
                     try {
                         for (const [name, value] of Object.entries(await result.settle()))
                             c.res.headers.set(name, value);
-                    } catch {
-                        /* swallow settle failure; preserve the handler outcome */
+                    } catch (settleError) {
+                        logSettleFailure(settleError);
                     }
                 }
                 return undefined;
@@ -733,6 +746,10 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
     return instance;
 }
 
+function logSettleFailure(error: unknown): void {
+    console.warn('[pay-kit] settlement failed; serving the response without settlement headers.', error);
+}
+
 /**
  * Run an Express handler with settle-after-response: buffer every commit path,
  * run the handler, settle the metered amount, then replay — so the settlement
@@ -796,8 +813,8 @@ async function runBufferedSettle(res: NodeResponse, next: NextFunction, result: 
         // refunds. Best-effort — forward the original handler error regardless.
         try {
             await result.settle();
-        } catch {
-            /* swallow settle failure; the handler error is what matters */
+        } catch (settleError) {
+            logSettleFailure(settleError);
         }
         next(error);
         return;
@@ -809,15 +826,11 @@ async function runBufferedSettle(res: NodeResponse, next: NextFunction, result: 
         // Settle even on a handler error: the meter is 0 unless the handler
         // reported usage, so a failed request finalizes the channel and refunds.
         for (const [name, value] of Object.entries(await result.settle())) res.setHeader(name, value);
-    } catch {
-        settled = true;
-        res.writeHead = originalWriteHead;
-        res.write = originalWrite;
-        res.end = originalEnd;
-        bufferedCalls = [];
-        res.statusCode = 402;
-        originalEnd();
-        return;
+    } catch (settleError) {
+        // The upto ceiling is already escrowed on-chain, so the request is paid;
+        // serve the buffered handler response without settlement headers and let
+        // the out-of-band refund retry.
+        logSettleFailure(settleError);
     }
     restoreAndReplay();
 }

--- a/typescript/packages/pay-kit/src/paykit.ts
+++ b/typescript/packages/pay-kit/src/paykit.ts
@@ -181,6 +181,13 @@ export type CreatePayKitOptions<P extends PricingDef> = ConfigureParams & {
     readonly adapters?: readonly ProtocolAdapter[];
     /** A pre-built, frozen config — skips the internal {@link configure} call. */
     readonly config?: PayKitConfig;
+    /**
+     * Invoked when settlement fails after the handler has run, so the request is
+     * served without settlement headers. Use it to route the event to a logger or
+     * alerting pipeline; a failed settlement is a payment event worth surfacing.
+     * Defaults to a `console.warn`.
+     */
+    readonly onSettleError?: (error: unknown) => void;
     /** The gate catalogue, inline. Gate names become typed on the returned instance. */
     readonly pricing?: P;
 };
@@ -212,8 +219,15 @@ export type CreatePayKitOptions<P extends PricingDef> = ConfigureParams & {
 export async function createPayKit<const P extends PricingDef = PricingDef>(
     options: CreatePayKitOptions<P> = {},
 ): Promise<PayKit<P>> {
-    const { adapters: adapterOverride, config: prebuilt, pricing: pricingDef, ...configureParams } = options;
+    const {
+        adapters: adapterOverride,
+        config: prebuilt,
+        onSettleError,
+        pricing: pricingDef,
+        ...configureParams
+    } = options;
     const config = prebuilt ?? (await configure(configureParams));
+    const handleSettleFailure = onSettleError ?? warnSettleFailure;
 
     const adapters =
         adapterOverride ??
@@ -603,7 +617,7 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
                     next();
                     return;
                 }
-                await runBufferedSettle(res, next, result);
+                await runBufferedSettle(res, next, result, handleSettleFailure);
             };
             // Tag the middleware so `openapiFromExpress` can recover the gate.
             return Object.assign(middleware, { [GATE_METADATA]: gate });
@@ -624,14 +638,14 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
                     try {
                         await result.settle();
                     } catch (settleError) {
-                        logSettleFailure(settleError);
+                        handleSettleFailure(settleError);
                     }
                     throw error;
                 }
                 try {
                     return await result.withSettlement(response);
                 } catch (settleError) {
-                    logSettleFailure(settleError);
+                    handleSettleFailure(settleError);
                     return response;
                 }
             };
@@ -654,7 +668,7 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
                         for (const [name, value] of Object.entries(await result.settle()))
                             c.res.headers.set(name, value);
                     } catch (settleError) {
-                        logSettleFailure(settleError);
+                        handleSettleFailure(settleError);
                     }
                 }
                 return undefined;
@@ -743,7 +757,7 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
     return instance;
 }
 
-function logSettleFailure(error: unknown): void {
+function warnSettleFailure(error: unknown): void {
     console.warn('[pay-kit] settlement failed; serving the response without settlement headers.', error);
 }
 
@@ -752,7 +766,12 @@ function logSettleFailure(error: unknown): void {
  * run the handler, settle the metered amount, then replay — so the settlement
  * header lands on the reply. Mirrors the x402 metered middleware.
  */
-async function runBufferedSettle(res: NodeResponse, next: NextFunction, result: PaymentGranted): Promise<void> {
+async function runBufferedSettle(
+    res: NodeResponse,
+    next: NextFunction,
+    result: PaymentGranted,
+    handleSettleFailure: (error: unknown) => void,
+): Promise<void> {
     const originalWriteHead = res.writeHead.bind(res);
     const originalWrite = res.write.bind(res);
     const originalEnd = res.end.bind(res);
@@ -811,7 +830,7 @@ async function runBufferedSettle(res: NodeResponse, next: NextFunction, result: 
         try {
             await result.settle();
         } catch (settleError) {
-            logSettleFailure(settleError);
+            handleSettleFailure(settleError);
         }
         next(error);
         return;
@@ -828,7 +847,7 @@ async function runBufferedSettle(res: NodeResponse, next: NextFunction, result: 
         // serve the buffered handler response without settlement headers. The
         // metered amount is not finalized in-process and nothing retries it — the
         // channel's on-chain timeout is the only fallback.
-        logSettleFailure(settleError);
+        handleSettleFailure(settleError);
     }
     restoreAndReplay();
 }

--- a/typescript/packages/pay-kit/src/paykit.ts
+++ b/typescript/packages/pay-kit/src/paykit.ts
@@ -490,9 +490,6 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
         return granted(payment, () => Promise.resolve(settlementHeaders));
     }
 
-    /** Settlement coin for a gate (its explicit preference, else the config default). */
-    const coinFor = (gate: Gate): string => resolveCoin(gate.amount, config.stablecoins);
-
     /**
      * The discovery `intent` for a gate kind. `subscription` and `session` are
      * first-class intents (the UI keys its nav off these); `fixed` and `usage`
@@ -503,7 +500,7 @@ export async function createPayKit<const P extends PricingDef = PricingDef>(
 
     /** The discovery offers for a gate — one per accepted protocol/scheme. */
     async function offersForGate(gate: Gate, request: Request): Promise<PaymentOffer[]> {
-        const coin = coinFor(gate);
+        const coin = resolveCoin(gate.amount, config.stablecoins);
         const intent = intentFor(gate);
         const toOffer = (entry: AcceptsEntry, max: boolean): PaymentOffer => {
             const extra = (entry.extra ?? {}) as { facilitator?: unknown; feePayer?: unknown };
@@ -828,8 +825,9 @@ async function runBufferedSettle(res: NodeResponse, next: NextFunction, result: 
         for (const [name, value] of Object.entries(await result.settle())) res.setHeader(name, value);
     } catch (settleError) {
         // The upto ceiling is already escrowed on-chain, so the request is paid;
-        // serve the buffered handler response without settlement headers and let
-        // the out-of-band refund retry.
+        // serve the buffered handler response without settlement headers. The
+        // metered amount is not finalized in-process and nothing retries it — the
+        // channel's on-chain timeout is the only fallback.
         logSettleFailure(settleError);
     }
     restoreAndReplay();


### PR DESCRIPTION
Quality fixes for the new `@solana/pay-kit` package, from a TypeScript review.

## Changes
- **Settlement fail-open + `onSettleError`** — unify the express/hono/fetch wrappers on one settle-failure contract: serve the handler response without settlement headers (the upto ceiling is already escrowed on-chain) and surface the error. Adds an optional `onSettleError` hook to `createPayKit`, defaulting to `console.warn`, so consumers can route failures to their own logger/alerting.
- **mpp handler cache-key fix** — key on every field a built handler captures (amount, description, externalId) so two gates differing only in those fields no longer share a handler (the cached closure was charging the first gate's amount).
- **Dedup** — `resolveCoin` + `requireMint` helpers and a shared `x402-shared` module (`x402PaymentHeader`, `errorMessage`); removes the copy-pasted coin/mint resolution and x402 header readers across the four adapters.
- **Docs** — document the `requirePayment` usage-gate settle contract; correct the upto comment (no in-process reconciler exists for upto; the on-chain channel timeout is the only fallback).
- **Tests** — cover the client `fetch` (passthrough, session-intent rejection, no-match) and the express buffered settle incl. the fail-open path. Coverage 61% → 72%.

No public API changes (the only behavior change is the error-path fail-open).

## Verification
typecheck · eslint · prettier · 79 tests · build + dts — all green.