### PR TITLE
fix(lua): require explicit shared replay stores

### DIFF
--- a/lua/pay_kit/protocols/mpp/init.lua
+++ b/lua/pay_kit/protocols/mpp/init.lua
@@ -55,8 +55,9 @@ local function replay_store_is_shared(replay_store)
     return replay_store:is_shared() == true
   end
   -- Custom Redis/Postgres adapters can declare the capability without
-  -- inheriting this package's shared-dict implementation.
-  return replay_store.shared == true or replay_store.durable == true
+  -- inheriting this package's shared-dict implementation. Durability alone
+  -- only proves restart survival, not an atomic cross-worker reservation.
+  return replay_store.shared == true
 end
 
 local function map_pay_kit_network(network)

--- a/lua/pay_kit/protocols/mpp/init.lua
+++ b/lua/pay_kit/protocols/mpp/init.lua
@@ -109,7 +109,7 @@ local function build_mpp_server(config, gate, store)
     warn_volatile_replay_store(network)
   end
   if network ~= 'localnet' and not replay_store_is_shared(replay_store) then
-    error('MPP replay store must be shared outside localnet; process-local stores are unsafe')
+    error('MPP replay store must declare shared=true outside localnet; durability alone does not prove atomic cross-worker reservations')
   end
 
   -- Enforce the replay-store policy before loading or initializing transport

--- a/lua/pay_kit/protocols/mpp/server/charge_handler.lua
+++ b/lua/pay_kit/protocols/mpp/server/charge_handler.lua
@@ -91,7 +91,7 @@ local function replay_store_is_shared(replay_store)
   if type(replay_store.is_shared) == 'function' then
     return replay_store:is_shared() == true
   end
-  return replay_store.shared == true or replay_store.durable == true
+  return replay_store.shared == true
 end
 
 --- Construct a new charge handler.

--- a/lua/pay_kit/protocols/mpp/server/charge_handler.lua
+++ b/lua/pay_kit/protocols/mpp/server/charge_handler.lua
@@ -133,7 +133,7 @@ function M.new(config)
   end
   local network = config.network or 'mainnet'
   if network ~= 'localnet' and not replay_store_is_shared(config.replay_store) then
-    error('replay_store must be shared outside localnet; process-local stores are unsafe')
+    error('replay_store must declare shared=true outside localnet; durability alone does not prove atomic cross-worker reservations')
   end
   if type(config.transaction_verifier) ~= 'function' then
     error('transaction_verifier function is required')

--- a/lua/tests/charge_handler_spec.lua
+++ b/lua/tests/charge_handler_spec.lua
@@ -102,7 +102,7 @@ t.test('handler constructor rejects a process-local replay store outside localne
       replay_store = store.memory(),
       transaction_verifier = function() end,
     })
-  end, 'replay_store must be shared outside localnet')
+  end, 'replay_store must declare shared=true outside localnet')
 end)
 
 t.test('handler constructor rejects a durable-only replay store outside localnet', function()
@@ -116,7 +116,7 @@ t.test('handler constructor rejects a durable-only replay store outside localnet
       },
       transaction_verifier = function() end,
     })
-  end, 'replay_store must be shared outside localnet')
+  end, 'replay_store must declare shared=true outside localnet')
 end)
 
 -- ─── Pull mode ────────────────────────────────────────────────────────────

--- a/lua/tests/charge_handler_spec.lua
+++ b/lua/tests/charge_handler_spec.lua
@@ -105,6 +105,20 @@ t.test('handler constructor rejects a process-local replay store outside localne
   end, 'replay_store must be shared outside localnet')
 end)
 
+t.test('handler constructor rejects a durable-only replay store outside localnet', function()
+  t.assert_error(function()
+    charge_handler.new({
+      rpc = fake_rpc({}),
+      network = 'devnet',
+      replay_store = {
+        durable = true,
+        put_if_absent = function() return true end,
+      },
+      transaction_verifier = function() end,
+    })
+  end, 'replay_store must be shared outside localnet')
+end)
+
 -- ─── Pull mode ────────────────────────────────────────────────────────────
 
 t.test('settle_pull happy path: verify → simulate → send → consume → await', function()

--- a/lua/tests/pay_kit/dispatcher_spec.lua
+++ b/lua/tests/pay_kit/dispatcher_spec.lua
@@ -128,6 +128,26 @@ helper.test('MPP on a non-localnet network rejects a process-local replay store'
   helper.assert_true(tostring(err):find('shared', 1, true) ~= nil, tostring(err))
 end)
 
+helper.test('MPP on a non-localnet network rejects a durable-only replay store', function()
+  pay_kit._reset_for_tests()
+  assert(pay_kit.configure({
+    network  = 'solana_devnet',
+    accept   = {'mpp'},
+    operator = {recipient = SELLER},
+    mpp      = {
+      challenge_binding_secret = 'test-secret-key-long-enough-32bytes',
+      replay_store = {
+        durable = true,
+        put_if_absent = function() return true end,
+      },
+    },
+  }))
+  assert(pay_kit.gate('report', {amount = assert(pay_kit.usd('0.10'))}))
+  local ok, err = pcall(pay_kit.try_payment, 'report', {headers = {}, path = '/report'})
+  helper.assert_true(not ok, 'expected a durable-only store to fail closed')
+  helper.assert_true(tostring(err):find('shared', 1, true) ~= nil, tostring(err))
+end)
+
 helper.test('MPP on a non-localnet network accepts an explicit shared replay store', function()
   pay_kit._reset_for_tests()
   assert(pay_kit.configure({


### PR DESCRIPTION
Reject durable-only custom replay stores outside localnet; they survive restarts but do not prove atomic cross-worker reservations.

Tests:
- `luajit` targeted charge-handler specs: 37 passed
- Full Lua suite is deferred to CI because this workstation lacks `lua-cjson` and `luasodium`.