### PR TITLE
php(x402): start upto payment-channel foundation (types, verify, challenge)

### DIFF
--- a/php/src/PayCore/PaymentChannels.php
+++ b/php/src/PayCore/PaymentChannels.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\PayCore;
+
+use InvalidArgumentException;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Programs\AssociatedTokenProgram;
+use SolanaPhpSdk\Programs\SystemProgram;
+use SolanaPhpSdk\Programs\TokenProgram;
+
+/**
+ * Hand-written on-chain glue for the payment-channels program.
+ *
+ * Mirrors Go `paycore/paymentchannels` and Python `_paycore.paymentchannels`:
+ * production program id, channel / event-authority PDA derivation, ATA
+ * derivation, and the 50-byte voucher preimage. Instruction builders that
+ * require the full Codama-generated client land in follow-up commits; this
+ * module is the pure shared foundation for x402 `upto` verify + settle.
+ *
+ * Layout and seeds MUST stay byte-identical across language SDKs so the
+ * on-chain program accepts them.
+ */
+final class PaymentChannels
+{
+    /** Canonical payment-channels program id deployed to the network. */
+    public const PROGRAM_ID = 'CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX';
+
+    /** Channel-open freshness window (slots). */
+    public const OPEN_SLOT_WINDOW = 1500;
+
+    /** Single-byte open instruction discriminator (not 8-byte Anchor). */
+    public const OPEN_INSTRUCTION_DISCRIMINATOR = 1;
+
+    /** Constant 2-byte magic prefixed to every signed voucher payload. */
+    public const VOUCHER_MAGIC = "\x56\x01";
+
+    public const RENT_SYSVAR_ID = 'SysvarRent111111111111111111111111111111111';
+    public const ED25519_PROGRAM_ID = 'Ed25519SigVerify111111111111111111111111111';
+    public const SYSVAR_INSTRUCTIONS = 'Sysvar1nstructions1111111111111111111111111';
+
+    private const CHANNEL_SEED = 'channel';
+    private const EVENT_AUTHORITY_SEED = 'event_authority';
+
+    /**
+     * 50-byte voucher preimage signed by the authorized signer.
+     *
+     * Layout: magic (2) || channelId (32) || cumulativeAmount LE u64 (8)
+     * || expiresAt LE i64 (8). Matches generated VoucherArgs Borsh layout.
+     *
+     * @throws InvalidArgumentException when channel id is not 32 bytes
+     */
+    public static function voucherMessageBytes(PublicKey $channelId, int $cumulative, int $expiresAt): string
+    {
+        $id = $channelId->toBytes();
+        if (strlen($id) !== 32) {
+            throw new InvalidArgumentException(
+                'channel id must be exactly 32 bytes, got ' . strlen($id),
+            );
+        }
+        if ($cumulative < 0 || $cumulative > 0xFFFFFFFFFFFFFFFF) {
+            throw new InvalidArgumentException('cumulative does not fit in u64');
+        }
+
+        return self::VOUCHER_MAGIC
+            . $id
+            . self::packU64Le($cumulative)
+            . self::packI64Le($expiresAt);
+    }
+
+    /**
+     * Derive the channel PDA.
+     *
+     * Seeds: ["channel", payer, payee, mint, authorizedSigner, salt u64 LE, openSlot u64 LE].
+     *
+     * @return array{0: PublicKey, 1: int} [address, bump]
+     */
+    public static function findChannelPda(
+        PublicKey $payer,
+        PublicKey $payee,
+        PublicKey $mint,
+        PublicKey $authorizedSigner,
+        int $salt,
+        int $openSlot,
+        ?PublicKey $programId = null,
+    ): array {
+        self::assertU64($salt, 'salt');
+        self::assertU64($openSlot, 'openSlot');
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+
+        return PublicKey::findProgramAddress(
+            [
+                self::CHANNEL_SEED,
+                $payer->toBytes(),
+                $payee->toBytes(),
+                $mint->toBytes(),
+                $authorizedSigner->toBytes(),
+                self::packU64Le($salt),
+                self::packU64Le($openSlot),
+            ],
+            $program,
+        );
+    }
+
+    /**
+     * Derive the event-authority PDA. Seeds: ["event_authority"].
+     *
+     * @return array{0: PublicKey, 1: int}
+     */
+    public static function findEventAuthorityPda(?PublicKey $programId = null): array
+    {
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+
+        return PublicKey::findProgramAddress([self::EVENT_AUTHORITY_SEED], $program);
+    }
+
+    /**
+     * Derive the associated token account for (owner, mint, token program).
+     *
+     * @return array{0: PublicKey, 1: int}
+     */
+    public static function findAssociatedTokenAddress(
+        PublicKey $owner,
+        PublicKey $mint,
+        PublicKey $tokenProgram,
+    ): array {
+        return AssociatedTokenProgram::findAssociatedTokenAddress($owner, $mint, $tokenProgram);
+    }
+
+    /**
+     * Encode open-instruction data (discriminator + openArgs without recipients).
+     *
+     * Layout: [u8 disc=1][u64 salt][u64 deposit][u32 grace][u64 openSlot][vec recipients…].
+     * Empty recipients is a trailing u32 length of 0.
+     */
+    public static function encodeOpenInstructionData(
+        int $salt,
+        int $deposit,
+        int $gracePeriod,
+        int $openSlot,
+    ): string {
+        self::assertU64($salt, 'salt');
+        self::assertU64($deposit, 'deposit');
+        self::assertU32($gracePeriod, 'gracePeriod');
+        self::assertU64($openSlot, 'openSlot');
+
+        return chr(self::OPEN_INSTRUCTION_DISCRIMINATOR)
+            . self::packU64Le($salt)
+            . self::packU64Le($deposit)
+            . self::packU32Le($gracePeriod)
+            . self::packU64Le($openSlot)
+            . self::packU32Le(0); // recipients len = 0
+    }
+
+    /**
+     * Decode open instruction data after the discriminator byte.
+     *
+     * @return array{salt: int, deposit: int, gracePeriod: int, openSlot: int}
+     */
+    public static function decodeOpenArgs(string $data): array
+    {
+        // disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) = 29 minimum
+        if (strlen($data) < 1 + 8 + 8 + 4 + 8) {
+            throw new InvalidArgumentException(
+                'open instruction data too short (' . strlen($data) . ' bytes)',
+            );
+        }
+        if (ord($data[0]) !== self::OPEN_INSTRUCTION_DISCRIMINATOR) {
+            throw new InvalidArgumentException('open transaction is not a channel-open instruction');
+        }
+
+        return [
+            'salt'        => self::unpackU64Le(substr($data, 1, 8)),
+            'deposit'     => self::unpackU64Le(substr($data, 9, 8)),
+            'gracePeriod' => self::unpackU32Le(substr($data, 17, 4)),
+            'openSlot'    => self::unpackU64Le(substr($data, 21, 8)),
+        ];
+    }
+
+    public static function systemProgramId(): string
+    {
+        return SystemProgram::PROGRAM_ID;
+    }
+
+    public static function tokenProgramId(): string
+    {
+        return TokenProgram::PROGRAM_ID;
+    }
+
+    public static function associatedTokenProgramId(): string
+    {
+        return AssociatedTokenProgram::PROGRAM_ID;
+    }
+
+    private static function packU64Le(int $value): string
+    {
+        // Portable little-endian: works for unsigned values and for two's
+        // complement negative i64s (arithmetic >> on signed PHP ints).
+        $out = '';
+        for ($i = 0; $i < 8; $i++) {
+            $out .= chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    private static function packI64Le(int $value): string
+    {
+        return self::packU64Le($value);
+    }
+
+    private static function packU32Le(int $value): string
+    {
+        $out = '';
+        for ($i = 0; $i < 4; $i++) {
+            $out .= chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    private static function unpackU64Le(string $bytes): int
+    {
+        $value = 0;
+        for ($i = 0; $i < 8; $i++) {
+            $value |= ord($bytes[$i]) << ($i * 8);
+        }
+
+        return $value;
+    }
+
+    private static function unpackU32Le(string $bytes): int
+    {
+        $value = 0;
+        for ($i = 0; $i < 4; $i++) {
+            $value |= ord($bytes[$i]) << ($i * 8);
+        }
+
+        return $value;
+    }
+
+    private static function assertU64(int $value, string $label): void
+    {
+        if ($value < 0 || $value > 0xFFFFFFFFFFFFFFFF) {
+            throw new InvalidArgumentException("{$label} {$value} does not fit in u64");
+        }
+    }
+
+    private static function assertU32(int $value, string $label): void
+    {
+        if ($value < 0 || $value > 0xFFFFFFFF) {
+            throw new InvalidArgumentException("{$label} {$value} does not fit in u32");
+        }
+    }
+}

--- a/php/src/PayCore/PaymentChannels.php
+++ b/php/src/PayCore/PaymentChannels.php
@@ -154,20 +154,39 @@ final class PaymentChannels
     }
 
     /**
-     * Decode open instruction data after the discriminator byte.
+     * Decode open instruction data (discriminator + openArgs).
+     *
+     * Pins the empty-recipients layout used by SVM `upto`:
+     *   disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) + recipients_len(4)=0
+     * Total length must be exactly 33. Non-empty recipients or trailing bytes
+     * are rejected so the open args stay byte-for-byte with the challenge path.
      *
      * @return array{salt: int, deposit: int, gracePeriod: int, openSlot: int}
      */
     public static function decodeOpenArgs(string $data): array
     {
-        // disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) = 29 minimum
-        if (strlen($data) < 1 + 8 + 8 + 4 + 8) {
+        // disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) + vec_len(4) = 33
+        $expectedLen = 1 + 8 + 8 + 4 + 8 + 4;
+        if (strlen($data) < $expectedLen) {
             throw new InvalidArgumentException(
                 'open instruction data too short (' . strlen($data) . ' bytes)',
             );
         }
         if (ord($data[0]) !== self::OPEN_INSTRUCTION_DISCRIMINATOR) {
             throw new InvalidArgumentException('open transaction is not a channel-open instruction');
+        }
+
+        $recipientsLen = self::unpackU32Le(substr($data, 29, 4));
+        if ($recipientsLen !== 0) {
+            throw new InvalidArgumentException(
+                "open instruction recipients length must be 0 for upto, got {$recipientsLen}",
+            );
+        }
+        if (strlen($data) !== $expectedLen) {
+            throw new InvalidArgumentException(
+                'open instruction data has trailing bytes after empty recipients '
+                . '(' . strlen($data) . ' bytes, expected ' . $expectedLen . ')',
+            );
         }
 
         return [

--- a/php/src/Protocols/X402/Upto/Engine.php
+++ b/php/src/Protocols/X402/Upto/Engine.php
@@ -162,15 +162,20 @@ final class Engine
 
         Verify::verifyUptoPayload($payload, $requirements, $receiverAuthorizer, time());
 
+        // payment-channel profile requires a pull-style open transaction; push
+        // (signature-only) is not accepted by this engine.
         $openTx = (string) ($payload['openTransaction'] ?? '');
-        if ($openTx !== '') {
-            $this->validateOpenTransaction(
-                $openTx,
-                $payload,
-                $requirements,
-                $receiverAuthorizer,
+        if ($openTx === '') {
+            throw new InvalidProofException(
+                'upto payment-channel payload missing openTransaction',
             );
         }
+        $this->validateOpenTransaction(
+            $openTx,
+            $payload,
+            $requirements,
+            $receiverAuthorizer,
+        );
 
         $maxBaseUnits = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
 
@@ -216,6 +221,13 @@ final class Engine
         }
 
         $message = $tx->message;
+        // Match SolanaChargeTransactionVerifier: open must not pull accounts
+        // from address lookup tables (static keys only).
+        if (($message->addressTableLookups ?? []) !== []) {
+            throw new InvalidProofException(
+                'v0 address lookup tables are not supported on upto open transactions',
+            );
+        }
         $accountKeys = array_map(
             static fn (PublicKey $k): string => (string) $k,
             $message->staticAccountKeys,

--- a/php/src/Protocols/X402/Upto/Engine.php
+++ b/php/src/Protocols/X402/Upto/Engine.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Protocols\X402\Upto;
+
+use PayKit\Config;
+use PayKit\Exception\InvalidProofException;
+use PayKit\Gate;
+use PayKit\PayCore\PaymentChannels;
+use PayKit\PayCore\Solana\Mints;
+use Psr\Http\Message\ServerRequestInterface;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Rpc\RpcClient;
+use SolanaPhpSdk\Transaction\VersionedTransaction;
+use Throwable;
+
+/**
+ * x402 `upto` (Solana) server engine — payment-channel profile.
+ *
+ * Two-phase flow (mirrors Rust/Go/Python):
+ *   1. {@see challengeHeaders}/{@see acceptsEntry} — advertise the ceiling.
+ *   2. {@see verifyOpenPayload} — validate payload + open instruction shape.
+ *   3. settle_and_seal broadcast — follow-up once instruction builders land.
+ *
+ * This first slice ships challenge generation and pure open-path validation.
+ * Full cosign + settle_and_seal broadcast lands next (Ruby #192 / Python
+ * settle path as reference).
+ */
+final class Engine
+{
+    private const PAYMENT_REQUIRED_HEADER = 'payment-required';
+    private const PAYMENT_SIGNATURE_HEADER = 'payment-signature';
+    private const PAYMENT_LEGACY_HEADER = 'x-payment';
+
+    /** @var \Closure():?array{blockhash: string, slot?: string}|null */
+    private $chainHintsProvider = null;
+
+    /**
+     * @param ?\Closure():?array{blockhash: string, slot?: string} $chainHintsProvider
+     *        Test hook for recentBlockhash / recentSlot without RPC.
+     */
+    public function __construct(
+        private readonly Config $config,
+        ?\Closure $chainHintsProvider = null,
+    ) {
+        $this->chainHintsProvider = $chainHintsProvider;
+    }
+
+    /**
+     * Single accepts[] entry for an `upto` challenge.
+     *
+     * @return array<string,mixed>
+     */
+    public function acceptsEntry(Gate $gate, ServerRequestInterface $request): array
+    {
+        $coin = $gate->amount->primaryCoin()?->value ?? $this->config->stablecoins[0]->value;
+        $asset = Mints::resolve($coin, $this->config->network->mintsLabel()) ?? $coin;
+        $tokenProgram = Mints::tokenProgramFor($coin, $this->config->network->mintsLabel());
+        $payTo = $gate->payTo ?? $this->config->effectiveRecipient();
+        // Match Exact adapter: Price is human units × 1e6 → base units string.
+        $amount = (string) $gate->total()->amount->multipliedBy(1_000_000)->toInt();
+        $signer = $this->config->effectiveX402Signer();
+        $feePayer = $signer?->pubkey() ?? '';
+        // Operator holds both seats: fee payer (lifecycle) + receiver authorizer
+        // (voucher signer). Matches createPayKit / Rust X402Upto.
+        $extra = [
+            'decimals'           => 6,
+            'tokenProgram'       => $tokenProgram,
+            'feePayer'           => $feePayer,
+            'receiverAuthorizer' => $feePayer,
+            'withdrawDelay'      => Types::DEFAULT_WITHDRAW_DELAY_SECONDS,
+        ];
+        $hints = $this->fetchChainHints();
+        if ($hints !== null) {
+            if (($hints['blockhash'] ?? '') !== '') {
+                $extra['recentBlockhash'] = $hints['blockhash'];
+            }
+            if (isset($hints['slot']) && $hints['slot'] !== '') {
+                $extra['recentSlot'] = (string) $hints['slot'];
+            }
+        }
+
+        return [
+            'protocol'          => 'x402',
+            'scheme'            => Types::SCHEME,
+            'network'           => $this->caip2(),
+            'asset'             => $asset,
+            'amount'            => $amount,
+            'maxAmountRequired' => $amount,
+            'payTo'             => $payTo,
+            'maxTimeoutSeconds' => Types::DEFAULT_MAX_TIMEOUT_SECONDS,
+            'extra'             => $extra,
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function challengeHeaders(Gate $gate, ServerRequestInterface $request): array
+    {
+        $challenge = [
+            'x402Version' => Types::X402_VERSION,
+            'resource'    => ['type' => 'http', 'url' => $request->getUri()->getPath()],
+            'accepts'     => [$this->acceptsEntry($gate, $request)],
+        ];
+        $encoded = base64_encode(
+            json_encode($challenge, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        );
+
+        return [self::PAYMENT_REQUIRED_HEADER => $encoded];
+    }
+
+    /**
+     * Decode and structurally validate an upto PAYMENT-SIGNATURE open.
+     *
+     * Does not broadcast yet — returns the verified payload + requirement
+     * binding for the settle phase. Callers that need on-chain open should
+     * use a follow-up that cosigns + sends (payment-channel builders).
+     *
+     * @param array<string,mixed> $requirements Route-pinned accepts[] entry
+     *
+     * @return array{
+     *   payload: array<string,mixed>,
+     *   requirements: array<string,mixed>,
+     *   maxBaseUnits: int,
+     *   payer: string,
+     *   channelId: string
+     * }
+     *
+     * @throws InvalidProofException
+     */
+    public function verifyOpenPayload(ServerRequestInterface $request, array $requirements): array
+    {
+        $header = $this->paymentHeader($request);
+        if ($header === null) {
+            throw new InvalidProofException('missing_x402_payment_header');
+        }
+
+        $raw = base64_decode($header, true);
+        if ($raw === false || $raw === '') {
+            throw new InvalidProofException('invalid_x402_payment_header');
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable $e) {
+            throw new InvalidProofException('invalid_x402_payment_header', 0, $e);
+        }
+        if (!is_array($decoded) || !isset($decoded['payload']) || !is_array($decoded['payload'])) {
+            throw new InvalidProofException('invalid_x402_payment_header');
+        }
+
+        /** @var array<string,mixed> $payload */
+        $payload = $decoded['payload'];
+        $extra = is_array($requirements['extra'] ?? null) ? $requirements['extra'] : [];
+        $receiverAuthorizer = (string) ($extra['receiverAuthorizer'] ?? '');
+        if ($receiverAuthorizer === '') {
+            throw new InvalidProofException('upto requirement missing receiverAuthorizer');
+        }
+
+        Verify::verifyUptoPayload($payload, $requirements, $receiverAuthorizer, time());
+
+        $openTx = (string) ($payload['openTransaction'] ?? '');
+        if ($openTx !== '') {
+            $this->validateOpenTransaction(
+                $openTx,
+                $payload,
+                $requirements,
+                $receiverAuthorizer,
+            );
+        }
+
+        $maxBaseUnits = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
+
+        return [
+            'payload'       => $payload,
+            'requirements'  => $requirements,
+            'maxBaseUnits'  => $maxBaseUnits,
+            'payer'         => (string) ($payload['from'] ?? ''),
+            'channelId'     => (string) ($payload['channelId'] ?? ''),
+        ];
+    }
+
+    /**
+     * Enforce actual ≤ max. Full settle_and_seal broadcast is the next slice.
+     *
+     * @throws InvalidProofException
+     */
+    public function assertSettlementAmount(int $actualBaseUnits, int $maxBaseUnits): void
+    {
+        Verify::assertSettlementWithinCeiling($actualBaseUnits, $maxBaseUnits);
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @param array<string,mixed> $requirements
+     *
+     * @throws InvalidProofException
+     */
+    private function validateOpenTransaction(
+        string $transactionBase64,
+        array $payload,
+        array $requirements,
+        string $receiverAuthorizer,
+    ): void {
+        $raw = base64_decode($transactionBase64, true);
+        if ($raw === false || $raw === '') {
+            throw new InvalidProofException('invalid open transaction base64');
+        }
+        try {
+            $tx = VersionedTransaction::deserialize($raw);
+        } catch (Throwable $e) {
+            throw new InvalidProofException('invalid open transaction parse', 0, $e);
+        }
+
+        $message = $tx->message;
+        $accountKeys = array_map(
+            static fn (PublicKey $k): string => (string) $k,
+            $message->staticAccountKeys,
+        );
+        $instructions = [];
+        foreach ($message->compiledInstructions as $ix) {
+            $instructions[] = [
+                'programIdIndex' => (int) $ix->programIdIndex,
+                'accounts'       => array_map('intval', $ix->accountKeyIndexes),
+                'data'           => is_string($ix->data) ? $ix->data : (string) $ix->data,
+            ];
+        }
+
+        $extra = is_array($requirements['extra'] ?? null) ? $requirements['extra'] : [];
+        $feePayer = new PublicKey((string) ($extra['feePayer'] ?? $receiverAuthorizer));
+        $receiver = new PublicKey($receiverAuthorizer);
+        $payer = new PublicKey((string) ($payload['from'] ?? ''));
+        // Channel payee is the fee payer (zero-share lifecycle seat) for upto.
+        $payee = $feePayer;
+        $mint = new PublicKey((string) ($requirements['asset'] ?? ''));
+        $tokenProgram = new PublicKey(
+            (string) ($extra['tokenProgram'] ?? PaymentChannels::tokenProgramId()),
+        );
+        $channelId = new PublicKey((string) ($payload['channelId'] ?? ''));
+        $maxAmount = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
+        $withdrawDelay = (int) ($extra['withdrawDelay'] ?? Types::DEFAULT_WITHDRAW_DELAY_SECONDS);
+        $recentSlot = isset($extra['recentSlot']) ? (int) $extra['recentSlot'] : null;
+
+        Verify::validateUptoOpenInstruction(
+            $accountKeys,
+            $instructions,
+            new PublicKey(PaymentChannels::PROGRAM_ID),
+            $feePayer,
+            $receiver,
+            $payer,
+            $payee,
+            $mint,
+            $tokenProgram,
+            $channelId,
+            $maxAmount,
+            $withdrawDelay,
+            (string) ($payload['nonce'] ?? ''),
+            (string) ($payload['openSlot'] ?? ''),
+            $recentSlot,
+        );
+    }
+
+    private function paymentHeader(ServerRequestInterface $request): ?string
+    {
+        $headers = $request->getHeaders();
+        foreach ([self::PAYMENT_SIGNATURE_HEADER, self::PAYMENT_LEGACY_HEADER] as $name) {
+            foreach ($headers as $key => $values) {
+                if (strtolower((string) $key) === $name && isset($values[0]) && $values[0] !== '') {
+                    return $values[0];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return ?array{blockhash: string, slot?: string}
+     */
+    private function fetchChainHints(): ?array
+    {
+        if ($this->chainHintsProvider !== null) {
+            try {
+                $value = ($this->chainHintsProvider)();
+
+                return is_array($value) ? $value : null;
+            } catch (Throwable) {
+                return null;
+            }
+        }
+        if ($this->config->rpcUrl === '') {
+            return null;
+        }
+        try {
+            $rpc = new RpcClient($this->config->rpcUrl);
+            $result = $rpc->getLatestBlockhash();
+            $blockhash = is_array($result) && isset($result['blockhash'])
+                ? (string) $result['blockhash']
+                : '';
+            if ($blockhash === '') {
+                return null;
+            }
+            $hints = ['blockhash' => $blockhash];
+            // Optional: getSlot when the client is available.
+            if (method_exists($rpc, 'getSlot')) {
+                try {
+                    $slot = $rpc->getSlot();
+                    if (is_int($slot) || (is_string($slot) && $slot !== '')) {
+                        $hints['slot'] = (string) $slot;
+                    }
+                } catch (Throwable) {
+                    // recentSlot optional on the challenge
+                }
+            }
+
+            return $hints;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function caip2(): string
+    {
+        return $this->config->network->caip2();
+    }
+}

--- a/php/src/Protocols/X402/Upto/Types.php
+++ b/php/src/Protocols/X402/Upto/Types.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Protocols\X402\Upto;
+
+/**
+ * x402 `upto` scheme constants and wire-shape documentation.
+ *
+ * Field names and amount/timestamp encodings mirror the Rust spine
+ * (`protocol/schemes/upto/types.rs`), Go (`go/protocols/x402/upto.go`), and
+ * Python (`protocols/x402/upto/types.py`) field-for-field: camelCase JSON
+ * keys, amounts as base-10 u64 strings, timestamps as Unix seconds.
+ *
+ * PHP uses associative arrays at the wire boundary (same as Exact); this
+ * class only holds constants so every language SDK shares identical strings.
+ */
+final class Types
+{
+    /** The x402 scheme identifier for usage-based `upto` authorizations. */
+    public const SCHEME = 'upto';
+
+    /** Default forced-close delay, in seconds, for SVM payment channels. */
+    public const DEFAULT_WITHDRAW_DELAY_SECONDS = 900;
+
+    /**
+     * Settlement error when the metered actual exceeds the signed ceiling.
+     * Identical string to Rust/Go/Python for cross-language error parity.
+     */
+    public const ERROR_SETTLEMENT_EXCEEDS_AMOUNT = 'invalid_upto_svm_payload_settlement_exceeds_amount';
+
+    /** x402 protocol version this server emits for upto challenges. */
+    public const X402_VERSION = 2;
+
+    /** Default authorization window (seconds). */
+    public const DEFAULT_MAX_TIMEOUT_SECONDS = 300;
+
+    private function __construct()
+    {
+    }
+}

--- a/php/src/Protocols/X402/Upto/Verify.php
+++ b/php/src/Protocols/X402/Upto/Verify.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Protocols\X402\Upto;
+
+use PayKit\Exception\InvalidProofException;
+use PayKit\PayCore\PaymentChannels;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Programs\AssociatedTokenProgram;
+use SolanaPhpSdk\Programs\SystemProgram;
+
+/**
+ * Pure verification for the x402 `upto` payment-channel profile.
+ *
+ * No I/O: validates already-decoded structures and raises
+ * {@see InvalidProofException} on rejection. Ordered checks mirror Rust/Go/
+ * Python (`VerifyUptoPayload`, `validateUptoOpenInstruction`).
+ */
+final class Verify
+{
+    /**
+     * Parse a base-10 u64 amount string.
+     *
+     * @throws InvalidProofException
+     */
+    public static function parseBaseUnits(string $value, string $label): int
+    {
+        if ($value === '' || !preg_match('/^[0-9]+$/', $value)) {
+            throw new InvalidProofException("invalid upto {$label} " . var_export($value, true));
+        }
+        // Reject values that overflow PHP platform int or u64.
+        if (strlen($value) > 20 || (strlen($value) === 20 && $value > '18446744073709551615')) {
+            throw new InvalidProofException("upto {$label} {$value} does not fit in u64");
+        }
+        $parsed = (int) $value;
+        if ($parsed < 0) {
+            throw new InvalidProofException("upto {$label} {$parsed} does not fit in u64");
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Validate the client payload against the route-pinned requirement.
+     *
+     * @param array<string,mixed> $payload
+     * @param array<string,mixed> $requirements accepts[] entry
+     *
+     * @throws InvalidProofException
+     */
+    public static function verifyUptoPayload(
+        array $payload,
+        array $requirements,
+        string $receiverAuthorizer,
+        int $now,
+    ): void {
+        $maxAmount = self::parseBaseUnits((string) ($requirements['amount'] ?? ''), 'amount');
+        $signedMax = self::parseBaseUnits((string) ($payload['maxAmount'] ?? ''), 'maxAmount');
+        if ($signedMax !== $maxAmount) {
+            throw new InvalidProofException(
+                "amount mismatch: expected {$maxAmount}, got {$signedMax}",
+            );
+        }
+
+        $deposit = self::parseBaseUnits((string) ($payload['deposit'] ?? ''), 'deposit');
+        if ($deposit !== $maxAmount) {
+            throw new InvalidProofException(
+                "channel deposit {$deposit} must equal the authorized maximum {$maxAmount}",
+            );
+        }
+
+        $validAfter = (int) ($payload['validAfter'] ?? 0);
+        $expiresAt = (int) ($payload['expiresAt'] ?? 0);
+        if ($now < $validAfter) {
+            throw new InvalidProofException(
+                "authorization not yet active (validAfter {$validAfter} > now {$now})",
+            );
+        }
+        if ($expiresAt === 0 || $now >= $expiresAt) {
+            throw new InvalidProofException(
+                "authorization expired (expiresAt {$expiresAt} < now {$now})",
+            );
+        }
+
+        if (($payload['authorizedSigner'] ?? null) !== $receiverAuthorizer) {
+            throw new InvalidProofException(
+                'voucher authorized_signer must be the advertised receiver authorizer',
+            );
+        }
+    }
+
+    /**
+     * Enforce actual <= max at settlement.
+     *
+     * @throws InvalidProofException
+     */
+    public static function assertSettlementWithinCeiling(int $actual, int $maxAmount): void
+    {
+        if ($actual > $maxAmount) {
+            throw new InvalidProofException(Types::ERROR_SETTLEMENT_EXCEEDS_AMOUNT);
+        }
+    }
+
+    /**
+     * Validate the client-built channel-open instruction byte-for-byte.
+     *
+     * The open transaction must contain exactly one instruction targeting the
+     * payment-channels program with the open discriminator and the 14 accounts
+     * in the fixed program order.
+     *
+     * @param list<string>                                                                 $accountKeys base58 pubkeys
+     * @param list<array{programIdIndex: int, accounts: list<int>, data: string}>            $instructions
+     *
+     * @throws InvalidProofException
+     */
+    public static function validateUptoOpenInstruction(
+        array $accountKeys,
+        array $instructions,
+        PublicKey $programId,
+        PublicKey $feePayer,
+        PublicKey $receiverAuthorizer,
+        PublicKey $payer,
+        PublicKey $payee,
+        PublicKey $mint,
+        PublicKey $tokenProgram,
+        PublicKey $channelId,
+        int $maxAmount,
+        int $withdrawDelay,
+        string $payloadNonce,
+        string $payloadOpenSlot,
+        ?int $recentSlot,
+    ): void {
+        if (count($instructions) !== 1) {
+            throw new InvalidProofException(
+                'open transaction must contain exactly one instruction, found ' . count($instructions),
+            );
+        }
+        $ix = $instructions[0];
+        $programIndex = (int) $ix['programIdIndex'];
+        if ($programIndex >= count($accountKeys)) {
+            throw new InvalidProofException('open instruction program id out of range');
+        }
+        if ($accountKeys[$programIndex] !== (string) $programId) {
+            throw new InvalidProofException('open transaction targets an unexpected program');
+        }
+        $data = $ix['data'];
+        if ($data === '' || ord($data[0]) !== PaymentChannels::OPEN_INSTRUCTION_DISCRIMINATOR) {
+            throw new InvalidProofException('open transaction is not a channel-open instruction');
+        }
+
+        $indices = $ix['accounts'];
+
+        $accountAt = static function (int $pos, string $label) use ($indices, $accountKeys): string {
+            if ($pos >= count($indices) || $indices[$pos] >= count($accountKeys)) {
+                throw new InvalidProofException(
+                    "open transaction {$label} mismatch: expected account at slot {$pos}, got <none>",
+                );
+            }
+
+            return $accountKeys[$indices[$pos]];
+        };
+
+        $expect = static function (int $pos, PublicKey $want, string $label) use ($accountAt): void {
+            $got = $accountAt($pos, $label);
+            if ($got !== (string) $want) {
+                throw new InvalidProofException(
+                    "open transaction {$label} mismatch: expected {$want}, got {$got}",
+                );
+            }
+        };
+
+        [$payerToken] = PaymentChannels::findAssociatedTokenAddress($payer, $mint, $tokenProgram);
+        [$channelToken] = PaymentChannels::findAssociatedTokenAddress($channelId, $mint, $tokenProgram);
+        [$eventAuthority] = PaymentChannels::findEventAuthorityPda($programId);
+
+        $expect(0, $payer, 'payer');
+        $expect(1, $feePayer, 'rent_payer');
+        $expect(2, $payee, 'payee');
+        $expect(3, $mint, 'mint');
+        $expect(4, $receiverAuthorizer, 'authorized_signer');
+        $expect(5, $channelId, 'channel');
+        $expect(6, $payerToken, 'payer_token_account');
+        $expect(7, $channelToken, 'channel_token_account');
+        $expect(8, $tokenProgram, 'token_program');
+        $expect(9, new PublicKey(SystemProgram::PROGRAM_ID), 'system_program');
+        $expect(10, new PublicKey(PaymentChannels::RENT_SYSVAR_ID), 'rent_sysvar');
+        $expect(11, new PublicKey(AssociatedTokenProgram::PROGRAM_ID), 'associated_token_program');
+        $expect(12, $eventAuthority, 'event_authority');
+        $expect(13, $programId, 'self_program');
+
+        try {
+            $args = PaymentChannels::decodeOpenArgs($data);
+        } catch (\InvalidArgumentException $e) {
+            throw new InvalidProofException($e->getMessage(), 0, $e);
+        }
+
+        if ($payloadNonce !== (string) $args['salt']) {
+            throw new InvalidProofException(
+                "open salt {$args['salt']} does not match payload nonce " . var_export($payloadNonce, true),
+            );
+        }
+        if ($payloadOpenSlot !== (string) $args['openSlot']) {
+            throw new InvalidProofException(
+                "open slot {$args['openSlot']} does not match payload openSlot " . var_export($payloadOpenSlot, true),
+            );
+        }
+        if ($args['gracePeriod'] !== $withdrawDelay) {
+            throw new InvalidProofException(
+                "open withdraw delay {$args['gracePeriod']} must equal the advertised withdrawDelay {$withdrawDelay}",
+            );
+        }
+
+        [$derivedChannel] = PaymentChannels::findChannelPda(
+            $payer,
+            $payee,
+            $mint,
+            $receiverAuthorizer,
+            $args['salt'],
+            $args['openSlot'],
+            $programId,
+        );
+        if (!$derivedChannel->equals($channelId)) {
+            throw new InvalidProofException(
+                "open channel PDA {$channelId} != derived {$derivedChannel}",
+            );
+        }
+        if ($args['deposit'] !== $maxAmount) {
+            throw new InvalidProofException(
+                "open deposit {$args['deposit']} must equal the authorized maximum {$maxAmount}",
+            );
+        }
+        if ($recentSlot !== null) {
+            if ($args['openSlot'] > $recentSlot) {
+                throw new InvalidProofException(
+                    "open openSlot {$args['openSlot']} is ahead of the challenged recentSlot {$recentSlot}",
+                );
+            }
+            if ($recentSlot - $args['openSlot'] > PaymentChannels::OPEN_SLOT_WINDOW) {
+                throw new InvalidProofException(
+                    "open openSlot {$args['openSlot']} is outside the "
+                    . PaymentChannels::OPEN_SLOT_WINDOW
+                    . "-slot freshness window of the challenged recentSlot {$recentSlot}",
+                );
+            }
+        }
+    }
+}

--- a/php/src/Protocols/X402/Upto/Verify.php
+++ b/php/src/Protocols/X402/Upto/Verify.php
@@ -19,8 +19,15 @@ use SolanaPhpSdk\Programs\SystemProgram;
  */
 final class Verify
 {
+    /** Unsigned 64-bit maximum as a decimal string. */
+    private const U64_MAX = '18446744073709551615';
+
     /**
-     * Parse a base-10 u64 amount string.
+     * Parse a base-10 u64 amount string into a PHP int.
+     *
+     * Rejects non-digit input, values above u64 max, and values above
+     * {@see PHP_INT_MAX} so the cast cannot saturate/truncate (values in
+     * (PHP_INT_MAX, u64_max] would otherwise lose their wire value).
      *
      * @throws InvalidProofException
      */
@@ -29,16 +36,76 @@ final class Verify
         if ($value === '' || !preg_match('/^[0-9]+$/', $value)) {
             throw new InvalidProofException("invalid upto {$label} " . var_export($value, true));
         }
-        // Reject values that overflow PHP platform int or u64.
-        if (strlen($value) > 20 || (strlen($value) === 20 && $value > '18446744073709551615')) {
+        // Strip leading zeros for length/lexicographic compare (keep "0").
+        $normalized = ltrim($value, '0');
+        if ($normalized === '') {
+            $normalized = '0';
+        }
+        if (self::decimalGreaterThan($normalized, self::U64_MAX)) {
             throw new InvalidProofException("upto {$label} {$value} does not fit in u64");
         }
-        $parsed = (int) $value;
-        if ($parsed < 0) {
-            throw new InvalidProofException("upto {$label} {$parsed} does not fit in u64");
+        $maxPlatform = (string) PHP_INT_MAX;
+        if (self::decimalGreaterThan($normalized, $maxPlatform)) {
+            throw new InvalidProofException(
+                "upto {$label} {$value} does not fit in platform int (PHP_INT_MAX)",
+            );
         }
 
-        return $parsed;
+        return (int) $normalized;
+    }
+
+    /**
+     * Parse a strict base-10 integer (optional leading `-`) into a PHP int.
+     *
+     * Used for authorization timestamps so `"123abc"` cannot silently become
+     * `123` via a cast. Rejects values outside [PHP_INT_MIN, PHP_INT_MAX].
+     *
+     * @param mixed $value
+     *
+     * @throws InvalidProofException
+     */
+    public static function parseStrictInt(mixed $value, string $label): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (!is_string($value) || $value === '' || !preg_match('/^-?[0-9]+$/', $value)) {
+            throw new InvalidProofException(
+                "invalid upto {$label} " . var_export($value, true),
+            );
+        }
+        // Exact platform min string (e.g. "-9223372036854775808") before
+        // magnitude checks so we do not reject PHP_INT_MIN as > PHP_INT_MAX.
+        if ($value === (string) PHP_INT_MIN) {
+            return PHP_INT_MIN;
+        }
+        $negative = $value[0] === '-';
+        $digits = $negative ? substr($value, 1) : $value;
+        $normalized = ltrim($digits, '0');
+        if ($normalized === '') {
+            return 0;
+        }
+        if (self::decimalGreaterThan($normalized, (string) PHP_INT_MAX)) {
+            throw new InvalidProofException(
+                "upto {$label} {$value} does not fit in platform int",
+            );
+        }
+
+        return $negative ? -((int) $normalized) : (int) $normalized;
+    }
+
+    /**
+     * Lexicographic compare of non-negative decimal digit strings (no leading zeros).
+     */
+    private static function decimalGreaterThan(string $a, string $b): bool
+    {
+        $la = strlen($a);
+        $lb = strlen($b);
+        if ($la !== $lb) {
+            return $la > $lb;
+        }
+
+        return $a > $b;
     }
 
     /**
@@ -70,8 +137,8 @@ final class Verify
             );
         }
 
-        $validAfter = (int) ($payload['validAfter'] ?? 0);
-        $expiresAt = (int) ($payload['expiresAt'] ?? 0);
+        $validAfter = self::parseStrictInt($payload['validAfter'] ?? 0, 'validAfter');
+        $expiresAt = self::parseStrictInt($payload['expiresAt'] ?? 0, 'expiresAt');
         if ($now < $validAfter) {
             throw new InvalidProofException(
                 "authorization not yet active (validAfter {$validAfter} > now {$now})",
@@ -150,6 +217,11 @@ final class Verify
         }
 
         $indices = $ix['accounts'];
+        if (count($indices) !== 14) {
+            throw new InvalidProofException(
+                'open instruction must reference exactly 14 accounts, found ' . count($indices),
+            );
+        }
 
         $accountAt = static function (int $pos, string $label) use ($indices, $accountKeys): string {
             if ($pos >= count($indices) || $indices[$pos] >= count($accountKeys)) {

--- a/php/tests/Protocols/X402/Upto/EngineTest.php
+++ b/php/tests/Protocols/X402/Upto/EngineTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402\Upto;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PayKit\Config;
+use PayKit\Gate;
+use PayKit\Operator;
+use PayKit\PayCore\Network;
+use PayKit\Price;
+use PayKit\Protocols\X402\Upto\Engine;
+use PayKit\Protocols\X402\Upto\Types;
+use PayKit\Signer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Challenge-shape coverage for the upto engine (no RPC / no on-chain).
+ */
+final class EngineTest extends TestCase
+{
+    public function testAcceptsEntryIsUptoSchemeWithOperatorSeats(): void
+    {
+        $engine = $this->engine();
+        $gate = new Gate(amount: Price::usd('0.10'));
+        $request = (new Psr17Factory())->createServerRequest('GET', '/usage');
+
+        $entry = $engine->acceptsEntry($gate, $request);
+
+        self::assertSame(Types::SCHEME, $entry['scheme']);
+        self::assertSame('x402', $entry['protocol']);
+        self::assertSame('100000', $entry['amount']);
+        self::assertArrayHasKey('extra', $entry);
+        $extra = $entry['extra'];
+        self::assertIsArray($extra);
+        self::assertSame($extra['feePayer'], $extra['receiverAuthorizer']);
+        self::assertNotSame('', $extra['feePayer']);
+        self::assertSame(Types::DEFAULT_WITHDRAW_DELAY_SECONDS, $extra['withdrawDelay']);
+        self::assertSame('hint-blockhash', $extra['recentBlockhash']);
+        self::assertSame('4242', $extra['recentSlot']);
+    }
+
+    public function testChallengeHeadersEmitPaymentRequiredBase64(): void
+    {
+        $engine = $this->engine();
+        $gate = new Gate(amount: Price::usd('0.10'));
+        $request = (new Psr17Factory())->createServerRequest('GET', '/usage');
+
+        $headers = $engine->challengeHeaders($gate, $request);
+        self::assertArrayHasKey('payment-required', $headers);
+        $raw = base64_decode($headers['payment-required'], true);
+        self::assertNotFalse($raw);
+        $body = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame(Types::X402_VERSION, $body['x402Version']);
+        self::assertSame(Types::SCHEME, $body['accepts'][0]['scheme']);
+        self::assertSame('/usage', $body['resource']['url']);
+    }
+
+    private function engine(): Engine
+    {
+        $signer = Signer::generate();
+        $config = new Config(
+            network: Network::SolanaDevnet,
+            operator: new Operator(
+                recipient: $signer->pubkey(),
+                signer: $signer,
+                feePayer: true,
+            ),
+            preflight: false,
+        );
+
+        return new Engine(
+            $config,
+            chainHintsProvider: static fn (): array => [
+                'blockhash' => 'hint-blockhash',
+                'slot'      => '4242',
+            ],
+        );
+    }
+}

--- a/php/tests/Protocols/X402/Upto/VerifyTest.php
+++ b/php/tests/Protocols/X402/Upto/VerifyTest.php
@@ -39,7 +39,78 @@ final class VerifyTest extends TestCase
         yield 'alpha' => ['abc'];
         yield 'negative' => ['-1'];
         yield 'decimal' => ['1.5'];
-        yield 'overflow' => [(string) (2 ** 64)];
+        // Explicit decimal: u64_max+1 (not (string)(2**64) which is scientific).
+        yield 'u64_overflow' => ['18446744073709551616'];
+        // Above PHP_INT_MAX on 64-bit (still within u64) must not saturate.
+        yield 'platform_overflow' => ['9223372036854775808'];
+    }
+
+    public function testParseStrictIntRejectsNonCanonical(): void
+    {
+        $this->expectException(InvalidProofException::class);
+        Verify::parseStrictInt('123abc', 'validAfter');
+    }
+
+    public function testParseStrictIntAcceptsIntAndDigitString(): void
+    {
+        self::assertSame(42, Verify::parseStrictInt(42, 'validAfter'));
+        self::assertSame(42, Verify::parseStrictInt('42', 'validAfter'));
+        self::assertSame(-5, Verify::parseStrictInt('-5', 'expiresAt'));
+    }
+
+    public function testDecodeOpenArgsRejectsTrailingBytes(): void
+    {
+        $data = PaymentChannels::encodeOpenInstructionData(7, self::MAX, 900, 4242);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('trailing bytes');
+        PaymentChannels::decodeOpenArgs($data . "\x00");
+    }
+
+    public function testDecodeOpenArgsRejectsNonEmptyRecipients(): void
+    {
+        // Build open data with recipients_len = 1 and no body → too short for
+        // entries, but decode rejects non-zero len before reading entries.
+        $base = PaymentChannels::encodeOpenInstructionData(7, self::MAX, 900, 4242);
+        // Last 4 bytes are recipients_len=0; rewrite to 1.
+        $data = substr($base, 0, 29) . "\x01\x00\x00\x00";
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('recipients length must be 0');
+        PaymentChannels::decodeOpenArgs($data);
+    }
+
+    public function testValidateOpenInstructionRequiresExactly14Accounts(): void
+    {
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('exactly 14 accounts');
+        $program = new PublicKey(PaymentChannels::PROGRAM_ID);
+        // 13 dummy static keys + program id at the end (programIdIndex = 13).
+        $keys = [];
+        for ($i = 1; $i <= 13; $i++) {
+            $keys[] = (string) new PublicKey(str_repeat(chr($i), 32));
+        }
+        $keys[] = (string) $program;
+        // Only 13 account metas — triggers the fixed-layout check.
+        Verify::validateUptoOpenInstruction(
+            $keys,
+            [[
+                'programIdIndex' => 13,
+                'accounts'       => range(0, 12),
+                'data'           => PaymentChannels::encodeOpenInstructionData(1, self::MAX, 900, 1),
+            ]],
+            $program,
+            new PublicKey($keys[1]),
+            new PublicKey($keys[4]),
+            new PublicKey($keys[0]),
+            new PublicKey($keys[2]),
+            new PublicKey($keys[3]),
+            new PublicKey($keys[8]),
+            new PublicKey($keys[5]),
+            self::MAX,
+            900,
+            '1',
+            '1',
+            null,
+        );
     }
 
     public function testVerifyUptoPayloadOk(): void

--- a/php/tests/Protocols/X402/Upto/VerifyTest.php
+++ b/php/tests/Protocols/X402/Upto/VerifyTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402\Upto;
+
+use PayKit\Exception\InvalidProofException;
+use PayKit\PayCore\PaymentChannels;
+use PayKit\Protocols\X402\Upto\Types;
+use PayKit\Protocols\X402\Upto\Verify;
+use PHPUnit\Framework\TestCase;
+use SolanaPhpSdk\Keypair\PublicKey;
+
+/**
+ * Offline pure-verifier coverage for x402 upto (payment-channel profile).
+ * Mirrors python/tests/test_pk_x402_upto_verifier.py payload checks.
+ */
+final class VerifyTest extends TestCase
+{
+    private const MAX = 100_000;
+    private const MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+    public function testParseBaseUnitsOk(): void
+    {
+        self::assertSame(100000, Verify::parseBaseUnits('100000', 'amount'));
+    }
+
+    /** @dataProvider badBaseUnits */
+    public function testParseBaseUnitsRejects(string $bad): void
+    {
+        $this->expectException(InvalidProofException::class);
+        Verify::parseBaseUnits($bad, 'amount');
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function badBaseUnits(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'alpha' => ['abc'];
+        yield 'negative' => ['-1'];
+        yield 'decimal' => ['1.5'];
+        yield 'overflow' => [(string) (2 ** 64)];
+    }
+
+    public function testVerifyUptoPayloadOk(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        Verify::verifyUptoPayload(
+            $this->payload($operator, $now),
+            $this->requirements($operator),
+            $operator,
+            $now,
+        );
+        $this->addToAssertionCount(1);
+    }
+
+    public function testVerifyUptoPayloadRejectsAmountMismatch(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['maxAmount'] = '1';
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('amount mismatch');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsDepositMismatch(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['deposit'] = '1';
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('channel deposit');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsExpired(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['expiresAt'] = $now - 1;
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('authorization expired');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsNotYetActive(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['validAfter'] = $now + 60;
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('not yet active');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsWrongAuthorizer(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['authorizedSigner'] = '11111111111111111111111111111112';
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('authorized_signer');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testAssertSettlementWithinCeiling(): void
+    {
+        Verify::assertSettlementWithinCeiling(50_000, self::MAX);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage(Types::ERROR_SETTLEMENT_EXCEEDS_AMOUNT);
+        Verify::assertSettlementWithinCeiling(self::MAX + 1, self::MAX);
+    }
+
+    public function testVoucherMessageBytesLayout(): void
+    {
+        $channel = new PublicKey(str_repeat("\x09", 32));
+        $got = PaymentChannels::voucherMessageBytes($channel, 42, 1234);
+        self::assertSame(50, strlen($got));
+        self::assertSame("\x56\x01", substr($got, 0, 2));
+        self::assertSame($channel->toBytes(), substr($got, 2, 32));
+        self::assertSame($this->leU64(42), substr($got, 34, 8));
+        self::assertSame($this->leI64(1234), substr($got, 42, 8));
+    }
+
+    public function testVoucherMessageBytesNegativeExpires(): void
+    {
+        $channel = new PublicKey(str_repeat("\x03", 32));
+        $got = PaymentChannels::voucherMessageBytes($channel, 7, -5);
+        self::assertSame(50, strlen($got));
+        self::assertSame($this->leI64(-5), substr($got, 42, 8));
+    }
+
+    public function testChannelPdaDeterministic(): void
+    {
+        $payer = new PublicKey(str_repeat("\x01", 32));
+        $payee = new PublicKey(str_repeat("\x02", 32));
+        $mint = new PublicKey(str_repeat("\x03", 32));
+        $signer = new PublicKey(str_repeat("\x04", 32));
+        [$a, $bumpA] = PaymentChannels::findChannelPda($payer, $payee, $mint, $signer, 99, 55_555);
+        [$b, $bumpB] = PaymentChannels::findChannelPda($payer, $payee, $mint, $signer, 99, 55_555);
+        self::assertTrue($a->equals($b));
+        self::assertSame($bumpA, $bumpB);
+        // Different openSlot → different channel.
+        [$c] = PaymentChannels::findChannelPda($payer, $payee, $mint, $signer, 99, 55_556);
+        self::assertFalse($a->equals($c));
+    }
+
+    public function testEncodeDecodeOpenArgsRoundTrip(): void
+    {
+        $data = PaymentChannels::encodeOpenInstructionData(7, self::MAX, 900, 4242);
+        $args = PaymentChannels::decodeOpenArgs($data);
+        self::assertSame(7, $args['salt']);
+        self::assertSame(self::MAX, $args['deposit']);
+        self::assertSame(900, $args['gracePeriod']);
+        self::assertSame(4242, $args['openSlot']);
+    }
+
+    /** @return array<string,mixed> */
+    private function requirements(string $operator): array
+    {
+        return [
+            'scheme'            => Types::SCHEME,
+            'network'           => 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+            'amount'            => (string) self::MAX,
+            'asset'             => self::MINT,
+            'payTo'             => $operator,
+            'maxTimeoutSeconds' => 300,
+            'extra'             => [
+                'decimals'           => 6,
+                'tokenProgram'       => PaymentChannels::tokenProgramId(),
+                'feePayer'           => $operator,
+                'receiverAuthorizer' => $operator,
+                'withdrawDelay'      => 900,
+                'recentBlockhash'    => '4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs',
+                'recentSlot'         => '4242',
+            ],
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function payload(string $operator, int $now): array
+    {
+        return [
+            'from'             => (string) new PublicKey(str_repeat("\x11", 32)),
+            'maxAmount'        => (string) self::MAX,
+            'expiresAt'        => $now + 300,
+            'validAfter'       => $now - 10,
+            'nonce'            => '7',
+            'channelId'        => '11111111111111111111111111111112',
+            'deposit'          => (string) self::MAX,
+            'authorizedSigner' => $operator,
+            'openSlot'         => '4242',
+        ];
+    }
+
+    private function operatorPubkey(): string
+    {
+        return (string) new PublicKey(str_repeat("\x0A", 32));
+    }
+
+    private function leU64(int $value): string
+    {
+        $out = '';
+        for ($i = 0; $i < 8; $i++) {
+            $out .= chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    private function leI64(int $value): string
+    {
+        return $this->leU64($value);
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the **PHP server** path for SVM `upto` ([#175](https://github.com/solana-foundation/pay-kit/issues/175)).

PHP already has x402 `exact` (challenge, structural verifier, cosign, broadcast). What was missing for `upto` is the payment-channel layer. This PR starts that foundation without inventing a new scheme or touching the occupied Ruby lane ([#192](https://github.com/solana-foundation/pay-kit/pull/192)).

### In this PR (+1177)

| Piece | Role |
|-------|------|
| `PayCore\PaymentChannels` | Program id `CHNLx…`, channel/event PDAs, ATA helper, 50-byte voucher preimage, open-args encode/decode |
| `Protocols\X402\Upto\Types` | Scheme constants (wire-parity with Rust/Go/Python) |
| `Protocols\X402\Upto\Verify` | Pure payload / ceiling / open-ix validation (no I/O) |
| `Protocols\X402\Upto\Engine` | Challenge (`accepts` + `payment-required`) + open-payload structural validation |
| PHPUnit | 19 offline tests green (PHP 8.3 + gmp) |

### Explicitly **not** in this PR

- Cosign + broadcast of channel `open`
- `settle_and_seal` / distribute instruction builders
- Harness `php-x402-upto` registration / CI leg
- Client-side upto builder
- Anything Ruby (#192 stays separate)

Those land in follow-up once the IDL instruction builders are ported (same shape as Go `paycore/paymentchannels` + Python settle path).

### Why this slice first

Same lesson as harness TS `#270`: small, pattern-matched, testable offline, no invented protocol. Full PHP upto is multi-PR depth (Ruby draft is ~5k LOC); landing pure verify + challenge is the credible foothold.

## Test plan

- [x] `phpunit tests/Protocols/X402/Upto` — 19 OK (Docker `php:8.3-cli` + `ext-gmp`)
- [ ] CI PHP unit / lint once fork workflows are approved
- [ ] Follow-up: open cosign + settle builders → harness leg vs `rust-x402-upto`

Refs: #175