### PR TITLE
perf(ci): cancel superseded pull-request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     working-directory: typescript

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-go:
     name: Go tests

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -22,6 +22,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build harness deps (once)

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -26,9 +26,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-kotlin:
     name: Kotlin tests

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-lua:
     name: Lua tests

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-php:
     name: PHP tests

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-python:
     name: Python tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-ruby:
     name: Ruby tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  # Cancel a pull-request run when a newer push supersedes it. Measured over
+  # the last 810 pull-request runs, 119 of them kept running after a newer
+  # push had already started, for 11.2 hours of runner time spent on commits
+  # nobody was waiting on. Pushes to main and reusable calls are left alone,
+  # since those runs are not superseded by anything.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-swift:
     name: Swift tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,9 +10,15 @@ concurrency:
   # Cancel a pull-request run when a newer push supersedes it. Measured over
   # the last 810 pull-request runs, 119 of them kept running after a newer
   # push had already started, for 11.2 hours of runner time spent on commits
-  # nobody was waiting on. Pushes to main and reusable calls are left alone,
-  # since those runs are not superseded by anything.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # nobody was waiting on.
+  #
+  # Non-pull-request runs get a group of their own, keyed on run_id, rather
+  # than sharing one keyed on the ref. A shared group would queue them against
+  # each other, and a concurrency group only holds one pending run: a third
+  # push landing while the first is still running evicts the second, which
+  # would then report no result at all for that commit. `cancel-in-progress`
+  # being false does not prevent that, it only protects the running run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@x402/core': file:.x402-vendor/x402-core-2.23.0.tgz
   '@hono/node-server': '>=2.0.10'
   fast-uri: '>=4.1.4'
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   ip-address: '>=10.3.1'
   js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'
@@ -88,7 +88,7 @@ importers:
         version: 25.5.0
       mppx:
         specifier: ^0.8.15
-        version: 0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
+        version: 0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
       surfpool-sdk:
         specifier: ^1.2.0
         version: 1.2.0
@@ -115,7 +115,7 @@ importers:
         version: 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       mppx:
         specifier: '>=0.5.5'
-        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
+        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
     devDependencies:
       '@solana/mpp':
         specifier: workspace:^
@@ -530,7 +530,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2714,8 +2714,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3222,7 +3222,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -3241,7 +3241,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
       viem: '>=2.54.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -4407,9 +4407,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@2.0.11(hono@4.13.1)':
+  '@hono/node-server@2.0.11(hono@4.13.7)':
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
 
   '@humanfs/core@0.19.1': {}
 
@@ -4641,7 +4641,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.13.1)
+      '@hono/node-server': 2.0.11(hono@4.13.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4651,7 +4651,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6735,7 +6735,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.13.1: {}
+  hono@4.13.7: {}
 
   html-escaper@2.0.2: {}
 
@@ -7371,7 +7371,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
-  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
+  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
@@ -7382,14 +7382,14 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1
-      hono: 4.13.1
+      hono: 4.13.7
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - openapi-types
       - supports-color
       - typescript
 
-  mppx@0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
+  mppx@0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0
@@ -7400,7 +7400,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1
-      hono: 4.13.1
+      hono: 4.13.7
     transitivePeerDependencies:
       - typescript
 

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ overrides:
   # fast-uri/hono/ip-address floors below track advisories reached via
   # @modelcontextprotocol/sdk (see `pnpm why <pkg>`); bump as new CVEs land.
   fast-uri: '>=4.1.4'
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   ip-address: '>=10.3.1'
   js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'


### PR DESCRIPTION
Second PR in the CI series (#260 → this → #264 → #267; see #261 for the investigation index).

> [!NOTE]
> Rebased onto current main on 2026-08-19. The original first half of this PR cut the Python test step from 182s to 59s by binding a short confirmation deadline in the unit suite. That commit is dropped: #259's session rewrite removed the four tests that waited out the 30 second timeout, and the Python step already runs at 59s on main. What remains is the concurrency change below.

## Superseded pull-request runs are never cancelled

None of the nine per-language workflows declare a `concurrency` group, so pushing to a branch that already has a run in flight leaves the old run going to completion on a commit nobody is waiting on.

Measured over the last 810 pull-request runs across all nine workflows:

| | |
|---|---|
| superseded by a newer push, still ran to completion | **119 of 810, 15%** |
| runner time spent on them | **11.2 hours** |

The Lua workflow alone accounted for 5.5 of those hours (#260 already cuts that by roughly 5x). This changes cost, not wall clock: the run a contributor waits on is always the newest, and that one is never cancelled.

Two commits:

1. **Cancel superseded pull-request runs.** Every workflow gets a concurrency group keyed on the PR number, `cancel-in-progress` for `pull_request` events only.
2. **Give non-pull-request runs their own group.** A concurrency group holds at most one *pending* run, so sharing one group for push and `workflow_call` runs would let a third push evict the queued second one, and that commit would report no result at all. `cancel-in-progress: false` does not prevent this; it only protects the run already executing. Keying those runs on `run_id` gives each its own group and keeps main/publish runs untouched.
