### PR TITLE
fix(ci): restore @solana/pay-kit npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -77,6 +77,11 @@ jobs:
           cache: pnpm
           cache-dependency-path: typescript/pnpm-lock.yaml
 
+      # Tokenless OIDC trusted publishing requires npm >= 11.5.1; the Node
+      # release bundles an older npm that publishes unauthenticated and 404s.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
+
       - name: Install dependencies
         run: cd typescript && pnpm install --frozen-lockfile
 
@@ -295,6 +300,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
           cache-dependency-path: typescript/pnpm-lock.yaml
+
+      # Tokenless OIDC trusted publishing requires npm >= 11.5.1; the Node
+      # release bundles an older npm that publishes unauthenticated and 404s.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
 
       # The vendored @x402 tarballs are committed under typescript/.x402-vendor,
       # so a plain frozen install resolves them — no submodule checkout needed.

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-uri: '>=4.1.1'
   hono: '>=4.12.25'
   ip-address: '>=10.1.1'
-  js-yaml: '>=5.2.1'
+  js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'
   qs: '>=6.15.2'
   yaml: '>=2.8.3'
@@ -2953,8 +2953,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4016,7 +4016,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4336,7 +4336,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4390,7 +4390,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -7114,7 +7114,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ allowBuilds:
   unrs-resolver: true
   utf-8-validate: false
 
+minimumReleaseAgeExclude:
+  - js-yaml@5.2.2
+
 # Force transitive `ws` past GHSA-58qx-3vcg-4xpx (uninitialized memory
 # disclosure, patched in 8.20.1). Reaches us via
 # @solana/kit > @solana/rpc-subscriptions > @solana/rpc-subscriptions-channel-websocket.
@@ -17,7 +20,7 @@ overrides:
   fast-uri: '>=4.1.1'
   hono: '>=4.12.25'
   ip-address: '>=10.1.1'
-  js-yaml: '>=5.2.1'
+  js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'
   qs: '>=6.15.2'
   yaml: '>=2.8.3'


### PR DESCRIPTION
## Summary

Fixes `@solana/pay-kit` publishing to npm, which was failing with a 404 masking a 403. Two independent root causes, both on the CI side (npm's trusted-publisher config was correct all along).

Validated end-to-end: [run 30115449143](https://github.com/solana-foundation/pay-kit/actions/runs/30115449143) published **`@solana/pay-kit@0.7.0`** successfully.

## 1. npm too old for tokenless OIDC trusted publishing

The publish uses tokenless OIDC trusted publishing (no `NPM_TOKEN`), and the package's npm "Publishing access" is set to *require 2FA and disallow tokens* — so tokenless OIDC is the only permitted automated path.

The runner's Node (22.13.0) bundles **npm 10.9.2**. That version can sign provenance but **cannot** authenticate the publish via OIDC — that landed in **npm 11.5.1**. With no token present, npm 10.9.2 `PUT`s the tarball unauthenticated, and the registry rejects it:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@solana%2fpay-kit
```

Fix: upgrade npm to `>=11.5.1` before publishing, in both publish jobs. Node 22.x never ships npm 11, so bumping `.node-version` within the LTS line wouldn't help (and would change the toolchain for all of CI); `setup-node` has no npm-version input.

## 2. js-yaml override under-pinned

Surfaced once #1 let CI progress: the `Audit production dependencies` gate flagged a high-severity advisory in a transitive prod dependency:

```
high  js-yaml: Exponential parsing time in flow collections  (GHSA-pm4m-ph32-ghv5)
Vulnerable versions: >=5.0.0 <=5.2.1
```

The repo already overrides `js-yaml`, but the floor of `>=5.2.1` still resolved to the vulnerable `5.2.1`. Raised to `>=5.2.2` (patched); audit now passes.

closes DEV-774
