### PR TITLE
perf(ci): thaw the frozen cargo caches

### DIFF
--- a/.github/actions/build-payment-channels/action.yml
+++ b/.github/actions/build-payment-channels/action.yml
@@ -32,12 +32,28 @@ runs:
         ref: ${{ inputs.ref }}
         path: _payment-channels
         fetch-depth: 1
+    # The build is fully determined by the pinned ref, the declared program
+    # id, and this action file (which carries the sentinel patch and the
+    # pinned platform-tools version), so the resulting .so can be cached on
+    # exactly those and the Anza CLI install (~16s), the platform-tools v1.52
+    # download (~45-60s of silence before the first Compiling line), and the
+    # build-sbf run are all skipped on a hit. No runner.os in the key: the
+    # artifact is SBF bytecode, host-independent, so the ubuntu-built .so
+    # serves the macOS legs too.
+    - name: Cache built program
+      id: so-cache
+      uses: actions/cache@v5
+      with:
+        path: _payment-channels/target/deploy
+        key: payment-channels-so-${{ inputs.ref }}-${{ inputs.program-id }}-${{ hashFiles('.github/actions/build-payment-channels/action.yml') }}
     - name: Install Anza CLI
+      if: steps.so-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
         echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
     - name: Patch payment channels treasury owner
+      if: steps.so-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: _payment-channels
       run: |
@@ -59,6 +75,7 @@ runs:
           exit 1
         fi
     - name: Build payment channels program
+      if: steps.so-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: _payment-channels/program/payment_channels
       run: cargo build-sbf --tools-version v1.52 --arch v1

--- a/.github/actions/setup-harness-leg/action.yml
+++ b/.github/actions/setup-harness-leg/action.yml
@@ -26,6 +26,13 @@ runs:
     # miss this cache — different runner.os — and compile Rust themselves, as
     # they do today.)
     - uses: dtolnay/rust-toolchain@stable
+    # Same key expression as setup-harness (see the comment there for why the
+    # gitignored-lockfile hash froze this cache): the build job saves under
+    # this key, the legs hit it exactly.
+    - name: Compute cargo cache key
+      id: cargo-key
+      shell: bash
+      run: echo "rustc=$(rustc -V | tr -d ' ()')" >> "$GITHUB_OUTPUT"
     - name: Restore shared cargo cache
       uses: actions/cache@v5
       with:
@@ -33,8 +40,8 @@ runs:
           ~/.cargo/registry
           ~/.cargo/git
           rust/target
