### PR TITLE
chore(pay-kit): bump typescript package to 0.4.0

### DIFF
--- a/typescript/packages/pay-kit/package.json
+++ b/typescript/packages/pay-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay-kit",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Building blocks for Agentic payments (x402, MPP, AP2)",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary
- Bump @solana/pay-kit from 0.3.0 to 0.4.0 for the next minor TypeScript package release

## Test Plan
- pnpm --dir typescript --filter @solana/pay-kit build