### PR TITLE
fix(php): exercise the exact verifier

### DIFF
--- a/php/conformance/runner.php
+++ b/php/conformance/runner.php
@@ -24,10 +24,9 @@ declare(strict_types=1);
  *                               first, which a server-only SDK cannot do.
  *   - build-transaction      -> unsupported (no client build path)
  *
- * x402-exact (intent === "x402-exact"): the cross-SDK oracle is the decoded
- * ENVELOPE shape, not the signed Solana transaction inside
- * payload.transaction (that is the harness matrix's job). PHP is server-only,
- * so:
+ * x402-exact (intent === "x402-exact"): PHP verifies payment envelopes and
+ * directly exercises the signed transaction's exact structural verifier.
+ * PHP is server-only, so:
  *
  *   - build-transaction (x402)  -> unsupported (no client envelope builder)
  *   - verify-transaction (x402) -> supported: drive the x402 envelope verify
@@ -40,6 +39,9 @@ declare(strict_types=1);
  *                                  and the rust spine line-for-line. The
  *                                  inner-transaction 11-rule structural check
  *                                  and broadcast are out of scope here.
+ *   - verify-x402-transaction   -> supported: run the real 11-rule exact
+ *                                  verifier and expose canonical rejects as
+ *                                  x402ExactRejectCode.
  *
  * For any mode this SDK cannot exercise, the runner emits a RunnerResult with
  * outcome "unsupported-mode" so the driver SKIPs that vector for PHP rather
@@ -63,6 +65,7 @@ use PayKit\Protocols\Mpp\Core\ChallengeEcho;
 use PayKit\Protocols\Mpp\Core\Credential;
 use PayKit\Protocols\Mpp\Intent\ChargeRequest;
 use PayKit\Protocols\Mpp\Server\SolanaChargeTransactionVerifier;
+use PayKit\Protocols\X402\Exact\Verifier;
 use PayKit\Protocols\X402\Exact\PaymentExtensions;
 use SolanaPhpSdk\Keypair\PublicKey;
 use SolanaPhpSdk\Programs\AssociatedTokenProgram;
@@ -753,9 +756,8 @@ function verify_x402_header(string $header, array $route): array
 }
 
 /**
- * Drive the x402-exact intent. PHP is server-only, so build vectors are
- * unsupported (no client envelope builder) and verify vectors run the
- * envelope-level verify against the vector's server route.
+ * Drive the x402-exact intent. Exact-transaction vectors call the production
+ * structural verifier; the envelope modes retain the server-only behavior.
  *
  * @param array<string, mixed> $vector
  * @return array<string, mixed>
@@ -765,6 +767,42 @@ function run_x402_vector(array $vector): array
     $id = Json::optionalString($vector['id'] ?? null, 'id');
     $mode = Json::optionalString($vector['mode'] ?? null, 'mode');
     $input = is_array($vector['input'] ?? null) ? Json::object($vector['input'], 'input') : [];
+
+    if ($mode === 'verify-x402-transaction') {
+        $transaction = $input['transaction'] ?? null;
+        if (!is_string($transaction) || $transaction === '') {
+            throw new InvalidArgumentException(
+                'invalid payload: verify-x402-transaction vector missing input.transaction',
+            );
+        }
+        $requirement = $input['x402ExactRequirement'] ?? null;
+        if (!is_array($requirement)) {
+            throw new InvalidArgumentException(
+                'invalid payload: verify-x402-transaction vector missing input.x402ExactRequirement',
+            );
+        }
+        $managed = $input['x402ExactManagedSigners'] ?? [];
+        if (!is_array($managed)) {
+            throw new InvalidArgumentException(
+                'invalid payload: x402ExactManagedSigners must be an array',
+            );
+        }
+        $managedSigners = [];
+        foreach ($managed as $signer) {
+            if (!is_string($signer) || $signer === '') {
+                throw new InvalidArgumentException(
+                    'invalid payload: x402ExactManagedSigners must contain non-empty strings',
+                );
+            }
+            $managedSigners[] = $signer;
+        }
+
+        Verifier::verify($transaction, $requirement, $managedSigners);
+        return [
+            'id' => $id,
+            'outcome' => 'accept',
+        ];
+    }
 
     if ($mode === 'build-transaction') {
         // PHP ships no client-side x402 envelope builder; build vectors are
@@ -952,6 +990,9 @@ try {
         $rejectCode = classify_reject($message);
         if ($rejectCode !== null) {
             $result['rejectCode'] = $rejectCode;
+        }
+        if (str_starts_with($message, 'invalid_exact_svm_payload_')) {
+            $result['x402ExactRejectCode'] = $message;
         }
         emit($result);
     }

--- a/php/conformance/runner.php
+++ b/php/conformance/runner.php
@@ -971,13 +971,42 @@ function run_vector(array $vector): array
     }
 }
 
+/** Extract the ASCII vector id before decoding so a PHP UTF-16 parser reject can
+ * still be reported through the runner ABI instead of terminating the process. */
+function vector_id_from_raw(string $raw): ?string
+{
+    if (preg_match('/"id"\s*:\s*"([A-Za-z0-9._-]+)"/', $raw, $matches) !== 1) {
+        return null;
+    }
+    return $matches[1];
+}
+
+$rawVector = read_stdin();
+$rawVectorId = vector_id_from_raw($rawVector);
+
 try {
-    $vector = json_decode(read_stdin(), true, flags: JSON_THROW_ON_ERROR);
+    $vector = json_decode($rawVector, true, flags: JSON_THROW_ON_ERROR);
     if (!is_array($vector)) {
         throw new InvalidArgumentException('vector must be a JSON object');
     }
     $vector = Json::object($vector, 'vector');
     $id = Json::optionalString($vector['id'] ?? null, 'id');
+
+    // Associative decoding collapses both `{}` and `[]` into an empty PHP
+    // array. Preserve the canonical-bytes value's JSON object/list identity by
+    // taking that subtree from a stdClass decode instead.
+    if (($vector['mode'] ?? null) === 'canonical-bytes') {
+        $objectVector = json_decode($rawVector, false, flags: JSON_THROW_ON_ERROR);
+        if (
+            $objectVector instanceof stdClass
+            && isset($objectVector->input)
+            && $objectVector->input instanceof stdClass
+            && property_exists($objectVector->input, 'value')
+            && is_array($vector['input'] ?? null)
+        ) {
+            $vector['input']['value'] = $objectVector->input->value;
+        }
+    }
     try {
         emit(run_vector($vector));
     } catch (Throwable $error) {
@@ -996,6 +1025,17 @@ try {
         }
         emit($result);
     }
+} catch (JsonException $fatal) {
+    if ($fatal->getCode() === JSON_ERROR_UTF16 && $rawVectorId !== null) {
+        emit([
+            'id' => $rawVectorId,
+            'outcome' => 'reject',
+            'error' => $fatal->getMessage(),
+        ]);
+        exit(0);
+    }
+    fwrite(STDERR, 'php conformance runner fatal: ' . $fatal->getMessage() . "\n");
+    exit(1);
 } catch (Throwable $fatal) {
     fwrite(STDERR, 'php conformance runner fatal: ' . $fatal->getMessage() . "\n");
     exit(1);

--- a/php/src/PayCore/Wire/Json.php
+++ b/php/src/PayCore/Wire/Json.php
@@ -50,6 +50,9 @@ final class Json
             }
             return self::encodeObject($value);
         }
