### PR TITLE
fix: mpp session lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,16 @@ jobs:
     name: Rust tests
     needs: build-html
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -219,6 +229,15 @@ jobs:
       - name: Run solana-pay-kit x402 library tests
         working-directory: rust
         run: cargo test -p solana-pay-kit --lib x402
+
+      - name: Run Redis channel store integration test
+        working-directory: rust
+        env:
+          PAY_KIT_TEST_REDIS_URL: redis://127.0.0.1:6379
+        run: >-
+          cargo test -p solana-pay-kit --features redis-store --lib
+          core::store::tests::redis_channel_store_roundtrip_and_atomic_watermark
+          -- --exact
 
       - name: Enforce Rust coverage floor (>=90 cross-SDK baseline)
         working-directory: rust

--- a/rust/crates/kit/Cargo.toml
+++ b/rust/crates/kit/Cargo.toml
@@ -24,6 +24,9 @@ client = ["dep:reqwest"]
 # plus the server side.
 axum = ["mpp", "x402", "server", "dep:axum"]
 gcp_kms = ["solana-keychain/gcp_kms"]
+# Durable server-side session state. Opt-in so clients and local-only servers
+# do not pull a Redis runtime into their dependency graph.
+redis-store = ["dep:redis"]
 # Token-2022 confidential transfers: ZK proof generation + the Token-2022
 # confidential-transfer instruction builders. Opt-in so non-confidential
 # consumers (mobile/wasm/FFI) stay lean.
@@ -152,6 +155,7 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 # Observability
 tracing = "0.1"
 async-trait = "0.1"
+redis = { version = "0.32.5", optional = true, features = ["tokio-comp", "connection-manager"] }
 
 # OpenTelemetry (feature `otel`) — optional.
 opentelemetry = { version = "0.31", optional = true }

--- a/rust/crates/kit/Cargo.toml
+++ b/rust/crates/kit/Cargo.toml
@@ -155,7 +155,7 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 # Observability
 tracing = "0.1"
 async-trait = "0.1"
-redis = { version = "0.32.5", optional = true, features = ["tokio-comp", "connection-manager"] }
+redis = { version = "0.32.5", optional = true, features = ["tokio-rustls-comp", "connection-manager"] }
 
 # OpenTelemetry (feature `otel`) — optional.
 opentelemetry = { version = "0.31", optional = true }

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -486,8 +486,14 @@ impl RedisChannelStore {
             .map_err(|e| StoreError::Internal(format!("Redis connect: {e}")))?;
         Ok(Self {
             connection,
-            key_prefix: key_prefix.into(),
+            key_prefix: Self::namespace_key_prefix(key_prefix.into()),
         })
+    }
+
+    fn namespace_key_prefix(key_prefix: String) -> String {
+        // Length-prefix the configured namespace so no encoded namespace can
+        // be a prefix of another, even when namespaces are nested.
+        format!("{}:{key_prefix}:", key_prefix.len())
     }
 
     fn key(&self, channel_id: &str) -> String {
@@ -808,6 +814,20 @@ mod tests {
     }
 
     #[cfg(feature = "redis-store")]
+    #[test]
+    fn redis_channel_store_prefix_has_namespace_boundary() {
+        let tenant = RedisChannelStore::namespace_key_prefix("tenant:1".to_string());
+        let adjacent = RedisChannelStore::namespace_key_prefix("tenant:10".to_string());
+        let nested = RedisChannelStore::namespace_key_prefix("tenant:1:child".to_string());
+
+        assert_eq!(tenant, "8:tenant:1:");
+        assert_eq!(adjacent, "9:tenant:10:");
+        assert_eq!(nested, "14:tenant:1:child:");
+        assert!(!adjacent.starts_with(&tenant));
+        assert!(!nested.starts_with(&tenant));
+    }
+
+    #[cfg(feature = "redis-store")]
     #[tokio::test]
     async fn redis_channel_store_roundtrip_and_atomic_watermark() {
         let Ok(redis_url) = std::env::var("PAY_KIT_TEST_REDIS_URL") else {
@@ -852,6 +872,43 @@ mod tests {
         let channels = store.list_channels().await.unwrap();
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].channel_id, "c1");
+
+        let prefix = format!("pay-kit:test:{}:{unique}:tenant", std::process::id());
+        let tenant_one = RedisChannelStore::connect(&redis_url, format!("{prefix}:1"))
+            .await
+            .unwrap();
+        let tenant_ten = RedisChannelStore::connect(&redis_url, format!("{prefix}:10"))
+            .await
+            .unwrap();
+        tenant_one
+            .put_channel("one", make_state("one", 1_000_000))
+            .await
+            .unwrap();
+        tenant_ten
+            .put_channel("ten", make_state("ten", 10_000_000))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tenant_one
+                .list_channels()
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|state| state.channel_id)
+                .collect::<Vec<_>>(),
+            vec!["one"]
+        );
+        assert_eq!(
+            tenant_ten
+                .list_channels()
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|state| state.channel_id)
+                .collect::<Vec<_>>(),
+            vec!["ten"]
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -272,6 +272,58 @@ pub trait ChannelStore: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>>;
 }
 
