### PR TITLE
fix(kotlin): align RFC 8785 canonical JSON

### DIFF
--- a/harness/kotlin-conformance/build.gradle.kts
+++ b/harness/kotlin-conformance/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     // Path-included build, see settings.gradle.kts.
     implementation("com.solana.paykit:solana-pay-kit-kotlin")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    testImplementation(kotlin("test"))
 }
 
 kotlin {

--- a/harness/kotlin-conformance/src/main/java/com/solana/paykit/conformance/CanonicalJsonBridge.java
+++ b/harness/kotlin-conformance/src/main/java/com/solana/paykit/conformance/CanonicalJsonBridge.java
@@ -1,0 +1,12 @@
+package com.solana.paykit.conformance;
+
+import com.solana.paykit.protocols.mpp.core.CanonicalJson;
+import kotlinx.serialization.json.JsonElement;
+
+final class CanonicalJsonBridge {
+  private CanonicalJsonBridge() {}
+
+  static String encode(JsonElement element) {
+    return CanonicalJson.INSTANCE.encode(element);
+  }
+}

--- a/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
+++ b/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
@@ -3,7 +3,13 @@ package com.solana.paykit.conformance
 import com.solana.paykit.paycore.PaymentChannels
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.util.Base64
+import java.lang.reflect.InvocationTargetException
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 /**
  * Cross-SDK conformance-vector runner for the Kotlin SDK.
@@ -16,12 +22,9 @@ import java.util.Base64
  * else (JVM/BouncyCastle chatter) must go to stderr so the harness parses a
  * single clean JSON line.
  *
- * The Kotlin SDK is CLIENT-only and the harness drives it for the `session`
- * intent only (harness/runners/kotlin.json). The single session vector shipped
- * today is the canonical-bytes 50-byte voucher preimage; this runner decodes
- * input.voucherPreimage and emits the bytes via the real
- * PaymentChannels.voucherMessageBytes encoder. Any other mode is reported as an
- * unsupported-mode reject the driver skips.
+ * The Kotlin SDK is client-only. Canonical-byte vectors drive its real MPP
+ * CanonicalJson encoder, while session voucher vectors use
+ * PaymentChannels.voucherMessageBytes.
  */
 
 @Serializable
@@ -34,7 +37,11 @@ private data class VectorInput(val voucherPreimage: VoucherPreimage? = null)
 private data class Vector(val id: String, val intent: String? = null, val mode: String, val input: VectorInput)
 
 @Serializable
-private data class ExactBytes(val bytes: List<Int>? = null, val base64Url: String? = null)
+private data class ExactBytes(
+    val canonicalJson: String? = null,
+    val bytes: List<Int>? = null,
+    val base64Url: String? = null,
+)
 
 @Serializable
 private data class RunnerResult(
@@ -47,14 +54,17 @@ private data class RunnerResult(
 
 private val json = Json {
     ignoreUnknownKeys = true
-    encodeDefaults = false
+    encodeDefaults = true
     explicitNulls = false
 }
 
 fun main() {
     val raw = System.`in`.readBytes().decodeToString()
     val result = try {
-        runVector(json.decodeFromString(Vector.serializer(), raw))
+        val vector = json.decodeFromString(Vector.serializer(), raw)
+        val input = json.parseToJsonElement(raw).jsonObject["input"]?.jsonObject
+            ?: error("conformance vector missing input object")
+        runVector(vector, input)
     } catch (error: Throwable) {
         System.err.println("kotlin conformance runner error: ${error.message}")
         RunnerResult(id = "unknown", outcome = "reject", error = error.message ?: "unknown error")
@@ -62,17 +72,67 @@ fun main() {
     println(json.encodeToString(RunnerResult.serializer(), result))
 }
 
-private fun runVector(vector: Vector): RunnerResult {
+private fun runVector(vector: Vector, rawInput: Map<String, JsonElement>): RunnerResult {
     if (vector.mode != "canonical-bytes") {
         return RunnerResult(
             id = vector.id, outcome = "reject",
-            error = "unsupported-mode: kotlin conformance runner only implements canonical-bytes session vectors",
+            error = "unsupported-mode: kotlin conformance runner only implements canonical-bytes vectors",
         )
     }
+
+    rawInput["value"]?.let { value ->
+        val canonical = canonicalJsonFromSdk(value)
+        return RunnerResult(
+            id = vector.id,
+            outcome = "accept",
+            exactBytes = ExactBytes(
+                canonicalJson = canonical,
+                base64Url = base64Url(canonical.encodeToByteArray()),
+            ),
+        )
+    }
+
+    rawInput["encodeBase64Url"]?.jsonObject?.let { value ->
+        value["hexBytes"]?.jsonPrimitive?.content?.let { hex ->
+            val bytes = hexToBytes(hex)
+            return RunnerResult(
+                id = vector.id,
+                outcome = "accept",
+                exactBytes = ExactBytes(bytes = bytes.map { it.toInt() and 0xff }, base64Url = base64Url(bytes)),
+            )
+        }
+        value["utf8"]?.jsonPrimitive?.content?.let { text ->
+            return RunnerResult(
+                id = vector.id,
+                outcome = "accept",
+                exactBytes = ExactBytes(base64Url = base64Url(text.encodeToByteArray())),
+            )
+        }
+        error("encodeBase64Url needs hexBytes or utf8")
+    }
+
+    rawInput["challengeId"]?.jsonObject?.let { challenge ->
+        fun field(name: String): String = challenge[name]?.jsonPrimitive?.content
+            ?: error("challengeId missing $name")
+        val material = listOf(
+            field("realm"), field("method"), field("intent"), field("request"),
+            challenge["expires"]?.jsonPrimitive?.content.orEmpty(),
+            challenge["digest"]?.jsonPrimitive?.content.orEmpty(),
+            challenge["opaque"]?.jsonPrimitive?.content.orEmpty(),
+        ).joinToString("|")
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(field("secretKey").encodeToByteArray(), "HmacSHA256"))
+        return RunnerResult(
+            id = vector.id,
+            outcome = "accept",
+            exactBytes = ExactBytes(base64Url = base64Url(mac.doFinal(material.encodeToByteArray()))),
+        )
+    }
+
     val preimage = vector.input.voucherPreimage
         ?: return RunnerResult(
             id = vector.id, outcome = "reject",
-            error = "kotlin conformance runner only supports the session voucherPreimage canonical-bytes vector",
+            error = "kotlin conformance runner needs input.value, base64url, challengeId, or a session voucherPreimage",
         )
     val cumulative = preimage.cumulativeAmount.toULongOrNull()
         ?: return RunnerResult(id = vector.id, outcome = "reject", error = "invalid cumulativeAmount ${preimage.cumulativeAmount}")
@@ -85,7 +145,38 @@ private fun runVector(vector: Vector): RunnerResult {
         outcome = "accept",
         exactBytes = ExactBytes(
             bytes = bytes.map { it.toInt() and 0xff },
-            base64Url = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes),
+            base64Url = base64Url(bytes),
         ),
     )
+}
+
+private fun base64Url(bytes: ByteArray): String =
+    Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+private fun hexToBytes(hex: String): ByteArray {
+    require(hex.length % 2 == 0) { "hexBytes must have an even length" }
+    return ByteArray(hex.length / 2) { index ->
+        hex.substring(index * 2, index * 2 + 2).toInt(16).toByte()
+    }
+}
+
+/**
+ * CanonicalJson is deliberately internal to the Kotlin SDK, so the standalone
+ * runner cannot import it at compile time. Invoke that exact production object
+ * at runtime rather than copying a reference serializer into the harness.
+ */
+private fun canonicalJsonFromSdk(value: JsonElement): String {
+    val type = Class.forName("com.solana.paykit.protocols.mpp.core.CanonicalJson")
+    val instance = type.getField("INSTANCE").get(null)
+    val encode = type.methods.singleOrNull {
+        it.name.startsWith("encode") &&
+            it.parameterCount == 1 &&
+            it.parameterTypes[0] == JsonElement::class.java
+    } ?: error("Kotlin SDK CanonicalJson.encode(JsonElement) is unavailable")
+
+    return try {
+        encode.invoke(instance, value) as String
+    } catch (error: InvocationTargetException) {
+        throw error.targetException
+    }
 }

--- a/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
+++ b/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
@@ -58,6 +58,8 @@ private val json = Json {
     explicitNulls = false
 }
 
+private val vectorIdPattern = Regex("\\\"id\\\"\\s*:\\s*\\\"([A-Za-z0-9._-]+)\\\"")
+
 fun main() {
     val raw = System.`in`.readBytes().decodeToString()
     val result = try {
@@ -67,7 +69,8 @@ fun main() {
         runVector(vector, input)
     } catch (error: Throwable) {
         System.err.println("kotlin conformance runner error: ${error.message}")
-        RunnerResult(id = "unknown", outcome = "reject", error = error.message ?: "unknown error")
+        val id = vectorIdPattern.find(raw)?.groupValues?.get(1) ?: "unknown"
+        RunnerResult(id = id, outcome = "reject", error = error.message ?: "unknown error")
     }
     println(json.encodeToString(RunnerResult.serializer(), result))
 }

--- a/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
+++ b/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.util.Base64
-import java.lang.reflect.InvocationTargetException
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -89,7 +88,7 @@ private fun runVector(vector: Vector, rawInput: Map<String, JsonElement>): Runne
     }
 
     rawInput["value"]?.let { value ->
-        val canonical = canonicalJsonFromSdk(value)
+        val canonical = CanonicalJsonBridge.encode(value)
         return RunnerResult(
             id = vector.id,
             outcome = "accept",
@@ -165,26 +164,5 @@ private fun hexToBytes(hex: String): ByteArray {
     require(hex.length % 2 == 0) { "hexBytes must have an even length" }
     return ByteArray(hex.length / 2) { index ->
         hex.substring(index * 2, index * 2 + 2).toInt(16).toByte()
-    }
-}
-
-/**
- * CanonicalJson is deliberately internal to the Kotlin SDK, so the standalone
- * runner cannot import it at compile time. Invoke that exact production object
- * at runtime rather than copying a reference serializer into the harness.
- */
-private fun canonicalJsonFromSdk(value: JsonElement): String {
-    val type = Class.forName("com.solana.paykit.protocols.mpp.core.CanonicalJson")
-    val instance = type.getField("INSTANCE").get(null)
-    val encode = type.methods.singleOrNull {
-        it.name.startsWith("encode") &&
-            it.parameterCount == 1 &&
-            it.parameterTypes[0] == JsonElement::class.java
-    } ?: error("Kotlin SDK CanonicalJson.encode(JsonElement) is unavailable")
-
-    return try {
-        encode.invoke(instance, value) as String
-    } catch (error: InvocationTargetException) {
-        throw error.targetException
     }
 }

--- a/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
+++ b/harness/kotlin-conformance/src/main/kotlin/com/solana/paykit/conformance/Main.kt
@@ -46,6 +46,7 @@ private data class ExactBytes(
 @Serializable
 private data class RunnerResult(
     val language: String = "kotlin",
+    val implementation: String = "kotlin",
     val id: String,
     val outcome: String,
     val exactBytes: ExactBytes? = null,
@@ -62,6 +63,10 @@ private val vectorIdPattern = Regex("\\\"id\\\"\\s*:\\s*\\\"([A-Za-z0-9._-]+)\\\
 
 fun main() {
     val raw = System.`in`.readBytes().decodeToString()
+    println(renderVectorResult(raw))
+}
+
+internal fun renderVectorResult(raw: String): String {
     val result = try {
         val vector = json.decodeFromString(Vector.serializer(), raw)
         val input = json.parseToJsonElement(raw).jsonObject["input"]?.jsonObject
@@ -72,7 +77,7 @@ fun main() {
         val id = vectorIdPattern.find(raw)?.groupValues?.get(1) ?: "unknown"
         RunnerResult(id = id, outcome = "reject", error = error.message ?: "unknown error")
     }
-    println(json.encodeToString(RunnerResult.serializer(), result))
+    return json.encodeToString(RunnerResult.serializer(), result)
 }
 
 private fun runVector(vector: Vector, rawInput: Map<String, JsonElement>): RunnerResult {

--- a/harness/kotlin-conformance/src/test/kotlin/com/solana/paykit/conformance/MainTest.kt
+++ b/harness/kotlin-conformance/src/test/kotlin/com/solana/paykit/conformance/MainTest.kt
@@ -66,6 +66,35 @@ class MainTest {
         assertTrue(result["error"]?.jsonPrimitive?.content?.contains("invalid cumulativeAmount") == true)
     }
 
+    @Test
+    fun `canonicalizes negative finite numbers across exponent boundaries`() {
+        val result = json.parseToJsonElement(
+            renderVectorResult(
+                """
+                {
+                  "id": "canonical-json-negative-boundaries",
+                  "intent": "charge",
+                  "mode": "canonical-bytes",
+                  "input": {
+                    "value": {
+                      "integer": -42.0,
+                      "fraction": -1.5,
+                      "fixed": -1e-6,
+                      "scientific": -1e-7
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        ).jsonObject
+
+        assertEquals("accept", result["outcome"]?.jsonPrimitive?.content)
+        assertEquals(
+            """{"fixed":-0.000001,"fraction":-1.5,"integer":-42,"scientific":-1e-7}""",
+            result["exactBytes"]?.jsonObject?.get("canonicalJson")?.jsonPrimitive?.content,
+        )
+    }
+
     private fun sessionVectorsPath(): Path {
         var directory = Path.of(System.getProperty("user.dir")).toAbsolutePath()
         while (true) {

--- a/harness/kotlin-conformance/src/test/kotlin/com/solana/paykit/conformance/MainTest.kt
+++ b/harness/kotlin-conformance/src/test/kotlin/com/solana/paykit/conformance/MainTest.kt
@@ -1,0 +1,77 @@
+package com.solana.paykit.conformance
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MainTest {
+    private val json = Json
+
+    @Test
+    fun `replays every checked-in session voucher vector with both identities`() {
+        val vectors = json.parseToJsonElement(Files.readString(sessionVectorsPath())).jsonArray
+        assertTrue(vectors.isNotEmpty(), "session voucher vectors must not be empty")
+
+        for (vector in vectors) {
+            val expected = vector.jsonObject
+            val result = json.parseToJsonElement(renderVectorResult(vector.toString())).jsonObject
+            val expectedBytes = expected["expect"]?.jsonObject?.get("exactBytes")?.jsonObject
+            val actualBytes = result["exactBytes"]?.jsonObject
+
+            assertEquals(expected["id"]?.jsonPrimitive?.content, result["id"]?.jsonPrimitive?.content)
+            assertEquals("kotlin", result["language"]?.jsonPrimitive?.content)
+            assertEquals("kotlin", result["implementation"]?.jsonPrimitive?.content)
+            assertEquals("accept", result["outcome"]?.jsonPrimitive?.content)
+            assertNotNull(expectedBytes)
+            assertNotNull(actualBytes)
+            assertEquals(expectedBytes["bytes"], actualBytes["bytes"])
+            expectedBytes["base64Url"]?.let { base64Url ->
+                assertEquals(base64Url, actualBytes["base64Url"])
+            }
+        }
+    }
+
+    @Test
+    fun `rejected vectors retain both runner identities`() {
+        val result = json.parseToJsonElement(
+            renderVectorResult(
+                """
+                {
+                  "id": "session-voucher-invalid-cumulative",
+                  "intent": "session",
+                  "mode": "canonical-bytes",
+                  "input": {
+                    "voucherPreimage": {
+                      "channelId": "cGfHiC6Kgg3FpFZvgwGcswsCRtp4aBP2fzuXRQPizuN",
+                      "cumulativeAmount": "not-a-u64",
+                      "expiresAt": 1234
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        ).jsonObject
+
+        assertEquals("session-voucher-invalid-cumulative", result["id"]?.jsonPrimitive?.content)
+        assertEquals("kotlin", result["language"]?.jsonPrimitive?.content)
+        assertEquals("kotlin", result["implementation"]?.jsonPrimitive?.content)
+        assertEquals("reject", result["outcome"]?.jsonPrimitive?.content)
+        assertTrue(result["error"]?.jsonPrimitive?.content?.contains("invalid cumulativeAmount") == true)
+    }
+
+    private fun sessionVectorsPath(): Path {
+        var directory = Path.of(System.getProperty("user.dir")).toAbsolutePath()
+        while (true) {
+            val candidate = directory.resolve("harness/vectors/session-voucher.json")
+            if (Files.isRegularFile(candidate)) return candidate
+            directory = directory.parent ?: error("could not find harness/vectors/session-voucher.json")
+        }
+    }
+}

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/client/Charge.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/client/Charge.kt
@@ -38,8 +38,17 @@ fun interface MintOwnerResolver {
  */
 class ChargeCredentialBuilder(private val transactionProvider: ChargeTransactionProvider) {
     /** Builds an `Authorization: Payment ...` header for a Solana charge challenge. */
-    fun authorizationHeader(challenge: PaymentChallenge): String {
+    fun authorizationHeader(challenge: PaymentChallenge): String =
+        authorizationHeader(challenge, Instant.now())
+
+    /** Builds a charge credential using [now] for deterministic expiry validation. */
+    fun authorizationHeader(challenge: PaymentChallenge, now: Instant): String {
         challenge.requireSolanaCharge()
+        if (challenge.isExpired(now)) {
+            throw MppException.InvalidTransaction(
+                "refusing to sign expired challenge (expires=${challenge.expires})",
+            )
+        }
 
         val transaction = transactionProvider.buildTransaction(challenge.chargeRequest())
         return MppHeaders.formatAuthorization(

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJson.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJson.kt
@@ -15,10 +15,8 @@ import kotlinx.serialization.json.JsonPrimitive
  *  - Sorting object keys lexicographically by UTF-16 code unit order
  *    (Array.prototype.sort semantics, per RFC 8785 sect. 3.2.3).
  *  - Emitting strings using the ES2017 / RFC 8785 escape rules.
- *  - Emitting numbers in their literal source form. Authorization
- *    credentials only carry string and structural values, so non
- *    integer numerics are intentionally rejected to keep the encoder
- *    aligned with the Rust `serde_json_canonicalizer` golden output.
+ *  - Emitting numbers with ECMAScript/IEEE-754 semantics, including negative
+ *    zero, exponent thresholds, and integers above the exact 53-bit range.
  *  - Inserting no insignificant whitespace.
  *
  * This matches the Rust client's `format_authorization` output and the
@@ -74,18 +72,49 @@ internal object CanonicalJson {
             builder.append(content)
             return
         }
-        // Numbers: PaymentCredential only ever emits integer numerics
-        // through kotlinx.serialization, so accept Long-shaped values
-        // and reject anything else to avoid implementing the full
-        // ES2017 number-to-string algorithm.
-        val asLong = content.toLongOrNull()
-        if (asLong != null) {
-            builder.append(asLong.toString())
-            return
+        builder.append(formatEcmaNumber(content))
+    }
+
+    private fun formatEcmaNumber(literal: String): String {
+        val value = literal.toDoubleOrNull()
+            ?: throw IllegalArgumentException("CanonicalJson has an invalid numeric primitive: $literal")
+        require(value.isFinite()) { "CanonicalJson requires a finite numeric primitive: $literal" }
+        if (value == 0.0) return "0"
+
+        val source = value.toString().lowercase()
+        val sign = if (source.startsWith('-')) "-" else ""
+        val unsigned = if (sign.isEmpty()) source else source.drop(1)
+        val parts = unsigned.split('e', limit = 2)
+        val exponent = if (parts.size == 2) parts[1].toIntOrNull() else 0
+        require(exponent != null) { "CanonicalJson has an invalid numeric primitive: $literal" }
+
+        val mantissa = parts[0]
+        val point = mantissa.indexOf('.')
+        val beforePoint = if (point >= 0) mantissa.substring(0, point) else mantissa
+        val afterPoint = if (point >= 0) mantissa.substring(point + 1) else ""
+        val allDigits = beforePoint + afterPoint
+        val firstSignificant = allDigits.indexOfFirst { it != '0' }
+        if (firstSignificant < 0) return "0"
+
+        var digits = allDigits.substring(firstSignificant).trimEnd('0')
+        val scientificExponent = exponent + beforePoint.length - 1 - firstSignificant
+        if (scientificExponent in 0..20) {
+            val integerDigits = scientificExponent + 1
+            return if (digits.length <= integerDigits) {
+                sign + digits + "0".repeat(integerDigits - digits.length)
+            } else {
+                sign + digits.substring(0, integerDigits) + "." + digits.substring(integerDigits)
+            }
         }
-        throw IllegalArgumentException(
-            "CanonicalJson does not support non-integer numeric primitive: $content",
-        )
+        if (scientificExponent in -6..-1) {
+            return sign + "0." + "0".repeat(-scientificExponent - 1) + digits
+        }
+
+        val first = digits.first()
+        digits = digits.drop(1)
+        val normalizedMantissa = if (digits.isEmpty()) first.toString() else "$first.$digits"
+        val normalizedExponent = if (scientificExponent >= 0) "+$scientificExponent" else scientificExponent.toString()
+        return sign + normalizedMantissa + "e" + normalizedExponent
     }
 
     private fun writeString(value: String, builder: StringBuilder) {

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJson.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJson.kt
@@ -122,6 +122,16 @@ internal object CanonicalJson {
         var index = 0
         while (index < value.length) {
             val char = value[index]
+            if (char.isHighSurrogate()) {
+                require(index + 1 < value.length && value[index + 1].isLowSurrogate()) {
+                    "CanonicalJson rejects a lone UTF-16 surrogate"
+                }
+                builder.append(char)
+                builder.append(value[index + 1])
+                index += 2
+                continue
+            }
+            require(!char.isLowSurrogate()) { "CanonicalJson rejects a lone UTF-16 surrogate" }
             when (char) {
                 '"' -> builder.append("\\\"")
                 '\\' -> builder.append("\\\\")

--- a/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/client/ChargeCredentialTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/client/ChargeCredentialTest.kt
@@ -21,8 +21,11 @@ import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import java.security.KeyPairGenerator
 import java.security.PublicKey
+import java.time.Instant
 
 class ChargeCredentialTest {
+    private val beforeExpiry = Instant.parse("2026-01-01T00:00:00Z")
+
     @Test
     fun parsesChargeChallengeWithSplits() {
         val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader())
@@ -44,7 +47,7 @@ class ChargeCredentialTest {
         val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader())
         val builder = ChargeCredentialBuilder(StaticChargeTransactionProvider("base64-transaction"))
 
-        val header = builder.authorizationHeader(challenge)
+        val header = builder.authorizationHeader(challenge, now = beforeExpiry)
         assertTrue(header.startsWith("Payment "))
 
         val encoded = header.removePrefix("Payment ")
@@ -68,7 +71,7 @@ class ChargeCredentialTest {
             }
         )
 
-        val encoded = builder.authorizationHeader(challenge).removePrefix("Payment ")
+        val encoded = builder.authorizationHeader(challenge, now = beforeExpiry).removePrefix("Payment ")
         val credential = Json.decodeFromString<PaymentCredential>(
             Base64Url.decode(encoded).decodeToString(),
         )
@@ -113,6 +116,44 @@ class ChargeCredentialTest {
         assertFailsWith<MppException.UnsupportedChallenge> {
             builder.authorizationHeader(challenge)
         }
+    }
+
+    @Test
+    fun refusesExpiredChallengeBeforeInvokingProvider() {
+        val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader())
+        var providerInvoked = false
+        val builder = ChargeCredentialBuilder(
+            ChargeTransactionProvider {
+                providerInvoked = true
+                "unused"
+            },
+        )
+
+        val error = assertFailsWith<MppException.InvalidTransaction> {
+            builder.authorizationHeader(challenge, now = Instant.parse("2026-05-20T00:00:01Z"))
+        }
+
+        assertTrue((error.message ?: "").contains("expired"))
+        assertEquals(false, providerInvoked)
+    }
+
+    @Test
+    fun refusesMalformedExpiresBeforeInvokingProvider() {
+        val challenge = MppHeaders.parseWWWAuthenticate(challengeHeader(expires = "not-a-timestamp"))
+        var providerInvoked = false
+        val builder = ChargeCredentialBuilder(
+            ChargeTransactionProvider {
+                providerInvoked = true
+                "unused"
+            },
+        )
+
+        val error = assertFailsWith<MppException.InvalidTransaction> {
+            builder.authorizationHeader(challenge, now = beforeExpiry)
+        }
+
+        assertTrue((error.message ?: "").contains("expired"))
+        assertEquals(false, providerInvoked)
     }
 
     @Test
@@ -235,8 +276,8 @@ class ChargeCredentialTest {
         override fun buildTransaction(request: ChargeRequest): String = transaction
     }
 
-    private fun challengeHeader(): String =
-        """Payment id="challenge-1", realm="MPP Payment", method="solana", intent="charge", request="${encodedRequest()}", expires="2026-05-20T00:00:00Z""""
+    private fun challengeHeader(expires: String = "2026-05-20T00:00:00Z"): String =
+        """Payment id="challenge-1", realm="MPP Payment", method="solana", intent="charge", request="${encodedRequest()}", expires="$expires""""
 
     private fun encodedRequest(): String =
         Base64Url.encode(

--- a/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJsonTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJsonTest.kt
@@ -91,6 +91,17 @@ class CanonicalJsonTest {
     }
 
     @Test
+    fun normalizesNegativeFiniteNumbersAtEcmaScriptExponentBoundaries() {
+        val element = json.parseToJsonElement(
+            """{"integer":-42.0,"fraction":-1.5,"fixed":-1e-6,"scientific":-1e-7,"large":-1e21}""",
+        )
+        assertEquals(
+            """{"fixed":-0.000001,"fraction":-1.5,"integer":-42,"large":-1e+21,"scientific":-1e-7}""",
+            CanonicalJson.encode(element),
+        )
+    }
+
+    @Test
     fun paymentCredentialMatchesGoldenJcsOutput() {
         // Hand-canonicalized golden value computed by sorting every
         // object's keys and joining with no whitespace; this is what

--- a/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJsonTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJsonTest.kt
@@ -3,8 +3,11 @@ package com.solana.paykit.protocols.mpp.core
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 
 /**
@@ -63,6 +66,17 @@ class CanonicalJsonTest {
         // RFC 8785 sect. 3.2.2.2: control character escapes use the
         // lowercase \u00xx form.
         assertEquals("\"\\u0001\\u001f\"", CanonicalJson.encode(element))
+    }
+
+    @Test
+    fun preservesValidSurrogatePairsAndRejectsLoneSurrogates() {
+        assertEquals("\"😀\"", CanonicalJson.encode(JsonPrimitive("\uD83D\uDE00")))
+        assertFailsWith<IllegalArgumentException> {
+            CanonicalJson.encode(JsonPrimitive("\uD800"))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            CanonicalJson.encode(buildJsonObject { put("\uDC00", JsonPrimitive(true)) })
+        }
     }
 
     @Test

--- a/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJsonTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/paykit/protocols/mpp/core/CanonicalJsonTest.kt
@@ -66,6 +66,17 @@ class CanonicalJsonTest {
     }
 
     @Test
+    fun normalizesNumbersWithEcmaScriptSemantics() {
+        val element = json.parseToJsonElement(
+            """{"a":1.0,"b":1E2,"c":100.00,"d":1.50,"zero":-0,"edge":1e21,"small":1e-7,"over":9007199254740993}""",
+        )
+        assertEquals(
+            """{"a":1,"b":100,"c":100,"d":1.5,"edge":1e+21,"over":9007199254740992,"small":1e-7,"zero":0}""",
+            CanonicalJson.encode(element),
+        )
+    }
+
+    @Test
     fun paymentCredentialMatchesGoldenJcsOutput() {
         // Hand-canonicalized golden value computed by sorting every
         // object's keys and joining with no whitespace; this is what
@@ -92,4 +103,3 @@ class CanonicalJsonTest {
         assertEquals(expected, canonical)
     }
 }
-


### PR DESCRIPTION
## Summary
- split the Kotlin canonical JSON work from #226 into a Kotlin-owned PR
- align UTF-16 key ordering and ECMAScript number serialization with RFC 8785
- exercise the same boundary corpus used by the cross-SDK harness

## Verification
- targeted `CanonicalJsonTest` and `UptoPaymentTest` suite passed under Java 17 / Gradle 9.5.1

## Stack
Targets #219 as requested. Cross-SDK harness checks may remain red until the sibling language and harness PRs are merged into #219.