+        if ($value instanceof \stdClass) {
+            return self::encodeObject(get_object_vars($value));
+        }
         throw new InvalidArgumentException('unsupported JSON value');
     }
 

--- a/php/src/Protocols/Mpp/Adapter.php
+++ b/php/src/Protocols/Mpp/Adapter.php
@@ -8,6 +8,7 @@ use PayKit\Config;
 use PayKit\Exception\InvalidProofException;
 use PayKit\Gate;
 use PayKit\Payment;
+use PayKit\PayCore\Network;
 use PayKit\Price;
 use PayKit\Protocol;
 use PayKit\Protocols\Mpp\Intent\ChargeRequest;
@@ -16,6 +17,7 @@ use PayKit\Protocols\Mpp\Server\ChargeSettlement;
 use PayKit\Protocols\Mpp\Server\PaymentRequiredResponse;
 use PayKit\Protocols\Mpp\Server\SolanaChargeHandler;
 use PayKit\Store\MemoryStore;
+use PayKit\Store\ReplayStoreCapability;
 use PayKit\Store\Store;
 use Psr\Http\Message\ServerRequestInterface;
 use SolanaPhpSdk\Keypair\Keypair;
@@ -40,24 +42,39 @@ final class Adapter
 
     /**
      * @param ?Store $replayStore Replay-protection store shared across every
-     *        {@see SolanaChargeHandler} this adapter builds. When null (the
-     *        default) an in-process {@see MemoryStore} is used and a loud
-     *        dev-only warning is emitted: a single-process memory store
-     *        loses replay protection across workers/restarts, so production
-     *        deployments MUST inject a shared atomic store (Redis, Postgres).
+     *        {@see SolanaChargeHandler} this adapter builds. When null, the
+     *        MPP config's replayStore is used. Localnet may fall back to an
+     *        in-process {@see MemoryStore}; every other network requires a
+     *        store that explicitly declares durable shared replay protection.
      */
     public function __construct(
         private readonly Config $config,
         ?Store $replayStore = null,
     ) {
+        $replayStore ??= $config->mpp->replayStore;
         if ($replayStore === null) {
+            if ($config->network !== Network::SolanaLocalnet) {
+                throw new \InvalidArgumentException(
+                    'pay_kit: MPP replayStore is required outside localnet; '
+                    . 'inject a durable shared Store (for example Redis or Postgres)',
+                );
+            }
             if (function_exists('error_log')) {
                 error_log(
                     'pay_kit: WARN: mpp adapter using in-memory replay store; '
-                    . 'dev-only. Inject a shared atomic Store (Redis/Postgres) in production.',
+                    . 'allowed only on localnet.',
                 );
             }
             $replayStore = new MemoryStore();
+        }
+        if (
+            $config->network !== Network::SolanaLocalnet
+            && (!$replayStore instanceof ReplayStoreCapability
+                || !$replayStore->providesDurableSharedReplayProtection())
+        ) {
+            throw new \InvalidArgumentException(
+                'pay_kit: MPP replayStore must explicitly declare durable shared replay protection outside localnet',
+            );
         }
         $this->replayStore = $replayStore;
     }

