### PR TITLE
build(go): move solana-go to the Solana Foundation v2 module

### DIFF
--- a/go/cmd/conformance/main.go
+++ b/go/cmd/conformance/main.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/cmd/conformance/offline_rpc.go
+++ b/go/cmd/conformance/offline_rpc.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 )
 
 // offlineRPC satisfies solanatx.RPCClient but refuses every network call.

--- a/go/examples/playground-api/main.go
+++ b/go/examples/playground-api/main.go
@@ -23,8 +23,8 @@ import (
 	"strconv"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/signer"

--- a/go/examples/playground-api/main_test.go
+++ b/go/examples/playground-api/main_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paykit"

--- a/go/examples/playground-api/playground_e2e_test.go
+++ b/go/examples/playground-api/playground_e2e_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/client"

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,32 +4,30 @@ go 1.26.1
 
 require (
 	github.com/gagliardetto/binary v0.8.0
-	github.com/gagliardetto/solana-go v0.0.0-20260403020633-3cb13b392078
 	github.com/mr-tron/base58 v1.2.0
 	github.com/shopspring/decimal v1.4.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0-rc
 )
 
-replace github.com/gagliardetto/solana-go => github.com/lgalabru/solana-go v0.0.0-20260403020633-3cb13b392078
-
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/gagliardetto/treeout v0.1.4 // indirect
+	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
+	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	go.mongodb.org/mongo-driver v1.17.3 // indirect
+	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
+	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,3 @@
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
-filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AlekSi/pointer v1.2.0 h1:glcy/gc4h8HnG2Z3ZECSzZ1IX1x2JxRVuDzaJwQE0+w=
 github.com/AlekSi/pointer v1.2.0/go.mod h1:gZGfd3dpW4vEc/UlyfKKi1roIqcCgwOIvb0tSNSBle0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -18,9 +16,10 @@ github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvS
 github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=
 github.com/gagliardetto/treeout v0.1.4/go.mod h1:loUefvXTrlRG5rYmJmExNryyBRh8f89VZhmMOyCyqok=
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -32,8 +31,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lgalabru/solana-go v0.0.0-20260403020633-3cb13b392078 h1:+bO7NRkxMIQd6NSLsQeEX8IziMUiQHE148ZH0I/vtrE=
-github.com/lgalabru/solana-go v0.0.0-20260403020633-3cb13b392078/go.mod h1:2n7osXNoDeUhq1r1lOgCMVkl90yYUVrV9FHGINBWPHU=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -42,7 +39,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
@@ -51,6 +47,8 @@ github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 h1:mPMvm
 github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1/go.mod h1:ye2e/VUEtE2BHE+G/QcKkcLQVAEJoYRFj5VUOQatCRE=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 h1:yfQ2sO9WJXUAIUR+g7NUkxJSKCAFJcR5sUDu+ZmjTZI=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729/go.mod h1:hVoHR2EVESiICEMbg137etN/Lx+lSrHPTD39Z/uE+2s=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -59,6 +57,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/solana-foundation/solana-go/v2 v2.0.0-rc h1:5un9mIN2Y1gSj2bGFGh8DoZRRxDrzzXgg6m7pLl4qlM=
+github.com/solana-foundation/solana-go/v2 v2.0.0-rc/go.mod h1:rCWFyIHBSzx1XxFqrqNjvxRza/iHB7viIfAtRJllfe8=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -69,9 +69,11 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
+github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
+github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
-go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
+go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
@@ -91,6 +93,7 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=

--- a/go/internal/testutil/fakes.go
+++ b/go/internal/testutil/fakes.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 
 	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 )
 
 // NewPrivateKey returns a fresh test signer. Panics on key-generation

--- a/go/internal/testutil/fakes_test.go
+++ b/go/internal/testutil/fakes_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 )
 
 func TestFakeRPCRoundTrip(t *testing.T) {

--- a/go/paycore/paymentchannels/paymentchannels.go
+++ b/go/paycore/paymentchannels/paymentchannels.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	generated "github.com/solana-foundation/pay-kit/go/protocols/programs/paymentchannels"
 )

--- a/go/paycore/paymentchannels/paymentchannels_test.go
+++ b/go/paycore/paymentchannels/paymentchannels_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	ag_binary "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	generated "github.com/solana-foundation/pay-kit/go/protocols/programs/paymentchannels"
 )

--- a/go/paycore/paymentchannels/settlement.go
+++ b/go/paycore/paymentchannels/settlement.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"math"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	generated "github.com/solana-foundation/pay-kit/go/protocols/programs/paymentchannels"
 )

