### PR TITLE
feat(x402): expose smart-wallet verification (Path 2) options for exact

### DIFF
--- a/docs/x402/exact-v1-spec.md
+++ b/docs/x402/exact-v1-spec.md
@@ -185,6 +185,13 @@ The facilitator MUST-checks on the signed transaction (compute-budget caps,
 `verify_exact_versioned_transaction` after the version gate
 (server/exact.rs:568-569).
 
+> **Divergence from the Rust spine.** TypeScript additionally exposes the vendored `@x402/svm`
+> smart-wallet verification (Path 2) as an opt-in
+> (`X402Options.enableSmartWalletVerification`); the Rust spine has no
+> Path 2 yet, so an enabled TypeScript server accepts smart-wallet
+> transactions that Rust rejects with
+> `invalid_exact_svm_payload_no_transfer_instruction`.
+
 The server still **emits v2 challenges by default**: `exact_with_options`
 and `exact_with_payment_options` build envelopes with
 `x402_version = X402_VERSION_V2` (server/exact.rs:182-189, 284-291).

--- a/typescript/packages/pay-kit/src/__tests__/x402.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/x402.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it, vi } from 'vitest';
+import type { ExactSvmSchemeOptions } from '@x402/svm';
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import type { X402Options } from '../config.js';
+
+// Compile-time drift guard against the vendored @x402/svm option type.
+expectTypeOf<
+    Pick<
+        ExactSvmSchemeOptions,
+        | 'enableSmartWalletVerification'
+        | 'smartWalletMaxComputeUnits'
+        | 'smartWalletMaxPriorityFeeMicroLamports'
+        | 'smartWalletAllowedPrograms'
+    >
+>().toExtend<X402Options>();
 
 // The upto challenge requires a server-fetched recentBlockhash + recentSlot
 // (one getLatestBlockhash call); stub the RPC so the enriched requirement is
 // deterministic offline, and let tests flip `fail` to exercise the
 // no-bare-offer failure path.
 const rpcState = vi.hoisted(() => ({ fail: false }));
+const ctorCalls = vi.hoisted(() => [] as unknown[][]);
 vi.mock('@solana/kit', async importOriginal => {
     const actual = await importOriginal<typeof import('@solana/kit')>();
     return {
@@ -23,6 +38,20 @@ vi.mock('@solana/kit', async importOriginal => {
                 },
             }),
         }),
+    };
+});
+
+// Subclass spy: records constructor args while preserving real behavior.
+vi.mock('@x402/svm/exact/facilitator', async importOriginal => {
+    const actual = await importOriginal<typeof import('@x402/svm/exact/facilitator')>();
+    return {
+        ...actual,
+        ExactSvmScheme: class extends actual.ExactSvmScheme {
+            constructor(...args: ConstructorParameters<typeof actual.ExactSvmScheme>) {
+                ctorCalls.push(args);
+                super(...args);
+            }
+        },
     };
 });
 
@@ -72,6 +101,55 @@ describe('x402 exact adapter', () => {
         const headers = await adapter.challengeHeaders(gateFor(config), new Request('http://localhost/r'));
         expect(typeof headers['payment-required']).toBe('string');
         expect(headers['payment-required'].length).toBeGreaterThan(0);
+    });
+});
+
+describe('x402 smart-wallet options', () => {
+    beforeEach(() => {
+        ctorCalls.length = 0;
+    });
+
+    it('passes x402 options through configure() into the frozen config', async () => {
+        const config = await configure({
+            mpp: { challengeBindingSecret: 'x402-test-secret' },
+            network: 'solana_localnet',
+            x402: { enableSmartWalletVerification: true, smartWalletMaxComputeUnits: 300_000 },
+        });
+        expect(config.x402.enableSmartWalletVerification).toBe(true);
+        expect(config.x402.smartWalletMaxComputeUnits).toBe(300_000);
+        expect(Object.isFrozen(config.x402)).toBe(true);
+    });
+
+    it('constructs the adapter with smart-wallet verification enabled', async () => {
+        const config = await configure({
+            mpp: { challengeBindingSecret: 'x402-test-secret' },
+            network: 'solana_localnet',
+            x402: { enableSmartWalletVerification: true },
+        });
+        expect(() => createX402ExactAdapter(config)).not.toThrow();
+    });
+
+    it('forwards config.x402 to the facilitator constructor', async () => {
+        const config = await configure({
+            mpp: { challengeBindingSecret: 'x402-test-secret' },
+            network: 'solana_localnet',
+            x402: { enableSmartWalletVerification: true, smartWalletMaxPriorityFeeMicroLamports: 25_000 },
+        });
+        createX402ExactAdapter(config);
+        expect(ctorCalls.length).toBeGreaterThan(0);
+        expect(ctorCalls.at(-1)?.[2]).toEqual(config.x402);
+    });
+
+    it('copies the allowlist so callers cannot mutate verification policy', async () => {
+        const allowed = ['SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf'];
+        const config = await configure({
+            mpp: { challengeBindingSecret: 'x402-test-secret' },
+            network: 'solana_localnet',
+            x402: { smartWalletAllowedPrograms: allowed },
+        });
+        allowed.push('mutated');
+        expect(config.x402.smartWalletAllowedPrograms).toEqual(['SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf']);
+        expect(Object.isFrozen(config.x402.smartWalletAllowedPrograms)).toBe(true);
     });
 });
 