--- a/php/src/Protocols/Mpp/MppConfig.php
+++ b/php/src/Protocols/Mpp/MppConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PayKit\Protocols\Mpp;
 
 use PayKit\Exception\ConfigurationException;
+use PayKit\Store\Store;
 
 /**
  * MPP scheme sub-configuration. `challengeBindingSecret` is the
@@ -37,6 +38,7 @@ final readonly class MppConfig
         public ?string $challengeBindingSecret = null,
         public int $expiresIn = 120,
         public bool $acceptPushMode = false,
+        public ?Store $replayStore = null,
     ) {
         if ($expiresIn < 0) {
             throw new ConfigurationException(
@@ -55,7 +57,13 @@ final readonly class MppConfig
 
     public function withChallengeBindingSecret(string $secret): self
     {
-        return new self($this->realm, $secret, $this->expiresIn, $this->acceptPushMode);
+        return new self(
+            $this->realm,
+            $secret,
+            $this->expiresIn,
+            $this->acceptPushMode,
+            $this->replayStore,
+        );
     }
 
     /**

--- a/php/src/Protocols/Mpp/Server/SolanaChargeHandler.php
+++ b/php/src/Protocols/Mpp/Server/SolanaChargeHandler.php
@@ -12,6 +12,7 @@ use PayKit\PayCore\Rpc\SolanaRpcGateway;
 use PayKit\Protocols\Mpp\Core\Credential;
 use PayKit\Protocols\Mpp\Intent\ChargeRequest;
 use PayKit\Store\MemoryStore;
+use PayKit\Store\ReplayStoreCapability;
 use PayKit\Store\Store;
 use SolanaPhpSdk\Keypair\Keypair;
 use SolanaPhpSdk\Rpc\RpcClient;
@@ -66,10 +67,9 @@ final class SolanaChargeHandler
      *        `getSignatureStatuses` before giving up. 40 attempts at the
      *        default delay = 10 seconds.
      * @param int $confirmationDelayMicros Sleep between polls in microseconds.
-     * @param ?Store $replayStore Replay-protection store. Defaults to an
-     *        in-process {@see MemoryStore}; production deployments should
-     *        inject a shared atomic store (Redis, Postgres) so replay
-     *        protection survives restarts and worker pools.
+     * @param ?Store $replayStore Replay-protection store. Localnet defaults to
+     *        an in-process {@see MemoryStore}; all other networks require a
+     *        store that explicitly declares durable shared replay protection.
      */
     private readonly RpcGateway $rpc;
 
@@ -93,7 +93,25 @@ final class SolanaChargeHandler
         $this->verifier = $verifier ?? new SolanaChargeTransactionVerifier(acceptPushMode: $acceptPushMode);
         $this->transactionVerifier = $transactionVerifier
             ?? ($this->verifier instanceof TransactionPayloadVerifier ? $this->verifier : new SolanaChargeTransactionVerifier(acceptPushMode: $acceptPushMode));