--- a/go/paycore/paymentchannels/settlement_test.go
+++ b/go/paycore/paymentchannels/settlement_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 )
 
 // fixedKey returns a deterministic 32-byte public key filled with b.

--- a/go/paycore/signer/signer.go
+++ b/go/paycore/signer/signer.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"strings"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paykit"
 )
 

--- a/go/paycore/solanatx/solanatx.go
+++ b/go/paycore/solanatx/solanatx.go
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/programs/token"
-	token2022 "github.com/gagliardetto/solana-go/programs/token-2022"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	computebudget "github.com/solana-foundation/solana-go/v2/programs/compute-budget"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
+	"github.com/solana-foundation/solana-go/v2/programs/token"
+	token2022 "github.com/solana-foundation/solana-go/v2/programs/token-2022"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 )

--- a/go/paycore/solanatx/solanatx_test.go
+++ b/go/paycore/solanatx/solanatx_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/paykit/adapters/mpp/adapter.go
+++ b/go/paykit/adapters/mpp/adapter.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 	"github.com/solana-foundation/pay-kit/go/paykit"

--- a/go/paykit/adapters/mpp/adapter_internal_test.go
+++ b/go/paykit/adapters/mpp/adapter_internal_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paycore/signer"
 	"github.com/solana-foundation/pay-kit/go/paykit"
 	core "github.com/solana-foundation/pay-kit/go/protocols/mpp/core"

--- a/go/paykit/adapters/x402/exact.go
+++ b/go/paykit/adapters/x402/exact.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paykit"
 	proto "github.com/solana-foundation/pay-kit/go/protocols/x402"

--- a/go/paykit/adapters/x402/usage_adapter_test.go
+++ b/go/paykit/adapters/x402/usage_adapter_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/paykit/adapters/x402/v1_server_test.go
+++ b/go/paykit/adapters/x402/v1_server_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/paycore/signer"
 	"github.com/solana-foundation/pay-kit/go/paykit"
 	proto "github.com/solana-foundation/pay-kit/go/protocols/x402"

--- a/go/paykit/adapters/x402/verify_test.go
+++ b/go/paykit/adapters/x402/verify_test.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/signer"

--- a/go/paykit/preflight.go
+++ b/go/paykit/preflight.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"strings"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 )

--- a/go/paykit/preflight_test.go
+++ b/go/paykit/preflight_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/paycore/signer"
 	"github.com/solana-foundation/pay-kit/go/paykit"
 )

--- a/go/protocols/mpp/client/audit_fixes_test.go
+++ b/go/protocols/mpp/client/audit_fixes_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/client/charge.go
+++ b/go/protocols/mpp/client/charge.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"

--- a/go/protocols/mpp/client/charge_test.go
+++ b/go/protocols/mpp/client/charge_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/client/payment_channels.go
+++ b/go/protocols/mpp/client/payment_channels.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/mpp/client/payment_channels_test.go
+++ b/go/protocols/mpp/client/payment_channels_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/client/session.go
+++ b/go/protocols/mpp/client/session.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"

--- a/go/protocols/mpp/client/session_test.go
+++ b/go/protocols/mpp/client/session_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/mpp/intents/session.go
+++ b/go/protocols/mpp/intents/session.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"
 )

--- a/go/protocols/mpp/server/audit_fixes_test.go
+++ b/go/protocols/mpp/server/audit_fixes_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/server/guards_test.go
+++ b/go/protocols/mpp/server/guards_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	core "github.com/solana-foundation/pay-kit/go/protocols/mpp/core"

--- a/go/protocols/mpp/server/methods.go
+++ b/go/protocols/mpp/server/methods.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/programs/token"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
+	"github.com/solana-foundation/solana-go/v2/programs/token"
 )
 
 // Side-effect imports from solana-go register instruction decoders used by verification.

--- a/go/protocols/mpp/server/parity_test.go
+++ b/go/protocols/mpp/server/parity_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/programs/token"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
+	"github.com/solana-foundation/solana-go/v2/programs/token"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/server/server.go
+++ b/go/protocols/mpp/server/server.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/programs/token"
-	token2022 "github.com/gagliardetto/solana-go/programs/token-2022"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
+	"github.com/solana-foundation/solana-go/v2/programs/token"
+	token2022 "github.com/solana-foundation/solana-go/v2/programs/token-2022"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"