--- a/typescript/packages/pay-kit/src/__tests__/x402.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/x402.test.ts
@@ -3,16 +3,13 @@ import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import type { X402Options } from '../config.js';
 
-// Compile-time drift guard against the vendored @x402/svm option type.
-expectTypeOf<
-    Pick<
-        ExactSvmSchemeOptions,
-        | 'enableSmartWalletVerification'
-        | 'smartWalletMaxComputeUnits'
-        | 'smartWalletMaxPriorityFeeMicroLamports'
-        | 'smartWalletAllowedPrograms'
-    >
->().toExtend<X402Options>();
+// Compile-time drift guard: X402Options must equal the full vendored
+// @x402/svm option surface modulo readonly (our config is frozen). Key drift
+// in either direction — including upstream adding an option we don't expose —
+// optionality drift, and per-key widening/narrowing all fail typecheck.
+type ImmutableValue<V> = V extends readonly (infer E)[] ? readonly E[] : V;
+type Immutable<T> = { readonly [K in keyof T]: ImmutableValue<T[K]> };
+expectTypeOf<Immutable<ExactSvmSchemeOptions>>().toEqualTypeOf<X402Options>();
 
 // The upto challenge requires a server-fetched recentBlockhash + recentSlot
 // (one getLatestBlockhash call); stub the RPC so the enriched requirement is

--- a/typescript/packages/pay-kit/src/adapters/x402.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402.ts
@@ -39,12 +39,21 @@ const PAYMENT_REQUIRED_HEADER = 'payment-required';
 export function createX402ExactAdapter(config: PayKitConfig): ProtocolAdapter {
     const network = caip2(config.network) as Network;
     const operator = config.operator.signer.pubkey;
+    const { smartWalletAllowedPrograms, ...schemeOptionsWithoutAllowlist } = config.x402;
+    const schemeOptions = {
+        ...schemeOptionsWithoutAllowlist,
+        ...(smartWalletAllowedPrograms && {
+            smartWalletAllowedPrograms: [...smartWalletAllowedPrograms],
+        }),
+    };
 
     // In-process facilitator: the operator both fee-pays and signs settlement.
     const facilitator = new x402Facilitator().register(
         network,
         new ExactSvmFacilitator(
             toFacilitatorSvmSigner(config.operator.signer.signer, { defaultRpcUrl: config.rpcUrl }),
+            undefined,
+            schemeOptions,
         ),
     );
 

--- a/typescript/packages/pay-kit/src/config.ts
+++ b/typescript/packages/pay-kit/src/config.ts
@@ -26,8 +26,17 @@ export type MppOptions = {
     readonly realm?: string;
 };
 
-/** x402 protocol options. Reserved for future scheme-specific settings. */
-export type X402Options = Record<string, never>;
+/**
+ * x402 options forwarded to the vendored exact-scheme facilitator; omitted
+ * fields use upstream defaults. Smart-wallet (Path 2) verification needs an
+ * RPC whose `simulateTransaction` returns inner instructions.
+ */
+export type X402Options = {
+    readonly enableSmartWalletVerification?: boolean;
+    readonly smartWalletAllowedPrograms?: readonly string[];
+    readonly smartWalletMaxComputeUnits?: number;
+    readonly smartWalletMaxPriorityFeeMicroLamports?: number;
+};
 
 /** Merchant identity: where money lands and which key signs. */
 export type OperatorParams = {
@@ -83,7 +92,7 @@ export type PayKitConfig = {
     readonly replayStore: Store.Store | undefined;
     readonly rpcUrl: string;
     readonly stablecoins: readonly Stablecoin[];
-    readonly x402: Record<string, never>;
+    readonly x402: X402Options;
 };
 
 const DEFAULT_EXPIRES_IN_SECONDS = 120;
@@ -184,7 +193,12 @@ export async function configure(params: ConfigureParams = {}): Promise<PayKitCon
         replayStore: params.replayStore,
         rpcUrl: params.rpcUrl ?? DEFAULT_RPC_URLS[toSolanaNetwork(network)] ?? DEFAULT_RPC_URLS.mainnet,
         stablecoins: Object.freeze([...stablecoins]),
-        x402: Object.freeze({}),
+        x402: Object.freeze({
+            ...params.x402,
+            ...(params.x402?.smartWalletAllowedPrograms && {
+                smartWalletAllowedPrograms: Object.freeze([...params.x402.smartWalletAllowedPrograms]),
+            }),
+        }),
     });
 }
 