-        $this->replayStore = $replayStore ?? new MemoryStore();
+        if ($replayStore === null) {
+            if ($network !== 'localnet') {
+                throw new InvalidArgumentException(
+                    'pay_kit: MPP replayStore is required outside localnet; '
+                    . 'inject a durable shared Store (for example Redis or Postgres)',
+                );
+            }
+            $replayStore = new MemoryStore();
+        }
+        if (
+            $network !== 'localnet'
+            && (!$replayStore instanceof ReplayStoreCapability
+                || !$replayStore->providesDurableSharedReplayProtection())
+        ) {
+            throw new InvalidArgumentException(
+                'pay_kit: MPP replayStore must explicitly declare durable shared replay protection outside localnet',
+            );
+        }
+        $this->replayStore = $replayStore;
     }
 
     /**

--- a/php/src/Protocols/X402/Exact/Verifier.php
+++ b/php/src/Protocols/X402/Exact/Verifier.php
@@ -24,7 +24,7 @@ use Throwable;
  *   2. ix[0] = ComputeBudget SetComputeUnitLimit
  *   3. ix[1] = ComputeBudget SetComputeUnitPrice <= MAX
  *   4. ix[2] = SPL TransferChecked
- *   5. Authority guard (no fee-payer in transfer auth)
+ *   5. Fund-mover guard (managed source, source ATA, or signer tail)
  *   6. Mint match
  *   7. Destination ATA match (re-derived)
  *   8. Amount match
@@ -203,23 +203,22 @@ final class Verifier
         $destination = self::accountAt($accountKeys, $ix, 2);
         $authority   = self::accountAt($accountKeys, $ix, 3);
 
-        // Rule 5: authority guard.
+        // Rule 5: a managed signer must never move funds. Scope this to
+        // transferChecked fund-moving roles, not every instruction account:
+        // the source itself, its ATA for the actual transfer program, and
+        // authority/multisig signer-tail accounts at positions 3 onward.
         foreach ($managedSigners as $managed) {
-            if ($managed === $authority || $managed === $source) {
+            if ($managed === $source
+                || $source === Mints::deriveAta($managed, $mint, $program)) {
                 throw new InvalidProofException(
                     'invalid_exact_svm_payload_transaction_fee_payer_transferring_funds',
                 );
             }
-        }
-        foreach ($ix->accountKeyIndexes as $idx) {
-            $key = $accountKeys[$idx] ?? null;
-            if ($key === null) {
-                continue;
-            }
-            foreach ($managedSigners as $managed) {
+            foreach (array_slice($ix->accountKeyIndexes, 3) as $idx) {
+                $key = $accountKeys[$idx] ?? '';
                 if ($managed === $key) {
                     throw new InvalidProofException(
-                        'invalid_exact_svm_payload_transaction_fee_payer_in_instruction_accounts',
+                        'invalid_exact_svm_payload_transaction_fee_payer_transferring_funds',
                     );
                 }
             }

--- a/php/src/Store/FileStore.php
+++ b/php/src/Store/FileStore.php
@@ -18,7 +18,7 @@ use RuntimeException;
  * arbitrary key strings (including ones containing path separators) without
  * worrying about filesystem-safe encodings.
  */
-final class FileStore implements Store
+final class FileStore implements Store, ReplayStoreCapability
 {
     public function __construct(private readonly string $directory)
     {
@@ -48,6 +48,13 @@ final class FileStore implements Store
         }
 
         return true;
+    }
+
+    public function providesDurableSharedReplayProtection(): bool
+    {
+        // A local filesystem may survive restarts, but it is not a shared
+        // backend for a multi-host deployment.
+        return false;
     }
 
     private function pathForKey(string $key): string

--- a/php/src/Store/MemoryStore.php
+++ b/php/src/Store/MemoryStore.php
@@ -11,7 +11,7 @@ namespace PayKit\Store;
  * shared atomic backing store (Redis, Postgres, DynamoDB) instead, otherwise
  * replay protection is lost across the worker pool.
  */