+impl<T> ChannelStore for std::sync::Arc<T>
+where
+    T: ChannelStore + ?Sized,
+{
+    fn get_channel(
+        &self,
+        channel_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<ChannelState>, StoreError>> + Send + '_>> {
+        (**self).get_channel(channel_id)
+    }
+
+    fn put_channel(
+        &self,
+        channel_id: &str,
+        state: ChannelState,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+        (**self).put_channel(channel_id, state)
+    }
+
+    fn update_channel(
+        &self,
+        channel_id: &str,
+        updater: Box<dyn FnOnce(Option<ChannelState>) -> Result<ChannelState, StoreError> + Send>,
+    ) -> Pin<Box<dyn Future<Output = Result<ChannelState, StoreError>> + Send + '_>> {
+        (**self).update_channel(channel_id, updater)
+    }
+
+    fn advance_cumulative(
+        &self,
+        channel_id: &str,
+        expected: u64,
+        new: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
+        (**self).advance_cumulative(channel_id, expected, new)
+    }
+
+    fn update_deposit(
+        &self,
+        channel_id: &str,
+        new_deposit: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+        (**self).update_deposit(channel_id, new_deposit)
+    }
+
+    fn mark_sealed(
+        &self,
+        channel_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+        (**self).mark_sealed(channel_id)
+    }
+}
+
 /// In-memory channel store backed by a Mutex.
 pub struct MemoryChannelStore {
     data: std::sync::Mutex<std::collections::HashMap<String, ChannelState>>,
@@ -379,6 +431,216 @@ impl ChannelStore for MemoryChannelStore {
     }
 }
 