-        key: ${{ runner.os }}-cargo-shared-harness-${{ hashFiles('rust/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-shared-harness-
+        key: ${{ runner.os }}-cargo-shared-harness-${{ steps.cargo-key.outputs.rustc }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+        restore-keys: ${{ runner.os }}-cargo-shared-harness-${{ steps.cargo-key.outputs.rustc }}-
     - name: Install harness
       working-directory: harness
       shell: bash

--- a/.github/actions/setup-harness/action.yml
+++ b/.github/actions/setup-harness/action.yml
@@ -44,6 +44,21 @@ runs:
     - name: Set up Rust toolchain
       if: inputs.cargo-bins != ''
       uses: dtolnay/rust-toolchain@stable
+    # rust/Cargo.lock is gitignored, so hashFiles on it alone resolves to the
+    # empty string and the key degenerates to a constant. A constant key is an
+    # exact primary hit on every run, and actions/cache never re-saves on an
+    # exact hit, so the cache stayed frozen at whatever the first run ever
+    # stored: artifacts from an older rustc that cargo discards, restored (up
+    # to 660 MB) and then fully recompiled, every run. Key on the live rustc
+    # version plus the manifest hash instead; the lockfile pattern stays in
+    # the hash so it starts contributing the moment the lockfile is committed.
+    # setup-harness-leg computes the same key so the legs restore what the
+    # build job saves.
+    - name: Compute cargo cache key
+      if: inputs.cargo-bins != ''
+      id: cargo-key
+      shell: bash
+      run: echo "rustc=$(rustc -V | tr -d ' ()')" >> "$GITHUB_OUTPUT"
     - name: Cache cargo registry + target
       if: inputs.cargo-bins != ''
       uses: actions/cache@v5
@@ -52,8 +67,8 @@ runs:
           ~/.cargo/registry
           ~/.cargo/git
           rust/target
-        key: ${{ runner.os }}-cargo-${{ inputs.cargo-cache-key }}-harness-${{ hashFiles('rust/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-${{ inputs.cargo-cache-key }}-harness-
+        key: ${{ runner.os }}-cargo-${{ inputs.cargo-cache-key }}-harness-${{ steps.cargo-key.outputs.rustc }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+        restore-keys: ${{ runner.os }}-cargo-${{ inputs.cargo-cache-key }}-harness-${{ steps.cargo-key.outputs.rustc }}-
     - name: Build Rust harness adapters
       if: inputs.cargo-bins != ''
       working-directory: rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,12 @@ jobs:
       # See .github/actions/setup-harness/action.yml for why the key must not
       # hash only the gitignored lockfile: a constant key froze this cache at
       # its first save and cargo rebuilt all ~890 crates on every run.
+      #
+      # The `-cov` namespace is load-bearing: this job builds coverage-
+      # instrumented artifacts under target/llvm-cov-target, while the E2E
+      # job below builds plain ones. Under a shared key the shorter E2E job
+      # wins the save race every time, this job restores artifacts it cannot
+      # use, and the instrumented build never gets cached at all.
       - name: Compute cargo cache key
         id: cargo-key
         run: echo "rustc=$(rustc -V | tr -d ' ()')" >> "$GITHUB_OUTPUT"
@@ -213,8 +219,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: ${{ runner.os }}-cargo-rust-${{ steps.cargo-key.outputs.rustc }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-rust-${{ steps.cargo-key.outputs.rustc }}-
+          key: ${{ runner.os }}-cargo-rust-cov-${{ steps.cargo-key.outputs.rustc }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-rust-cov-${{ steps.cargo-key.outputs.rustc }}-
       - name: Download HTML assets
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,14 +201,20 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
+      # See .github/actions/setup-harness/action.yml for why the key must not
+      # hash only the gitignored lockfile: a constant key froze this cache at
+      # its first save and cargo rebuilt all ~890 crates on every run.
+      - name: Compute cargo cache key
+        id: cargo-key
+        run: echo "rustc=$(rustc -V | tr -d ' ()')" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: ${{ runner.os }}-cargo-rust-${{ hashFiles('rust/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-rust-
+          key: ${{ runner.os }}-cargo-rust-${{ steps.cargo-key.outputs.rustc }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-rust-${{ steps.cargo-key.outputs.rustc }}-
       - name: Download HTML assets
         uses: actions/download-artifact@v7
         with:
@@ -406,14 +412,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      # Same key as the Rust tests job above, same rationale: a key hashing
+      # only the gitignored lockfile is constant, so this cache was frozen and
+      # the test server rebuilt ~490 crates per run.
+      - name: Compute cargo cache key
+        id: cargo-key
+        run: echo "rustc=$(rustc -V | tr -d ' ()')" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: ${{ runner.os }}-cargo-rust-${{ hashFiles('rust/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-rust-
+          key: ${{ runner.os }}-cargo-rust-${{ steps.cargo-key.outputs.rustc }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-rust-${{ steps.cargo-key.outputs.rustc }}-
       - uses: pnpm/action-setup@v5
         with:
           package_json_file: package.json

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -108,46 +108,13 @@ jobs:
         with:
           cargo-bins: "paykit-harness-bins:mpp_harness_client,x402_harness_client,x402_harness_upto_client,x402_harness_upto_server"
           cargo-cache-key: go
-      - name: Checkout payment channels program
-        uses: actions/checkout@v5
-        with:
-          repository: Moonsong-Labs/solana-payment-channels
-          ref: 0c07d5751c8972abf6a219570a3f39a72f46f879
-          path: _payment-channels
-          fetch-depth: 1
-      - name: Install Anza CLI
-        run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
-      - name: Patch payment channels localnet artifact
-        working-directory: _payment-channels
-        run: |
-          old_program_id="CQAyft83tN1w2bRofB5PZ79eVDU2xZUVo43LU1qL4zRg"
-          new_program_id="CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
-          sentinel_file="program/payment_channels/src/constants.rs"
-          sentinel_prefix="    0xb0, 0x41, 0xd9, 0xd3, 0x37, 0xb7, 0x21, 0xbe, 0x57, 0x89, 0x4e, 0xb6, 0x9c, 0x3b, 0x68, 0x09,"
-          sentinel_suffix="    0xa5, 0x3a, 0x0e, 0x2b, 0x6a, 0x23, 0x99, 0xfc, 0x7d, 0x5b, 0x7e, 0xda, 0x8c, 0xac, 0x89, 0xaa,"
-          grep_args=(--exclude-dir=.git --exclude-dir=target)
-          mapfile -t id_files < <(grep -RIl "${grep_args[@]}" "$old_program_id" .)
-          if [ "${#id_files[@]}" -gt 0 ]; then
-            sed -i "s/$old_program_id/$new_program_id/g" "${id_files[@]}"
-          fi
-          perl -0pi -e 's/const TREASURY_OWNER_SENTINEL: \[u8; 32\] = \[\n.*?\n\];/const TREASURY_OWNER_SENTINEL: [u8; 32] = [\n    0xb0, 0x41, 0xd9, 0xd3, 0x37, 0xb7, 0x21, 0xbe, 0x57, 0x89, 0x4e, 0xb6, 0x9c, 0x3b, 0x68, 0x09,\n    0xa5, 0x3a, 0x0e, 0x2b, 0x6a, 0x23, 0x99, 0xfc, 0x7d, 0x5b, 0x7e, 0xda, 0x8c, 0xac, 0x89, 0xaa,\n];/s' "$sentinel_file"
-          if ! grep -R "${grep_args[@]}" "$new_program_id" . >/dev/null; then
-            echo "::error::payment-channels program id patch did not write $new_program_id"
-            exit 1
-          fi
-          if grep -R "${grep_args[@]}" "$old_program_id" . >/dev/null; then
-            echo "::error::payment-channels program id patch left $old_program_id in the checkout"
-            exit 1
-          fi
-          if ! grep -Fq "$sentinel_prefix" "$sentinel_file" || ! grep -Fq "$sentinel_suffix" "$sentinel_file"; then
-            echo "::error::payment-channels treasury sentinel patch did not apply"
-            exit 1
-          fi
+      # x402 upto settles on the canonical payment-channels program; the upto
+      # e2e deploys this localnet SBF artifact onto the embedded surfnet. The
+      # composite action carries the checkout, the sentinel patch, and the
+      # build, and caches the resulting .so on the pinned ref, so a warm run
+      # skips the Anza CLI install and the platform-tools download entirely.
       - name: Build payment channels program
-        working-directory: _payment-channels/program/payment_channels
-        run: cargo build-sbf --tools-version v1.52 --arch v1
+        uses: ./.github/actions/build-payment-channels
       - name: Build Go paykit harness server
         working-directory: harness/go-server
         run: go build -o paykit-server .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,42 +87,12 @@ jobs:
           cargo-bins: "paykit-harness-bins:mpp_harness_client,mpp_harness_server,x402_harness_client,x402_harness_server,x402_harness_upto_client,x402_harness_upto_server"
           cargo-cache-key: python
       # x402 upto settles on the canonical payment-channels program; the upto
-      # e2e deploys this localnet SBF artifact onto the embedded surfnet. Mirrors
-      # the harness-go job in .github/workflows/go.yml.
-      - name: Checkout payment channels program
-        uses: actions/checkout@v5
-        with:
-          repository: Moonsong-Labs/solana-payment-channels
-          ref: 0c07d5751c8972abf6a219570a3f39a72f46f879
-          path: _payment-channels
-          fetch-depth: 1
-      - name: Install Anza CLI
-        run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
-      - name: Patch payment channels treasury owner
-        working-directory: _payment-channels
-        run: |
-          program_id="CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
-          lib_file="program/payment_channels/src/lib.rs"
-          sentinel_file="program/payment_channels/src/constants.rs"
-          sentinel_prefix="    0xb0, 0x41, 0xd9, 0xd3, 0x37, 0xb7, 0x21, 0xbe, 0x57, 0x89, 0x4e, 0xb6, 0x9c, 0x3b, 0x68, 0x09,"
-          sentinel_suffix="    0xa5, 0x3a, 0x0e, 0x2b, 0x6a, 0x23, 0x99, 0xfc, 0x7d, 0x5b, 0x7e, 0xda, 0x8c, 0xac, 0x89, 0xaa,"
-          # The pinned upstream ref already declares our canonical program id, so
-          # only the localnet treasury-owner sentinel needs patching. Guard the id
-          # assumption so a future ref bump that changes it fails loudly here.
-          if ! grep -Fq "declare_id!(\"$program_id\")" "$lib_file"; then
-            echo "::error::payment-channels no longer declares $program_id; revisit this patch"
-            exit 1
-          fi
-          perl -0pi -e 's/const TREASURY_OWNER_SENTINEL: \[u8; 32\] = \[\n.*?\n\];/const TREASURY_OWNER_SENTINEL: [u8; 32] = [\n    0xb0, 0x41, 0xd9, 0xd3, 0x37, 0xb7, 0x21, 0xbe, 0x57, 0x89, 0x4e, 0xb6, 0x9c, 0x3b, 0x68, 0x09,\n    0xa5, 0x3a, 0x0e, 0x2b, 0x6a, 0x23, 0x99, 0xfc, 0x7d, 0x5b, 0x7e, 0xda, 0x8c, 0xac, 0x89, 0xaa,\n];/s' "$sentinel_file"
-          if ! grep -Fq "$sentinel_prefix" "$sentinel_file" || ! grep -Fq "$sentinel_suffix" "$sentinel_file"; then
-            echo "::error::payment-channels treasury sentinel patch did not apply"
-            exit 1
-          fi
+      # e2e deploys this localnet SBF artifact onto the embedded surfnet. The
+      # composite action carries the checkout, the sentinel patch, and the
+      # build, and caches the resulting .so on the pinned ref, so a warm run
+      # skips the Anza CLI install and the platform-tools download entirely.
       - name: Build payment channels program
-        working-directory: _payment-channels/program/payment_channels
-        run: cargo build-sbf --tools-version v1.52 --arch v1
+        uses: ./.github/actions/build-payment-channels
       # Sync the uv environment the conformance runner (runners/python.json:
       # ``uv run python conformance_runner.py``) executes in, so the cross-SDK
       # vectors - including the frozen 48-byte session voucher preimage - run

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,7 +71,15 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
           working-directory: ruby
+      # Every other workflow that drives a rust client passes `cargo-bins` so
+      # the binary is prebuilt (and cached) before the tests run. This one did
+      # not, so the x402 smoke's in-test `cargo run --quiet` was the job's
+      # first cargo invocation ever: a cold, silent compile of the full
+      # dependency tree that showed up as a single 99-second test.
       - uses: ./.github/actions/setup-harness
+        with:
+          cargo-bins: "paykit-harness-bins:x402_harness_client"
+          cargo-cache-key: ruby
       # Dual-protocol proof: one e2e run drives MPP charge scenarios
       # (typescript client) and x402 exact (rust-x402 client) against
       # the same ruby adapter binary. The harness's harnessEnv exposes


### PR DESCRIPTION
Third PR in the CI series (#260 → #262 → this, stacked on #262; see #261 for the investigation index). Everything here was measured before it was changed and verified warm after; no SDK behaviour is touched.

## The bug

Every cargo cache in the repo keys on `hashFiles('rust/Cargo.lock')` — but `Cargo.lock` is gitignored (`.gitignore:20`), so the hash is always the empty string and each key degenerates to a constant:

```
key: Linux-cargo-rust-            ← nothing after the dash, every run
Cache hit occurred on the primary key Linux-cargo-rust-, not saving cache.
```

A constant key means an exact primary hit on every run, and `actions/cache` never re-saves on an exact hit. So each cache froze at whatever its first run ever stored — artifacts from an older rustc that cargo discards wholesale. The result, measured across one green run (branch `perf/lua-coverage-ci`):

| job | restored | then compiled anyway |
|---|---|---|
| Rust tests | 660 MB | **890 crates, 4m55s** |
| Payment links E2E: Rust | ~500 MB | 489 crates, 3m05s |
| harness.yml build job | ~500 MB | 474 crates, ~103s |
| ci.yml TS harness | ~500 MB | 474 crates, ~101s |
| go / php / kotlin setup-harness | ~400 MB | 251 crates, ~70s each |
| Swift ×3 legs (macOS, 10x billing) | 492-557 MB | ~90s each |

Control experiment, locally, same `cargo llvm-cov` invocation as CI:

```
cold:  890 crates compiled   88s
warm:    2 crates compiled   21.6s   (coverage identical, 91.16%)
```

So `cargo-llvm-cov`'s default clean is not the problem (it only cleans workspace crates); the frozen key is, and `--no-clean` is not needed.

## The fixes

**1. Key on rustc version + manifest hash** (`ci.yml` ×2, `setup-harness`, `setup-harness-leg`)

`rustc -V` goes into the key because artifacts are unusable across rustc bumps anyway; `hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml')` covers dependency changes, and the lockfile pattern starts contributing automatically the moment #216 commits the lockfile — no conflict, just a better key later. `restore-keys` falls back only within the same rustc version: the old frozen caches are dead weight and not worth their download time. `setup-harness` and `setup-harness-leg` compute the identical expression so the harness build job's save stays an exact hit for the eleven legs (the pairing the leg action was already written for — and the legs are the part that works today, zero `Compiling` lines).

**2. Cache the payment-channels `.so`** (`build-payment-channels/action.yml`)

The action builds a **pinned commit** yet paid the Anza CLI curl-install (~16s), the platform-tools v1.52 download (a 45-60s silent gap before the first `Compiling` line), and `cargo build-sbf`, on every run. The output is fully determined by (ref, program-id, this action file), so the artifact is cached on exactly those and install/patch/build are skipped on a hit. The key omits `runner.os` deliberately: SBF bytecode is host-independent, so the ubuntu-built `.so` serves the macOS legs. Nothing downstream needs the Anza CLI on PATH (verified: consumers read the `.so` path from the action output; the only later match for `solana` in those jobs is a comment).

**3. Prebuild the rust x402 client in `ruby.yml`**

The 99.4-second `x402-exact-basic: rust-x402 client pays ruby server` test — 69% of the harness-ruby job — was not a slow test. `ruby.yml` was the only workflow driving a rust client without passing `cargo-bins` to setup-harness, so the in-test `cargo run --quiet` was the job's first cargo invocation ever: a cold compile of the full dependency tree, silent because of `--quiet`, visible in the raw log as a 101-second gap with zero output. Passing `cargo-bins` like every sibling workflow moves the build into the setup step, under the now-working cache.

## Measured effect

Three runs on this branch: a cold run (new keys miss, build, and save for the first time), then a warm run that exposed one bug in this PR's own first draft (below), then the verification warm run. All 43 checks green on the final run. Cold-vs-warm, same code (the warm trigger was an empty commit):

| job | before (frozen cache) | final warm | |
|---|---|---|---|
| Rust tests | 479s | **146s** | 3.3x |
| Swift x402-upto (macOS, 10x billing) | 340s | **107s** | 3.2x |
| Payment links E2E: Rust | 261s | **95s** | 2.7x |
| Go PayKit harness | 274s | **124s** | 2.2x |
| Python harness matrix | 350s | **175s** | 2.0x |
| harness.yml build job | 160s | **80s** | 2.0x |
| Kotlin x402-upto | 242s | **124s** | 2.0x |
| Harness: Ruby | 183s | **110s** | 1.7x |
| Harness: TypeScript (ci.yml) | 255s | **178s** | 1.4x |

Wall clock for the full 43-check suite: **9.6 min → 4.5 min**. Combined with #260 (Lua 20.3 min → ~4.5 min) the critical path of a PR has gone from ~20.5 minutes at the start of this series to 4.5.

**The save race the first warm run caught:** the first draft of this PR gave `Rust tests` and `Payment links E2E: Rust` a shared `cargo-rust-` key. The coverage job builds instrumented artifacts under `target/llvm-cov-target`; the E2E job builds plain ones, finishes first, and wins the save every time — so the coverage job restored artifacts it could not use and recompiled 1100 crates on a run whose cache reported an exact primary hit. The `cargo-rust-cov-` namespace in the last commit fixes it, and 479→117s is the measured result. Worth keeping in mind for any future cache: two jobs may share a key only if they build with identical flags.

One unrelated flake surfaced during measurement (`charge-basic: typescript client pays python server`, "fee payer pubkey not present in transaction accounts") — it failed on one run and passed on the rerun and on both neighbouring runs of identical code; main's history shows the same leg failing sporadically. Not introduced here.

## What this deliberately does not touch

- ci.yml's duplicate "Harness: TypeScript harness" job (255s of repeated setup) — that is a job-topology question, raised on #261 instead.