-final class MemoryStore implements Store
+final class MemoryStore implements Store, ReplayStoreCapability
 {
     /**
      * @var array<string, mixed>
@@ -25,5 +25,10 @@ final class MemoryStore implements Store
         }
         $this->values[$key] = $value;
         return true;
+    }
+
+    public function providesDurableSharedReplayProtection(): bool
+    {
+        return false;
     }
 }

--- a/php/src/Store/ReplayStoreCapability.php
+++ b/php/src/Store/ReplayStoreCapability.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Store;
+
+/**
+ * Explicit capability declaration for replay-protection stores.
+ *
+ * Non-localnet MPP servers fail closed unless their Store implements this
+ * interface and returns true. A Store that does not implement this interface
+ * is intentionally treated as unsafe until its author makes the durability
+ * and cross-worker sharing guarantee explicit.
+ */
+interface ReplayStoreCapability
+{
+    /**
+     * True only when atomic replay reservations are durable and shared across
+     * every server worker that can accept the same payment credential.
+     */
+    public function providesDurableSharedReplayProtection(): bool;
+}

--- a/php/tests/Conformance/X402ExactVerifierVectorTest.php
+++ b/php/tests/Conformance/X402ExactVerifierVectorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Conformance;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Drives the x402 exact structural-verifier vectors through the PHP runner's
+ * real stdin/stdout ABI. This protects both the production Verifier route and
+ * the x402ExactRejectCode field that the shared harness asserts verbatim.
+ */
+final class X402ExactVerifierVectorTest extends TestCase
+{
+    private const RUNNER = __DIR__ . '/../../conformance/runner.php';
+    private const VECTORS = __DIR__ . '/../../../harness/vectors/x402-exact-reject.json';
+
+    /**
+     * @param array<string, mixed> $vector
+     * @return array<string, mixed>
+     */
+    private function runVector(array $vector): array
+    {
+        $process = proc_open(
+            [PHP_BINARY, self::RUNNER],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+        if (!is_resource($process)) {
+            throw new RuntimeException('failed to spawn php conformance runner');
+        }
+        fwrite($pipes[0], json_encode($vector, JSON_THROW_ON_ERROR));
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $code = proc_close($process);
+        if ($code !== 0) {
+            throw new RuntimeException("runner exited $code: $stderr");
+        }
+        $result = json_decode(trim((string) $stdout), true, flags: JSON_THROW_ON_ERROR);
+        if (!is_array($result)) {
+            throw new RuntimeException('runner emitted non-object: ' . $stdout);
+        }
+        return $result;
+    }
+
+    public function testExactVerifierVectorsConform(): void
+    {
+        $raw = file_get_contents(self::VECTORS);
+        if ($raw === false) {
+            throw new RuntimeException('missing x402 exact verifier vectors');
+        }
+        $vectors = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($vectors);
+        self::assertNotEmpty($vectors, 'expected x402 exact verifier vectors');
+
+        foreach ($vectors as $vector) {
+            self::assertIsArray($vector);
+            $id = $vector['id'] ?? '?';
+            $expect = $vector['expect'] ?? [];
+            self::assertSame('verify-x402-transaction', $vector['mode'] ?? null, "mode mismatch for $id");
+
+            $result = $this->runVector($vector);
+            self::assertSame(
+                $expect['outcome'] ?? null,
+                $result['outcome'] ?? null,
+                "outcome mismatch for $id: " . json_encode($result),
+            );
+
+            if (($expect['outcome'] ?? null) === 'reject') {
+                self::assertSame(
+                    $expect['x402ExactRejectCode'] ?? null,
+                    $result['x402ExactRejectCode'] ?? null,
+                    "x402ExactRejectCode mismatch for $id: " . json_encode($result),
+                );
+            }
+        }
+    }
+}

--- a/php/tests/Middleware/RequirePaymentTest.php
+++ b/php/tests/Middleware/RequirePaymentTest.php
@@ -18,6 +18,9 @@ use PayKit\Pricing;
 use PayKit\Protocol;
 use PayKit\Protocols\Mpp\MppConfig;
 use PayKit\Signer;
+use PayKit\Store\MemoryStore;
+use PayKit\Store\ReplayStoreCapability;
+use PayKit\Store\Store;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,7 +37,10 @@ final class RequirePaymentTest extends TestCase
             network: Network::SolanaDevnet,
             operator: new Operator(recipient: Signer::generate()->pubkey(), signer: Signer::generate(), feePayer: true),
             preflight: false,
-            mpp: new MppConfig(challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01'),
+            mpp: new MppConfig(
+                challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01',
+                replayStore: new MiddlewareDurableSharedReplayStore(),
+            ),
         ));
         $this->factory = new Psr17Factory();
     }
@@ -163,5 +169,25 @@ final class RequirePaymentTest extends TestCase
         $request = $this->factory->createServerRequest('GET', '/');
         $this->expectException(\PayKit\Exception\PaymentRequiredException::class);
         \PayKit\Middleware\requirePayment($request);
+    }
+}
+
+final class MiddlewareDurableSharedReplayStore implements Store, ReplayStoreCapability
+{
+    private MemoryStore $store;
+
+    public function __construct()
+    {
+        $this->store = new MemoryStore();
+    }
+
+    public function putIfAbsent(string $key, mixed $value): bool
+    {
+        return $this->store->putIfAbsent($key, $value);
+    }
+
+    public function providesDurableSharedReplayProtection(): bool
+    {
+        return true;
     }
 }

--- a/php/tests/PayCore/Wire/Base64UrlTest.php
+++ b/php/tests/PayCore/Wire/Base64UrlTest.php
@@ -69,12 +69,12 @@ final class Base64UrlTest extends TestCase
         Base64Url::decodeJson(Base64Url::encode('{'));
     }
 
-    public function testRejectsNonJsonValuesDuringCanonicalization(): void
+    public function testCanonicalizesStdClassAsJsonObject(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('unsupported JSON value');
+        $encoded = Base64Url::encodeJson(['object' => (object)['not' => 'json']]);
 
-        Base64Url::encodeJson(['object' => (object)['not' => 'json']]);
+        self::assertSame('{"object":{"not":"json"}}', Base64Url::decode($encoded));
+        self::assertSame(['object' => ['not' => 'json']], Base64Url::decodeJson($encoded));
     }
 
     public function testRejectsJsonScalars(): void

--- a/php/tests/PayCore/Wire/JsonCanonicalTest.php
+++ b/php/tests/PayCore/Wire/JsonCanonicalTest.php
@@ -126,7 +126,11 @@ final class JsonCanonicalTest extends TestCase
     public function testCanonicalizeEmptyArrayAndObject(): void
     {
         self::assertSame('[]', Json::canonicalize([]));
-        // Non-list array with one item works through encodeObject; empty array is list-shape per array_is_list.
+        self::assertSame('{}', Json::canonicalize(new \stdClass()));
+        self::assertSame(
+            '{"array":[],"object":{}}',
+            Json::canonicalize(['object' => new \stdClass(), 'array' => []]),
+        );
     }
 
     public function testCanonicalizeRejectsUnsupportedValue(): void

