### PR TITLE
docs(ts): surface session channel reuse next to client.fetch

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -246,14 +246,21 @@ once. Calls 2..N need no fresh open and no re-deposited ceiling, so the open,
 close, and the deposit float amortize across the session.
 
 ```ts
-import { createSessionFetch } from '@solana/mpp/client'
+import { createPaymentChannelSessionOpener, createSessionFetch } from '@solana/mpp/client'
+
+const client = createSessionFetch({
+  opener: createPaymentChannelSessionOpener({ signer, rpcUrl }),
+})
+
+const res = await client.fetch('https://api.example/paid')
 ```
 
-`createSessionFetch` returns a `SessionFetchClient` that you open once and then
-feed your running metered amount while it throttles the voucher commits. This is
-why `client.fetch` intentionally throws on a `session` challenge and points you
-here. It works end to end only when the resource server advertises a `session`
-challenge, not just `upto`.
+`createSessionFetch` returns a `SessionFetchClient` that opens one channel
+through the supplied opener and then reuses it: you feed your running metered
+amount and it throttles the cumulative-voucher commits. This is why the
+top-level `client.fetch` intentionally throws on a `session` challenge and points
+you here. It works end to end only when the resource server advertises a
+`session` challenge, not just `upto`.
 
 ---
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -233,6 +233,28 @@ matching protocol (MPP or x402) and retries the request with the
 `Authorization: Payment` credential. Pass a third argument
 (`'x402'` / `'mpp'`) to force a rail when an endpoint offers both.
 
+### Reusing a channel across calls
+
+`client.fetch` runs one full payment per call. For `upto` (usage-based) that
+means a fresh payment-channel open, settle, and finalize every time, because
+the x402 `upto` scheme is single-settlement by spec: each authorization settles
+exactly once and cannot be reused.
+
+For many small calls to the same host, reuse a channel with the MPP `session`
+scheme instead: open one channel, sign a cumulative voucher per call, and close
+once. Calls 2..N need no fresh open and no re-deposited ceiling, so the open,
+close, and the deposit float amortize across the session.
+
+```ts
+import { createSessionFetch } from '@solana/mpp/client'
+```
+
+`createSessionFetch` returns a `SessionFetchClient` that you open once and then
+feed your running metered amount while it throttles the voucher commits. This is
+why `client.fetch` intentionally throws on a `session` challenge and points you
+here. It works end to end only when the resource server advertises a `session`
+challenge, not just `upto`.
+
 ---
 
 ## Vocabulary

--- a/typescript/packages/pay-kit/src/client/index.ts
+++ b/typescript/packages/pay-kit/src/client/index.ts
@@ -116,7 +116,8 @@ export function createPayKitClient(options: PayKitClientOptions): Promise<PayKit
             const intent = mppIntent(probe.headers.get('www-authenticate'));
             if (intent === 'session') {
                 throw new ConfigurationError(
-                    'Session payments are streaming; use the dedicated session client (createSessionFetch), not client.fetch.',
+                    'Session payments are streaming and reuse one channel across calls; ' +
+                        "use the dedicated session client (`createSessionFetch` from '@solana/mpp/client'), not client.fetch.",
                 );
             }
             const mppx = intent === 'subscription' ? subscriptionClient() : chargeClient();


### PR DESCRIPTION
## Summary

Surface the `session` scheme (channel reuse) right where consumers look, prompted by #212. A production consumer paid a full payment-channel open/settle/finalize per call against an `upto` endpoint, then had to reverse-engineer the `client.fetch` throw to find `createSessionFetch`. Nothing was wrong with the code; the reusable-channel path just was not discoverable.

Two small, docs-and-message-only changes:
- `typescript/README.md`: a "Reusing a channel across calls" section after the Client section. It states that `upto` is single-settlement by spec (open/settle/finalize per call) and points repeated-call workloads at the MPP `session` scheme (open once, cumulative voucher per call, close once), with the `createSessionFetch` import and the one dependency (the server must advertise a `session` challenge).
- `packages/pay-kit/src/client/index.ts`: the session-challenge `ConfigurationError` now names the import path (`createSessionFetch` from `@solana/mpp/client`) so it is directly actionable.

## Read order
1. `typescript/README.md` (the Client section) — the new subsection.
2. `packages/pay-kit/src/client/index.ts` — the one-line error-message change.

## Generated vs handwritten
No generated files. ~25 handwritten lines, docs and one string.

## Test plan
- `pnpm --dir typescript lint` and `format:check` (prettier clean on both files).
- No behavior change; the throw still fires on the same `session`-intent path, only the message text is longer. No test asserts the message.

## Reviewer note
This deliberately does not touch `upto` or add any channel-management API. Per the canonical x402 `upto` spec, `upto` is single-settlement and reuse is out of scope; channel reuse is the `session` scheme, which already ships (`createSessionFetch`). The end-to-end gap for #212 is on the gateway (it must advertise a `session` challenge), tracked separately in solana-foundation/pay#394.

## Fable 5 self-review
Verdict: correct and minimal. This is a discoverability fix, not a feature, and it resists the tempting-but-wrong move of adding settle-without-close to `upto`, which would break x402 spec conformance. What I would flag as a stranger: it is docs plus one string, so its value depends on people reading the README; a follow-up worth considering is a runnable session example under `examples/`, which I left out to keep this small. The error-message change is safe (no test pins the text) but does lengthen a user-facing string.

Closes part of #212 (client discoverability). The gateway session route is solana-foundation/pay#394.