### PR TITLE
fix(typescript): bind session and upto settlements

### DIFF
--- a/typescript/packages/mpp/src/__tests__/session-on-chain.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-on-chain.test.ts
@@ -37,7 +37,9 @@ import {
     MULTI_DELEGATOR_PROGRAM_ID,
     PAYMENT_CHANNELS_PROGRAM_ID,
     verifyOpenTx,
+    verifyTopUpTransaction,
 } from '../server/session/on-chain.js';
+import { buildAndSignWireTransaction } from '../server/session/wire-tx.js';
 
 function makeSeed(byte: number): Uint8Array {
     const seed = new Uint8Array(32);
@@ -238,6 +240,72 @@ describe('buildTopUpInstruction', () => {
         expect(data[0]).toBe(3); // discriminator
         const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
         expect(view.getBigUint64(1, true)).toBe(1_234_567n);
+    });
+});
+
+describe('verifyTopUpTransaction', () => {
+    async function buildTopUpWire(amount: bigint) {
+        const [payer] = await loadFixedSigners();
+        const channelId = '11111111111111111111111111111111';
+        const instruction = await buildTopUpInstruction({
+            amount,
+            channelId,
+            mint: USDC.mainnet!,
+            payer,
+            tokenProgram: TOKEN_PROGRAM,
+        });
+        const wire = await buildAndSignWireTransaction(
+            {
+                getLatestBlockhash: () => ({
+                    send: async () => ({
+                        value: {
+                            blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N' as never,
+                            lastValidBlockHeight: 100n,
+                        },
+                    }),
+                }),
+            },
+            payer,
+            [instruction],
+        );
+        return { channelId, signature: extractTxSignature(wire), wire };
+    }
+
+    function transactionRpc(wire: string) {
+        return {
+            getTransaction: () => ({
+                send: async () => ({ meta: { err: null }, transaction: [wire, 'base64'] as const }),
+            }),
+        };
+    }
+
+    test('accepts an encoded payment-channel top-up with the exact deposit delta', async () => {
+        const amount = 1_234_567n;
+        const { channelId, signature, wire } = await buildTopUpWire(amount);
+
+        await expect(
+            verifyTopUpTransaction({
+                amount,
+                channelId,
+                programId: PAYMENT_CHANNELS_PROGRAM_ID,
+                rpc: transactionRpc(wire),
+                signature,
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    test('rejects an encoded payment-channel top-up whose delta does not match', async () => {
+        const { channelId, signature, wire } = await buildTopUpWire(500n);
+
+        await expect(
+            verifyTopUpTransaction({
+                amount: 499n,
+                channelId,
+                programId: PAYMENT_CHANNELS_PROGRAM_ID,
+                rpc: transactionRpc(wire),
+                signature,
+            }),
+        ).rejects.toThrow(/on-chain top-up total 500 != expected delta 499/);
     });
 });
 

--- a/typescript/packages/mpp/src/__tests__/session-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-server.test.ts
@@ -444,7 +444,10 @@ describe('session() verify() topUp', () => {
     });
 
     test('topUp atomically rejects a concurrent duplicate signature', async () => {
-        const store = createMemorySessionStore();
+        const store = {
+            ...createMemorySessionStore(),
+            sessionStoreDurability: 'durable-shared' as const,
+        };
         const signer = await generateKeyPairSigner();
         const method = session({
             cap: 5_000_000n,

--- a/typescript/packages/mpp/src/__tests__/session-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-server.test.ts
@@ -1215,6 +1215,20 @@ describe('session() verify() close monotonicity', () => {
         expect(state?.closeRequestedAt).toBeDefined();
         expect(state?.cumulative).toBe(250n);
     });
+
+    test('close without a final voucher preserves the current watermark', async () => {
+        const { method, store } = await setupWithWatermark();
+
+        const receipt = await method.verify({
+            credential: makeCred({ action: 'close', channelId }),
+            request: {} as never,
+        });
+        expect(receipt.status).toBe('success');
+
+        const state = await store.getChannel(channelId);
+        expect(state?.closeRequestedAt).toBeDefined();
+        expect(state?.cumulative).toBe(250n);
+    });
 });
 
 // ── verify() — close retry after a failed settlement ────────────────────

--- a/typescript/packages/mpp/src/__tests__/session-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-server.test.ts
@@ -427,6 +427,58 @@ describe('session() verify() topUp', () => {
         expect(receipt.reference).toBe('topup-sig');
         const state = await store.getChannel(channelId);
         expect(state?.deposit).toBe(5_000n);
+        expect(state?.usedTopUpSignatures).toEqual(['topup-sig']);
+
+        await expect(
+            method.verify({
+                credential: makeCred({
+                    action: 'topUp',
+                    channelId,
+                    newDeposit: '9000',
+                    signature: 'topup-sig',
+                }),
+                request: {} as never,
+            }),
+        ).rejects.toThrow(/already accepted/);
+        expect((await store.getChannel(channelId))?.deposit).toBe(5_000n);
+    });
+
+    test('topUp atomically rejects a concurrent duplicate signature', async () => {
+        const store = createMemorySessionStore();
+        const signer = await generateKeyPairSigner();
+        const method = session({
+            cap: 5_000_000n,
+            currency: 'USDC',
+            decimals: 6,
+            network: 'devnet',
+            operator: OPERATOR,
+            pricing: {},
+            recipient: RECIPIENT,
+            store,
+        });
+        const channelId = '11111111111111111111111111111111';
+        await method.verify({
+            credential: makeCred({
+                action: 'open',
+                authorizedSigner: signer.address,
+                channelId,
+                deposit: '1000',
+                mode: 'push',
+                signature: 'open-sig',
+            }),
+            request: {} as never,
+        });
+
+        const topUp = () =>
+            method.verify({
+                credential: makeCred({ action: 'topUp', channelId, newDeposit: '5000', signature: 'topup-sig' }),
+                request: {} as never,
+            });
+        const results = await Promise.allSettled([topUp(), topUp()]);
+
+        expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+        expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+        expect((await store.getChannel(channelId))?.deposit).toBe(5_000n);
     });
 
     test('topUp rejects when below current deposit', async () => {

--- a/typescript/packages/mpp/src/__tests__/session-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-server.test.ts
@@ -1116,14 +1116,19 @@ describe('session() verify() topUp hardening', () => {
                 request: {} as never,
             }),
         ).rejects.toThrow(/getTransaction/);
-        expect(rpc.calls).toContain('topup-sig');
+        expect(rpc.calls).not.toContain('topup-sig');
         expect((await store.getChannel(channelId))?.deposit).toBe(1_000n);
     });
 
     test('topUp rejects when the signature is unknown on-chain', async () => {
         const store = createMemorySessionStore();
         const signer = await generateKeyPairSigner();
-        const rpc = mockStatusRpc({ 'open-sig': { err: null } });
+        const rpc = {
+            ...mockStatusRpc({ 'open-sig': { err: null } }),
+            getTransaction: () => {
+                throw new Error('getTransaction should not run for an unknown signature');
+            },
+        };
         const method = session({
             cap: 5_000_000n,
             currency: 'USDC',

--- a/typescript/packages/mpp/src/__tests__/session-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-server.test.ts
@@ -1093,7 +1093,7 @@ describe('session() verify() topUp hardening', () => {
         ).rejects.toThrow(/sealed/);
     });
 
-    test('topUp verifies the signature on-chain when rpc is configured', async () => {
+    test('topUp requires transaction bytes when rpc is configured', async () => {
         const store = createMemorySessionStore();
         const signer = await generateKeyPairSigner();
         const rpc = mockStatusRpc({ 'open-sig': { err: null }, 'topup-sig': { err: null } });
@@ -1110,13 +1110,14 @@ describe('session() verify() topUp hardening', () => {
         });
         await openChannel(method, signer);
 
-        const receipt = await method.verify({
-            credential: makeCred({ action: 'topUp', channelId, newDeposit: '5000', signature: 'topup-sig' }),
-            request: {} as never,
-        });
-        expect(receipt.status).toBe('success');
+        await expect(
+            method.verify({
+                credential: makeCred({ action: 'topUp', channelId, newDeposit: '5000', signature: 'topup-sig' }),
+                request: {} as never,
+            }),
+        ).rejects.toThrow(/getTransaction/);
         expect(rpc.calls).toContain('topup-sig');
-        expect((await store.getChannel(channelId))?.deposit).toBe(5_000n);
+        expect((await store.getChannel(channelId))?.deposit).toBe(1_000n);
     });
 
     test('topUp rejects when the signature is unknown on-chain', async () => {

--- a/typescript/packages/mpp/src/__tests__/session-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-server.test.ts
@@ -444,16 +444,13 @@ describe('session() verify() topUp', () => {
     });
 
     test('topUp atomically rejects a concurrent duplicate signature', async () => {
-        const store = {
-            ...createMemorySessionStore(),
-            sessionStoreDurability: 'durable-shared' as const,
-        };
+        const store = createMemorySessionStore();
         const signer = await generateKeyPairSigner();
         const method = session({
             cap: 5_000_000n,
             currency: 'USDC',
             decimals: 6,
-            network: 'devnet',
+            network: 'localnet',
             operator: OPERATOR,
             pricing: {},
             recipient: RECIPIENT,
@@ -491,7 +488,7 @@ describe('session() verify() topUp', () => {
             cap: 5_000_000n,
             currency: 'USDC',
             decimals: 6,
-            network: 'devnet',
+            network: 'localnet',
             operator: OPERATOR,
             pricing: {},
             recipient: RECIPIENT,

--- a/typescript/packages/mpp/src/index.ts
+++ b/typescript/packages/mpp/src/index.ts
@@ -1,6 +1,7 @@
 // Shared types and method definition
 export * from './constants.js';
 export { charge, session, subscription } from './Methods.js';
+export { guardChallengeValue } from './shared/challenge-guard.js';
 export {
     assertPeriodHoursInRange,
     deriveSubscriptionAuthorityPda,

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -578,6 +578,7 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
         operator: channelPayer ?? payload.owner ?? payload.payer,
         pendingDeliveries: [],
         sealed: false,
+        usedTopUpSignatures: [],
     };
 
     // The existence check lives inside the atomic mutator so a concurrent
@@ -754,10 +755,14 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
         if (current.closeRequestedAt !== undefined) {
             throw new Error('Channel close is pending — no further top-ups accepted');
         }
+        const usedSignatures = current.usedTopUpSignatures ?? [];
+        if (usedSignatures.includes(args.payload.signature)) {
+            throw new Error(`topUp signature ${args.payload.signature} was already accepted for this channel`);
+        }
         if (newDeposit <= current.deposit) {
             throw new Error(`newDeposit ${newDeposit} must exceed current deposit ${current.deposit}`);
         }
-        return { ...current, deposit: newDeposit };
+        return { ...current, deposit: newDeposit, usedTopUpSignatures: [...usedSignatures, args.payload.signature] };
     });
     args.lifecycle?.touch(result.channelId);
 
@@ -1307,7 +1312,11 @@ export declare namespace session {
         readonly pullVoucherStrategy?: SessionPullVoucherStrategy;
         /** Primary recipient (base58). */
         readonly recipient: string;
-        /** Optional RPC client used for on-chain checks + transactions. */
+        /**
+         * Optional RPC client used for on-chain checks + transactions. Without
+         * it, open/top-up assertions are trusted input and the host must verify
+         * them out of band; do not expose that mode to untrusted clients.
+         */
         readonly rpc?: RpcLike;
         /** RPC URL for blockhash prefetch. Defaults from `network`. */
         readonly rpcUrl?: string;

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -813,6 +813,7 @@ async function handleClose(args: HandleCloseArgs): Promise<Receipt.Receipt> {
             throw new Error('Close already requested');
         }
 
+        // nosemgrep: security-check-gated-on-optional-field-ts -- A missing final voucher intentionally closes at the persisted watermark.
         if (args.payload.voucher) {
             const signed = normalizeSignedVoucher(args.payload.voucher);
             // Route the final voucher (replay AND advancing) through the verifier

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -735,10 +735,10 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
     // Confirm the top-up transaction on-chain before raising the deposit
     // (parity with the open-signature verification).
     if (args.rpc) {
-        await assertSignatureSucceeded(args.rpc as VerifyOpenRpc, args.payload.signature, 'topUp');
         if (!isTopUpTransactionRpc(args.rpc)) {
             throw new Error('topUp requires an rpc client with getTransaction to bind the deposit delta');
         }
+        await assertSignatureSucceeded(args.rpc as VerifyOpenRpc, args.payload.signature, 'topUp');
         await verifyTopUpTransaction({
             amount: newDeposit - existing.deposit,
             channelId: args.payload.channelId,

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -29,7 +29,9 @@ import {
     submitOpenTx,
     submitSettleAndDistribute,
     type SubmitSettleAndDistributeResult,
+    type TopUpTransactionRpc,
     verifyOpenTx,
+    verifyTopUpTransaction,
 } from './session/on-chain.js';
 import {
     type ChannelState,
@@ -272,6 +274,7 @@ export function session(parameters: session.Parameters) {
                         pullVoucherStrategy,
                         recipient,
                         rpc,
+                        splits,
                         store,
                     });
                 case 'voucher':
@@ -300,6 +303,7 @@ export function session(parameters: session.Parameters) {
                         externalId: cred.challenge.request.externalId,
                         lifecycle: lifecycleRef.value,
                         payload: cred.payload,
+                        programId: resolvedProgramId,
                         rpc,
                         store,
                     });
@@ -422,6 +426,7 @@ interface HandleOpenArgs {
     readonly pullVoucherStrategy: SessionPullVoucherStrategy | undefined;
     readonly recipient: string;
     readonly rpc: RpcLike | undefined;
+    readonly splits: readonly SessionSplit[] | undefined;
     readonly store: SessionStore;
 }
 
@@ -452,6 +457,9 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
     }
 
     if (payload.transaction) {
+        if (args.openTxSubmitter === 'client' && args.rpc && isPlaceholderSignature(payload.signature)) {
+            throw new Error('client-submitted open requires a non-placeholder signature when rpc is configured');
+        }
         // Payment-channel-backed open. This covers push sessions and
         // clientVoucher pull sessions whose deposit lives in an on-chain
         // payment channel (the `createPaymentChannelSessionOpener` flow):
@@ -467,6 +475,7 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
             operator: args.operator,
             programId: args.programId.toString(),
             recipient: args.recipient,
+            splits: args.splits ?? [],
         };
 
         if (args.openTxSubmitter === 'server') {
@@ -704,6 +713,7 @@ interface HandleTopUpArgs {
         readonly newDeposit: string;
         readonly signature: string;
     };
+    readonly programId: Address;
     readonly rpc: RpcLike | undefined;
     readonly store: SessionStore;
 }
@@ -726,6 +736,16 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
     // (parity with the open-signature verification).
     if (args.rpc) {
         await assertSignatureSucceeded(args.rpc as VerifyOpenRpc, args.payload.signature, 'topUp');
+        if (!isTopUpTransactionRpc(args.rpc)) {
+            throw new Error('topUp requires an rpc client with getTransaction to bind the deposit delta');
+        }
+        await verifyTopUpTransaction({
+            amount: newDeposit - existing.deposit,
+            channelId: args.payload.channelId,
+            programId: args.programId,
+            rpc: args.rpc,
+            signature: args.payload.signature as Signature,
+        });
     }
 
     const result = await args.store.updateChannel(args.payload.channelId, current => {
@@ -1152,6 +1172,14 @@ function isMultiDelegateSubmitRpc(rpc: RpcLike | undefined): rpc is MultiDelegat
         typeof candidate.sendTransaction === 'function' &&
         typeof candidate.getSignatureStatuses === 'function'
     );
+}
+
+function isTopUpTransactionRpc(rpc: RpcLike | undefined): rpc is RpcLike & TopUpTransactionRpc {
+    return typeof (rpc as { getTransaction?: unknown } | undefined)?.getTransaction === 'function';
+}
+
+function isPlaceholderSignature(signature: string | undefined): boolean {
+    return !signature || /^1+$/.test(signature);
 }
 
 function expectString(value: string | undefined, name: string): string {

--- a/typescript/packages/mpp/src/server/session/on-chain.ts
+++ b/typescript/packages/mpp/src/server/session/on-chain.ts
@@ -41,11 +41,17 @@ import { findAssociatedTokenPda } from '@solana-program/token';
 
 import { ASSOCIATED_TOKEN_PROGRAM, defaultTokenProgramForCurrency, resolveStablecoinMint } from '../../constants.js';
 import { getDistributeInstruction } from '../../generated/payment-channels/instructions/distribute.js';
+import { getOpenInstructionDataDecoder } from '../../generated/payment-channels/instructions/open.js';
 import { getReclaimInstruction } from '../../generated/payment-channels/instructions/reclaim.js';
 import { getSettleAndSealInstruction } from '../../generated/payment-channels/instructions/settleAndSeal.js';
-import { getTopUpInstruction } from '../../generated/payment-channels/instructions/topUp.js';
+import {
+    getTopUpInstruction,
+    getTopUpInstructionDataDecoder,
+    TOP_UP_DISCRIMINATOR,
+} from '../../generated/payment-channels/instructions/topUp.js';
 import { findEventAuthorityPda } from '../../generated/payment-channels/pdas/eventAuthority.js';
 import { PAYMENT_CHANNELS_PROGRAM_ADDRESS } from '../../generated/payment-channels/programs/paymentChannels.js';
+import type { OpenArgs } from '../../generated/payment-channels/types/openArgs.js';
 import type { OpenPayload, SignedVoucher } from '../../shared/session-types.js';
 import { VOUCHER_MAGIC } from '../../shared/voucher.js';
 import { coSignBase64Transaction } from '../../utils/transactions.js';
@@ -444,6 +450,8 @@ export interface VerifyOpenTxExpected {
     readonly programId?: string | undefined;
     /** Primary recipient (challenge `recipient`). */
     readonly recipient: string;
+    /** Exact payment-channel distribution advertised by the challenge. */
+    readonly splits?: readonly { readonly bps: number; readonly recipient: string }[] | undefined;
     /** Optional explicit token program (otherwise derived from currency/network). */
     readonly tokenProgram?: string | undefined;
 }
@@ -620,15 +628,13 @@ export async function verifyOpenTx(args: VerifyOpenTxArgs): Promise<VerifyOpenTx
         throw new Error(`verifyOpenTx: rentPayer ${rentPayerAddr} != expected operator ${expected.operator}`);
     }
 
-    // ix data: [discriminator u8][salt u64][deposit u64][grace u32][openSlot u64][recipients array]
-    if (openIx.data.length < 1 + 8 + 8 + 4 + 8) {
-        throw new Error('verifyOpenTx: open instruction data too short');
+    let openArgs: OpenArgs;
+    try {
+        openArgs = getOpenInstructionDataDecoder().decode(openIx.data).openArgs;
+    } catch (error) {
+        throw new Error(`verifyOpenTx: invalid open instruction data: ${errorMessage(error)}`);
     }
-    const view = new DataView(openIx.data.buffer, openIx.data.byteOffset, openIx.data.byteLength);
-    const salt = view.getBigUint64(1, true);
-    const deposit = view.getBigUint64(9, true);
-    const gracePeriod = view.getUint32(17, true);
-    const openSlot = view.getBigUint64(21, true);
+    const { deposit, gracePeriod, openSlot, recipients, salt } = openArgs;
 
     if (deposit === 0n) {
         throw new Error('verifyOpenTx: deposit must be greater than zero');
@@ -638,6 +644,25 @@ export async function verifyOpenTx(args: VerifyOpenTxArgs): Promise<VerifyOpenTx
     }
     if (expected.openSlot !== undefined && openSlot !== expected.openSlot) {
         throw new Error(`verifyOpenTx: openSlot ${openSlot} != challenge-issued openSlot ${expected.openSlot}`);
+    }
+    if (expected.splits !== undefined) {
+        if (recipients.length !== expected.splits.length) {
+            throw new Error(
+                `verifyOpenTx: recipient split count ${recipients.length} != expected ${expected.splits.length}`,
+            );
+        }
+        for (let index = 0; index < recipients.length; index += 1) {
+            const actual = recipients[index];
+            const expectedSplit = expected.splits[index];
+            if (
+                !actual ||
+                !expectedSplit ||
+                actual.recipient !== expectedSplit.recipient ||
+                actual.bps !== expectedSplit.bps
+            ) {
+                throw new Error(`verifyOpenTx: recipient split at index ${index} does not match the challenge`);
+            }
+        }
     }
 
     // Re-derive the channel PDA and assert it matches.
@@ -677,6 +702,89 @@ export async function verifyOpenTx(args: VerifyOpenTxArgs): Promise<VerifyOpenTx
     }
 
     return { channelId: channelAddr, deposit, gracePeriod, openSlot, payer: payerAddr, salt };
+}
+
+/** Minimal RPC shape required to bind a top-up signature to its transaction. */
+export interface TopUpTransactionRpc {
+    getTransaction(
+        signature: Signature,
+        config: { readonly encoding: 'base64'; readonly maxSupportedTransactionVersion: 0 },
+    ): {
+        send(): Promise<{
+            meta: { err: unknown } | null;
+            transaction: readonly [string, string];
+        } | null>;
+    };
+}
+
+/**
+ * Confirms that a landed transaction contains exactly the required payment-channel
+ * top-up: same program, same channel account, and the precise deposit delta.
+ */
+export async function verifyTopUpTransaction(args: {
+    readonly amount: bigint;
+    readonly channelId: string;
+    readonly programId: string;
+    readonly rpc: TopUpTransactionRpc;
+    readonly signature: Signature;
+}): Promise<void> {
+    const fetched = await args.rpc
+        .getTransaction(args.signature, { encoding: 'base64', maxSupportedTransactionVersion: 0 })
+        .send();
+    if (!fetched) {
+        throw new Error(`verifyTopUpTransaction: tx ${args.signature} not found on-chain`);
+    }
+    if (fetched.meta?.err) {
+        throw new Error(
+            `verifyTopUpTransaction: tx ${args.signature} failed on-chain: ${JSON.stringify(fetched.meta.err)}`,
+        );
+    }
+    const [wire, encoding] = fetched.transaction;
+    if (encoding !== 'base64') {
+        throw new Error(`verifyTopUpTransaction: expected base64 transaction data, got ${encoding}`);
+    }
+
+    let message: {
+        instructions: readonly {
+            accountIndices?: readonly number[];
+            data?: Uint8Array | undefined;
+            programAddressIndex: number;
+        }[];
+        staticAccounts: readonly string[];
+    };
+    try {
+        const decoded = getTransactionDecoder().decode(getBase64Codec().encode(wire));
+        message = getCompiledTransactionMessageDecoder().decode(decoded.messageBytes) as typeof message;
+    } catch (error) {
+        throw new Error(`verifyTopUpTransaction: invalid transaction data: ${errorMessage(error)}`);
+    }
+
+    let topUpCount = 0;
+    let topUpTotal = 0n;
+    for (const instruction of message.instructions) {
+        if (message.staticAccounts[instruction.programAddressIndex] !== args.programId) continue;
+        if (!instruction.data || instruction.data[0] !== TOP_UP_DISCRIMINATOR) continue;
+        const channelIndex = instruction.accountIndices?.[1];
+        if (channelIndex === undefined || message.staticAccounts[channelIndex] !== args.channelId) continue;
+
+        try {
+            topUpCount += 1;
+            topUpTotal += getTopUpInstructionDataDecoder().decode(instruction.data).topUpArgs.amount;
+        } catch (error) {
+            throw new Error(`verifyTopUpTransaction: invalid top-up instruction: ${errorMessage(error)}`);
+        }
+    }
+
+    if (topUpCount === 0) {
+        throw new Error(`verifyTopUpTransaction: no top-up for channel ${args.channelId} found in ${args.signature}`);
+    }
+    if (topUpTotal !== args.amount) {
+        throw new Error(`verifyTopUpTransaction: on-chain top-up total ${topUpTotal} != expected delta ${args.amount}`);
+    }
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
 }
 
 /** Tuning knobs for {@link waitForSignatureConfirmation}. */

--- a/typescript/packages/mpp/src/server/session/on-chain.ts
+++ b/typescript/packages/mpp/src/server/session/on-chain.ts
@@ -226,6 +226,7 @@ export function buildSettleAndSealInstructions(args: SettleAndSealBuildArgs): Se
     let expiresAt = 0n;
     let hasVoucher = 0;
 
+    // nosemgrep: security-check-gated-on-optional-field-ts -- Voucher-less settlement intentionally emits hasVoucher=0 and requires no Ed25519 precompile.
     if (args.voucher) {
         const { signed, authorizedSigner } = args.voucher;
         cumulativeAmount = parseU64String(signed.data.cumulativeAmount, 'voucher.cumulativeAmount');

--- a/typescript/packages/mpp/src/server/session/store.ts
+++ b/typescript/packages/mpp/src/server/session/store.ts
@@ -76,6 +76,12 @@ export interface ChannelState {
     readonly sealed: boolean;
     /** On-chain settle_and_seal transaction signature (base58), once submitted. */
     readonly settledSignature?: string | undefined;
+    /**
+     * Top-up transaction signatures already applied to this channel.
+     * Kept in the channel record so replay rejection and the deposit increase
+     * share the same atomic `updateChannel` operation.
+     */
+    readonly usedTopUpSignatures?: readonly string[] | undefined;
 }
 
 /**

--- a/typescript/packages/mpp/src/shared/challenge-guard.ts
+++ b/typescript/packages/mpp/src/shared/challenge-guard.ts
@@ -47,6 +47,14 @@ function assertWithinSizeCap(value: string): void {
     }
 }
 
+/** Guard a value before mppx interpolates it into a quoted auth parameter. */
+export function guardChallengeValue(field: string, value: string): string {
+    if (/[\r\n]/.test(value)) {
+        throw new Error(`challenge field "${field}" must not contain a carriage-return or newline`);
+    }
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 /**
  * Deserializes a `WWW-Authenticate` header value to a challenge, rejecting a
  * challenge whose `id` is empty (canonical mpp-tools requires a non-empty,

--- a/typescript/packages/pay-kit/src/__tests__/config.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/config.test.ts
@@ -24,8 +24,13 @@ describe('configure', () => {
     it('refuses the demo signer on mainnet', async () => {
         await expect(configure({ ...SECRET, network: 'solana_mainnet' })).rejects.toThrow(DemoSignerOnMainnetError);
         const signer = await Signer.generate();
-        const config = await configure({ ...SECRET, network: 'solana_mainnet', operator: { signer } });
-        expect(config.operator.recipient).toBe(signer.pubkey);
+        process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE = '1';
+        try {
+            const config = await configure({ ...SECRET, network: 'solana_mainnet', operator: { signer } });
+            expect(config.operator.recipient).toBe(signer.pubkey);
+        } finally {
+            delete process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE;
+        }
     });
 
     it('accepts the shipped protocols (mpp + x402)', async () => {
@@ -51,9 +56,38 @@ describe('configure', () => {
         delete process.env.MPP_SECRET_KEY;
         await expect(configure({ network: 'solana_devnet', operator: { signer } })).rejects.toThrow(ConfigurationError);
         process.env.MPP_SECRET_KEY = 'env-secret';
-        const config = await configure({ network: 'solana_devnet', operator: { signer } });
-        expect(config.mpp.challengeBindingSecret).toBe('env-secret');
-        delete process.env.MPP_SECRET_KEY;
+        process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE = '1';
+        try {
+            const config = await configure({ network: 'solana_devnet', operator: { signer } });
+            expect(config.mpp.challengeBindingSecret).toBe('env-secret');
+        } finally {
+            delete process.env.MPP_SECRET_KEY;
+            delete process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE;
+        }
+    });
+
+    it('requires a shared MPP replay store outside localnet unless explicitly opted in', async () => {
+        const signer = await Signer.generate();
+        await expect(
+            configure({
+                ...SECRET,
+                network: 'solana_devnet',
+                operator: { signer },
+            }),
+        ).rejects.toThrow(/PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE/);
+
+        process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE = '1';
+        try {
+            await expect(
+                configure({
+                    ...SECRET,
+                    network: 'solana_devnet',
+                    operator: { signer },
+                }),
+            ).resolves.toMatchObject({ network: 'solana_devnet' });
+        } finally {
+            delete process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE;
+        }
     });
 
     it('configures from prefixed environment variables', async () => {
@@ -62,6 +96,7 @@ describe('configure', () => {
         process.env.PAY_KIT_MPP_EXPIRES_IN = '60';
         process.env.PAY_KIT_STABLECOINS = '';
         process.env.PAY_KIT_RPC_URL = 'http://rpc.example';
+        process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE = '1';
         try {
             const config = await configureFromEnv();
             expect(config.network).toBe('solana_devnet');
@@ -75,6 +110,7 @@ describe('configure', () => {
             delete process.env.PAY_KIT_MPP_EXPIRES_IN;
             delete process.env.PAY_KIT_STABLECOINS;
             delete process.env.PAY_KIT_RPC_URL;
+            delete process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE;
         }
     });
 });

--- a/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
@@ -5,6 +5,7 @@ import { createMppAdapter } from '../adapters/mpp.js';
 import { configure } from '../config.js';
 import { Gate } from '../gate.js';
 import { usd } from '../price.js';
+import { createUnsafeMemoryReplayStore } from '../replay-store.js';
 import { Signer } from '../signer.js';
 
 const SELLER = 'AyNAa2VPe2t5pgg8M61iE6kqMudkV98zsT4rkAZuU6tj';

--- a/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
@@ -18,6 +18,10 @@ async function setup() {
     return { adapter: createMppAdapter(config), config };
 }
 
+function createSharedTestReplayStore() {
+    return { ...createUnsafeMemoryReplayStore(), isDurable: true as const, isShared: true as const };
+}
+
 function gate(params: Parameters<typeof Gate.create>[0]['feeWithin'] = undefined) {
     return Gate.create(
         { amount: usd('10.00'), feeWithin: params, name: 'marketplace', payTo: SELLER },
@@ -93,8 +97,9 @@ describe('createMppAdapter', () => {
     it('round-trips a quote/backslash-bearing realm', async () => {
         const realm = 'ac"me\\corp';
         const config = await configure({
-            mpp: { allowUnsafeMemoryStore: true, challengeBindingSecret: 'adapter-test-secret', realm },
+            mpp: { challengeBindingSecret: 'adapter-test-secret', realm },
             operator: { recipient: SELLER, signer: await Signer.generate() },
+            replayStore: createSharedTestReplayStore(),
         });
         const adapter = createMppAdapter(config);
         const headers = await adapter.challengeHeaders(gate(), new Request('http://t/marketplace'));
@@ -118,11 +123,11 @@ describe('createMppAdapter', () => {
     it('rejects a realm containing CRLF', async () => {
         const config = await configure({
             mpp: {
-                allowUnsafeMemoryStore: true,
                 challengeBindingSecret: 'adapter-test-secret',
                 realm: 'api.example.com\r\nInjected: evil',
             },
             operator: { recipient: SELLER, signer: await Signer.generate() },
+            replayStore: createSharedTestReplayStore(),
         });
         const adapter = createMppAdapter(config);
         await expect(adapter.challengeHeaders(gate(), new Request('http://t/marketplace'))).rejects.toThrow(

--- a/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
@@ -1,3 +1,4 @@
+import { Challenge } from '@solana/mpp/client';
 import { describe, expect, it } from 'vitest';
 
 import { createMppAdapter } from '../adapters/mpp.js';
@@ -74,5 +75,54 @@ describe('createMppAdapter', () => {
         expect(headers['www-authenticate']).toContain('intent="charge"');
         expect(headers['www-authenticate']).toContain('method="solana"');
         expect(headers['www-authenticate']).toContain('realm="Adapter test"');
+    });
+
+    it.each([
+        ['description', 'Access to "premium" \\ API'],
+        ['description', '\\"quoted\\"'],
+    ])('round-trips a quote/backslash-bearing %s', async (_field, description) => {
+        const { adapter } = await setup();
+        const describedGate = Gate.create(
+            { amount: usd('10.00'), description, name: 'quoted', payTo: SELLER },
+            { accept: ['mpp'], payTo: SELLER },
+        );
+        const headers = await adapter.challengeHeaders(describedGate, new Request('http://t/quoted'));
+        expect(Challenge.deserialize(headers['www-authenticate'] as string).description).toBe(description);
+    });
+
+    it('round-trips a quote/backslash-bearing realm', async () => {
+        const realm = 'ac"me\\corp';
+        const config = await configure({
+            mpp: { challengeBindingSecret: 'adapter-test-secret', realm },
+            operator: { recipient: SELLER, signer: await Signer.generate() },
+        });
+        const adapter = createMppAdapter(config);
+        const headers = await adapter.challengeHeaders(gate(), new Request('http://t/marketplace'));
+        expect(Challenge.deserialize(headers['www-authenticate'] as string).realm).toBe(realm);
+    });
+
+    it.each([
+        ['carriage return', 'legit\rInjected-Header: evil'],
+        ['newline', 'legit\nInjected-Header: evil'],
+    ])('rejects a description containing a %s', async (_name, description) => {
+        const { adapter } = await setup();
+        const injectedGate = Gate.create(
+            { amount: usd('10.00'), description, name: 'injected', payTo: SELLER },
+            { accept: ['mpp'], payTo: SELLER },
+        );
+        await expect(adapter.challengeHeaders(injectedGate, new Request('http://t/injected'))).rejects.toThrow(
+            /must not contain a carriage-return or newline/,
+        );
+    });
+
+    it('rejects a realm containing CRLF', async () => {
+        const config = await configure({
+            mpp: { challengeBindingSecret: 'adapter-test-secret', realm: 'api.example.com\r\nInjected: evil' },
+            operator: { recipient: SELLER, signer: await Signer.generate() },
+        });
+        const adapter = createMppAdapter(config);
+        await expect(adapter.challengeHeaders(gate(), new Request('http://t/marketplace'))).rejects.toThrow(
+            /must not contain a carriage-return or newline/,
+        );
     });
 });

--- a/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
@@ -5,7 +5,6 @@ import { createMppAdapter } from '../adapters/mpp.js';
 import { configure } from '../config.js';
 import { Gate } from '../gate.js';
 import { usd } from '../price.js';
-import { createUnsafeMemoryReplayStore } from '../replay-store.js';
 import { Signer } from '../signer.js';
 
 const SELLER = 'AyNAa2VPe2t5pgg8M61iE6kqMudkV98zsT4rkAZuU6tj';
@@ -20,7 +19,23 @@ async function setup() {
 }
 
 function createSharedTestReplayStore() {
-    return { ...createUnsafeMemoryReplayStore(), isDurable: true as const, isShared: true as const };
+    const entries = new Map<string, unknown>();
+    return {
+        delete: async (key: string) => {
+            entries.delete(key);
+        },
+        get: async (key: string) => entries.get(key) ?? null,
+        isDurable: true as const,
+        isShared: true as const,
+        put: async (key: string, value: unknown) => {
+            entries.set(key, value);
+        },
+        putIfAbsent: async (key: string, value: unknown) => {
+            if (entries.has(key)) return false;
+            entries.set(key, value);
+            return true;
+        },
+    };
 }
 
 function gate(params: Parameters<typeof Gate.create>[0]['feeWithin'] = undefined) {

--- a/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-adapter.test.ts
@@ -93,7 +93,7 @@ describe('createMppAdapter', () => {
     it('round-trips a quote/backslash-bearing realm', async () => {
         const realm = 'ac"me\\corp';
         const config = await configure({
-            mpp: { challengeBindingSecret: 'adapter-test-secret', realm },
+            mpp: { allowUnsafeMemoryStore: true, challengeBindingSecret: 'adapter-test-secret', realm },
             operator: { recipient: SELLER, signer: await Signer.generate() },
         });
         const adapter = createMppAdapter(config);
@@ -117,7 +117,11 @@ describe('createMppAdapter', () => {
 
     it('rejects a realm containing CRLF', async () => {
         const config = await configure({
-            mpp: { challengeBindingSecret: 'adapter-test-secret', realm: 'api.example.com\r\nInjected: evil' },
+            mpp: {
+                allowUnsafeMemoryStore: true,
+                challengeBindingSecret: 'adapter-test-secret',
+                realm: 'api.example.com\r\nInjected: evil',
+            },
             operator: { recipient: SELLER, signer: await Signer.generate() },
         });
         const adapter = createMppAdapter(config);

--- a/typescript/packages/pay-kit/src/__tests__/mpp-session.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/mpp-session.test.ts
@@ -1,0 +1,68 @@
+import { createMemorySessionStore } from '@solana/mpp/server';
+import { Store } from 'mppx';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSessionEngine } from '../adapters/mpp-session.js';
+import { configure } from '../config.js';
+import { Gate } from '../gate.js';
+import { usd } from '../price.js';
+import { session } from '../pricing.js';
+import { Signer } from '../signer.js';
+
+async function setup(
+    options: {
+        readonly network?: 'solana_devnet' | 'solana_localnet';
+        readonly sessionStore?: ReturnType<typeof createMemorySessionStore>;
+    } = {},
+) {
+    const signer = await Signer.generate();
+    const config = await configure({
+        mpp: {
+            challengeBindingSecret: 'session-store-test-secret',
+            ...(options.sessionStore ? { sessionStore: options.sessionStore } : {}),
+        },
+        network: options.network ?? 'solana_localnet',
+        operator: { signer },
+        replayStore: Store.memory(),
+    });
+    const gate = Gate.create(
+        {
+            ...session(usd('1.00'), { unitPrice: usd('0.0001') }),
+            name: 'metered',
+            payTo: signer.pubkey,
+        },
+        { accept: ['mpp'], payTo: signer.pubkey },
+    );
+    return { config, gate };
+}
+
+describe('createSessionEngine', () => {
+    it('rejects a nonlocal session engine without an injected store', async () => {
+        const { config, gate } = await setup({ network: 'solana_devnet' });
+
+        expect(() => createSessionEngine(config, gate)).toThrow(/mpp\.sessionStore is required outside localnet/);
+    });
+
+    it('uses the injected store outside localnet', async () => {
+        const store = createMemorySessionStore();
+        const getChannel = vi.spyOn(store, 'getChannel');
+        const { config, gate } = await setup({ network: 'solana_devnet', sessionStore: store });
+
+        const engine = createSessionEngine(config, gate);
+        await expect(engine.receipt('missing')).resolves.toBeUndefined();
+        expect(getChannel).toHaveBeenCalledWith('missing');
+    });
+
+    it('retains the localnet and explicit-override in-memory fallbacks', async () => {
+        const localnet = await setup();
+        expect(() => createSessionEngine(localnet.config, localnet.gate)).not.toThrow();
+
+        process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE = '1';
+        try {
+            const devnet = await setup({ network: 'solana_devnet' });
+            expect(() => createSessionEngine(devnet.config, devnet.gate)).not.toThrow();
+        } finally {
+            delete process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE;
+        }
+    });
+});

--- a/typescript/packages/pay-kit/src/__tests__/x402.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/x402.test.ts
@@ -132,14 +132,20 @@ describe('Charge meter', () => {
         expect(charge.settledBaseUnits()).toBe(400_000n);
     });
 
-    it('preserves overages for settlement rejection and floors negatives', () => {
+    it('preserves overages for settlement rejection and rejects negatives', () => {
         const overCharge = new Charge(1_000_000n);
         overCharge.charge(2_000_000n);
         expect(overCharge.settledBaseUnits()).toBe(2_000_000n);
 
         const negative = new Charge(1_000_000n);
-        negative.charge(-5);
-        expect(negative.settledBaseUnits()).toBe(0n);
+        expect(() => negative.charge(-5)).toThrow(/must be non-negative/);
+    });
+
+    it('rejects a direct negative settlement before touching the network', async () => {
+        const upto = new X402Upto(await testConfig());
+        await expect(upto.settle({} as never, -1n)).rejects.toMatchObject({
+            code: 'invalid_upto_svm_payload_settlement_negative_amount',
+        });
     });
 
     it('accepts a plain number', () => {

--- a/typescript/packages/pay-kit/src/__tests__/x402.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/x402.test.ts
@@ -132,10 +132,10 @@ describe('Charge meter', () => {
         expect(charge.settledBaseUnits()).toBe(400_000n);
     });
 
-    it('clamps above the ceiling and floors negatives', () => {
+    it('preserves overages for settlement rejection and floors negatives', () => {
         const overCharge = new Charge(1_000_000n);
         overCharge.charge(2_000_000n);
-        expect(overCharge.settledBaseUnits()).toBe(1_000_000n);
+        expect(overCharge.settledBaseUnits()).toBe(2_000_000n);
 
         const negative = new Charge(1_000_000n);
         negative.charge(-5);

--- a/typescript/packages/pay-kit/src/adapters/mpp-session.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp-session.ts
@@ -8,11 +8,11 @@
  *
  * pay-kit does NOT auto-mount the side-channel routes (mppx-consistent): the
  * instance exposes `handler` / `deliveries` / `commit` / `receipt` and the app
- * mounts them. All four share one in-memory session store per gate.
+ * mounts them. All four share the configured session store per gate.
  */
 import { createSolanaRpc } from '@solana/kit';
 import { resolveStablecoinMint } from '@solana/mpp';
-import { createMemorySessionStore, Mppx, session } from '@solana/mpp/server';
+import { createMemorySessionStore, Mppx, session, type SessionStore } from '@solana/mpp/server';
 
 import { requireMint, resolveCoin } from '../coin.js';
 import type { PayKitConfig } from '../config.js';
@@ -47,9 +47,9 @@ export type SessionEngine = {
 };
 
 /**
- * Build the session engine for a `session` gate. One in-memory store is shared
- * across the gated handler and the side-channel routes so the receipt poll can
- * read whichever channel a request opened.
+ * Build the session engine for a `session` gate. One store is shared across the
+ * gated handler and the side-channel routes so the receipt poll can read
+ * whichever channel a request opened.
  */
 export function createSessionEngine(config: PayKitConfig, gate: Gate): SessionEngine {
     if (!gate.session) {
@@ -65,7 +65,7 @@ export function createSessionEngine(config: PayKitConfig, gate: Gate): SessionEn
     const mint = requireMint(coin, resolveStablecoinMint(coin, network), config.network);
 
     const signer = config.operator.signer.signer;
-    const store = createMemorySessionStore();
+    const store = resolveSessionStore(config);
     const params = {
         cap: gate.amount.baseUnits(),
         ...(gate.session.closeDelayMs !== undefined ? { closeDelayMs: gate.session.closeDelayMs } : {}),
@@ -113,4 +113,15 @@ export function createSessionEngine(config: PayKitConfig, gate: Gate): SessionEn
             };
         },
     };
+}
+
+function resolveSessionStore(config: PayKitConfig): SessionStore {
+    if (config.mpp.sessionStore) return config.mpp.sessionStore;
+    if (config.network === 'solana_localnet' || process.env.PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE === '1') {
+        return createMemorySessionStore();
+    }
+    throw new ConfigurationError(
+        'mpp.sessionStore is required outside localnet; provide a durable shared store or set ' +
+            'PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE=1 for an explicit in-memory override.',
+    );
 }

--- a/typescript/packages/pay-kit/src/adapters/mpp.ts
+++ b/typescript/packages/pay-kit/src/adapters/mpp.ts
@@ -1,4 +1,4 @@
-import { resolveStablecoinMint, TOKEN_PROGRAM } from '@solana/mpp';
+import { guardChallengeValue, resolveStablecoinMint, TOKEN_PROGRAM } from '@solana/mpp';
 import { Mppx, solana } from '@solana/mpp/server';
 import { Receipt } from 'mppx';
 
@@ -71,6 +71,8 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
         let handler = handlers.get(key);
         if (!handler) {
             const signer = config.operator.feePayer ? { signer: config.operator.signer.signer } : {};
+            const realm = guardChallengeValue('realm', config.mpp.realm);
+            const description = gate.description ? guardChallengeValue('description', gate.description) : undefined;
             if (gate.subscription) {
                 const { periodCount, periodUnit, planId, puller } = gate.subscription;
                 const mppx = Mppx.create({
@@ -89,14 +91,14 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
                             ...signer,
                         }),
                     ],
-                    realm: config.mpp.realm,
+                    realm,
                     secretKey: config.mpp.challengeBindingSecret,
                 });
                 handler = request =>
                     mppx.subscription({
                         amount: totalAmount(gate).toString(),
                         currency: mint,
-                        ...(gate.description ? { description: gate.description } : {}),
+                        ...(description !== undefined ? { description } : {}),
                         ...(gate.externalId ? { externalId: gate.externalId } : {}),
                     })(request);
             } else {
@@ -114,20 +116,20 @@ export function createMppAdapter(config: PayKitConfig): ProtocolAdapter {
                             ...(config.replayStore ? { store: config.replayStore } : {}),
                         }),
                     ],
-                    realm: config.mpp.realm,
+                    realm,
                     secretKey: config.mpp.challengeBindingSecret,
                 });
-                handler = request => mppx.charge(optionsFor(gate))(request);
+                handler = request => mppx.charge(optionsFor(gate, description))(request);
             }
             handlers.set(key, handler);
         }
         return handler;
     }
 
-    function optionsFor(gate: Gate) {
+    function optionsFor(gate: Gate, description: string | undefined) {
         return {
             amount: totalAmount(gate).toString(),
-            ...(gate.description ? { description: gate.description } : {}),
+            ...(description !== undefined ? { description } : {}),
             ...(gate.externalId ? { externalId: gate.externalId } : {}),
             ...(config.mpp.expiresIn > 0
                 ? { expires: new Date(Date.now() + config.mpp.expiresIn * 1000).toISOString() }

--- a/typescript/packages/pay-kit/src/adapters/x402-upto.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402-upto.ts
@@ -174,13 +174,19 @@ export class X402Upto {
     }
 
     /**
-     * Settle the metered amount (`actualBaseUnits`, clamped to the ceiling) against
-     * a verified open: receiver-authorizer voucher, settle-and-seal, refund the remainder.
+     * Settle the metered amount (`actualBaseUnits`) against a verified open:
+     * receiver-authorizer voucher, settle-and-seal, refunding the remainder.
      *
-     * @throws {InvalidProofError} when settlement fails.
+     * @throws {InvalidProofError} when the meter exceeds its authorized ceiling or settlement fails.
      */
     async settle(verified: UptoVerified, actualBaseUnits: bigint): Promise<UptoSettlement> {
-        const actual = actualBaseUnits > verified.maxBaseUnits ? verified.maxBaseUnits : actualBaseUnits;
+        if (actualBaseUnits > verified.maxBaseUnits) {
+            throw new InvalidProofError(
+                'invalid_upto_svm_payload_settlement_exceeds_amount',
+                `settlement amount ${actualBaseUnits} exceeds authorized ceiling ${verified.maxBaseUnits}`,
+            );
+        }
+        const actual = actualBaseUnits < 0n ? 0n : actualBaseUnits;
         const payload = parseUptoPayload(verified.payload);
         const rpc = createSolanaRpc(this.#rpcUrl);
         const confirmRpc = rpc as unknown as SettlementConfirmRpc;

--- a/typescript/packages/pay-kit/src/adapters/x402-upto.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402-upto.ts
@@ -48,13 +48,13 @@ export class Charge {
         this.maxBaseUnits = maxBaseUnits;
     }
 
-    /** Record the actual amount consumed (base units). Values above the ceiling are clamped; negatives floor to 0. */
+    /** Record the actual amount consumed (base units). Negatives floor to 0; overages reach settlement and reject. */
     charge(baseUnits: bigint | number): void {
         const value = typeof baseUnits === 'bigint' ? baseUnits : BigInt(Math.trunc(baseUnits));
-        this.#amount = value < 0n ? 0n : value > this.maxBaseUnits ? this.maxBaseUnits : value;
+        this.#amount = value < 0n ? 0n : value;
     }
 
-    /** The amount to settle (base units): the clamped charge, or `0` if never set. */
+    /** The amount to settle (base units): the recorded charge, or `0` if never set. */
     settledBaseUnits(): bigint {
         return this.#amount ?? 0n;
     }

--- a/typescript/packages/pay-kit/src/adapters/x402-upto.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402-upto.ts
@@ -48,10 +48,16 @@ export class Charge {
         this.maxBaseUnits = maxBaseUnits;
     }
 
-    /** Record the actual amount consumed (base units). Negatives floor to 0; overages reach settlement and reject. */
+    /** Record the actual amount consumed (base units). Invalid negative values and overages reject at settlement. */
     charge(baseUnits: bigint | number): void {
         const value = typeof baseUnits === 'bigint' ? baseUnits : BigInt(Math.trunc(baseUnits));
-        this.#amount = value < 0n ? 0n : value;
+        if (value < 0n) {
+            throw new InvalidProofError(
+                'invalid_upto_svm_payload_settlement_negative_amount',
+                `settlement amount ${value} must be non-negative`,
+            );
+        }
+        this.#amount = value;
     }
 
     /** The amount to settle (base units): the recorded charge, or `0` if never set. */
@@ -180,13 +186,19 @@ export class X402Upto {
      * @throws {InvalidProofError} when the meter exceeds its authorized ceiling or settlement fails.
      */
     async settle(verified: UptoVerified, actualBaseUnits: bigint): Promise<UptoSettlement> {
+        if (actualBaseUnits < 0n) {
+            throw new InvalidProofError(
+                'invalid_upto_svm_payload_settlement_negative_amount',
+                `settlement amount ${actualBaseUnits} must be non-negative`,
+            );
+        }
         if (actualBaseUnits > verified.maxBaseUnits) {
             throw new InvalidProofError(
                 'invalid_upto_svm_payload_settlement_exceeds_amount',
                 `settlement amount ${actualBaseUnits} exceeds authorized ceiling ${verified.maxBaseUnits}`,
             );
         }
-        const actual = actualBaseUnits < 0n ? 0n : actualBaseUnits;
+        const actual = actualBaseUnits;
         const payload = parseUptoPayload(verified.payload);
         const rpc = createSolanaRpc(this.#rpcUrl);
         const confirmRpc = rpc as unknown as SettlementConfirmRpc;

--- a/typescript/packages/pay-kit/src/config.ts
+++ b/typescript/packages/pay-kit/src/config.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_RPC_URLS } from '@solana/mpp';
+import type { SessionStore } from '@solana/mpp/server';
 import type { Store } from 'mppx';
 
 import { ConfigurationError, DemoSignerOnMainnetError, ProtocolNotSupportedError } from './errors.js';
@@ -24,6 +25,11 @@ export type MppOptions = {
      */
     readonly html?: boolean;
     readonly realm?: string;
+    /**
+     * Storage for MPP session channels. Provide a durable, shared store in
+     * production because it records voucher and delivery state.
+     */
+    readonly sessionStore?: SessionStore;
 };
 
 /** x402 protocol options. Reserved for future scheme-specific settings. */
@@ -76,6 +82,7 @@ export type PayKitConfig = {
         readonly expiresIn: number;
         readonly html: boolean;
         readonly realm: string;
+        readonly sessionStore: SessionStore | undefined;
     };
     readonly network: Network;
     readonly operator: Operator;
@@ -189,6 +196,7 @@ export async function configure(params: ConfigureParams = {}): Promise<PayKitCon
             expiresIn,
             html: params.mpp?.html ?? false,
             realm: params.mpp?.realm ?? 'App',
+            sessionStore: params.mpp?.sessionStore,
         }),
         network,
         operator: Object.freeze(operator),

--- a/typescript/packages/pay-kit/src/config.ts
+++ b/typescript/packages/pay-kit/src/config.ts
@@ -87,6 +87,7 @@ export type PayKitConfig = {
 };
 
 const DEFAULT_EXPIRES_IN_SECONDS = 120;
+const ALLOW_INMEMORY_REPLAY_STORE_ENV = 'PAY_KIT_ALLOW_INMEMORY_REPLAY_STORE';
 
 function resolveChallengeBindingSecret(network: Network, provided: string | undefined): string {
     const secret = provided ?? process.env.PAY_KIT_MPP_SECRET ?? process.env.MPP_SECRET_KEY;
@@ -169,6 +170,17 @@ export async function configure(params: ConfigureParams = {}): Promise<PayKitCon
     const challengeBindingSecret = accept.includes('mpp')
         ? resolveChallengeBindingSecret(network, params.mpp?.challengeBindingSecret)
         : (params.mpp?.challengeBindingSecret ?? '');
+
+    if (
+        accept.includes('mpp') &&
+        network !== 'solana_localnet' &&
+        params.replayStore === undefined &&
+        process.env[ALLOW_INMEMORY_REPLAY_STORE_ENV] !== '1'
+    ) {
+        throw new ConfigurationError(
+            `no shared replay store configured outside localnet; provide replayStore or set ${ALLOW_INMEMORY_REPLAY_STORE_ENV}=1`,
+        );
+    }
 
     return Object.freeze({
         accept: Object.freeze([...accept]),


### PR DESCRIPTION
## Summary
- split the TypeScript security work from #226 into a TypeScript-owned PR
- bind session top-ups and split recipients to the decoded on-chain transaction
- reject x402 upto amounts above the offered ceiling instead of silently clamping

## Verification
- targeted Vitest suite (75 passed)
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`

## Stack
Targets #219 as requested. Cross-SDK harness checks may remain red until the sibling language and harness PRs are merged into #219.