--- a/php/tests/Protocols/Mpp/AdapterTest.php
+++ b/php/tests/Protocols/Mpp/AdapterTest.php
@@ -17,6 +17,9 @@ use PayKit\Protocols\Mpp\Intent\ChargeRequest;
 use PayKit\Protocols\Mpp\MppConfig;
 use PayKit\Signer;
 use PayKit\PayCore\Stablecoin;
+use PayKit\Store\MemoryStore;
+use PayKit\Store\ReplayStoreCapability;
+use PayKit\Store\Store;
 use PHPUnit\Framework\TestCase;
 
 final class AdapterTest extends TestCase
@@ -31,8 +34,42 @@ final class AdapterTest extends TestCase
                 feePayer:  true,
             ),
             preflight: false,
+            mpp: new MppConfig(
+                challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01',
+                replayStore: new AdapterDurableSharedReplayStore(),
+            ),
+        );
+    }
+
+    public function testNonLocalnetRejectsMissingReplayStore(): void
+    {
+        $config = new Config(
+            network: Network::SolanaDevnet,
+            preflight: false,
             mpp: new MppConfig(challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01'),
         );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('replayStore is required outside localnet');
+
+        new Adapter($config);
+    }
+
+    public function testNonLocalnetRejectsStoreWithoutDurableSharedCapability(): void
+    {
+        $config = new Config(
+            network: Network::SolanaDevnet,
+            preflight: false,
+            mpp: new MppConfig(
+                challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01',
+                replayStore: new MemoryStore(),
+            ),
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must explicitly declare durable shared replay protection');
+
+        new Adapter($config);
     }
 
     public function testAcceptsEntryShape(): void
@@ -227,7 +264,11 @@ final class AdapterTest extends TestCase
                 feePayer:  true,
             ),
             preflight: false,
-            mpp: new MppConfig(challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01', expiresIn: $expiresIn),
+            mpp: new MppConfig(
+                challengeBindingSecret: 'unit-test-secret-0123456789abcdef-01',
+                expiresIn: $expiresIn,
+                replayStore: new AdapterDurableSharedReplayStore(),
+            ),
         );
     }
 
@@ -287,5 +328,25 @@ final class AdapterTest extends TestCase
         $this->assertSame('', $challenge->expires, 'expiresIn=0 must issue an empty (never-expires) challenge');
         $farFuture = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->add(new \DateInterval('P3650D'));
         $this->assertFalse($challenge->isExpired($farFuture));
+    }
+}
+
+final class AdapterDurableSharedReplayStore implements Store, ReplayStoreCapability
+{
+    private MemoryStore $store;
+
+    public function __construct()
+    {
+        $this->store = new MemoryStore();
+    }
+
+    public function putIfAbsent(string $key, mixed $value): bool
+    {
+        return $this->store->putIfAbsent($key, $value);
+    }
+
+    public function providesDurableSharedReplayProtection(): bool
+    {
+        return true;
     }
 }

--- a/php/tests/Protocols/Mpp/Server/SolanaChargeHandlerInternalsTest.php
+++ b/php/tests/Protocols/Mpp/Server/SolanaChargeHandlerInternalsTest.php
@@ -29,7 +29,7 @@ final class SolanaChargeHandlerInternalsTest extends TestCase
             ),
             rpc: $rpc,
             feePayer: null,
-            network: 'mainnet',
+            network: 'localnet',
             verifier: new SolanaChargeTransactionVerifier(),
             confirmationAttempts: $confirmationAttempts,
             confirmationDelayMicros: $confirmationDelayMicros,

--- a/php/tests/Protocols/Mpp/Server/SolanaChargeHandlerTest.php
+++ b/php/tests/Protocols/Mpp/Server/SolanaChargeHandlerTest.php
@@ -16,6 +16,8 @@ use PayKit\Protocols\Mpp\Server\SolanaChargeHandler;
 use PayKit\Protocols\Mpp\Server\TransactionPayloadVerifier;
 use PayKit\Protocols\Mpp\Server\VerificationResult;
 use PayKit\Store\FileStore;
+use PayKit\Store\MemoryStore;
+use PayKit\Store\ReplayStoreCapability;
 use PayKit\Store\Store;
 use SolanaPhpSdk\Util\Base58;
 use SolanaPhpSdk\Keypair\Keypair;
@@ -175,6 +177,7 @@ final class SolanaChargeHandlerTest extends TestCase
             challenges: $challenges,
             verifier: new AlwaysAcceptVerifier(),
             network: 'devnet',
+            replayStore: new HandlerDurableSharedReplayStore(),
         );
 
         $result = $handler->handle($credential->toAuthorizationHeader(), $request);
