### PR TITLE
perf(lua): 5x faster coverage job, and put ATA back under the gate

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -74,13 +74,12 @@ jobs:
           luacov
           ./scripts/check_coverage.sh ../luacov.report.out 90
 
-      # Codex PR #103 P3: the coverage gate excludes pay_kit/solana/ata
-      # because luacov disables LuaJIT trace recording and the on-curve check
-      # becomes ~100x slower under coverage. Run the suite a second time
-      # WITHOUT luacov so the protocol-critical ATA fixture spec
-      # (`ata.derive matches the Ruby reference for the USDC Token-2022 ATA`)
-      # is actually exercised. test_helper.lua skips it when luacov is loaded.
-      - name: Run protocol-critical ATA fixture suite without coverage
+      # The coverage gate excludes pay_kit/solana/ata because luacov disables
+      # LuaJIT trace recording and the on-curve check gets far slower under
+      # coverage. This second run exercises the suite on the JIT path, which
+      # is the one downstream users actually run: a regression that only
+      # shows up with the trace compiler on would otherwise never surface.
+      - name: Run the suite on the JIT path, without coverage
         working-directory: lua
         run: |
           eval "$(luarocks --lua-version=5.1 --tree lua_modules path)"

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -74,11 +74,10 @@ jobs:
           luacov
           ./scripts/check_coverage.sh ../luacov.report.out 90
 
-      # The coverage gate excludes pay_kit/solana/ata because luacov disables
-      # LuaJIT trace recording and the on-curve check gets far slower under
-      # coverage. This second run exercises the suite on the JIT path, which
-      # is the one downstream users actually run: a regression that only
-      # shows up with the trace compiler on would otherwise never surface.
+      # This second run exercises the suite on the JIT path, which is the one
+      # downstream users actually run. luacov's line hook stops LuaJIT from
+      # running compiled traces, so a regression that only shows up with the
+      # trace compiler on would otherwise never surface.
       - name: Run the suite on the JIT path, without coverage
         working-directory: lua
         run: |

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -27,10 +27,10 @@ jobs:
           path: lua/lua_modules
           # Keep the dev toolchain separate from the runtime-only harness
           # cache: the latter does not contain luacheck or luacov.
-          key: ${{ runner.os }}-luarocks-dev-v3-${{ hashFiles('lua/pay-kit-dev-1.rockspec', 'lua/.luacov', 'lua/.luacheckrc') }}
-          restore-keys: ${{ runner.os }}-luarocks-dev-v3-
+          key: ${{ runner.os }}-luarocks-dev-v4-${{ hashFiles('lua/pay-kit-dev-1.rockspec', 'lua/.luacov', 'lua/.luacheckrc') }}
+          restore-keys: ${{ runner.os }}-luarocks-dev-v4-
 
-      - name: Install dev rocks (luacheck + luacov + luasocket + luasodium + luasec + lua-resty-openssl + cjson)
+      - name: Install dev rocks (luacheck + luacov + cluacov + luasocket + luasodium + luasec + lua-resty-openssl + cjson)
         if: steps.cache-rocks.outputs.cache-hit != 'true'
         working-directory: lua
         run: |
@@ -38,6 +38,12 @@ jobs:
           luarocks --lua-version=5.1 init --lua-versions 5.1 || true
           luarocks --lua-version=5.1 install --tree lua_modules luacheck
           luarocks --lua-version=5.1 install --tree lua_modules luacov
+          # LuaCov swaps its pure-Lua line hook for cluacov's C hook when the
+          # rock is present. The hook fires on every executed line and cannot
+          # be avoided (a debug hook is what stops LuaJIT from running compiled
+          # traces in the first place), so moving the per-line work out of Lua
+          # is where the wall-clock goes. Same stats, same report.
+          luarocks --lua-version=5.1 install --tree lua_modules cluacov
           luarocks --lua-version=5.1 install --tree lua_modules luasocket
           luarocks --lua-version=5.1 install --tree lua_modules luasodium
           luarocks --lua-version=5.1 install --tree lua_modules luasec OPENSSL_DIR=/usr

