### PR TITLE
chore: release @solana/pay-kit 0.5.0 and deprecate @solana/mpp

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package to publish'
+        # @solana/pay-kit is the go-forward package. @solana/mpp is deprecated
+        # and retained here only for its final release; do not publish it after
+        # that.
+        description: 'Package to publish (mpp is deprecated, final release only)'
         required: true
         default: pay-kit
         type: choice
@@ -38,8 +41,11 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
+  # Deprecated: @solana/mpp is superseded by @solana/pay-kit. This job is kept
+  # only to cut the final @solana/mpp release (which carries the #211 TOCTOU
+  # fix); remove it once that release is out and `npm deprecate` has run.
   publish:
-    name: Publish @solana/mpp
+    name: Publish @solana/mpp (deprecated)
     runs-on: ubuntu-latest
     needs: [ci]
     if: ${{ github.event.inputs.package == 'mpp' || github.event.inputs.package == 'all' }}
@@ -104,7 +110,8 @@ jobs:
       - name: Pack tarball
         run: |
           mkdir -p .npm-pack
-          cp README.md typescript/packages/mpp/README.md
+          # @solana/mpp is deprecated in favor of @solana/pay-kit, so ship the
+          # package's own deprecation README rather than the root pay-kit one.
           pnpm --dir typescript/packages/mpp pack --pack-destination "$(pwd)/.npm-pack"
           TARBALL=$(find .npm-pack -maxdepth 1 -name '*.tgz' -print -quit)
 
@@ -118,7 +125,6 @@ jobs:
           echo ""
           echo "Packed tarball:"
           ls -la .npm-pack/
-          rm -f typescript/packages/mpp/README.md
 
       - name: "Guard - Fail if tarball contains workspace: protocol"
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -198,10 +198,12 @@ jobs:
 
             const body = `## @solana/mpp v${version}
 
-            ### Installation
+            > **Deprecated.** \`@solana/mpp\` is superseded by [\`@solana/pay-kit\`](https://www.npmjs.com/package/@solana/pay-kit). This is a final maintenance release; new work lands in \`@solana/pay-kit\`.
+
+            ### Migrate
 
             \`\`\`bash
-            pnpm add @solana/mpp
+            pnpm remove @solana/mpp && pnpm add @solana/pay-kit
             \`\`\`
 
             [npm](https://www.npmjs.com/package/@solana/mpp/v/${version})

--- a/typescript/packages/mpp/README.md
+++ b/typescript/packages/mpp/README.md
@@ -1,0 +1,24 @@
+# @solana/mpp (deprecated)
+
+> **This package is deprecated.** It is superseded by
+> [`@solana/pay-kit`](https://www.npmjs.com/package/@solana/pay-kit), which
+> provides the same MPP support alongside x402 and AP2 behind one surface.
+
+`@solana/mpp` is no longer actively developed. New work lands in `@solana/pay-kit`.
+
+## Migrate
+
+```sh
+npm remove @solana/mpp
+npm install @solana/pay-kit
+```
+
+The MPP server and client live under `@solana/pay-kit`. See the
+[pay-kit README](https://github.com/solana-foundation/pay-kit/tree/main/typescript)
+for the current API.
+
+## Last release
+
+The final `@solana/mpp` release carries the concurrent-signature-replay
+(TOCTOU) fix from [#211](https://github.com/solana-foundation/pay-kit/pull/211).
+Existing users should take it and then migrate to `@solana/pay-kit`.

--- a/typescript/packages/pay-kit/package.json
+++ b/typescript/packages/pay-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay-kit",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Building blocks for Agentic payments (x402, MPP, AP2)",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary

Bumps `@solana/pay-kit` to `0.5.0` for release and deprecates `@solana/mpp` in
favor of it. No wire or runtime behavior changes: this is a version string, a
deprecation README, and a publish-workflow tweak.

## Read order

1. `typescript/packages/pay-kit/package.json` — the bump, `0.4.0` to `0.5.0`. One line.
2. `typescript/packages/mpp/README.md` — new deprecation notice. Check the
   migration path (`@solana/mpp` to `@solana/pay-kit`) and the note that the
   final release carries the #211 TOCTOU fix.
3. `.github/workflows/npm-publish.yml` — the mpp pack step no longer copies the
   root pay-kit README over the package one, so the deprecation notice ships;
   the mpp job and the workflow input are marked deprecated. Confirm the pack
   step still yields a valid tarball with `dist/`.

## Generated vs handwritten

- **Skim (mechanical):** `package.json` version bump, 1 line.
- **Review (handwritten):** `mpp/README.md` (24 lines of docs) and
  `npm-publish.yml` (about 6 net logic lines plus comments). Roughly **30
  handwritten lines**, all docs and CI config. No product code changes.

## Test plan

No product build needed (version + docs + CI). To confirm the mpp tarball ships
the deprecation README instead of the root one:

```sh
cd typescript && pnpm install --frozen-lockfile && pnpm build
pnpm --dir packages/mpp pack --pack-destination /tmp/mpp-pack
tar -tzf /tmp/mpp-pack/*.tgz | grep -E 'package/README.md'
head -3 <(tar -xzOf /tmp/mpp-pack/*.tgz package/README.md)   # should say "deprecated"
```

Workflow stays valid YAML: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/npm-publish.yml'))"`.

## Reviewer note

One deliberate judgment call, and the place to be skeptical: I did **not** remove
the `@solana/mpp` publish job. The #211 security fix lives in `@solana/mpp`
(`server/Charge.ts`, `server/keyLock.ts`) and published mpp latest (`0.6.0`)
does not have it, so the job is kept, marked deprecated, to cut one final
`@solana/mpp@0.7.0` that carries the fix before `npm deprecate`. If you would
rather strip the job in this PR, the final mpp release has to be cut from
pre-merge main first. Publish sequence is spelled out in the PR description.

Also: the deprecation README ships even though it is not in the package `files`
array, because npm always includes `README.md`.

## Fable 5 self-review

Verdict: Approve. Small, self-contained, no code paths touched; the version bump
picks up #211 through pay-kit's mpp dist dependency, which is the intended flow.

If this were someone else's PR I would flag two things: (1) keeping the mpp
publish job is a conscious deviation from "remove mpp from publish" and depends
on the maintainer running the final mpp release then `npm deprecate` in order, so
the sequencing is the real risk, not the code; (2) I did not run a local
`pnpm build` since nothing compiles differently here, so the tarball-README
assertion in the test plan is reasoned, not executed. CI covers the build.

Fable 5 self-review