--- a/go/protocols/mpp/server/server_allowlist_test.go
+++ b/go/protocols/mpp/server/server_allowlist_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/programs/token"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
+	"github.com/solana-foundation/solana-go/v2/programs/token"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/server/server_replay_durability_test.go
+++ b/go/protocols/mpp/server/server_replay_durability_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/client"

--- a/go/protocols/mpp/server/server_test.go
+++ b/go/protocols/mpp/server/server_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/token"
-	token2022 "github.com/gagliardetto/solana-go/programs/token-2022"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/token"
+	token2022 "github.com/solana-foundation/solana-go/v2/programs/token-2022"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/server/session.go
+++ b/go/protocols/mpp/server/session.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )

--- a/go/protocols/mpp/server/session_e2e_test.go
+++ b/go/protocols/mpp/server/session_e2e_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/server/session_method.go
+++ b/go/protocols/mpp/server/session_method.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 	core "github.com/solana-foundation/pay-kit/go/protocols/mpp/core"

--- a/go/protocols/mpp/server/session_method_branch_test.go
+++ b/go/protocols/mpp/server/session_method_branch_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/mpp/server/session_method_gap_test.go
+++ b/go/protocols/mpp/server/session_method_gap_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	core "github.com/solana-foundation/pay-kit/go/protocols/mpp/core"

--- a/go/protocols/mpp/server/session_method_test.go
+++ b/go/protocols/mpp/server/session_method_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/mpp/server/session_onchain.go
+++ b/go/protocols/mpp/server/session_onchain.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/mpp/server/session_onchain_test.go
+++ b/go/protocols/mpp/server/session_onchain_test.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/mpp/server/session_server_test.go
+++ b/go/protocols/mpp/server/session_server_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )

--- a/go/protocols/mpp/server/session_voucher.go
+++ b/go/protocols/mpp/server/session_voucher.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )

--- a/go/protocols/mpp/server/session_voucher_test.go
+++ b/go/protocols/mpp/server/session_voucher_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )

--- a/go/protocols/mpp/server/verify_prebroadcast.go
+++ b/go/protocols/mpp/server/verify_prebroadcast.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"