--- a/lua/.luacov
+++ b/lua/.luacov
@@ -18,16 +18,6 @@ return {
   exclude = {
     "tests/.+",
     "pay_kit/protocols/mpp/server/html_assets/gen$",
-    -- The pure-Lua modular-arithmetic on-curve check inside
-    -- pay_kit/solana/ata is exercised end-to-end by the
-    -- `ata.derive matches the Ruby reference` spec, which passes the
-    -- canonical fixture and asserts the derived address. luacov
-    -- instrumentation disables LuaJIT trace recording, so the bump
-    -- loop inside `find_program_address` multiplies that test's
-    -- wall-clock time by ~100x. Exclude the bignum file from the
-    -- coverage percentage while keeping the public surface
-    -- (`derive`, `find_program_address`) live in the unit suite.
-    "pay_kit/solana/ata$",
   },
   includeuntestedfiles = {
     "pay_kit",

--- a/lua/pay_kit/solana/ata.lua
+++ b/lua/pay_kit/solana/ata.lua
@@ -350,6 +350,19 @@ function M.find_program_address(seeds, program_id)
   error('unable to find program address')
 end
 
+-- `derive` is a pure function of three base58 strings, and the bump search
+-- above costs roughly 18ms of pure-Lua modular arithmetic per call even
+-- with the LuaJIT trace compiler on. The gateway plugins re-derive the
+-- same recipient ATA on every request they verify, so memoize the result.
+--
+-- The cache key contains caller-supplied input, so the table is capped and
+-- dropped wholesale once it fills rather than grown without bound. Only
+-- successful derivations are stored: the byte-length validation below runs
+-- before the lookup, so malformed input keeps raising as it did before.
+local DERIVE_CACHE_LIMIT = 256
+local derive_cache = {}
+local derive_cache_entries = 0
+
 --- Derive the Associated Token Account address for the given owner / mint
 --- / token program. Mirrors `ruby/lib/mpp/methods/solana/associated_token.rb`
 --- and the Rust spine's `AssociatedToken::find_program_address`.
@@ -360,10 +373,22 @@ function M.derive(owner, mint, token_program)
   if #owner_bytes ~= 32 or #token_bytes ~= 32 or #mint_bytes ~= 32 then
     error('ATA derivation requires base58 inputs that decode to 32 bytes')
   end
+  -- `/` is outside the base58 alphabet, so the joined key is unambiguous.
+  local cache_key = owner .. '/' .. mint .. '/' .. token_program
+  local cached = derive_cache[cache_key]
+  if cached then
+    return cached
+  end
   local address, _bump = M.find_program_address(
     { owner_bytes, token_bytes, mint_bytes },
     'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
   )
+  if derive_cache_entries >= DERIVE_CACHE_LIMIT then
+    derive_cache = {}
+    derive_cache_entries = 0
+  end
+  derive_cache[cache_key] = address
+  derive_cache_entries = derive_cache_entries + 1
   return address
 end
 

--- a/lua/tests/methods_solana_ata_spec.lua
+++ b/lua/tests/methods_solana_ata_spec.lua
@@ -27,6 +27,27 @@ helper.test('ata.derive matches the Ruby reference for the USDC Token-2022 ATA',
   )
 end)
 
+helper.test('ata.derive is stable across repeated calls', function()
+  -- `derive` memoizes on (owner, mint, token_program). A cache that keyed
+  -- on the wrong tuple, or that handed back a stale entry, would surface
+  -- here as a second call disagreeing with the pinned fixture. The
+  -- Token-2022 spec above pins the same owner / mint against a different
+  -- token program, so a key that collapsed the token program would fail
+  -- that assertion too.
+  local first = ata.derive(OWNER, USDC_MAINNET_MINT, TOKEN_PROGRAM)
+  local second = ata.derive(OWNER, USDC_MAINNET_MINT, TOKEN_PROGRAM)
+  helper.assert_equal(second, first)
+  helper.assert_equal(second, '3EjekkZPxiKdDB91mdJjUcjFjRmyWjP1Y4ySvfwSaQ4b')
+end)
+
+helper.test('ata.derive rejects malformed input even after a cached success', function()
+  -- The byte-length validation runs before the cache lookup, so a bad
+  -- input never short-circuits into a cached address.
+  helper.assert_error(function()
+    ata.derive(OWNER, USDC_MAINNET_MINT, '1111')
+  end, 'ATA derivation requires base58 inputs that decode to 32 bytes')
+end)
+
 helper.test('find_program_address rejects a non-32-byte program id', function()
   helper.assert_error(function()
     ata.find_program_address({ string.rep('\0', 32) }, '1111')

--- a/lua/tests/run.lua
+++ b/lua/tests/run.lua
@@ -1,8 +1,15 @@
+-- No `./` prefix on these patterns. Lua resolves the relative paths the
+-- same way either way, but the prefix leaks into `debug.getinfo().source`
+-- and coverage tooling keys its per-file stats off that string. LuaCov's
+-- pure-Lua hook strips a leading `./`; the C hook from `cluacov` does not,
+-- so a prefixed path makes every file show up twice in the report (once
+-- with real hit counts, once as a 0% "untested" entry discovered by the
+-- filesystem walk) and halves the reported total.
 package.path = table.concat({
-  './?.lua',
-  './?/init.lua',
-  './lua/?.lua',
-  './lua/?/init.lua',
+  '?.lua',
+  '?/init.lua',
+  'lua/?.lua',
+  'lua/?/init.lua',
   package.path,
 }, ';')
 

--- a/lua/tests/test_helper.lua
+++ b/lua/tests/test_helper.lua
@@ -69,21 +69,6 @@ local SKIP = {
   ['challenge_to_html escapes HTML in description'] = true,
 }
 
--- Under luacov instrumentation the LuaJIT trace recorder is disabled, so
--- the pure-Lua modular-arithmetic on-curve check in mpp/methods/solana/ata
--- becomes ~100x slower. Skip only the heaviest ATA spec (which derives
--- twice). The verifier specs that internally call ata.derive still run
--- under coverage, because letting them in gives us branch coverage for
--- the SPL transferChecked / ATA-allowlist code paths.
-local SLOW_UNDER_COVER = {
-  ['ata.derive matches the Ruby reference for the USDC Token-2022 ATA'] = true,
-}
-if package.loaded['luacov'] then
-  for name, _ in pairs(SLOW_UNDER_COVER) do
-    SKIP[name] = true
-  end
-end
-
 function M.run()
   local passed = 0
   local failed = 0


### PR DESCRIPTION
## Problem

`Lua tests` is the critical path on every pull request. On the run I profiled (a PR whose 100 changed files included none under `lua/`) the job took **20m20s**, and **19m58s** of that was one step:

```
Run tests with coverage                                   19m58s   luajit -lluacov tests/run.lua
Run protocol-critical ATA fixture suite without coverage       3s   luajit tests/run.lua
everything else (checkout, apt, cache hit, lint)              16s
```

The next slowest check on the same commit was 7.9 min. The 20-minute step also produces no extra test signal: `tests/test_helper.lua` skips the Token-2022 ATA fixture when luacov is loaded, so the 3-second step actually runs one more test than the 20-minute one. The 20 minutes buys a percentage, nothing else.

## Why it is slow

LuaCov installs a debug line hook. Two things follow:

1. A debug hook is what stops LuaJIT from running compiled traces, so the process falls back to the interpreter for its whole lifetime.
2. Every executed line then pays a Lua-level callback that calls `debug.getinfo`, runs a `string.match` and allocates two `gsub` substrings, all of that *before* it checks whether the file is excluded. Excluding a file from the report saves the table increment at the end and nothing else.

The hot path is `pay_kit/solana/ata.lua`. One `ata.derive` executes **17.9 million** Lua lines: `find_program_address` walks bump bytes, and each candidate runs a pure-Lua base-2^24 bignum on-curve check with three modular exponentiations. Measured on one derive:

```
no hook (LuaJIT traces)     0.018s
empty line hook             0.642s
real luacov                 7.252s     403x
```

The suite calls `derive` 70 times across only **13 distinct** `(owner, mint, token_program)` triples. A/B with the derives memoized shows the split is roughly half and half: ~51% of the wall clock is the ATA bignum, ~49% is flat hook overhead across the rest of the suite.

## Changes

**1. Memoize `ata.derive`** (`lua/pay_kit/solana/ata.lua`)

It is a pure function of three base58 strings. The cache is bounded at 256 entries and dropped wholesale when it fills, because the key contains caller-supplied input. Byte-length validation still runs before the lookup, so malformed input raises exactly as before and only successful derivations are stored.

This is a runtime win independent of CI: the Kong and APISIX plugins re-derive the same recipient ATA on every request they verify, ~18ms of pure-Lua modular arithmetic each time, inside the payment verification path.

**2. Install `cluacov`** (`.github/workflows/lua.yml`)

LuaCov swaps its pure-Lua line hook for cluacov's C hook whenever the rock is present. The hook cannot be removed without giving up coverage, but the per-line work can move out of Lua. Same stats, same report. The rocks cache key is bumped to `v4` so the existing tree without cluacov is not restored.

**3. Drop the `./` prefix from the test runner's `package.path`** (`lua/tests/run.lua`)

Required by 2. The prefix leaks into `debug.getinfo().source` and LuaCov keys its per-file stats off that string. The pure-Lua hook strips a leading `./` before storing, the C hook does not. With the prefix, every file lands in the report twice, once with real hit counts and once as a 0% "untested" entry from the `includeuntestedfiles` filesystem walk. That drops the reported total from 90.62% to 47.76% and fails the gate. Lua resolves the relative paths identically either way.

**4. Stop skipping the ATA fixture spec under coverage** (`lua/tests/test_helper.lua`)

`test_helper.lua` checked `package.loaded['luacov']` and skipped the Token-2022 ATA fixture when the suite ran instrumented, because that test derived twice at ~17s each. So the coverage run executed 603 tests while the uninstrumented run executed 604, and the reported percentage described a subset of the suite rather than the suite. That derive now costs 1.5s, so the workaround is gone and both runs execute the same 604 tests.

The second uninstrumented CI run stays. Its rationale is corrected in the comment: it exercises the JIT path, which is the one downstream users run, so a regression that only appears with the trace compiler on still surfaces.

**5. Put `pay_kit/solana/ata` back in the coverage gate** (`lua/.luacov`)

The exclusion existed because instrumenting the bignum was too slow, not because the file was hard to cover. It also was not protecting the number: including it adds 206 relevant lines at 96.12% and moves the total up. The module holds the on-curve check that decides which address a payment is allowed to land in, and it was the one file the report could not show a reviewer.

Lua was the only SDK excluding its ATA implementation. Ruby, Swift and Kotlin hand-roll the same on-curve check and cover it normally; their coverage tooling instruments at the C, LLVM and bytecode level and never had the interpreter penalty that made this exclusion look necessary.

## Result

Full suite, measured locally (this machine runs the current CI configuration in 9m17s against CI's 19m58s, so roughly 2.15x faster):

Local, full suite, measured in one sitting (this machine runs the pre-change configuration in 9m17s against CI's 19m58s, so roughly 2.15x faster):

| | wall | tests | coverage |
|---|---|---|---|
| before | 9m17s | 603 | 90.62% |
| + memoized `ata.derive` | 5m23s | 603 | 90.62% |
| + cluacov and the path fix | **1m36s** | 603 | 90.71% |

On CI, the `Run tests with coverage` step went **19m58s to 3m08s** with those three changes, and the last two commits (un-skip, un-exclude) take it to **3m55s**. The +47s is mostly the per-line bookkeeping the hook now does for `ata.lua`, around 230M line executions; roughly 3s of it is the ATA fixture spec no longer being skipped. Final numbers on CI: 604 tests, `Lua coverage 90.93% meets required 90.00%`.

The 90% gate is unchanged and still runs on every pull request. The percentage moves up 0.09 points because cluacov's `deepactivelines` counts active lines slightly more accurately; the per-file summary is otherwise identical, 56 rows before and after.

## Tests

Two guards added in `lua/tests/methods_solana_ata_spec.lua`: repeated calls agree with the pinned fixture, and malformed input still raises after a cached success. A cache key that collapsed the token program would also fail the existing Token-2022 fixture spec, which pins the same owner and mint against a different program.

## Verification

Run locally with the CI toolchain (LuaJIT 2.1, luarocks tree with luacheck, luacov, cluacov, luasodium, luasec, lua-resty-openssl, cjson, luasocket):

- `luacheck pay_kit/ plugins/ tests/`: 0 warnings, 0 errors across 107 files
- `luajit tests/run.lua`: 604 passed, 1 skipped, 0 failed (2.7s, was 4.5s)
- `luajit -lluacov tests/run.lua`: 604 passed, 1 skipped, 0 failed
- `./scripts/check_coverage.sh ../luacov.report.out 90`: `Lua coverage 90.93% meets required 90.00%`, with `pay_kit/solana/ata.lua` at 198/8 (96.12%)

The pre-change local coverage run reproduced CI's numbers exactly (4386 hits / 454 missed / 90.62%), which is what anchors the 2.15x projection above.

## Not in this PR

- **Adding a path filter to `lua.yml`.** The `harness-lua` job legitimately depends on `harness/`, `typescript/` and `rust/`, so a correct filter would cover most of the repo and skip almost nothing. With this change the Lua job is no longer the critical path, so the machinery would not pay for itself.