+// ── Redis channel store ──
+
+/// Durable Redis-backed payment-channel state.
+///
+/// Enabled by the `redis-store` feature. Every read/modify/write operation is
+/// guarded by a Lua compare-and-set, so multiple gateway instances cannot
+/// silently overwrite one another. A conflicting generic `update_channel`
+/// returns an error and is safe for the caller to retry; the dedicated
+/// `advance_cumulative` operation reports the conflict as `Ok(false)`, matching
+/// the [`ChannelStore`] contract.
+#[cfg(feature = "redis-store")]
+#[derive(Clone)]
+pub struct RedisChannelStore {
+    connection: redis::aio::ConnectionManager,
+    key_prefix: String,
+}
+
+#[cfg(feature = "redis-store")]
+impl RedisChannelStore {
+    /// Connect to Redis and namespace channel records under `key_prefix`.
+    pub async fn connect(
+        redis_url: &str,
+        key_prefix: impl Into<String>,
+    ) -> Result<Self, StoreError> {
+        let client = redis::Client::open(redis_url)
+            .map_err(|e| StoreError::Internal(format!("Redis client: {e}")))?;
+        let connection = client
+            .get_connection_manager()
+            .await
+            .map_err(|e| StoreError::Internal(format!("Redis connect: {e}")))?;
+        Ok(Self {
+            connection,
+            key_prefix: key_prefix.into(),
+        })
+    }
+
+    fn key(&self, channel_id: &str) -> String {
+        format!("{}{}", self.key_prefix, channel_id)
+    }
+
+    async fn get_raw(&self, channel_id: &str) -> Result<Option<String>, StoreError> {
+        let mut connection = self.connection.clone();
+        redis::cmd("GET")
+            .arg(self.key(channel_id))
+            .query_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Internal(format!("Redis GET: {e}")))
+    }
+
+    async fn compare_and_set(
+        &self,
+        channel_id: &str,
+        expected: Option<&str>,
+        new_value: &str,
+    ) -> Result<bool, StoreError> {
+        // Compare the complete serialized value. This works on ordinary Redis
+        // (no RedisJSON dependency) and makes the write indivisible across
+        // gateway instances.
+        const SCRIPT: &str = r#"
+local current = redis.call('GET', KEYS[1])
+if ARGV[1] == '0' then
+  if current then return 0 end
+elseif (not current) or current ~= ARGV[2] then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[3])
+return 1
+"#;
+        let mut connection = self.connection.clone();
+        let updated: i32 = redis::Script::new(SCRIPT)
+            .key(self.key(channel_id))
+            .arg(if expected.is_some() { "1" } else { "0" })
+            .arg(expected.unwrap_or_default())
+            .arg(new_value)
+            .invoke_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Internal(format!("Redis CAS: {e}")))?;
+        Ok(updated == 1)
+    }
+
+    fn decode(raw: &str) -> Result<ChannelState, StoreError> {
+        serde_json::from_str(raw).map_err(|e| StoreError::Serialization(e.to_string()))
+    }
+
+    fn encode(state: &ChannelState) -> Result<String, StoreError> {
+        serde_json::to_string(state).map_err(|e| StoreError::Serialization(e.to_string()))
+    }
+}
+
+#[cfg(feature = "redis-store")]
+impl ChannelStore for RedisChannelStore {
+    fn get_channel(
+        &self,
+        channel_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<ChannelState>, StoreError>> + Send + '_>> {
+        let channel_id = channel_id.to_string();
+        Box::pin(async move {
+            self.get_raw(&channel_id)
+                .await?
+                .as_deref()
+                .map(Self::decode)
+                .transpose()
+        })
+    }
+
+    fn put_channel(
+        &self,
+        channel_id: &str,
+        state: ChannelState,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+        let key = self.key(channel_id);
+        Box::pin(async move {
+            let encoded = Self::encode(&state)?;
+            let mut connection = self.connection.clone();
+            redis::cmd("SET")
+                .arg(key)
+                .arg(encoded)
+                .query_async::<()>(&mut connection)
+                .await
+                .map_err(|e| StoreError::Internal(format!("Redis SET: {e}")))
+        })
+    }
+
+    fn update_channel(
+        &self,
+        channel_id: &str,
+        updater: Box<dyn FnOnce(Option<ChannelState>) -> Result<ChannelState, StoreError> + Send>,
+    ) -> Pin<Box<dyn Future<Output = Result<ChannelState, StoreError>> + Send + '_>> {
+        let channel_id = channel_id.to_string();
+        Box::pin(async move {
+            let current_raw = self.get_raw(&channel_id).await?;
+            let current = current_raw.as_deref().map(Self::decode).transpose()?;
+            let new_state = updater(current)?;
+            let new_raw = Self::encode(&new_state)?;
+            if !self
+                .compare_and_set(&channel_id, current_raw.as_deref(), &new_raw)
+                .await?
+            {
+                return Err(StoreError::Internal(
+                    "Concurrent channel update; retry the request".to_string(),
+                ));
+            }
+            Ok(new_state)
+        })
+    }
+
+    fn advance_cumulative(
+        &self,
+        channel_id: &str,
+        expected: u64,
+        new: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
+        let channel_id = channel_id.to_string();
+        Box::pin(async move {
+            let Some(current_raw) = self.get_raw(&channel_id).await? else {
+                return Err(StoreError::Internal("Channel not found".to_string()));
+            };
+            let mut state = Self::decode(&current_raw)?;
+            if state.cumulative != expected {
+                return Ok(false);
+            }
+            state.cumulative = new;
+            let new_raw = Self::encode(&state)?;
+            self.compare_and_set(&channel_id, Some(&current_raw), &new_raw)
+                .await
+        })
+    }
+
+    fn update_deposit(
+        &self,
+        channel_id: &str,
+        new_deposit: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+        let channel_id = channel_id.to_string();
+        Box::pin(async move {
+            self.update_channel(
+                &channel_id,
+                Box::new(move |state| {
+                    let mut state = state
+                        .ok_or_else(|| StoreError::Internal("Channel not found".to_string()))?;
+                    state.deposit = new_deposit;
+                    Ok(state)
+                }),
+            )
+            .await
+            .map(|_| ())
+        })
+    }
+
+    fn mark_sealed(
+        &self,
+        channel_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+        let channel_id = channel_id.to_string();
+        Box::pin(async move {
+            self.update_channel(
+                &channel_id,
+                Box::new(|state| {
+                    let mut state = state
+                        .ok_or_else(|| StoreError::Internal("Channel not found".to_string()))?;
+                    state.sealed = true;
+                    Ok(state)
+                }),
+            )
+            .await
+            .map(|_| ())
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -438,6 +700,64 @@ mod tests {
         assert_eq!(state.deposit, 1_000_000);
         assert_eq!(state.cumulative, 0);
         assert!(!state.sealed);
+    }
+
+    #[tokio::test]
+    async fn channel_store_works_behind_arc_trait_object() {
+        let store: std::sync::Arc<dyn ChannelStore> =
+            std::sync::Arc::new(MemoryChannelStore::new());
+        store
+            .put_channel("c1", make_state("c1", 1_000_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_channel("c1").await.unwrap().unwrap().deposit,
+            1_000_000
+        );
+    }
+
+    #[cfg(feature = "redis-store")]
+    #[tokio::test]
+    async fn redis_channel_store_roundtrip_and_atomic_watermark() {
+        let Ok(redis_url) = std::env::var("PAY_KIT_TEST_REDIS_URL") else {
+            // CI/local unit runs do not require a Redis daemon. Set this env
+            // var to exercise the real integration path.
+            return;
+        };
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let store = RedisChannelStore::connect(
+            &redis_url,
+            format!("pay-kit:test:{}:{unique}:", std::process::id()),
+        )
+        .await
+        .unwrap();
+        store
+            .put_channel("c1", make_state("c1", 1_000_000))
+            .await
+            .unwrap();
+
+        let (left, right) = tokio::join!(
+            store.advance_cumulative("c1", 0, 100),
+            store.advance_cumulative("c1", 0, 200),
+        );
+        let successes = [left.unwrap(), right.unwrap()]
+            .into_iter()
+            .filter(|updated| *updated)
+            .count();
+        assert_eq!(successes, 1, "exactly one concurrent CAS must win");
+        assert!(matches!(
+            store.get_channel("c1").await.unwrap().unwrap().cumulative,
+            100 | 200
+        ));
+
+        store.update_deposit("c1", 2_000_000).await.unwrap();
+        store.mark_sealed("c1").await.unwrap();
+        let state = store.get_channel("c1").await.unwrap().unwrap();
+        assert_eq!(state.deposit, 2_000_000);
+        assert!(state.sealed);
     }
 
     #[tokio::test]

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -240,6 +240,11 @@ pub trait ChannelStore: Send + Sync {
         channel_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<Option<ChannelState>, StoreError>> + Send + '_>>;
 
+    /// Atomically create a channel.
+    ///
+    /// Implementations MUST reject an existing `channel_id`; overwriting a
+    /// live channel could reset its accepted voucher watermark and allow the
+    /// same payment to serve twice.
     fn put_channel(
         &self,
         channel_id: &str,
@@ -380,11 +385,16 @@ impl ChannelStore for MemoryChannelStore {
         channel_id: &str,
         state: ChannelState,
     ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
-        self.data
-            .lock()
-            .unwrap()
-            .insert(channel_id.to_string(), state);
-        Box::pin(async { Ok(()) })
+        let result = match self.data.lock().unwrap().entry(channel_id.to_string()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(state);
+                Ok(())
+            }
+            std::collections::hash_map::Entry::Occupied(_) => Err(StoreError::Internal(format!(
+                "Channel {channel_id} already exists"
+            ))),
+        };
+        Box::pin(async move { result })
     }
 
     fn update_channel(
@@ -641,16 +651,15 @@ impl ChannelStore for RedisChannelStore {
         channel_id: &str,
         state: ChannelState,
     ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
-        let key = self.key(channel_id);
+        let channel_id = channel_id.to_string();
         Box::pin(async move {
             let encoded = Self::encode(&state)?;
-            let mut connection = self.connection.clone();
-            redis::cmd("SET")
-                .arg(key)
-                .arg(encoded)
-                .query_async::<()>(&mut connection)
-                .await
-                .map_err(|e| StoreError::Internal(format!("Redis SET: {e}")))
+            if !self.compare_and_set(&channel_id, None, &encoded).await? {
+                return Err(StoreError::Internal(format!(
+                    "Channel {channel_id} already exists"
+                )));
+            }
+            Ok(())
         })
     }
 
@@ -804,6 +813,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn channel_store_put_rejects_existing_without_reset() {
+        let store = MemoryChannelStore::new();
+        store
+            .put_channel("c1", make_state("c1", 1_000_000))
+            .await
+            .unwrap();
+        assert!(store
+            .put_channel("c1", make_state("c1", 2_000_000))
+            .await
+            .is_err());
+        assert_eq!(
+            store.get_channel("c1").await.unwrap().unwrap().deposit,
+            1_000_000
+        );
+    }
+
+    #[tokio::test]
     async fn channel_store_works_behind_arc_trait_object() {
         let store: std::sync::Arc<dyn ChannelStore> =
             std::sync::Arc::new(MemoryChannelStore::new());
@@ -834,11 +860,8 @@ mod tests {
     #[cfg(feature = "redis-store")]
     #[tokio::test]
     async fn redis_channel_store_roundtrip_and_atomic_watermark() {
-        let Ok(redis_url) = std::env::var("PAY_KIT_TEST_REDIS_URL") else {
-            // CI/local unit runs do not require a Redis daemon. Set this env
-            // var to exercise the real integration path.
-            return;
-        };
+        let redis_url = std::env::var("PAY_KIT_TEST_REDIS_URL")
+            .expect("PAY_KIT_TEST_REDIS_URL is required for the Redis integration test");
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -876,6 +899,27 @@ mod tests {
         let channels = store.list_channels().await.unwrap();
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].channel_id, "c1");
+
+        let create_one = make_state("created-once", 1_000_000);
+        let create_two = make_state("created-once", 2_000_000);
+        let (left, right) = tokio::join!(
+            store.put_channel("created-once", create_one),
+            store.put_channel("created-once", create_two),
+        );
+        assert_eq!(
+            [left, right].into_iter().filter(Result::is_ok).count(),
+            1,
+            "exactly one concurrent channel creation must win"
+        );
+        assert!(matches!(
+            store
+                .get_channel("created-once")
+                .await
+                .unwrap()
+                .unwrap()
+                .deposit,
+            1_000_000 | 2_000_000
+        ));
 
         let prefix = format!("pay-kit:test:{}:{unique}:tenant", std::process::id());
         let tenant_one = RedisChannelStore::connect(&redis_url, format!("{prefix}:1"))

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -225,6 +225,16 @@ pub struct ChannelState {
 /// Implementations MUST guarantee that `advance_cumulative` is atomic to
 /// prevent double-spend under concurrent requests.
 pub trait ChannelStore: Send + Sync {
+    /// Return a weakly-consistent snapshot of every channel in this store's
+    /// namespace.
+    ///
+    /// This is intended for durable reconciliation workers. Implementations
+    /// may observe concurrent inserts or updates on a later scan; callers must
+    /// therefore reconcile each result against the authoritative chain state.
+    fn list_channels(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ChannelState>, StoreError>> + Send + '_>>;
+
     fn get_channel(
         &self,
         channel_id: &str,
@@ -276,6 +286,12 @@ impl<T> ChannelStore for std::sync::Arc<T>
 where
     T: ChannelStore + ?Sized,
 {
+    fn list_channels(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ChannelState>, StoreError>> + Send + '_>> {
+        (**self).list_channels()
+    }
+
     fn get_channel(
         &self,
         channel_id: &str,
@@ -344,6 +360,13 @@ impl MemoryChannelStore {
 }
 
 impl ChannelStore for MemoryChannelStore {
+    fn list_channels(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ChannelState>, StoreError>> + Send + '_>> {
+        let channels = self.data.lock().unwrap().values().cloned().collect();
+        Box::pin(async move { Ok(channels) })
+    }
+
     fn get_channel(
         &self,
         channel_id: &str,
@@ -471,6 +494,20 @@ impl RedisChannelStore {
         format!("{}{}", self.key_prefix, channel_id)
     }
 
+    fn scan_pattern(&self) -> String {
+        // Redis MATCH uses glob syntax. Escape metacharacters so a configured
+        // namespace is always interpreted literally.
+        let mut pattern = String::with_capacity(self.key_prefix.len() + 1);
+        for ch in self.key_prefix.chars() {
+            if matches!(ch, '*' | '?' | '[' | ']' | '\\') {
+                pattern.push('\\');
+            }
+            pattern.push(ch);
+        }
+        pattern.push('*');
+        pattern
+    }
+
     async fn get_raw(&self, channel_id: &str) -> Result<Option<String>, StoreError> {
         let mut connection = self.connection.clone();
         redis::cmd("GET")
@@ -522,6 +559,59 @@ return 1
 
 #[cfg(feature = "redis-store")]
 impl ChannelStore for RedisChannelStore {
+    fn list_channels(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ChannelState>, StoreError>> + Send + '_>> {
+        Box::pin(async move {
+            let mut connection = self.connection.clone();
+            let pattern = self.scan_pattern();
+            let mut cursor = 0_u64;
+            let mut channels = Vec::new();
+            let mut seen_keys = std::collections::HashSet::new();
+
+            loop {
+                let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                    .arg(cursor)
+                    .arg("MATCH")
+                    .arg(&pattern)
+                    .arg("COUNT")
+                    .arg(100)
+                    .query_async(&mut connection)
+                    .await
+                    .map_err(|e| StoreError::Internal(format!("Redis SCAN: {e}")))?;
+
+                let keys = keys
+                    .into_iter()
+                    // SCAN may return the same key more than once while the
+                    // keyspace changes. Never enqueue a channel twice in one
+                    // reconciliation pass.
+                    .filter(|key| seen_keys.insert(key.clone()))
+                    .collect::<Vec<_>>();
+                if !keys.is_empty() {
+                    let values: Vec<Option<String>> = redis::cmd("MGET")
+                        .arg(&keys)
+                        .query_async(&mut connection)
+                        .await
+                        .map_err(|e| StoreError::Internal(format!("Redis MGET: {e}")))?;
+                    channels.extend(
+                        values
+                            .into_iter()
+                            .flatten()
+                            .map(|raw| Self::decode(&raw))
+                            .collect::<Result<Vec<_>, _>>()?,
+                    );
+                }
+
+                cursor = next_cursor;
+                if cursor == 0 {
+                    break;
+                }
+            }
+
+            Ok(channels)
+        })
+    }
+
     fn get_channel(
         &self,
         channel_id: &str,
@@ -700,6 +790,7 @@ mod tests {
         assert_eq!(state.deposit, 1_000_000);
         assert_eq!(state.cumulative, 0);
         assert!(!state.sealed);
+        assert_eq!(store.list_channels().await.unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -758,6 +849,9 @@ mod tests {
         let state = store.get_channel("c1").await.unwrap().unwrap();
         assert_eq!(state.deposit, 2_000_000);
         assert!(state.sealed);
+        let channels = store.list_channels().await.unwrap();
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].channel_id, "c1");
     }
 
     #[tokio::test]

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -474,6 +474,10 @@ pub struct RedisChannelStore {
 #[cfg(feature = "redis-store")]
 impl RedisChannelStore {
     /// Connect to Redis and namespace channel records under `key_prefix`.
+    ///
+    /// The namespace is length-prefixed to keep scans disjoint. Raw-prefix
+    /// keys written by pre-release builds are intentionally not read; clear
+    /// those keys once when deploying the released key format.
     pub async fn connect(
         redis_url: &str,
         key_prefix: impl Into<String>,

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   ws: ^8.21.0
   '@x402/core': file:.x402-vendor/x402-core-2.16.0.tgz
-  '@hono/node-server': '>=1.19.13'
-  fast-uri: '>=3.1.2'
+  '@hono/node-server': '>=2.0.10'
+  fast-uri: '>=4.1.1'
   hono: '>=4.12.25'
   ip-address: '>=10.1.1'
   js-yaml: '>=5.2.1'
@@ -519,8 +519,8 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@hono/node-server@2.0.6':
-    resolution: {integrity: sha512-7DeRlKG57JDBNZ5Qj2jwVdgwQy4b0tLubRLl3zCf91/rCf9i7p1V5FtW/yWibm1uUHE493ts9ZXH/7g/LQWl+g==}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.12.25'
@@ -2537,8 +2537,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.0:
-    resolution: {integrity: sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
@@ -3769,10 +3769,6 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
@@ -4363,7 +4359,7 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@2.0.6(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -4597,7 +4593,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.6(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -5960,7 +5956,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.0
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6500,7 +6496,7 @@ snapshots:
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6519,7 +6515,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.0: {}
+  fast-uri@4.1.1: {}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     optional: true
@@ -7885,12 +7881,6 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.2
 
   type-is@2.1.0:
     dependencies:

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -13,8 +13,8 @@ allowBuilds:
 overrides:
   ws: '^8.21.0'
   '@x402/core': 'file:.x402-vendor/x402-core-2.16.0.tgz'
-  '@hono/node-server': '>=1.19.13'
-  fast-uri: '>=3.1.2'
+  '@hono/node-server': '>=2.0.10'
+  fast-uri: '>=4.1.1'
   hono: '>=4.12.25'
   ip-address: '>=10.1.1'
   js-yaml: '>=5.2.1'


### PR DESCRIPTION
## Summary
- add a feature-gated Redis ChannelStore with atomic compare-and-swap updates
- make channel creation atomic and reject duplicate channel IDs without resetting accepted voucher state
- support TLS Redis connections
- add cursor-based, namespace-scoped channel enumeration for reconciliation workers
- deduplicate Redis SCAN results within each snapshot
- exercise the Redis store against a real Redis service in CI

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p solana-pay-kit --lib`
- `PAY_KIT_TEST_REDIS_URL=redis://127.0.0.1:6379 cargo test -p solana-pay-kit --features redis-store --lib core::store::tests::redis_channel_store_roundtrip_and_atomic_watermark -- --exact`