--- a/go/protocols/mpp/server/verify_prebroadcast_test.go
+++ b/go/protocols/mpp/server/verify_prebroadcast_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/programs/paymentchannels/account_channel.go
+++ b/go/protocols/programs/paymentchannels/account_channel.go
@@ -8,7 +8,7 @@ package payment_channels
 
 import (
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 type Channel struct {

--- a/go/protocols/programs/paymentchannels/instruction_distribute.go
+++ b/go/protocols/programs/paymentchannels/instruction_distribute.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var DistributeDiscriminator = 7

--- a/go/protocols/programs/paymentchannels/instruction_emit_event.go
+++ b/go/protocols/programs/paymentchannels/instruction_emit_event.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var EmitEventDiscriminator = 228

--- a/go/protocols/programs/paymentchannels/instruction_open.go
+++ b/go/protocols/programs/paymentchannels/instruction_open.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var OpenDiscriminator = 1

--- a/go/protocols/programs/paymentchannels/instruction_reclaim.go
+++ b/go/protocols/programs/paymentchannels/instruction_reclaim.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var ReclaimDiscriminator = 9

--- a/go/protocols/programs/paymentchannels/instruction_request_close.go
+++ b/go/protocols/programs/paymentchannels/instruction_request_close.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var RequestCloseDiscriminator = 5

--- a/go/protocols/programs/paymentchannels/instruction_seal.go
+++ b/go/protocols/programs/paymentchannels/instruction_seal.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var SealDiscriminator = 6

--- a/go/protocols/programs/paymentchannels/instruction_settle.go
+++ b/go/protocols/programs/paymentchannels/instruction_settle.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var SettleDiscriminator = 2

--- a/go/protocols/programs/paymentchannels/instruction_settle_and_seal.go
+++ b/go/protocols/programs/paymentchannels/instruction_settle_and_seal.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var SettleAndSealDiscriminator = 4

--- a/go/protocols/programs/paymentchannels/instruction_top_up.go
+++ b/go/protocols/programs/paymentchannels/instruction_top_up.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var TopUpDiscriminator = 3

--- a/go/protocols/programs/paymentchannels/instruction_withdraw_payer.go
+++ b/go/protocols/programs/paymentchannels/instruction_withdraw_payer.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 var WithdrawPayerDiscriminator = 8

--- a/go/protocols/programs/paymentchannels/instructions.go
+++ b/go/protocols/programs/paymentchannels/instructions.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 const ProgramName = "PaymentChannels"

--- a/go/protocols/programs/paymentchannels/type_distribution_entry.go
+++ b/go/protocols/programs/paymentchannels/type_distribution_entry.go
@@ -7,7 +7,7 @@
 package payment_channels
 
 import (
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 type DistributionEntry struct {

--- a/go/protocols/programs/paymentchannels/type_opened.go
+++ b/go/protocols/programs/paymentchannels/type_opened.go
@@ -7,7 +7,7 @@
 package payment_channels
 
 import (
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 type Opened struct {

--- a/go/protocols/programs/paymentchannels/type_payout_redirected.go
+++ b/go/protocols/programs/paymentchannels/type_payout_redirected.go
@@ -7,7 +7,7 @@
 package payment_channels
 
 import (
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 type PayoutRedirected struct {

--- a/go/protocols/programs/paymentchannels/type_voucher_args.go
+++ b/go/protocols/programs/paymentchannels/type_voucher_args.go
@@ -7,7 +7,7 @@
 package payment_channels
 
 import (
-	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_solanago "github.com/solana-foundation/solana-go/v2"
 )
 
 type VoucherArgs struct {

--- a/go/protocols/programs/paymentchannels_parity_test/parity_test.go
+++ b/go/protocols/programs/paymentchannels_parity_test/parity_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	bin "github.com/gagliardetto/binary"
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	pc "github.com/solana-foundation/pay-kit/go/protocols/programs/paymentchannels"
 )

--- a/go/protocols/x402/client/client.go
+++ b/go/protocols/x402/client/client.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 	x402 "github.com/solana-foundation/pay-kit/go/protocols/x402"

--- a/go/protocols/x402/client/client_test.go
+++ b/go/protocols/x402/client/client_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"

--- a/go/protocols/x402/client/parity_test.go
+++ b/go/protocols/x402/client/parity_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	x402 "github.com/solana-foundation/pay-kit/go/protocols/x402"

--- a/go/protocols/x402/client/upto.go
+++ b/go/protocols/x402/client/upto.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 	x402 "github.com/solana-foundation/pay-kit/go/protocols/x402"

--- a/go/protocols/x402/client/upto_test.go
+++ b/go/protocols/x402/client/upto_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/x402/upto.go
+++ b/go/protocols/x402/upto.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/shopspring/decimal"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/x402/upto_coverage_test.go
+++ b/go/protocols/x402/upto_coverage_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"

--- a/go/protocols/x402/upto_test.go
+++ b/go/protocols/x402/upto_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"

--- a/go/protocols/x402/verify.go
+++ b/go/protocols/x402/verify.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 )

--- a/go/protocols/x402/verify_full_coverage_test.go
+++ b/go/protocols/x402/verify_full_coverage_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/paycore"
 	"github.com/solana-foundation/pay-kit/go/paycore/solanatx"
 )

--- a/go/protocols/x402/x402.go
+++ b/go/protocols/x402/x402.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	solana "github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	solana "github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 )
 
 const (

--- a/go/protocols/x402/x402_coverage_test.go
+++ b/go/protocols/x402/x402_coverage_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	solana "github.com/gagliardetto/solana-go"
+	solana "github.com/solana-foundation/solana-go/v2"
 	"github.com/solana-foundation/pay-kit/go/internal/testutil"
 	"github.com/solana-foundation/pay-kit/go/paycore/paymentchannels"
 )


### PR DESCRIPTION
## What

Moves the Go SDK's `solana-go` dependency to the Solana Foundation's namespaced v2 module.

- **Before** (on `main`): `github.com/gagliardetto/solana-go` pinned to a pseudo-version and pulled from the **lgalabru personal fork** via a `replace` directive.
- **After**: `github.com/solana-foundation/solana-go/v2` at `v2.0.0-rc`, imported directly (no `replace`).

## Why it is a pure import rewrite

The Foundation's v2 carries three breaking changes vs v1: (1) the module path, (2) `programs/loader-v2/v3/v4` realignment, (3) the WebSocket subscription API. pay-kit's Go SDK imports only the root, `/rpc`, and `/programs/{token,system,token-2022,compute-budget}` packages — it touches **neither** the loader packages **nor** `/rpc/ws` — so only breaking change (1) applies. The code is functionally identical to the `v1.22.0` line pay-kit already ran; this is an 80-file import-path rewrite plus `go.mod`/`go.sum`.

## Verification

- `go build ./...` — clean
- `go test ./...` — 20/20 packages green

## Follow-up

Pinned to `v2.0.0-rc` (the current v2 release candidate). Bump to `v2.0.0` once the Foundation tags GA.
