### PR TITLE
harness: register TypeScript x402 upto client in conformance matrix

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -375,6 +375,49 @@ jobs:
           X402_HARNESS_SERVERS: rust-x402
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "kotlin-x402 client pays rust-x402 server" --testTimeout 180000
 
+
+  # x402 upto: TypeScript pay-kit client (UptoSvmScheme via createPayKitClient)
+  # against the canonical Rust upto server. Mirrors harness-kotlin-x402-upto /
+  # python focused upto legs. Needs payment-channels .so + pay-kit dist (the
+  # fixture is excluded from the base harness typecheck for that reason).
+  ts-x402-upto:
+    name: "Harness: TypeScript x402 upto client to Rust upto server"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-harness
+        with:
+          cargo-bins: "paykit-harness-bins:x402_harness_upto_client,x402_harness_upto_server"
+          cargo-cache-key: ts-x402-upto
+      # Fixture imports @solana/pay-kit/client; setup-harness only builds @solana/mpp.
+      - name: Build @solana/pay-kit
+        working-directory: typescript
+        run: pnpm --filter @solana/pay-kit build
+      - name: Typecheck TypeScript upto harness fixture
+        working-directory: harness
+        run: pnpm exec tsc --noEmit src/fixtures/typescript/upto-client.ts --esModuleInterop --module ESNext --moduleResolution Bundler --target ES2022 --strict --skipLibCheck --types node
+      # x402 upto settles on the canonical payment-channels program; the upto
+      # e2e runs this localnet SBF build on the embedded surfnet.
+      - name: Build payment channels program
+        id: payment-channels
+        uses: ./.github/actions/build-payment-channels
+      # Drive the TS createPayKitClient upto path (channel open) against the
+      # canonical Rust upto server (broadcast + voucher settle on embedded
+      # surfnet). Scenarios match kotlin/python: basic + zero-actual.
+      - name: Run TypeScript x402 upto client to Rust upto server harness
+        working-directory: harness
+        env:
+          MPP_HARNESS_CLIENTS: ""
+          MPP_HARNESS_SERVERS: ""
+          MPP_HARNESS_INTENTS: x402-upto
+          MPP_HARNESS_SCENARIOS: x402-upto-basic,x402-upto-zero-actual
+          X402_HARNESS_CLIENTS: ts-x402-upto
+          X402_HARNESS_SERVERS: rust-x402-upto
+          PAYMENT_CHANNELS_PROGRAM_SO: ${{ steps.payment-channels.outputs.program-so }}
+          PAYMENT_CHANNELS_PROGRAM_ID: CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX
+          SURFPOOL_DATASOURCE_RPC_URL: ${{ secrets.SURFPOOL_DATASOURCE_RPC_URL }}
+        run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
+
   # Real on-chain settlement gate: forks mainnet (surfpool 1.4) and executes the
   # deployed payment-channels program, so a green run proves settlement actually
   # lands on-chain (the byte-shape harness above cannot). Needs @solana/pay-kit

