### PR TITLE
[throwaway] verify changes-filter skip path with a docs-only diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,5 @@ pnpm dev   # server on :3000, web app on :5173
 ## License
 
 MIT
+
+<!-- CI changes-filter verification: docs-only change, every job except the changes filters should skip. Throwaway PR, will be closed. -->


### PR DESCRIPTION
Verification companion for #267: this diff touches only README.md, which no filter matches. Expected result: nine ~10s `changes` jobs succeed, every other job reports skipped. Will be closed after the run is captured — do not merge.