@@ -182,6 +185,40 @@ final class SolanaChargeHandlerTest extends TestCase
         self::assertInstanceOf(PaymentRequiredResponse::class, $result);
         self::assertStringContainsString('Surfpool localnet blockhash', $result->body['detail']);
         self::assertStringContainsString('devnet', $result->body['detail']);
+    }
+
+    public function testNonLocalnetRejectsMissingReplayStore(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('replayStore is required outside localnet');
+
+        $this->handler(network: 'devnet');
+    }
+
+    public function testNonLocalnetRejectsMemoryReplayStore(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must explicitly declare durable shared replay protection');
+
+        $this->handler(network: 'devnet', replayStore: new MemoryStore());
+    }
+
+    public function testNonLocalnetRejectsStoreWithoutReplayCapability(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must explicitly declare durable shared replay protection');
+
+        $this->handler(network: 'devnet', replayStore: new HandlerUnspecifiedReplayStore());
+    }
+
+    public function testNonLocalnetAcceptsExplicitDurableSharedReplayStore(): void
+    {
+        $handler = $this->handler(
+            network: 'devnet',
+            replayStore: new HandlerDurableSharedReplayStore(),
+        );
+
+        self::assertInstanceOf(SolanaChargeHandler::class, $handler);
     }
 
     public function testReturns402WhenBroadcastReportsOnChainFailure(): void
@@ -575,7 +612,7 @@ final class SolanaChargeHandlerTest extends TestCase
     private function handler(
         ?ChargeServer $challenges = null,
         ?Keypair $feePayer = null,
-        string $network = 'mainnet-beta',
+        string $network = 'localnet',
         ?RpcClient $rpc = null,
         ?PaymentVerifier $verifier = null,
         ?TransactionPayloadVerifier $transactionVerifier = null,
@@ -652,6 +689,41 @@ final class SolanaChargeHandlerTest extends TestCase
             recipient: 'CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY',
             methodDetails: ['network' => 'localnet', 'decimals' => 6],
         );
+    }
+}
+
+final class HandlerUnspecifiedReplayStore implements Store
+{
+    private MemoryStore $store;
+
+    public function __construct()
+    {
+        $this->store = new MemoryStore();
+    }
+
+    public function putIfAbsent(string $key, mixed $value): bool
+    {
+        return $this->store->putIfAbsent($key, $value);
+    }
+}
+
+final class HandlerDurableSharedReplayStore implements Store, ReplayStoreCapability
+{
+    private MemoryStore $store;
+
+    public function __construct()
+    {
+        $this->store = new MemoryStore();
+    }
+
+    public function putIfAbsent(string $key, mixed $value): bool
+    {
+        return $this->store->putIfAbsent($key, $value);
+    }
+
+    public function providesDurableSharedReplayProtection(): bool
+    {
+        return true;
     }
 }
 

--- a/php/tests/Protocols/X402/Exact/AtaCreateRejectTest.php
+++ b/php/tests/Protocols/X402/Exact/AtaCreateRejectTest.php
@@ -39,16 +39,21 @@ final class AtaCreateRejectTest extends TestCase
      * return [base64, requirement].
      *
      * @param list<array{program:string,data:string,accounts:list<string>}> $optionals
+     * @param list<string> $signerTail
      * @return array{0:string,1:array<string,mixed>}
      */
-    private function buildTransaction(array $optionals): array
-    {
+    private function buildTransaction(
+        array $optionals,
+        ?string $source = null,
+        ?string $authority = null,
+        array $signerTail = [],
+        string $tokenProgram = self::TOKEN_PROGRAM,
+    ): array {
         $payer     = Keypair::generate()->getPublicKey()->toBase58();
-        $authority = Keypair::generate()->getPublicKey()->toBase58();
-        $source    = Keypair::generate()->getPublicKey()->toBase58();
+        $authority ??= Keypair::generate()->getPublicKey()->toBase58();
+        $source ??= Keypair::generate()->getPublicKey()->toBase58();
         $payTo     = Keypair::generate()->getPublicKey()->toBase58();
         $mint      = self::USDC_MINT;
-        $tokenProgram = self::TOKEN_PROGRAM;
         $destination  = Mints::deriveAta($payTo, $mint, $tokenProgram);
         $amount = 100000;
 
@@ -81,7 +86,10 @@ final class AtaCreateRejectTest extends TestCase
         );
         $instructions[] = new CompiledInstructionV0(
             $indexOf($tokenProgram),
-            [$indexOf($source), $indexOf($mint), $indexOf($destination), $indexOf($authority)],
+            array_map(
+                $indexOf,
+                array_merge([$source, $mint, $destination, $authority], $signerTail),
+            ),
             $transferData,
         );
         foreach ($optionals as $opt) {
@@ -125,10 +133,15 @@ final class AtaCreateRejectTest extends TestCase
         return [base64_encode($wire), $requirement];
     }
 
+    private function unrelatedManagedSigner(): string
+    {
+        return Keypair::generate()->getPublicKey()->toBase58();
+    }
+
     public function testTransactionWithoutOptionalsVerifies(): void
     {
         [$tx, $req] = $this->buildTransaction([]);
-        $result = Verifier::verify($tx, $req, ['someFacilitatorPubkeyThatIsNotInTx']);
+        $result = Verifier::verify($tx, $req, [$this->unrelatedManagedSigner()]);
         $this->assertSame(self::TOKEN_PROGRAM, $result['program']);
         $this->assertSame(100000, $result['amount']);
         $this->assertArrayNotHasKey('destinationCreateAta', $result);
@@ -142,7 +155,7 @@ final class AtaCreateRejectTest extends TestCase
             ['program' => self::LIGHTHOUSE, 'data' => chr(0), 'accounts' => []],
             ['program' => self::LIGHTHOUSE, 'data' => chr(0), 'accounts' => []],
         ]);