--- a/harness/src/fixtures/typescript/upto-client.ts
+++ b/harness/src/fixtures/typescript/upto-client.ts
@@ -1,0 +1,108 @@
+// TypeScript x402 `upto` harness client.
+//
+// Mirrors the Python/Rust/Go upto harness clients: GET the target, parse the
+// `upto` 402 challenge, build a real PAYMENT-SIGNATURE (payment-channel open
+// via the TS pay-kit client), GET again with it, then print exactly one result
+// JSON line to stdout. Diagnostics go to stderr.
+//
+// Unlike the `exact` fixture (`exact-client.ts`), this is NOT a wire-level
+// stub: the TS SDK already registers `UptoSvmScheme` on the x402 client, so
+// the harness exercises that real path against the Rust/Go/Python upto
+// servers in the matrix (see `test/x402-upto.e2e.test.ts`).
+//
+// Env contract (shared with the rust/go/python upto clients):
+//
+// * `X402_HARNESS_TARGET_URL`        - required, the gated resource URL.
+// * `X402_HARNESS_RPC_URL`           - required, used to build the channel open.
+// * `X402_HARNESS_CLIENT_SECRET_KEY` - required, JSON int array (secret-key bytes).
+// * `X402_HARNESS_SETTLEMENT_HEADER` - optional; default `x-fixture-settlement`.
+// * `X402_HARNESS_ACTUAL_AMOUNT`     - optional; forwarded as
+//   `X402-HARNESS-ACTUAL-AMOUNT` on the paid request (server metering hint).
+
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { createPayKitClient } from "@solana/pay-kit/client";
+
+const DEFAULT_SETTLEMENT_HEADER = "x-fixture-settlement";
+
+function readRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function parseSecretKey(name: string): Uint8Array {
+  const raw = readRequiredEnv(name);
+  const parsed = JSON.parse(raw) as number[];
+  return new Uint8Array(parsed);
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const raw = await response.text();
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+async function main() {
+  const targetUrl = readRequiredEnv("X402_HARNESS_TARGET_URL");
+  const rpcUrl = readRequiredEnv("X402_HARNESS_RPC_URL");
+  const clientSecretKey = parseSecretKey("X402_HARNESS_CLIENT_SECRET_KEY");
+  const settlementHeader =
+    process.env.X402_HARNESS_SETTLEMENT_HEADER ?? DEFAULT_SETTLEMENT_HEADER;
+  const actualAmount = process.env.X402_HARNESS_ACTUAL_AMOUNT ?? "0";
+
+  const signer = await createKeyPairSignerFromBytes(clientSecretKey);
+  // x402 only: the matrix servers offer `upto`, and forcing the rail avoids
+  // the MPP-preferred path in createPayKitClient when both headers exist.
+  const client = await createPayKitClient({
+    accept: ["x402"],
+    rpcUrl,
+    signer,
+  });
+
+  const paidResponse = await client.fetch(
+    targetUrl,
+    {
+      headers: {
+        // Forwarded so harness servers that meter from the paid request (Rust
+        // spine, Go client pair) see the scenario's actualAmount. Harmless if
+        // the server reads actualAmount only from its own env.
+        "X402-HARNESS-ACTUAL-AMOUNT": actualAmount,
+      },
+    },
+    "x402",
+  );
+
+  console.log(
+    JSON.stringify({
+      type: "result",
+      implementation: "typescript",
+      role: "client",
+      ok: paidResponse.ok,
+      status: paidResponse.status,
+      responseHeaders: Object.fromEntries(paidResponse.headers.entries()),
+      responseBody: await readResponseBody(paidResponse),
+      settlement: paidResponse.headers.get(settlementHeader),
+    }),
+  );
+}
+
+void main().catch(error => {
+  console.log(
+    JSON.stringify({
+      type: "result",
+      implementation: "typescript",
+      role: "client",
+      ok: false,
+      status: 0,
+      responseHeaders: {},
+      responseBody: null,
+      settlement: null,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+});

--- a/harness/src/implementations.ts
+++ b/harness/src/implementations.ts
@@ -293,6 +293,25 @@ export const clientImplementations: ImplementationDefinition[] = [
     intents: ["x402-upto"],
     reportsAs: "python",
   },
+  {
+    id: "ts-x402-upto",
+    label: "TypeScript x402 upto client",
+    role: "client",
+    // Real SDK path: `@solana/pay-kit/client` already registers UptoSvmScheme.
+    // Fixture builds a payment-channel credential and retries — not a wire
+    // stub like `ts-x402` exact. Opt in via `X402_HARNESS_CLIENTS=ts-x402-upto`.
+    command: [
+      "pnpm",
+      "exec",
+      "node",
+      "--import",
+      "tsx",
+      "src/fixtures/typescript/upto-client.ts",
+    ],
+    enabled: isEnabled("ts-x402-upto", "X402_HARNESS_CLIENTS", false),
+    intents: ["x402-upto"],
+    reportsAs: "typescript",
+  },
 ];
 
 export const serverImplementations: ImplementationDefinition[] = [

--- a/harness/tsconfig.json
+++ b/harness/tsconfig.json
@@ -12,6 +12,10 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src", "test"],
-  "//": "The on-chain suite imports @solana/pay-kit (a file: dep built separately) and only runs against a forked validator. Excluded from the base typecheck so the cross-language CI jobs (which build only @solana/mpp) stay green; typecheck it via tsconfig.onchain.json where pay-kit is built.",
-  "exclude": ["src/onchain", "test/onchain.e2e.test.ts"]
+  "//": "Suites that import @solana/pay-kit (file: dep, built separately) are excluded from the base typecheck so cross-language CI jobs (which build only @solana/mpp) stay green. Typecheck onchain via tsconfig.onchain.json; typecheck upto-client in the ts-x402-upto harness job after building pay-kit.",
+  "exclude": [
+    "src/onchain",
+    "test/onchain.e2e.test.ts",
+    "src/fixtures/typescript/upto-client.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

The TypeScript SDK already implements client-side x402 `upto` (`UptoSvmScheme` on `createPayKitClient`), but the harness only registered `ts-x402` with `intents: ["x402-exact"]`. That left the flagship language out of the cross-language upto matrix while Go/Rust/Python (and Kotlin/Swift clients) were already present.

This PR adds the harness fixture, registration, **and CI leg** — no new protocol logic.

### Changes

1. **New** `harness/src/fixtures/typescript/upto-client.ts`  
   - Shape from `exact-client.ts` (result JSON, env contract)  
   - Flow from `python-x402-upto-client` / rust: real `createPayKitClient({ accept: ["x402"] })` + channel open (not a wire stub)

2. **`ts-x402-upto`** in `implementations.ts`  
   - `intents: ["x402-upto"]`, `reportsAs: "typescript"`, opt-in via `X402_HARNESS_CLIENTS`

3. **CI** `harness.yml` job `ts-x402-upto` (mirrors `harness-kotlin-x402-upto`)  
   - `MPP_HARNESS_INTENTS: x402-upto`  
   - `MPP_HARNESS_SCENARIOS: x402-upto-basic,x402-upto-zero-actual`  
   - `X402_HARNESS_CLIENTS: ts-x402-upto` / `X402_HARNESS_SERVERS: rust-x402-upto`  
   - payment-channels localnet build + `@solana/pay-kit` build  
   - `upto-client.ts` excluded from base harness typecheck (needs pay-kit dist; typechecked in this job)

### Not in scope

- Ruby `#192` (Efe)  
- PHP/Lua server ports  
- New scenarios beyond the two above  