### PR DESCRIPTION
## What

Exposes the four smart-wallet verification options that the vendored `@x402/svm` tarball (`x402-svm-2.16.0-paykit.2.tgz`) already ships, through pay-kit's config surface:

```ts
configure({
    x402: {
        enableSmartWalletVerification: true,
        // optional; upstream defaults apply when omitted:
        smartWalletMaxComputeUnits: 400_000,
        smartWalletMaxPriorityFeeMicroLamports: 50_000,
        smartWalletAllowedPrograms: [...],
    },
});
```

This is pure wiring:
- no new verification logic, no version bump
- `configure()` previously hardcoded `x402: Object.freeze({})` and the adapter never passed the options argument
- so the vendored Path 2 implementation was unreachable

## Why

Users paying from smart wallets (Squads, Swig, SPL Governance) execute the token transfer as a CPI inside their own program instruction. The static verification path sees an unknown program at `instructions[2]` and rejects with `invalid_exact_svm_payload_no_transfer_instruction`. The upstream scheme explicitly allows this shape (`scheme_exact_svm.md`):

> The transfer MAY appear either as a top-level instruction or as an inner instruction (CPI) emitted by another program. This is what allows smart wallets to satisfy the scheme.

Path 2 verifies these transactions by simulating and inspecting the CPI inner-instruction trace. It exists in the vendored tarball today; these payments are rejected only because the option was never wired.

Upstream references:
- https://github.com/x402-foundation/x402/pull/1527
- https://github.com/x402-foundation/x402/pull/829
- https://github.com/x402-foundation/x402/pull/2509

## Compatibility

- **Default off.** Unset options preserve existing behavior exactly.
- Conformance vectors are envelope-level and unaffected.
- Path 2 is opt-in per the upstream spec: it needs an RPC whose `simulateTransaction` returns inner instructions, and adds a trust assumption on the program allowlist — an operator decision.

## Divergence from the Rust spine

The Rust verifier has no Path 2 yet: a TypeScript server with this option enabled accepts smart-wallet transactions that a Rust server rejects. Flagged inline in `docs/x402/exact-v1-spec.md`; the Rust port is a separate track.

## Notes

- `X402Options` is declared locally rather than `Pick`ed from `@x402/svm`: the tarball is a bundled devDependency, so re-exporting its type would leak an unresolvable import into the published `dist/index.d.ts`. A compile-time drift guard in tests keeps it tied to the upstream type (verified: `dist/index.d.ts` contains zero `@x402` references).
- Simulation is not the sponsor-funds protection — fee-payer safety comes from the pre-sign isolation check, and merchant-payment truth from post-settlement re-verification (spec §2.1.1 / §3.4). The constructor enforces the required signer methods and throws otherwise; `toFacilitatorSvmSigner` already provides them.

## Follow-ups (out of scope)

- Client discovery: `features.smartWalletSupported` is not yet advertised in `extra` — adding a field there risks the v2 `accepted` deep-equal binding against Rust servers, so it needs its own pass.
- Harness tx-byte evaluation mode, then smart-wallet conformance vectors.
- Rust spine Path 2 port.