### PR TITLE
ci: gate jobs on a changes filter instead of running all 43 checks on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,62 @@ defaults:
     working-directory: typescript
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      ts: ${{ steps.filter.outputs.ts }}
+      rust: ${{ steps.filter.outputs.rust }}
+      linksdemo: ${{ steps.filter.outputs.linksdemo }}
+      linksrust: ${{ steps.filter.outputs.linksrust }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ts:
+              - 'typescript/**'
+              - 'html/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            rust:
+              - 'rust/**'
+              - 'html/**'
+              - '.github/**'
+            linksdemo:
+              - 'html/**'
+              - 'typescript/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            linksrust:
+              - 'rust/**'
+              - 'html/**'
+              - 'typescript/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            harness:
+              - 'ruby/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   audit:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true'
     name: Audit
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +115,8 @@ jobs:
           fi
 
   lint:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true'
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +138,8 @@ jobs:
 
   typecheck:
     name: Typecheck
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -104,7 +162,8 @@ jobs:
 
   test-ts:
     name: TypeScript tests
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -183,7 +242,8 @@ jobs:
 
   test-rust:
     name: Rust tests
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     services:
       redis:
@@ -307,7 +367,8 @@ jobs:
 
   integration:
     name: Integration tests
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -347,7 +408,8 @@ jobs:
 
   test-payment-links-demo:
     name: "Payment links E2E: Playground (TypeScript)"
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.linksdemo == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -413,7 +475,8 @@ jobs:
 
   test-payment-links-rust:
     name: "Payment links E2E: Rust"
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.linksrust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -485,7 +548,8 @@ jobs:
 
   harness:
     name: "Harness: TypeScript harness"
-    needs: build-html
+    needs: [changes, build-html]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,9 +43,11 @@ jobs:
           filters: |
             go:
               - 'go/**'
+              - 'html/**'
               - '.github/**'
             harness:
               - 'go/**'
+              - 'html/**'
               - 'harness/**'
               - 'typescript/**'
               - 'rust/**'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,47 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      harness: ${{ steps.filter.outputs.harness }}
+      playground: ${{ steps.filter.outputs.playground }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - 'go/**'
+              - '.github/**'
+            harness:
+              - 'go/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            playground:
+              - 'go/**'
+              - 'html/**'
+              - 'typescript/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-go:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
     name: Go tests
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +109,8 @@ jobs:
           path: go/coverage.out
 
   lint-go:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
     name: Go lint
     runs-on: ubuntu-latest
     steps:
@@ -96,7 +138,8 @@ jobs:
 
   harness-go:
     name: Go PayKit harness (mpp charge + x402 exact + x402 upto)
-    needs: test-go
+    needs: [changes, test-go]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-go'].result == 'success' || needs['test-go'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -150,7 +193,8 @@ jobs:
 
   playground-go:
     name: "Payment links E2E: Playground (Go)"
-    needs: test-go
+    needs: [changes, test-go]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.playground == 'true') && (needs['test-go'].result == 'success' || needs['test-go'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -38,7 +38,114 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      go: ${{ steps.filter.outputs.go }}
+      python: ${{ steps.filter.outputs.python }}
+      ruby: ${{ steps.filter.outputs.ruby }}
+      lua: ${{ steps.filter.outputs.lua }}
+      php: ${{ steps.filter.outputs.php }}
+      swift: ${{ steps.filter.outputs.swift }}
+      kotlin: ${{ steps.filter.outputs.kotlin }}
+      any: ${{ steps.filter.outputs.any }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            go:
+              - 'go/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            python:
+              - 'python/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            ruby:
+              - 'ruby/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            lua:
+              - 'lua/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            php:
+              - 'php/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            swift:
+              - 'swift/**'
+              - 'Package.swift'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            kotlin:
+              - 'kotlin/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+            any:
+              - 'go/**'
+              - 'python/**'
+              - 'ruby/**'
+              - 'lua/**'
+              - 'php/**'
+              - 'kotlin/**'
+              - 'swift/**'
+              - 'Package.swift'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   build:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.any == 'true'
     name: Build harness deps (once)
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +165,8 @@ jobs:
 
   ts:
     name: "Harness: TypeScript (Rust client/server)"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.core == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -78,7 +186,8 @@ jobs:
 
   go:
     name: "Harness: Go (mpp charge + x402 exact)"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -103,7 +212,8 @@ jobs:
 
   python:
     name: "Harness: Python"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.python == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -159,7 +269,8 @@ jobs:
 
   ruby:
     name: "Harness: Ruby PayKit server (dual protocol)"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.ruby == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -181,7 +292,8 @@ jobs:
 
   lua:
     name: "Harness: Lua focused matrix"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.lua == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -235,7 +347,8 @@ jobs:
 
   php:
     name: "Harness: PHP"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.php == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -272,7 +385,8 @@ jobs:
 
   swift:
     name: "Harness: Swift client to TypeScript + Rust servers"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.swift == 'true') && needs['build'].result == 'success' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
@@ -306,7 +420,8 @@ jobs:
 
   swift-x402:
     name: "Harness: Swift x402 client to Rust x402 server"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.swift == 'true') && needs['build'].result == 'success' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
@@ -333,7 +448,8 @@ jobs:
 
   kotlin:
     name: "Harness: Kotlin client to TypeScript server"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.kotlin == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -365,7 +481,8 @@ jobs:
 
   kotlin-x402:
     name: "Harness: Kotlin x402 client to Rust x402 server"
-    needs: build
+    needs: [changes, build]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.kotlin == 'true') && needs['build'].result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -395,6 +512,8 @@ jobs:
   # lands on-chain (the byte-shape harness above cannot). Needs @solana/pay-kit
   # built (the on-chain suite imports it) and a mainnet RPC to fork from.
   onchain:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.core == 'true'
     name: "Harness: on-chain settlement (mainnet fork)"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -22,7 +22,39 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      kotlin: ${{ steps.filter.outputs.kotlin }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            kotlin:
+              - 'kotlin/**'
+              - '.github/**'
+            harness:
+              - 'kotlin/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-kotlin:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.kotlin == 'true'
     name: Kotlin tests
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +85,8 @@ jobs:
 
   harness-kotlin:
     name: "Harness: Kotlin client to TypeScript server"
-    needs: test-kotlin
+    needs: [changes, test-kotlin]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-kotlin'].result == 'success' || needs['test-kotlin'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -85,7 +118,8 @@ jobs:
 
   harness-kotlin-x402:
     name: "Harness: Kotlin x402 client to Rust x402 server"
-    needs: test-kotlin
+    needs: [changes, test-kotlin]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-kotlin'].result == 'success' || needs['test-kotlin'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -124,7 +158,8 @@ jobs:
 
   harness-kotlin-x402-upto:
     name: "Harness: Kotlin x402 upto client to Rust upto server"
-    needs: test-kotlin
+    needs: [changes, test-kotlin]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-kotlin'].result == 'success' || needs['test-kotlin'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -42,9 +42,11 @@ jobs:
           filters: |
             lua:
               - 'lua/**'
+              - 'html/**'
               - '.github/**'
             harness:
               - 'lua/**'
+              - 'html/**'
               - 'harness/**'
               - 'typescript/**'
               - 'rust/**'

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -22,7 +22,39 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      lua: ${{ steps.filter.outputs.lua }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            lua:
+              - 'lua/**'
+              - '.github/**'
+            harness:
+              - 'lua/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-lua:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.lua == 'true'
     name: Lua tests
     runs-on: ubuntu-latest
     steps:
@@ -115,6 +147,8 @@ jobs:
           if-no-files-found: ignore
 
   harness-lua:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true'
     name: Lua harness focused matrix
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,7 +22,39 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            php:
+              - 'php/**'
+              - '.github/**'
+            harness:
+              - 'php/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-php:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.php == 'true'
     name: PHP tests
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +89,8 @@ jobs:
 
   harness-php:
     name: PHP harness
-    needs: test-php
+    needs: [changes, test-php]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-php'].result == 'success' || needs['test-php'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -91,8 +91,7 @@ jobs:
             --cov=solana_pay_kit \
             --cov-report=term-missing \
             --cov-report=json:coverage.json \
-            --cov-fail-under=90 \
-            --ignore=tests/test_server_html.py
+            --cov-fail-under=90
       - name: Upload Python coverage
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,9 +42,11 @@ jobs:
           filters: |
             python:
               - 'python/**'
+              - 'html/**'
               - '.github/**'
             harness:
               - 'python/**'
+              - 'html/**'
               - 'harness/**'
               - 'typescript/**'
               - 'rust/**'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,39 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'python/**'
+              - '.github/**'
+            harness:
+              - 'python/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-python:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.python == 'true'
     name: Python tests
     runs-on: ubuntu-latest
     steps:
@@ -69,7 +101,8 @@ jobs:
   harness-python:
     name: Python harness matrix
     runs-on: ubuntu-latest
-    needs: test-python
+    needs: [changes, test-python]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-python'].result == 'success' || needs['test-python'].result == 'skipped') }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,39 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      ruby: ${{ steps.filter.outputs.ruby }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ruby:
+              - 'ruby/**'
+              - '.github/**'
+            harness:
+              - 'ruby/**'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-ruby:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ruby == 'true'
     name: Ruby tests
     runs-on: ubuntu-latest
     steps:
@@ -62,7 +94,8 @@ jobs:
 
   harness-ruby:
     name: "Harness: Ruby PayKit server (dual protocol)"
-    needs: test-ruby
+    needs: [changes, test-ruby]
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true') && (needs['test-ruby'].result == 'success' || needs['test-ruby'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,41 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which parts of the tree this pull request touches. Every other job in
+  # this workflow gates on these outputs for pull_request events; pushes to
+  # main and workflow_call runs are never filtered. A harness leg's filter
+  # lists every language that participates in the leg, not just the server
+  # language, so a cross-SDK change still runs the pairs it can break (#261).
+  # Any change under .github/ invalidates every filter.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      swift: ${{ steps.filter.outputs.swift }}
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            swift:
+              - 'swift/**'
+              - 'Package.swift'
+              - '.github/**'
+            harness:
+              - 'swift/**'
+              - 'Package.swift'
+              - 'harness/**'
+              - 'typescript/**'
+              - 'rust/**'
+              - 'package.json'
+              - '.node-version'
+              - '.github/**'
+
   test-swift:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.swift == 'true'
     name: Swift tests
     runs-on: macos-latest
     steps:
@@ -40,6 +74,8 @@ jobs:
           if-no-files-found: ignore
 
   harness-swift:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true'
     name: "Harness: Swift client to TypeScript + Rust servers"
     runs-on: macos-latest
     steps:
@@ -70,6 +106,8 @@ jobs:
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "swift client pays rust server"
 
   harness-swift-x402:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true'
     name: "Harness: Swift x402 client to Rust x402 server"
     runs-on: macos-latest
     steps:
@@ -105,6 +143,8 @@ jobs:
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "swift-x402 client pays rust-x402 server" --testTimeout 180000
 
   harness-swift-x402-upto:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.harness == 'true'
     name: "Harness: Swift x402 upto client to Rust x402 upto server"
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
Implements #261. Fourth PR in the CI series, stacked on #264 (#260 → #262 → #264 → this).

## What it does

Every workflow now opens with a ~10s `changes` job (`dorny/paths-filter@v3`) and every other job gates on its outputs. Three rules carry the safety argument:

1. **Only `pull_request` events are filtered.** Pushes to `main` and `workflow_call` runs (the publish pipelines) always run the full matrix, and `dorny/paths-filter`'s push-event diffing semantics never come into play.
2. **A harness leg's filter lists every participant, not just the server language.** This is the constraint #261 called load-bearing: `harness-lua` runs on changes to `lua/`, `harness/`, `typescript/` or `rust/`, because the TS and Rust clients drive it. A typescript-only PR therefore still runs the Lua/Ruby/Swift/Go harness legs — what it skips is the per-language *unit* suites it cannot break.
3. **Anything under `.github/` invalidates every filter.** CI changes run everything, including this PR itself, which doubles as the no-regression check.

Two mechanical details reviewers should look at:

- Fail-fast gates in front of harness legs (`harness-ruby` needs `test-ruby`, etc.) switch from the implicit `success()` to `!cancelled() && … && (needs['test-ruby'].result == 'success' || needs['test-ruby'].result == 'skipped')`. Without this, a typescript-only PR would skip `test-ruby` and the skip would cascade into the harness leg that *should* run. Failure still blocks, so fail-fast is preserved when the unit suite actually ran.
- `harness.yml` legs require `build` strictly (`result == 'success'`, no skip tolerance) because they consume its `mpp-dist` artifact; `build`'s own filter is the union of every leg's filter, so it can only skip when every leg also skips. `ci.yml`'s `build-html` stays ungated: five jobs consume its artifact and it costs 26 seconds.

## Filter map

| job(s) | runs when the PR touches |
|---|---|
| per-language unit suites (`test-lua`, `test-go`, …) | that language, `.github/` |
| per-language harness legs | that language + `harness/` + `typescript/` + `rust/` (+ root `package.json`, `.node-version`) |
| `ci.yml` TS jobs (lint, typecheck, tests, audit, integration) | `typescript/`, `html/` |
| `ci.yml` Rust tests / payment-links E2E | `rust/`, `html/` (+`typescript/` for E2E) |
| `harness.yml` build | union of all legs |
| everything | `.github/**` |

`html/**` sits in the TS and Rust filters because `build-html` generates `html-assets.gen.ts` and the embedded assets those suites consume.

## Expected effect

| PR shape | today | with this |
|---|---|---|
| single-language (e.g. python-only) | 43 checks, ~4.5 min wall, ~55 min compute | that language + its harness legs, **~2-3 min wall**, roughly half the compute |
| docs-only | 43 checks | **nine ~10s filter jobs, nothing else** |
| touches `typescript/` or `rust/` | full matrix | near-full matrix (they participate almost everywhere) — correct, not a regression |
| touches `.github/` | full matrix | full matrix |

This PR touches only `.github/workflows/`, so its own run exercises the "everything still runs" path; a companion draft PR with a docs-only change will demonstrate the skip path before this merges.

`actionlint` passes (the remaining shellcheck notes predate this change).

## Known tradeoffs

- 9 extra ~10s jobs per PR (the filters). Net win everywhere except a full-matrix PR, where it adds ~10s of parallel wall clock.
- If required status checks are ever configured, skipped jobs report as skipped-success, which is the behavior that makes this pattern safe for branch protection — but the required-check list should then name the `changes` jobs too.
- The filter map is now something to maintain: a new harness leg must list its participants. The header comment in each workflow says exactly that.