-        $result = Verifier::verify($tx, $req, ['someFacilitatorPubkeyThatIsNotInTx']);
+        $result = Verifier::verify($tx, $req, [$this->unrelatedManagedSigner()]);
         $this->assertSame(100000, $result['amount']);
     }
 
@@ -151,7 +164,7 @@ final class AtaCreateRejectTest extends TestCase
         [$tx, $req] = $this->buildTransaction([
             ['program' => self::MEMO_PROGRAM, 'data' => 'abc123nonce', 'accounts' => []],
         ]);
-        $result = Verifier::verify($tx, $req, ['someFacilitatorPubkeyThatIsNotInTx']);
+        $result = Verifier::verify($tx, $req, [$this->unrelatedManagedSigner()]);
         $this->assertSame(100000, $result['amount']);
     }
 
@@ -166,10 +179,54 @@ final class AtaCreateRejectTest extends TestCase
         [$tx, $req] = $this->buildTransaction([]);
         unset($req['extra']['tokenProgram']);
 
-        $result = Verifier::verify($tx, $req, ['someFacilitatorPubkeyThatIsNotInTx']);
+        $result = Verifier::verify($tx, $req, [$this->unrelatedManagedSigner()]);
 
         $this->assertSame(self::TOKEN_PROGRAM, $result['program']);
         $this->assertSame(100000, $result['amount']);
+    }
+
+    public function testManagedSignerAsDirectSourceRejected(): void
+    {
+        $managed = Keypair::generate()->getPublicKey()->toBase58();
+        [$tx, $req] = $this->buildTransaction([], source: $managed);
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage(
+            'invalid_exact_svm_payload_transaction_fee_payer_transferring_funds',
+        );
+        Verifier::verify($tx, $req, [$managed]);
+    }
+
+    public function testManagedSourceAtaForActualToken2022ProgramRejected(): void
+    {
+        $managed = Keypair::generate()->getPublicKey()->toBase58();
+        $source = Mints::deriveAta($managed, self::USDC_MINT, Verifier::TOKEN_2022_PROGRAM);
+        [$tx, $req] = $this->buildTransaction(
+            [],
+            source: $source,
+            tokenProgram: Verifier::TOKEN_2022_PROGRAM,
+        );
+        // The transfer instruction's program is authoritative even if an
+        // offer pins the legacy Token program in extra.tokenProgram.
+        $req['extra']['tokenProgram'] = self::TOKEN_PROGRAM;
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage(
+            'invalid_exact_svm_payload_transaction_fee_payer_transferring_funds',
+        );
+        Verifier::verify($tx, $req, [$managed]);
+    }
+
+    public function testManagedSignerInTransferCheckedSignerTailRejected(): void
+    {
+        $managed = Keypair::generate()->getPublicKey()->toBase58();
+        [$tx, $req] = $this->buildTransaction([], signerTail: [$managed]);
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage(
+            'invalid_exact_svm_payload_transaction_fee_payer_transferring_funds',
+        );
+        Verifier::verify($tx, $req, [$managed]);
     }
 
     public function testAtaCreateOptionalInstructionRejected(): void
@@ -192,6 +249,6 @@ final class AtaCreateRejectTest extends TestCase
         ]);
         $this->expectException(InvalidProofException::class);
         $this->expectExceptionMessageMatches('/unknown_fourth_instruction/');
-        Verifier::verify($tx, $req, ['someFacilitatorPubkeyThatIsNotInTx']);
+        Verifier::verify($tx, $req, [$this->unrelatedManagedSigner()]);
     }
 }


### PR DESCRIPTION
## Summary
- split the PHP verifier work from #226 into a PHP-owned PR
- reject managed signer authority/source/multisig-tail and source-ATA drain shapes
- run shared x402 exact vectors through the production PHP verifier

## Verification
- `composer validate --strict`
- `composer run lint`
- `composer run test` (435 tests, 1166 assertions)

## Stack
Targets #219 as requested. Cross-SDK harness checks may remain red until the sibling language and harness PRs are merged into #219.
