### PR TITLE
harness: register PHP x402 upto server in matrix + CI

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -255,6 +255,42 @@ jobs:
           X402_HARNESS_SERVERS: ""
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "php server" --testTimeout 180000
 
+  # x402 upto: PHP PayKit server against rust upto client. Mirrors
+  # harness-php-x402-upto in php.yml / python focused upto legs.
+  php-x402-upto:
+    name: "Harness: PHP x402 upto server (rust client)"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: gmp
+      - uses: ./.github/actions/setup-harness
+        with:
+          cargo-bins: "paykit-harness-bins:x402_harness_upto_client,x402_harness_upto_server"
+          cargo-cache-key: php-x402-upto
+      - name: Install PHP harness dependencies
+        working-directory: php
+        run: composer install --no-interaction --no-progress
+      - name: Build payment channels program
+        id: payment-channels
+        uses: ./.github/actions/build-payment-channels
+      - name: Run rust-x402-upto client to PHP x402 upto server
+        working-directory: harness
+        env:
+          MPP_HARNESS_CLIENTS: ""
+          MPP_HARNESS_SERVERS: ""
+          MPP_HARNESS_INTENTS: x402-upto
+          MPP_HARNESS_SCENARIOS: x402-upto-basic
+          X402_HARNESS_CLIENTS: rust-x402-upto
+          X402_HARNESS_SERVERS: php-x402-upto
+          PAYMENT_CHANNELS_PROGRAM_SO: ${{ steps.payment-channels.outputs.program-so }}
+          PAYMENT_CHANNELS_PROGRAM_ID: CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX
+          SURFPOOL_DATASOURCE_RPC_URL: ${{ secrets.SURFPOOL_DATASOURCE_RPC_URL }}
+        run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
+
   swift:
     name: "Harness: Swift client to TypeScript + Rust servers"
     needs: build

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -84,3 +84,41 @@ jobs:
           X402_HARNESS_CLIENTS: rust-x402
           X402_HARNESS_SERVERS: ""
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "php server" --testTimeout 180000
+
+  # x402 upto: PHP PayKit server (channel open + voucher settle + distribute)
+  # against the Rust upto client. Mirrors harness-kotlin-x402-upto / python
+  # focused upto legs. Needs payment-channels .so on embedded surfnet.
+  # x402-upto-basic only — zero-actual stays on rust-x402-upto (serverIds pin).
+  harness-php-x402-upto:
+    name: "Harness: PHP x402 upto server (rust client)"
+    needs: test-php
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: gmp
+      - uses: ./.github/actions/setup-harness
+        with:
+          cargo-bins: "paykit-harness-bins:x402_harness_upto_client,x402_harness_upto_server"
+          cargo-cache-key: php-x402-upto
+      - name: Install PHP harness dependencies
+        working-directory: php
+        run: composer install --no-interaction --no-progress
+      - name: Build payment channels program
+        id: payment-channels
+        uses: ./.github/actions/build-payment-channels
+      - name: Run rust-x402-upto client to PHP x402 upto server
+        working-directory: harness
+        env:
+          MPP_HARNESS_CLIENTS: ""
+          MPP_HARNESS_SERVERS: ""
+          MPP_HARNESS_INTENTS: x402-upto
+          MPP_HARNESS_SCENARIOS: x402-upto-basic
+          X402_HARNESS_CLIENTS: rust-x402-upto
+          X402_HARNESS_SERVERS: php-x402-upto
+          PAYMENT_CHANNELS_PROGRAM_SO: ${{ steps.payment-channels.outputs.program-so }}
+          PAYMENT_CHANNELS_PROGRAM_ID: CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX
+          SURFPOOL_DATASOURCE_RPC_URL: ${{ secrets.SURFPOOL_DATASOURCE_RPC_URL }}
+        run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000

--- a/harness/php-server/server.php
+++ b/harness/php-server/server.php
@@ -38,6 +38,7 @@ use PayKit\Protocols\Mpp\MppConfig;
 use PayKit\Protocols\Mpp\Server\ChargeServer;
 use PayKit\Protocols\Mpp\Server\SolanaChargeHandler;
 use PayKit\Protocols\X402\Adapter as X402Adapter;
+use PayKit\Protocols\X402\Upto\Engine as X402UptoEngine;
 use PayKit\Signer;
 use PayKit\PayCore\Stablecoin;
 use PayKit\Store\FileStore;
@@ -78,13 +79,16 @@ function secret_key_from_json(string $raw): string
 }
 
 // ── Detect intent ───────────────────────────────────────────────────────────
+// Modes: exact | upto | mpp. Mirrors harness/python-server protocol picker.
 
 $explicit = strtolower(optional_env('PAY_KIT_HARNESS_PROTOCOL', ''));
-$x402Active = false;
-if ($explicit === 'x402') {
-    $x402Active = true;
+$mode = 'mpp';
+if ($explicit === 'x402-upto' || $explicit === 'upto') {
+    $mode = 'upto';
+} elseif ($explicit === 'x402' || $explicit === 'x402-exact' || $explicit === 'exact') {
+    $mode = 'exact';
 } elseif ($explicit === 'mpp' || $explicit === 'charge') {
-    $x402Active = false;
+    $mode = 'mpp';
 } else {
     $x402Set = (getenv('X402_HARNESS_RPC_URL') ?: '') !== '';
     $mppSet  = (getenv('MPP_HARNESS_RPC_URL') ?: '') !== '';
@@ -92,20 +96,35 @@ if ($explicit === 'x402') {
         fwrite(STDERR, "set exactly one of X402_HARNESS_RPC_URL / MPP_HARNESS_RPC_URL, or set PAY_KIT_HARNESS_PROTOCOL\n");
         exit(2);
     }
-    $x402Active = $x402Set;
+    $mode = $x402Set ? 'exact' : 'mpp';
 }
+$x402Active = $mode === 'exact' || $mode === 'upto';
+$uptoActive = $mode === 'upto';
 
 // ── Per-protocol env read ───────────────────────────────────────────────────
 
 if ($x402Active) {
     $rpcUrl       = require_env('X402_HARNESS_RPC_URL');
     $payTo        = require_env('X402_HARNESS_PAY_TO');
-    $facilitatorSecretJson = require_env('X402_HARNESS_FACILITATOR_SECRET_KEY');
+    // Prefer fee-payer key for upto (rent/fee seat); fall back to facilitator.
+    $feePayerEnv = getenv('X402_HARNESS_FEE_PAYER_SECRET_KEY');
+    $facilitatorSecretJson = (is_string($feePayerEnv) && $feePayerEnv !== '')
+        ? $feePayerEnv
+        : require_env('X402_HARNESS_FACILITATOR_SECRET_KEY');
     $amountUnits  = optional_env('X402_HARNESS_AMOUNT', '1000');
     $mint         = optional_env('X402_HARNESS_MINT', 'USDC');
     $networkRaw   = optional_env('X402_HARNESS_NETWORK', 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1');
-    $resourcePath = optional_env('X402_HARNESS_RESOURCE_PATH', '/paid');
-    $settlementHeader = optional_env('X402_HARNESS_SETTLEMENT_HEADER', 'x-payment-settlement-signature');
+    $resourcePath = optional_env(
+        'X402_HARNESS_RESOURCE_PATH',
+        $uptoActive ? '/usage' : '/paid',
+    );
+    $settlementHeader = optional_env(
+        'X402_HARNESS_SETTLEMENT_HEADER',
+        'x-payment-settlement-signature',
+    );
+    $priceHuman = optional_env('X402_HARNESS_PRICE', '0.10');
+    // Metered actual after open (base units). zero-actual matrix stays on rust.
+    $actualAmount = (int) optional_env('X402_HARNESS_ACTUAL_AMOUNT', '0');
 } else {
     $rpcUrl       = require_env('MPP_HARNESS_RPC_URL');
     $payTo        = require_env('MPP_HARNESS_PAY_TO');
@@ -127,9 +146,29 @@ if ($x402Active) {
 
 // ── Boot the SDK ────────────────────────────────────────────────────────────
 
-if ($x402Active) {
-    // x402 mode: build the umbrella PayKit + X402 Adapter with the
-    // facilitator key as the operator's signer.
+/** @var X402Adapter|null $adapter */
+$adapter = null;
+/** @var X402UptoEngine|null $uptoEngine */
+$uptoEngine = null;
+/** @var Gate|null $gate */
+$gate = null;
+
+if ($uptoActive) {
+    // x402 upto: payment-channel open + voucher settle via Upto\Engine.
+    $signer = Signer::json($facilitatorSecretJson);
+    $config = new Config(
+        network:     resolve_network($networkRaw),
+        accept:      [Protocol::X402],
+        stablecoins: [Stablecoin::Usdc],
+        rpcUrl:      $rpcUrl,
+        operator:    new Operator(recipient: $payTo, signer: $signer, feePayer: true),
+        mpp:         new MppConfig(challengeBindingSecret: 'unused-x402-upto'),
+        preflight:   false,
+    );
+    $uptoEngine = new X402UptoEngine($config);
+    $gate = new Gate(amount: Price::usd($priceHuman), payTo: $payTo);
+} elseif ($x402Active) {
+    // x402 exact: umbrella PayKit + X402 Adapter with facilitator as operator.
     $signer = Signer::json($facilitatorSecretJson);
     $client = new PayKit(new Config(
         network:     resolve_network($networkRaw),
@@ -307,12 +346,17 @@ if (!is_string($name)) {
 }
 $port = (int) substr($name, strrpos($name, ':') + 1);
 
+$capability = match ($mode) {
+    'upto'  => 'upto',
+    'exact' => 'exact',
+    default => 'charge',
+};
 fwrite(STDOUT, json_encode([
     'type'           => 'ready',
     'implementation' => 'php',
     'role'           => 'server',
     'port'           => $port,
-    'capabilities'   => [$x402Active ? 'exact' : 'charge'],
+    'capabilities'   => [$capability],
 ], JSON_THROW_ON_ERROR) . "\n");
 fflush(STDOUT);
 
@@ -353,8 +397,68 @@ while (is_resource($listener)) {
             continue;
         }
 
-        if ($x402Active) {
-            // x402 path through the umbrella adapter.
+        if ($uptoActive) {
+            // x402 upto: challenge → open (cosign+broadcast) → settle → distribute.
+            assert($uptoEngine instanceof X402UptoEngine && $gate instanceof Gate);
+            $psrReq = psr7_from_socket($req);
+            $sig = $req['headers']['payment-signature'] ?? '';
+            $requirements = $uptoEngine->acceptsEntry($gate, $psrReq);
+            if ($sig === '') {
+                $challengeHeaders = $uptoEngine->challengeHeaders($gate, $psrReq);
+                write_response($conn, 402, array_merge(['content-type' => 'application/json'], $challengeHeaders), [
+                    'error'    => 'payment_required',
+                    'resource' => $req['path'],
+                    'accepts'  => [$requirements],
+                ]);
+            } else {
+                try {
+                    $verified = $uptoEngine->verifyOpenAndBroadcast($psrReq, $requirements);
+                    $expiresAt = (int) ($verified['payload']['expiresAt'] ?? (time() + 300));
+                    $settleSig = $uptoEngine->settleAndSealAndBroadcast(
+                        $verified['channelId'],
+                        $actualAmount,
+                        $verified['maxBaseUnits'],
+                        $expiresAt,
+                    );
+                    $extra = is_array($requirements['extra'] ?? null) ? $requirements['extra'] : [];
+                    $tokenProgram = (string) ($extra['tokenProgram'] ?? \PayKit\PayCore\PaymentChannels::tokenProgramId());
+                    $uptoEngine->distributeAndBroadcast(
+                        $verified['channelId'],
+                        $verified['payer'],
+                        (string) $requirements['asset'],
+                        $tokenProgram,
+                    );
+                    $settlementBody = [
+                        'success'     => true,
+                        'transaction' => $settleSig,
+                        'network'     => (string) ($requirements['network'] ?? ''),
+                        'amount'      => (string) $actualAmount,
+                        'payer'       => $verified['payer'],
+                    ];
+                    $headers = [
+                        'content-type'     => 'application/json',
+                        'payment-response' => base64_encode(
+                            json_encode($settlementBody, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+                        ),
+                        $settlementHeader  => $settleSig,
+                    ];
+                    write_response($conn, 200, $headers, [
+                        'ok'          => true,
+                        'paid'        => true,
+                        'protocol'    => 'x402-upto',
+                        'transaction' => $settleSig,
+                    ]);
+                } catch (Throwable $e) {
+                    fwrite(STDERR, 'harness php upto error: ' . $e->getMessage() . "\n");
+                    write_response($conn, 402, ['content-type' => 'application/json'], [
+                        'error'   => 'invalid_proof',
+                        'message' => $e->getMessage(),
+                    ]);
+                }
+            }
+        } elseif ($x402Active) {
+            // x402 exact path through the umbrella adapter.
+            assert($adapter instanceof X402Adapter && $gate instanceof Gate);
             $psrReq = psr7_from_socket($req);
             $sig = $req['headers']['payment-signature'] ?? '';
             if ($sig === '') {

--- a/harness/src/implementations.ts
+++ b/harness/src/implementations.ts
@@ -515,4 +515,16 @@ export const serverImplementations: ImplementationDefinition[] = [
     intents: ["x402-upto"],
     reportsAs: "python",
   },
+  {
+    id: "php-x402-upto",
+    label: "PHP PayKit x402 upto server",
+    role: "server",
+    // Same dual-protocol php-server binary; PAY_KIT_HARNESS_PROTOCOL=x402-upto
+    // mounts Upto\Engine (open cosign + settle_and_seal + distribute). Opt in
+    // via X402_HARNESS_SERVERS=php-x402-upto. Zero-actual stays on rust only.
+    command: ["php", "php-server/server.php"],
+    enabled: isEnabled("php-x402-upto", "X402_HARNESS_SERVERS", false),
+    intents: ["x402-upto"],
+    reportsAs: "php",
+  },
 ];

--- a/php/src/PayCore/PaymentChannels.php
+++ b/php/src/PayCore/PaymentChannels.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\PayCore;
+
+use InvalidArgumentException;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Programs\AssociatedTokenProgram;
+use SolanaPhpSdk\Programs\SystemProgram;
+use SolanaPhpSdk\Programs\TokenProgram;
+
+/**
+ * Hand-written on-chain glue for the payment-channels program.
+ *
+ * Mirrors Go `paycore/paymentchannels` and Python `_paycore.paymentchannels`:
+ * production program id, channel / event-authority PDA derivation, ATA
+ * derivation, and the 50-byte voucher preimage. Instruction builders that
+ * require the full Codama-generated client land in follow-up commits; this
+ * module is the pure shared foundation for x402 `upto` verify + settle.
+ *
+ * Layout and seeds MUST stay byte-identical across language SDKs so the
+ * on-chain program accepts them.
+ */
+final class PaymentChannels
+{
+    /** Canonical payment-channels program id deployed to the network. */
+    public const PROGRAM_ID = 'CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX';
+
+    /** Channel-open freshness window (slots). */
+    public const OPEN_SLOT_WINDOW = 1500;
+
+    /** Single-byte open instruction discriminator (not 8-byte Anchor). */
+    public const OPEN_INSTRUCTION_DISCRIMINATOR = 1;
+
+    /** Constant 2-byte magic prefixed to every signed voucher payload. */
+    public const VOUCHER_MAGIC = "\x56\x01";
+
+    public const RENT_SYSVAR_ID = 'SysvarRent111111111111111111111111111111111';
+    public const ED25519_PROGRAM_ID = 'Ed25519SigVerify111111111111111111111111111';
+    public const SYSVAR_INSTRUCTIONS = 'Sysvar1nstructions1111111111111111111111111';
+
+    private const CHANNEL_SEED = 'channel';
+    private const EVENT_AUTHORITY_SEED = 'event_authority';
+
+    /**
+     * 50-byte voucher preimage signed by the authorized signer.
+     *
+     * Layout: magic (2) || channelId (32) || cumulativeAmount LE u64 (8)
+     * || expiresAt LE i64 (8). Matches generated VoucherArgs Borsh layout.
+     *
+     * @throws InvalidArgumentException when channel id is not 32 bytes
+     */
+    public static function voucherMessageBytes(PublicKey $channelId, int $cumulative, int $expiresAt): string
+    {
+        $id = $channelId->toBytes();
+        if (strlen($id) !== 32) {
+            throw new InvalidArgumentException(
+                'channel id must be exactly 32 bytes, got ' . strlen($id),
+            );
+        }
+        if ($cumulative < 0 || $cumulative > 0xFFFFFFFFFFFFFFFF) {
+            throw new InvalidArgumentException('cumulative does not fit in u64');
+        }
+
+        return self::VOUCHER_MAGIC
+            . $id
+            . self::packU64Le($cumulative)
+            . self::packI64Le($expiresAt);
+    }
+
+    /**
+     * Derive the channel PDA.
+     *
+     * Seeds: ["channel", payer, payee, mint, authorizedSigner, salt u64 LE, openSlot u64 LE].
+     *
+     * @return array{0: PublicKey, 1: int} [address, bump]
+     */
+    public static function findChannelPda(
+        PublicKey $payer,
+        PublicKey $payee,
+        PublicKey $mint,
+        PublicKey $authorizedSigner,
+        int $salt,
+        int $openSlot,
+        ?PublicKey $programId = null,
+    ): array {
+        self::assertU64($salt, 'salt');
+        self::assertU64($openSlot, 'openSlot');
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+
+        return PublicKey::findProgramAddress(
+            [
+                self::CHANNEL_SEED,
+                $payer->toBytes(),
+                $payee->toBytes(),
+                $mint->toBytes(),
+                $authorizedSigner->toBytes(),
+                self::packU64Le($salt),
+                self::packU64Le($openSlot),
+            ],
+            $program,
+        );
+    }
+
+    /**
+     * Derive the event-authority PDA. Seeds: ["event_authority"].
+     *
+     * @return array{0: PublicKey, 1: int}
+     */
+    public static function findEventAuthorityPda(?PublicKey $programId = null): array
+    {
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+
+        return PublicKey::findProgramAddress([self::EVENT_AUTHORITY_SEED], $program);
+    }
+
+    /**
+     * Derive the associated token account for (owner, mint, token program).
+     *
+     * @return array{0: PublicKey, 1: int}
+     */
+    public static function findAssociatedTokenAddress(
+        PublicKey $owner,
+        PublicKey $mint,
+        PublicKey $tokenProgram,
+    ): array {
+        return AssociatedTokenProgram::findAssociatedTokenAddress($owner, $mint, $tokenProgram);
+    }
+
+    /**
+     * Encode open-instruction data (discriminator + openArgs without recipients).
+     *
+     * Layout: [u8 disc=1][u64 salt][u64 deposit][u32 grace][u64 openSlot][vec recipients…].
+     * Empty recipients is a trailing u32 length of 0.
+     */
+    public static function encodeOpenInstructionData(
+        int $salt,
+        int $deposit,
+        int $gracePeriod,
+        int $openSlot,
+    ): string {
+        self::assertU64($salt, 'salt');
+        self::assertU64($deposit, 'deposit');
+        self::assertU32($gracePeriod, 'gracePeriod');
+        self::assertU64($openSlot, 'openSlot');
+
+        return chr(self::OPEN_INSTRUCTION_DISCRIMINATOR)
+            . self::packU64Le($salt)
+            . self::packU64Le($deposit)
+            . self::packU32Le($gracePeriod)
+            . self::packU64Le($openSlot)
+            . self::packU32Le(0); // recipients len = 0
+    }
+
+    /**
+     * Decode open instruction data after the discriminator byte.
+     *
+     * @return array{salt: int, deposit: int, gracePeriod: int, openSlot: int}
+     */
+    public static function decodeOpenArgs(string $data): array
+    {
+        // disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) = 29 minimum
+        if (strlen($data) < 1 + 8 + 8 + 4 + 8) {
+            throw new InvalidArgumentException(
+                'open instruction data too short (' . strlen($data) . ' bytes)',
+            );
+        }
+        if (ord($data[0]) !== self::OPEN_INSTRUCTION_DISCRIMINATOR) {
+            throw new InvalidArgumentException('open transaction is not a channel-open instruction');
+        }
+
+        return [
+            'salt'        => self::unpackU64Le(substr($data, 1, 8)),
+            'deposit'     => self::unpackU64Le(substr($data, 9, 8)),
+            'gracePeriod' => self::unpackU32Le(substr($data, 17, 4)),
+            'openSlot'    => self::unpackU64Le(substr($data, 21, 8)),
+        ];
+    }
+
+    public static function systemProgramId(): string
+    {
+        return SystemProgram::PROGRAM_ID;
+    }
+
+    public static function tokenProgramId(): string
+    {
+        return TokenProgram::PROGRAM_ID;
+    }
+
+    public static function associatedTokenProgramId(): string
+    {
+        return AssociatedTokenProgram::PROGRAM_ID;
+    }
+
+    private static function packU64Le(int $value): string
+    {
+        // Portable little-endian: works for unsigned values and for two's
+        // complement negative i64s (arithmetic >> on signed PHP ints).
+        $out = '';
+        for ($i = 0; $i < 8; $i++) {
+            $out .= chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    private static function packI64Le(int $value): string
+    {
+        return self::packU64Le($value);
+    }
+
+    private static function packU32Le(int $value): string
+    {
+        $out = '';
+        for ($i = 0; $i < 4; $i++) {
+            $out .= chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    private static function unpackU64Le(string $bytes): int
+    {
+        $value = 0;
+        for ($i = 0; $i < 8; $i++) {
+            $value |= ord($bytes[$i]) << ($i * 8);
+        }
+
+        return $value;
+    }
+
+    private static function unpackU32Le(string $bytes): int
+    {
+        $value = 0;
+        for ($i = 0; $i < 4; $i++) {
+            $value |= ord($bytes[$i]) << ($i * 8);
+        }
+
+        return $value;
+    }
+
+    private static function assertU64(int $value, string $label): void
+    {
+        if ($value < 0 || $value > 0xFFFFFFFFFFFFFFFF) {
+            throw new InvalidArgumentException("{$label} {$value} does not fit in u64");
+        }
+    }
+
+    private static function assertU32(int $value, string $label): void
+    {
+        if ($value < 0 || $value > 0xFFFFFFFF) {
+            throw new InvalidArgumentException("{$label} {$value} does not fit in u32");
+        }
+    }
+}

--- a/php/src/PayCore/PaymentChannels.php
+++ b/php/src/PayCore/PaymentChannels.php
@@ -9,15 +9,16 @@ use SolanaPhpSdk\Keypair\PublicKey;
 use SolanaPhpSdk\Programs\AssociatedTokenProgram;
 use SolanaPhpSdk\Programs\SystemProgram;
 use SolanaPhpSdk\Programs\TokenProgram;
+use SolanaPhpSdk\Transaction\AccountMeta;
+use SolanaPhpSdk\Transaction\TransactionInstruction;
 
 /**
  * Hand-written on-chain glue for the payment-channels program.
  *
  * Mirrors Go `paycore/paymentchannels` and Python `_paycore.paymentchannels`:
  * production program id, channel / event-authority PDA derivation, ATA
- * derivation, and the 50-byte voucher preimage. Instruction builders that
- * require the full Codama-generated client land in follow-up commits; this
- * module is the pure shared foundation for x402 `upto` verify + settle.
+ * derivation, 50-byte voucher preimage, and instruction builders
+ * (open / settle_and_seal / distribute / ed25519) for x402 `upto`.
  *
  * Layout and seeds MUST stay byte-identical across language SDKs so the
  * on-chain program accepts them.
@@ -211,6 +212,237 @@ final class PaymentChannels
     {
         return AssociatedTokenProgram::PROGRAM_ID;
     }
+
+
+    public const SETTLE_AND_SEAL_DISCRIMINATOR = 4;
+    public const DISTRIBUTE_DISCRIMINATOR = 7;
+
+    /** Treasury owner baked into the deployed (mainnet-build) program. */
+    public const TREASURY_OWNER = 'Cs2zdfUNonRdRGsiZUQQLdTxzxVvJZmgiX2mpLYKuEqP';
+
+    /**
+     * Build the `open` instruction (14 accounts, disc=1 + openArgs).
+     *
+     * Account order and flags match Go `BuildOpenInstruction` /
+     * Python `build_open_instruction`. Derives channel PDA, payer/channel ATAs,
+     * and event-authority PDA. Empty recipients only (upto path).
+     *
+     * @return TransactionInstruction
+     */
+    public static function buildOpenInstruction(
+        PublicKey $payer,
+        PublicKey $rentPayer,
+        PublicKey $payee,
+        PublicKey $mint,
+        PublicKey $authorizedSigner,
+        int $salt,
+        int $deposit,
+        int $gracePeriod,
+        int $openSlot,
+        PublicKey $tokenProgram,
+        ?PublicKey $programId = null,
+    ): TransactionInstruction {
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+        [$channel] = self::findChannelPda(
+            $payer,
+            $payee,
+            $mint,
+            $authorizedSigner,
+            $salt,
+            $openSlot,
+            $program,
+        );
+        [$payerToken] = self::findAssociatedTokenAddress($payer, $mint, $tokenProgram);
+        [$channelToken] = self::findAssociatedTokenAddress($channel, $mint, $tokenProgram);
+        [$eventAuthority] = self::findEventAuthorityPda($program);
+
+        $accounts = [
+            AccountMeta::signerWritable($payer),
+            AccountMeta::signerWritable($rentPayer),
+            AccountMeta::readonly($payee),
+            AccountMeta::readonly($mint),
+            AccountMeta::readonly($authorizedSigner),
+            AccountMeta::writable($channel),
+            AccountMeta::writable($payerToken),
+            AccountMeta::writable($channelToken),
+            AccountMeta::readonly($tokenProgram),
+            AccountMeta::readonly(new PublicKey(self::systemProgramId())),
+            AccountMeta::readonly(new PublicKey(self::RENT_SYSVAR_ID)),
+            AccountMeta::readonly(new PublicKey(self::associatedTokenProgramId())),
+            AccountMeta::readonly($eventAuthority),
+            AccountMeta::readonly($program),
+        ];
+
+        $data = self::encodeOpenInstructionData($salt, $deposit, $gracePeriod, $openSlot);
+
+        return new TransactionInstruction($program, $accounts, $data);
+    }
+
+    /**
+     * Ed25519 precompile that verifies a voucher signature (sibling of settle).
+     *
+     * Layout mirrors Go/Python: pubkey @16, signature @48, message @112.
+     */
+    public static function buildEd25519VerifyInstruction(
+        PublicKey $authorizedSigner,
+        string $signature,
+        string $message,
+    ): TransactionInstruction {
+        if (strlen($signature) !== 64) {
+            throw new InvalidArgumentException(
+                'ed25519 signature must be 64 bytes, got ' . strlen($signature),
+            );
+        }
+        if (strlen($message) > 0xFFFF) {
+            throw new InvalidArgumentException(
+                'voucher message too long: ' . strlen($message) . ' bytes',
+            );
+        }
+
+        $publicKeyOffset = 16;
+        $signatureOffset = 48;
+        $messageDataOffset = 112;
+        $currentInstruction = 0xFFFF;
+
+        $data = str_repeat("\x00", $messageDataOffset + strlen($message));
+        $data[0] = chr(1); // num_signatures
+        $data[1] = chr(0); // padding
+        $data = self::pokeU16Le($data, 2, $signatureOffset);
+        $data = self::pokeU16Le($data, 4, $currentInstruction);
+        $data = self::pokeU16Le($data, 6, $publicKeyOffset);
+        $data = self::pokeU16Le($data, 8, $currentInstruction);
+        $data = self::pokeU16Le($data, 10, $messageDataOffset);
+        $data = self::pokeU16Le($data, 12, strlen($message));
+        $data = self::pokeU16Le($data, 14, $currentInstruction);
+
+        $pk = $authorizedSigner->toBytes();
+        for ($i = 0; $i < 32; $i++) {
+            $data[$publicKeyOffset + $i] = $pk[$i];
+        }
+        for ($i = 0; $i < 64; $i++) {
+            $data[$signatureOffset + $i] = $signature[$i];
+        }
+        for ($i = 0, $n = strlen($message); $i < $n; $i++) {
+            $data[$messageDataOffset + $i] = $message[$i];
+        }
+
+        return new TransactionInstruction(
+            new PublicKey(self::ED25519_PROGRAM_ID),
+            [],
+            $data,
+        );
+    }
+
+    /**
+     * Build settle_and_seal sequence: optional Ed25519 precompile + settleAndSeal.
+     *
+     * @param string|null $signature 64-byte Ed25519 voucher signature, or null for voucherless
+     * @return list<TransactionInstruction>
+     */
+    public static function buildSettleAndSealInstructions(
+        PublicKey $payee,
+        PublicKey $channel,
+        PublicKey $authorizedSigner,
+        ?string $signature,
+        int $cumulativeAmount,
+        int $expiresAt,
+        ?PublicKey $programId = null,
+    ): array {
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+        $instructions = [];
+        $hasVoucher = 0;
+
+        if ($signature !== null) {
+            $message = self::voucherMessageBytes($channel, $cumulativeAmount, $expiresAt);
+            $instructions[] = self::buildEd25519VerifyInstruction(
+                $authorizedSigner,
+                $signature,
+                $message,
+            );
+            $hasVoucher = 1;
+        }
+
+        $accounts = [
+            AccountMeta::signerReadonly($payee),
+            AccountMeta::writable($channel),
+            AccountMeta::readonly(new PublicKey(self::SYSVAR_INSTRUCTIONS)),
+        ];
+        $data = chr(self::SETTLE_AND_SEAL_DISCRIMINATOR) . chr($hasVoucher);
+        $instructions[] = new TransactionInstruction($program, $accounts, $data);
+
+        return $instructions;
+    }
+
+    /**
+     * Build distribute (11 fixed accounts + one writable recipient ATA per split).
+     *
+     * @param list<array{recipient: PublicKey, bps: int}> $recipients
+     */
+    public static function buildDistributeInstruction(
+        PublicKey $channel,
+        PublicKey $payer,
+        PublicKey $rentPayer,
+        PublicKey $payee,
+        PublicKey $mint,
+        PublicKey $tokenProgram,
+        array $recipients = [],
+        ?PublicKey $treasury = null,
+        ?PublicKey $programId = null,
+    ): TransactionInstruction {
+        $program = $programId ?? new PublicKey(self::PROGRAM_ID);
+        $treasuryOwner = $treasury ?? new PublicKey(self::TREASURY_OWNER);
+
+        [$channelToken] = self::findAssociatedTokenAddress($channel, $mint, $tokenProgram);
+        [$payerToken] = self::findAssociatedTokenAddress($payer, $mint, $tokenProgram);
+        [$payeeToken] = self::findAssociatedTokenAddress($payee, $mint, $tokenProgram);
+        [$treasuryToken] = self::findAssociatedTokenAddress($treasuryOwner, $mint, $tokenProgram);
+        [$eventAuthority] = self::findEventAuthorityPda($program);
+
+        $accounts = [
+            AccountMeta::writable($channel),
+            AccountMeta::writable($payer),
+            AccountMeta::writable($rentPayer),
+            AccountMeta::writable($channelToken),
+            AccountMeta::writable($payerToken),
+            AccountMeta::writable($payeeToken),
+            AccountMeta::writable($treasuryToken),
+            AccountMeta::readonly($mint),
+            AccountMeta::readonly($tokenProgram),
+            AccountMeta::readonly($eventAuthority),
+            AccountMeta::readonly($program),
+        ];
+
+        $data = chr(self::DISTRIBUTE_DISCRIMINATOR) . self::packU32Le(count($recipients));
+        foreach ($recipients as $entry) {
+            $recipient = $entry['recipient'];
+            $bps = $entry['bps'];
+            if (!$recipient instanceof PublicKey) {
+                throw new InvalidArgumentException('recipient must be a PublicKey');
+            }
+            if ($bps < 0 || $bps > 0xFFFF) {
+                throw new InvalidArgumentException("recipient bps {$bps} does not fit in u16");
+            }
+            [$recipientToken] = self::findAssociatedTokenAddress($recipient, $mint, $tokenProgram);
+            $accounts[] = AccountMeta::writable($recipientToken);
+            $data .= $recipient->toBytes() . self::packU16Le($bps);
+        }
+
+        return new TransactionInstruction($program, $accounts, $data);
+    }
+
+    private static function pokeU16Le(string $data, int $offset, int $value): string
+    {
+        $data[$offset] = chr($value & 0xFF);
+        $data[$offset + 1] = chr(($value >> 8) & 0xFF);
+
+        return $data;
+    }
+
+    private static function packU16Le(int $value): string
+    {
+        return chr($value & 0xFF) . chr(($value >> 8) & 0xFF);
+    }
+
 
     private static function packU64Le(int $value): string
     {

--- a/php/src/PayCore/PaymentChannels.php
+++ b/php/src/PayCore/PaymentChannels.php
@@ -154,20 +154,39 @@ final class PaymentChannels
     }
 
     /**
-     * Decode open instruction data after the discriminator byte.
+     * Decode open instruction data (discriminator + openArgs).
+     *
+     * Pins the empty-recipients layout used by SVM `upto`:
+     *   disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) + recipients_len(4)=0
+     * Total length must be exactly 33. Non-empty recipients or trailing bytes
+     * are rejected so the open args stay byte-for-byte with the challenge path.
      *
      * @return array{salt: int, deposit: int, gracePeriod: int, openSlot: int}
      */
     public static function decodeOpenArgs(string $data): array
     {
-        // disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) = 29 minimum
-        if (strlen($data) < 1 + 8 + 8 + 4 + 8) {
+        // disc(1) + salt(8) + deposit(8) + grace(4) + openSlot(8) + vec_len(4) = 33
+        $expectedLen = 1 + 8 + 8 + 4 + 8 + 4;
+        if (strlen($data) < $expectedLen) {
             throw new InvalidArgumentException(
                 'open instruction data too short (' . strlen($data) . ' bytes)',
             );
         }
         if (ord($data[0]) !== self::OPEN_INSTRUCTION_DISCRIMINATOR) {
             throw new InvalidArgumentException('open transaction is not a channel-open instruction');
+        }
+
+        $recipientsLen = self::unpackU32Le(substr($data, 29, 4));
+        if ($recipientsLen !== 0) {
+            throw new InvalidArgumentException(
+                "open instruction recipients length must be 0 for upto, got {$recipientsLen}",
+            );
+        }
+        if (strlen($data) !== $expectedLen) {
+            throw new InvalidArgumentException(
+                'open instruction data has trailing bytes after empty recipients '
+                . '(' . strlen($data) . ' bytes, expected ' . $expectedLen . ')',
+            );
         }
 
         return [

--- a/php/src/Protocols/X402/Upto/Engine.php
+++ b/php/src/Protocols/X402/Upto/Engine.php
@@ -8,6 +8,9 @@ use PayKit\Config;
 use PayKit\Exception\InvalidProofException;
 use PayKit\Gate;
 use PayKit\PayCore\PaymentChannels;
+use PayKit\PayCore\Rpc\RpcGateway;
+use PayKit\PayCore\Rpc\SolanaRpcGateway;
+use SolanaPhpSdk\Keypair\Keypair;
 use PayKit\PayCore\Solana\Mints;
 use Psr\Http\Message\ServerRequestInterface;
 use SolanaPhpSdk\Keypair\PublicKey;
@@ -18,14 +21,11 @@ use Throwable;
 /**
  * x402 `upto` (Solana) server engine — payment-channel profile.
  *
- * Two-phase flow (mirrors Rust/Go/Python):
+ * Flow (mirrors Rust/Go/Python):
  *   1. {@see challengeHeaders}/{@see acceptsEntry} — advertise the ceiling.
  *   2. {@see verifyOpenPayload} — validate payload + open instruction shape.
- *   3. settle_and_seal broadcast — follow-up once instruction builders land.
- *
- * This first slice ships challenge generation and pure open-path validation.
- * Full cosign + settle_and_seal broadcast lands next (Ruby #192 / Python
- * settle path as reference).
+ *   3. {@see verifyOpenAndBroadcast} — cosign as fee payer, broadcast open, confirm.
+ *   4. settle_and_seal + distribute — later slice after open is live.
  */
 final class Engine
 {
@@ -43,6 +43,9 @@ final class Engine
     public function __construct(
         private readonly Config $config,
         ?\Closure $chainHintsProvider = null,
+        private ?RpcGateway $rpc = null,
+        private readonly int $confirmationAttempts = 40,
+        private readonly int $confirmationDelayMicros = 250_000,
     ) {
         $this->chainHintsProvider = $chainHintsProvider;
     }
@@ -242,16 +245,20 @@ final class Engine
         }
 
         $extra = is_array($requirements['extra'] ?? null) ? $requirements['extra'] : [];
-        $feePayer = new PublicKey((string) ($extra['feePayer'] ?? $receiverAuthorizer));
-        $receiver = new PublicKey($receiverAuthorizer);
-        $payer = new PublicKey((string) ($payload['from'] ?? ''));
+        $feePayer = $this->requirePubkey(
+            (string) ($extra['feePayer'] ?? $receiverAuthorizer),
+            'feePayer',
+        );
+        $receiver = $this->requirePubkey($receiverAuthorizer, 'receiverAuthorizer');
+        $payer = $this->requirePubkey((string) ($payload['from'] ?? ''), 'from');
         // Channel payee is the fee payer (zero-share lifecycle seat) for upto.
         $payee = $feePayer;
-        $mint = new PublicKey((string) ($requirements['asset'] ?? ''));
-        $tokenProgram = new PublicKey(
+        $mint = $this->requirePubkey((string) ($requirements['asset'] ?? ''), 'asset');
+        $tokenProgram = $this->requirePubkey(
             (string) ($extra['tokenProgram'] ?? PaymentChannels::tokenProgramId()),
+            'tokenProgram',
         );
-        $channelId = new PublicKey((string) ($payload['channelId'] ?? ''));
+        $channelId = $this->requirePubkey((string) ($payload['channelId'] ?? ''), 'channelId');
         $maxAmount = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
         $withdrawDelay = (int) ($extra['withdrawDelay'] ?? Types::DEFAULT_WITHDRAW_DELAY_SECONDS);
         $recentSlot = isset($extra['recentSlot']) ? (int) $extra['recentSlot'] : null;
@@ -273,6 +280,164 @@ final class Engine
             (string) ($payload['openSlot'] ?? ''),
             $recentSlot,
         );
+
+        // Greptile P1: rentPayer on the open ix can match the operator while
+        // the tx fee payer (static account key 0) is someone else — cosign
+        // would then fail at broadcast. Bind fee payer here like Python.
+        if ($accountKeys === [] || $accountKeys[0] !== (string) $feePayer) {
+            throw new InvalidProofException(
+                'open transaction fee payer must be the advertised fee payer',
+            );
+        }
+    }
+
+
+    /**
+     * Validate open credential, cosign as fee payer, broadcast, and confirm.
+     *
+     * @param array<string,mixed> $requirements
+     * @return array{
+     *   payload: array<string,mixed>,
+     *   requirements: array<string,mixed>,
+     *   maxBaseUnits: int,
+     *   payer: string,
+     *   channelId: string,
+     *   openSignature: string
+     * }
+     *
+     * @throws InvalidProofException
+     */
+    public function verifyOpenAndBroadcast(ServerRequestInterface $request, array $requirements): array
+    {
+        $verified = $this->verifyOpenPayload($request, $requirements);
+        $openTx = (string) ($verified['payload']['openTransaction'] ?? '');
+        $sig = $this->cosignAndBroadcastOpenTransaction($openTx);
+        $verified['openSignature'] = $sig;
+
+        return $verified;
+    }
+
+    /**
+     * Cosign the client-built open as the advertised fee payer and broadcast.
+     *
+     * The client signed the payer slot; the operator (fee payer / rentPayer)
+     * completes the missing signature then sends the wire transaction.
+     *
+     * @throws InvalidProofException
+     */
+    public function cosignAndBroadcastOpenTransaction(string $transactionBase64): string
+    {
+        $signer = $this->config->effectiveX402Signer();
+        if ($signer === null) {
+            throw new InvalidProofException('upto cosign requires an x402 operator signer');
+        }
+
+        $raw = base64_decode($transactionBase64, true);
+        if ($raw === false || $raw === '') {
+            throw new InvalidProofException('invalid open transaction base64');
+        }
+        try {
+            $tx = VersionedTransaction::deserialize($raw);
+        } catch (Throwable $e) {
+            throw new InvalidProofException('invalid open transaction parse', 0, $e);
+        }
+
+        $feePayer = $this->requirePubkey($signer->pubkey(), 'feePayer');
+        $keys = $tx->message->staticAccountKeys;
+        if ($keys === [] || (string) $keys[0] !== (string) $feePayer) {
+            throw new InvalidProofException(
+                'open transaction fee payer must be the advertised fee payer',
+            );
+        }
+
+        try {
+            $kp = Keypair::fromSecretKey($signer->secretKey());
+            $tx->partialSign($kp);
+            $wire = $tx->serialize(verifySignatures: false);
+        } catch (Throwable $e) {
+            throw new InvalidProofException('upto cosign failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        $rpc = $this->rpc();
+        try {
+            $sig = $rpc->sendRawTransaction($wire, [
+                'encoding'              => 'base64',
+                'skipPreflight'         => false,
+                'preflightCommitment'   => 'confirmed',
+            ]);
+        } catch (Throwable $e) {
+            throw new InvalidProofException(
+                'pay_kit: invalid proof: open broadcast failed: ' . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+        if (!is_string($sig) || $sig === '') {
+            throw new InvalidProofException('pay_kit: empty open broadcast result');
+        }
+
+        try {
+            $this->awaitConfirmation($sig);
+        } catch (Throwable $e) {
+            throw new InvalidProofException(
+                'pay_kit: invalid proof: open not confirmed: ' . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        return $sig;
+    }
+
+    private function rpc(): RpcGateway
+    {
+        if ($this->rpc !== null) {
+            return $this->rpc;
+        }
+        if ($this->config->rpcUrl === '') {
+            throw new InvalidProofException('upto broadcast requires Config::$rpcUrl or an injected RpcGateway');
+        }
+
+        return $this->rpc = new SolanaRpcGateway(new RpcClient($this->config->rpcUrl));
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    private function awaitConfirmation(string $signature): void
+    {
+        $rpc = $this->rpc();
+        for ($attempt = 0; $attempt < $this->confirmationAttempts; $attempt += 1) {
+            $statuses = $rpc->getSignatureStatuses([$signature]);
+            $status = $statuses[0] ?? null;
+            if (is_array($status)) {
+                if (($status['err'] ?? null) !== null) {
+                    throw new \RuntimeException(
+                        "Transaction $signature failed: " . json_encode($status['err'], JSON_THROW_ON_ERROR),
+                    );
+                }
+                $confirmationStatus = $status['confirmationStatus'] ?? null;
+                if ($confirmationStatus === 'confirmed' || $confirmationStatus === 'finalized') {
+                    return;
+                }
+            }
+            if ($this->confirmationDelayMicros > 0 && $attempt + 1 < $this->confirmationAttempts) {
+                usleep($this->confirmationDelayMicros);
+            }
+        }
+        throw new \RuntimeException("Transaction $signature not confirmed after {$this->confirmationAttempts} attempts");
+    }
+
+    private function requirePubkey(string $value, string $label): PublicKey
+    {
+        if ($value === '') {
+            throw new InvalidProofException("invalid {$label} public key: empty");
+        }
+        try {
+            return new PublicKey($value);
+        } catch (Throwable $e) {
+            throw new InvalidProofException("invalid {$label} public key", 0, $e);
+        }
     }
 
     private function paymentHeader(ServerRequestInterface $request): ?string

--- a/php/src/Protocols/X402/Upto/Engine.php
+++ b/php/src/Protocols/X402/Upto/Engine.php
@@ -15,6 +15,8 @@ use PayKit\PayCore\Solana\Mints;
 use Psr\Http\Message\ServerRequestInterface;
 use SolanaPhpSdk\Keypair\PublicKey;
 use SolanaPhpSdk\Rpc\RpcClient;
+use SolanaPhpSdk\Transaction\MessageV0;
+use SolanaPhpSdk\Transaction\TransactionInstruction;
 use SolanaPhpSdk\Transaction\VersionedTransaction;
 use Throwable;
 
@@ -25,7 +27,7 @@ use Throwable;
  *   1. {@see challengeHeaders}/{@see acceptsEntry} — advertise the ceiling.
  *   2. {@see verifyOpenPayload} — validate payload + open instruction shape.
  *   3. {@see verifyOpenAndBroadcast} — cosign as fee payer, broadcast open, confirm.
- *   4. settle_and_seal + distribute — later slice after open is live.
+ *   4. {@see settleAndSealAndBroadcast} / {@see distributeAndBroadcast} — post-usage.
  */
 final class Engine
 {
@@ -192,13 +194,216 @@ final class Engine
     }
 
     /**
-     * Enforce actual ≤ max. Full settle_and_seal broadcast is the next slice.
+     * Enforce actual ≤ max at settlement.
      *
      * @throws InvalidProofException
      */
     public function assertSettlementAmount(int $actualBaseUnits, int $maxBaseUnits): void
     {
         Verify::assertSettlementWithinCeiling($actualBaseUnits, $maxBaseUnits);
+    }
+
+    /**
+     * Settle the metered actual against an open channel and broadcast.
+     *
+     * - actual == 0 → voucherless settle_and_seal (1 instruction).
+     * - actual  > 0 → operator signs voucher preimage, then ed25519 + settle_and_seal
+     *   (2 instructions). Ceiling enforced via {@see Verify::assertSettlementWithinCeiling}.
+     *
+     * Payee seat is the operator fee payer (zero-share lifecycle authority), matching
+     * the open path. Returns the base58 settlement signature.
+     *
+     * @param ?string $recentBlockhash Optional test/RPC-free blockhash override.
+     *
+     * @throws InvalidProofException
+     */
+    public function settleAndSealAndBroadcast(
+        string $channelId,
+        int $actualBaseUnits,
+        int $maxBaseUnits,
+        int $expiresAt,
+        ?string $recentBlockhash = null,
+    ): string {
+        Verify::assertSettlementWithinCeiling($actualBaseUnits, $maxBaseUnits);
+
+        $signer = $this->config->effectiveX402Signer();
+        if ($signer === null) {
+            throw new InvalidProofException('upto settle requires an x402 operator signer');
+        }
+
+        $feePayer = $this->requirePubkey($signer->pubkey(), 'feePayer');
+        $channel = $this->requirePubkey($channelId, 'channelId');
+        // Operator holds both seats: payee (lifecycle) + receiver authorizer (voucher).
+        $payee = $feePayer;
+        $authorizedSigner = $feePayer;
+
+        $voucherSig = null;
+        if ($actualBaseUnits > 0) {
+            $message = PaymentChannels::voucherMessageBytes($channel, $actualBaseUnits, $expiresAt);
+            $voucherSig = $signer->sign($message);
+            if (strlen($voucherSig) !== 64) {
+                throw new InvalidProofException(
+                    'voucher signature length ' . strlen($voucherSig) . ', want 64',
+                );
+            }
+        }
+
+        $instructions = PaymentChannels::buildSettleAndSealInstructions(
+            $payee,
+            $channel,
+            $authorizedSigner,
+            $voucherSig,
+            $actualBaseUnits,
+            $expiresAt,
+        );
+
+        return $this->signInstructionsAndBroadcast(
+            $instructions,
+            $feePayer,
+            $recentBlockhash,
+            'settle',
+        );
+    }
+
+    /**
+     * Build, sign, and broadcast a `distribute` for a sealed channel.
+     *
+     * Account order matches Go/Python builders. Operator is fee payer + rentPayer.
+     * `$payee` defaults to the operator (upto zero-share payee seat).
+     *
+     * @param list<array{recipient: string, bps: int}> $recipients base58 recipient + bps
+     * @param ?string $recentBlockhash Optional test/RPC-free blockhash override.
+     *
+     * @throws InvalidProofException
+     */
+    public function distributeAndBroadcast(
+        string $channelId,
+        string $payer,
+        string $mint,
+        string $tokenProgram,
+        array $recipients = [],
+        ?string $payee = null,
+        ?string $recentBlockhash = null,
+    ): string {
+        $signer = $this->config->effectiveX402Signer();
+        if ($signer === null) {
+            throw new InvalidProofException('upto distribute requires an x402 operator signer');
+        }
+
+        $feePayer = $this->requirePubkey($signer->pubkey(), 'feePayer');
+        $channel = $this->requirePubkey($channelId, 'channelId');
+        $payerPk = $this->requirePubkey($payer, 'payer');
+        $mintPk = $this->requirePubkey($mint, 'mint');
+        $tokenProgramPk = $this->requirePubkey($tokenProgram, 'tokenProgram');
+        $payeePk = $this->requirePubkey($payee ?? $signer->pubkey(), 'payee');
+
+        $split = [];
+        foreach ($recipients as $i => $entry) {
+            if (!is_array($entry) || !isset($entry['recipient'], $entry['bps'])) {
+                throw new InvalidProofException("invalid distribute recipients[{$i}]");
+            }
+            $split[] = [
+                'recipient' => $this->requirePubkey((string) $entry['recipient'], "recipients[{$i}].recipient"),
+                'bps'       => (int) $entry['bps'],
+            ];
+        }
+
+        $ix = PaymentChannels::buildDistributeInstruction(
+            $channel,
+            $payerPk,
+            $feePayer, // rentPayer
+            $payeePk,
+            $mintPk,
+            $tokenProgramPk,
+            $split,
+        );
+
+        return $this->signInstructionsAndBroadcast(
+            [$ix],
+            $feePayer,
+            $recentBlockhash,
+            'distribute',
+        );
+    }
+
+    /**
+     * Compile, fee-payer-sign, broadcast, and confirm a list of instructions.
+     *
+     * @param list<TransactionInstruction> $instructions
+     *
+     * @throws InvalidProofException
+     */
+    private function signInstructionsAndBroadcast(
+        array $instructions,
+        PublicKey $feePayer,
+        ?string $recentBlockhash,
+        string $label,
+    ): string {
+        $signer = $this->config->effectiveX402Signer();
+        if ($signer === null) {
+            throw new InvalidProofException("upto {$label} requires an x402 operator signer");
+        }
+
+        $blockhash = $recentBlockhash;
+        if ($blockhash === null || $blockhash === '') {
+            $hints = $this->fetchChainHints();
+            $blockhash = is_array($hints) ? ($hints['blockhash'] ?? null) : null;
+        }
+        if ($blockhash === null || $blockhash === '') {
+            throw new InvalidProofException("upto {$label} requires a recent blockhash");
+        }
+
+        try {
+            $message = MessageV0::compile($feePayer, $instructions, $blockhash);
+            $tx = new VersionedTransaction($message);
+            $kp = Keypair::fromSecretKey($signer->secretKey());
+            $tx->sign($kp);
+            $wire = $tx->serialize(verifySignatures: false);
+        } catch (Throwable $e) {
+            throw new InvalidProofException(
+                "upto {$label} sign failed: " . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        return $this->sendAndConfirmWire($wire, $label);
+    }
+
+    /**
+     * @throws InvalidProofException
+     */
+    private function sendAndConfirmWire(string $wire, string $label): string
+    {
+        $rpc = $this->rpc();
+        try {
+            $sig = $rpc->sendRawTransaction($wire, [
+                'encoding'            => 'base64',
+                'skipPreflight'       => false,
+                'preflightCommitment' => 'confirmed',
+            ]);
+        } catch (Throwable $e) {
+            throw new InvalidProofException(
+                "pay_kit: invalid proof: {$label} broadcast failed: " . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+        if (!is_string($sig) || $sig === '') {
+            throw new InvalidProofException("pay_kit: empty {$label} broadcast result");
+        }
+
+        try {
+            $this->awaitConfirmation($sig);
+        } catch (Throwable $e) {
+            throw new InvalidProofException(
+                "pay_kit: invalid proof: {$label} not confirmed: " . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        return $sig;
     }
 
     /**
@@ -358,35 +563,7 @@ final class Engine
             throw new InvalidProofException('upto cosign failed: ' . $e->getMessage(), 0, $e);
         }
 
-        $rpc = $this->rpc();
-        try {
-            $sig = $rpc->sendRawTransaction($wire, [
-                'encoding'              => 'base64',
-                'skipPreflight'         => false,
-                'preflightCommitment'   => 'confirmed',
-            ]);
-        } catch (Throwable $e) {
-            throw new InvalidProofException(
-                'pay_kit: invalid proof: open broadcast failed: ' . $e->getMessage(),
-                0,
-                $e,
-            );
-        }
-        if (!is_string($sig) || $sig === '') {
-            throw new InvalidProofException('pay_kit: empty open broadcast result');
-        }
-
-        try {
-            $this->awaitConfirmation($sig);
-        } catch (Throwable $e) {
-            throw new InvalidProofException(
-                'pay_kit: invalid proof: open not confirmed: ' . $e->getMessage(),
-                0,
-                $e,
-            );
-        }
-
-        return $sig;
+        return $this->sendAndConfirmWire($wire, 'open');
     }
 
     private function rpc(): RpcGateway

--- a/php/src/Protocols/X402/Upto/Engine.php
+++ b/php/src/Protocols/X402/Upto/Engine.php
@@ -162,15 +162,20 @@ final class Engine
 
         Verify::verifyUptoPayload($payload, $requirements, $receiverAuthorizer, time());
 
+        // payment-channel profile requires a pull-style open transaction; push
+        // (signature-only) is not accepted by this engine.
         $openTx = (string) ($payload['openTransaction'] ?? '');
-        if ($openTx !== '') {
-            $this->validateOpenTransaction(
-                $openTx,
-                $payload,
-                $requirements,
-                $receiverAuthorizer,
+        if ($openTx === '') {
+            throw new InvalidProofException(
+                'upto payment-channel payload missing openTransaction',
             );
         }
+        $this->validateOpenTransaction(
+            $openTx,
+            $payload,
+            $requirements,
+            $receiverAuthorizer,
+        );
 
         $maxBaseUnits = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
 
@@ -216,6 +221,13 @@ final class Engine
         }
 
         $message = $tx->message;
+        // Match SolanaChargeTransactionVerifier: open must not pull accounts
+        // from address lookup tables (static keys only).
+        if (($message->addressTableLookups ?? []) !== []) {
+            throw new InvalidProofException(
+                'v0 address lookup tables are not supported on upto open transactions',
+            );
+        }
         $accountKeys = array_map(
             static fn (PublicKey $k): string => (string) $k,
             $message->staticAccountKeys,

--- a/php/src/Protocols/X402/Upto/Engine.php
+++ b/php/src/Protocols/X402/Upto/Engine.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Protocols\X402\Upto;
+
+use PayKit\Config;
+use PayKit\Exception\InvalidProofException;
+use PayKit\Gate;
+use PayKit\PayCore\PaymentChannels;
+use PayKit\PayCore\Solana\Mints;
+use Psr\Http\Message\ServerRequestInterface;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Rpc\RpcClient;
+use SolanaPhpSdk\Transaction\VersionedTransaction;
+use Throwable;
+
+/**
+ * x402 `upto` (Solana) server engine — payment-channel profile.
+ *
+ * Two-phase flow (mirrors Rust/Go/Python):
+ *   1. {@see challengeHeaders}/{@see acceptsEntry} — advertise the ceiling.
+ *   2. {@see verifyOpenPayload} — validate payload + open instruction shape.
+ *   3. settle_and_seal broadcast — follow-up once instruction builders land.
+ *
+ * This first slice ships challenge generation and pure open-path validation.
+ * Full cosign + settle_and_seal broadcast lands next (Ruby #192 / Python
+ * settle path as reference).
+ */
+final class Engine
+{
+    private const PAYMENT_REQUIRED_HEADER = 'payment-required';
+    private const PAYMENT_SIGNATURE_HEADER = 'payment-signature';
+    private const PAYMENT_LEGACY_HEADER = 'x-payment';
+
+    /** @var \Closure():?array{blockhash: string, slot?: string}|null */
+    private $chainHintsProvider = null;
+
+    /**
+     * @param ?\Closure():?array{blockhash: string, slot?: string} $chainHintsProvider
+     *        Test hook for recentBlockhash / recentSlot without RPC.
+     */
+    public function __construct(
+        private readonly Config $config,
+        ?\Closure $chainHintsProvider = null,
+    ) {
+        $this->chainHintsProvider = $chainHintsProvider;
+    }
+
+    /**
+     * Single accepts[] entry for an `upto` challenge.
+     *
+     * @return array<string,mixed>
+     */
+    public function acceptsEntry(Gate $gate, ServerRequestInterface $request): array
+    {
+        $coin = $gate->amount->primaryCoin()?->value ?? $this->config->stablecoins[0]->value;
+        $asset = Mints::resolve($coin, $this->config->network->mintsLabel()) ?? $coin;
+        $tokenProgram = Mints::tokenProgramFor($coin, $this->config->network->mintsLabel());
+        $payTo = $gate->payTo ?? $this->config->effectiveRecipient();
+        // Match Exact adapter: Price is human units × 1e6 → base units string.
+        $amount = (string) $gate->total()->amount->multipliedBy(1_000_000)->toInt();
+        $signer = $this->config->effectiveX402Signer();
+        $feePayer = $signer?->pubkey() ?? '';
+        // Operator holds both seats: fee payer (lifecycle) + receiver authorizer
+        // (voucher signer). Matches createPayKit / Rust X402Upto.
+        $extra = [
+            'decimals'           => 6,
+            'tokenProgram'       => $tokenProgram,
+            'feePayer'           => $feePayer,
+            'receiverAuthorizer' => $feePayer,
+            'withdrawDelay'      => Types::DEFAULT_WITHDRAW_DELAY_SECONDS,
+        ];
+        $hints = $this->fetchChainHints();
+        if ($hints !== null) {
+            if (($hints['blockhash'] ?? '') !== '') {
+                $extra['recentBlockhash'] = $hints['blockhash'];
+            }
+            if (isset($hints['slot']) && $hints['slot'] !== '') {
+                $extra['recentSlot'] = (string) $hints['slot'];
+            }
+        }
+
+        return [
+            'protocol'          => 'x402',
+            'scheme'            => Types::SCHEME,
+            'network'           => $this->caip2(),
+            'asset'             => $asset,
+            'amount'            => $amount,
+            'maxAmountRequired' => $amount,
+            'payTo'             => $payTo,
+            'maxTimeoutSeconds' => Types::DEFAULT_MAX_TIMEOUT_SECONDS,
+            'extra'             => $extra,
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function challengeHeaders(Gate $gate, ServerRequestInterface $request): array
+    {
+        $challenge = [
+            'x402Version' => Types::X402_VERSION,
+            'resource'    => ['type' => 'http', 'url' => $request->getUri()->getPath()],
+            'accepts'     => [$this->acceptsEntry($gate, $request)],
+        ];
+        $encoded = base64_encode(
+            json_encode($challenge, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        );
+
+        return [self::PAYMENT_REQUIRED_HEADER => $encoded];
+    }
+
+    /**
+     * Decode and structurally validate an upto PAYMENT-SIGNATURE open.
+     *
+     * Does not broadcast yet — returns the verified payload + requirement
+     * binding for the settle phase. Callers that need on-chain open should
+     * use a follow-up that cosigns + sends (payment-channel builders).
+     *
+     * @param array<string,mixed> $requirements Route-pinned accepts[] entry
+     *
+     * @return array{
+     *   payload: array<string,mixed>,
+     *   requirements: array<string,mixed>,
+     *   maxBaseUnits: int,
+     *   payer: string,
+     *   channelId: string
+     * }
+     *
+     * @throws InvalidProofException
+     */
+    public function verifyOpenPayload(ServerRequestInterface $request, array $requirements): array
+    {
+        $header = $this->paymentHeader($request);
+        if ($header === null) {
+            throw new InvalidProofException('missing_x402_payment_header');
+        }
+
+        $raw = base64_decode($header, true);
+        if ($raw === false || $raw === '') {
+            throw new InvalidProofException('invalid_x402_payment_header');
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable $e) {
+            throw new InvalidProofException('invalid_x402_payment_header', 0, $e);
+        }
+        if (!is_array($decoded) || !isset($decoded['payload']) || !is_array($decoded['payload'])) {
+            throw new InvalidProofException('invalid_x402_payment_header');
+        }
+
+        /** @var array<string,mixed> $payload */
+        $payload = $decoded['payload'];
+        $extra = is_array($requirements['extra'] ?? null) ? $requirements['extra'] : [];
+        $receiverAuthorizer = (string) ($extra['receiverAuthorizer'] ?? '');
+        if ($receiverAuthorizer === '') {
+            throw new InvalidProofException('upto requirement missing receiverAuthorizer');
+        }
+
+        Verify::verifyUptoPayload($payload, $requirements, $receiverAuthorizer, time());
+
+        $openTx = (string) ($payload['openTransaction'] ?? '');
+        if ($openTx !== '') {
+            $this->validateOpenTransaction(
+                $openTx,
+                $payload,
+                $requirements,
+                $receiverAuthorizer,
+            );
+        }
+
+        $maxBaseUnits = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
+
+        return [
+            'payload'       => $payload,
+            'requirements'  => $requirements,
+            'maxBaseUnits'  => $maxBaseUnits,
+            'payer'         => (string) ($payload['from'] ?? ''),
+            'channelId'     => (string) ($payload['channelId'] ?? ''),
+        ];
+    }
+
+    /**
+     * Enforce actual ≤ max. Full settle_and_seal broadcast is the next slice.
+     *
+     * @throws InvalidProofException
+     */
+    public function assertSettlementAmount(int $actualBaseUnits, int $maxBaseUnits): void
+    {
+        Verify::assertSettlementWithinCeiling($actualBaseUnits, $maxBaseUnits);
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @param array<string,mixed> $requirements
+     *
+     * @throws InvalidProofException
+     */
+    private function validateOpenTransaction(
+        string $transactionBase64,
+        array $payload,
+        array $requirements,
+        string $receiverAuthorizer,
+    ): void {
+        $raw = base64_decode($transactionBase64, true);
+        if ($raw === false || $raw === '') {
+            throw new InvalidProofException('invalid open transaction base64');
+        }
+        try {
+            $tx = VersionedTransaction::deserialize($raw);
+        } catch (Throwable $e) {
+            throw new InvalidProofException('invalid open transaction parse', 0, $e);
+        }
+
+        $message = $tx->message;
+        $accountKeys = array_map(
+            static fn (PublicKey $k): string => (string) $k,
+            $message->staticAccountKeys,
+        );
+        $instructions = [];
+        foreach ($message->compiledInstructions as $ix) {
+            $instructions[] = [
+                'programIdIndex' => (int) $ix->programIdIndex,
+                'accounts'       => array_map('intval', $ix->accountKeyIndexes),
+                'data'           => is_string($ix->data) ? $ix->data : (string) $ix->data,
+            ];
+        }
+
+        $extra = is_array($requirements['extra'] ?? null) ? $requirements['extra'] : [];
+        $feePayer = new PublicKey((string) ($extra['feePayer'] ?? $receiverAuthorizer));
+        $receiver = new PublicKey($receiverAuthorizer);
+        $payer = new PublicKey((string) ($payload['from'] ?? ''));
+        // Channel payee is the fee payer (zero-share lifecycle seat) for upto.
+        $payee = $feePayer;
+        $mint = new PublicKey((string) ($requirements['asset'] ?? ''));
+        $tokenProgram = new PublicKey(
+            (string) ($extra['tokenProgram'] ?? PaymentChannels::tokenProgramId()),
+        );
+        $channelId = new PublicKey((string) ($payload['channelId'] ?? ''));
+        $maxAmount = Verify::parseBaseUnits((string) $requirements['amount'], 'amount');
+        $withdrawDelay = (int) ($extra['withdrawDelay'] ?? Types::DEFAULT_WITHDRAW_DELAY_SECONDS);
+        $recentSlot = isset($extra['recentSlot']) ? (int) $extra['recentSlot'] : null;
+
+        Verify::validateUptoOpenInstruction(
+            $accountKeys,
+            $instructions,
+            new PublicKey(PaymentChannels::PROGRAM_ID),
+            $feePayer,
+            $receiver,
+            $payer,
+            $payee,
+            $mint,
+            $tokenProgram,
+            $channelId,
+            $maxAmount,
+            $withdrawDelay,
+            (string) ($payload['nonce'] ?? ''),
+            (string) ($payload['openSlot'] ?? ''),
+            $recentSlot,
+        );
+    }
+
+    private function paymentHeader(ServerRequestInterface $request): ?string
+    {
+        $headers = $request->getHeaders();
+        foreach ([self::PAYMENT_SIGNATURE_HEADER, self::PAYMENT_LEGACY_HEADER] as $name) {
+            foreach ($headers as $key => $values) {
+                if (strtolower((string) $key) === $name && isset($values[0]) && $values[0] !== '') {
+                    return $values[0];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return ?array{blockhash: string, slot?: string}
+     */
+    private function fetchChainHints(): ?array
+    {
+        if ($this->chainHintsProvider !== null) {
+            try {
+                $value = ($this->chainHintsProvider)();
+
+                return is_array($value) ? $value : null;
+            } catch (Throwable) {
+                return null;
+            }
+        }
+        if ($this->config->rpcUrl === '') {
+            return null;
+        }
+        try {
+            $rpc = new RpcClient($this->config->rpcUrl);
+            $result = $rpc->getLatestBlockhash();
+            $blockhash = is_array($result) && isset($result['blockhash'])
+                ? (string) $result['blockhash']
+                : '';
+            if ($blockhash === '') {
+                return null;
+            }
+            $hints = ['blockhash' => $blockhash];
+            // Optional: getSlot when the client is available.
+            if (method_exists($rpc, 'getSlot')) {
+                try {
+                    $slot = $rpc->getSlot();
+                    if (is_int($slot) || (is_string($slot) && $slot !== '')) {
+                        $hints['slot'] = (string) $slot;
+                    }
+                } catch (Throwable) {
+                    // recentSlot optional on the challenge
+                }
+            }
+
+            return $hints;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function caip2(): string
+    {
+        return $this->config->network->caip2();
+    }
+}

--- a/php/src/Protocols/X402/Upto/Types.php
+++ b/php/src/Protocols/X402/Upto/Types.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Protocols\X402\Upto;
+
+/**
+ * x402 `upto` scheme constants and wire-shape documentation.
+ *
+ * Field names and amount/timestamp encodings mirror the Rust spine
+ * (`protocol/schemes/upto/types.rs`), Go (`go/protocols/x402/upto.go`), and
+ * Python (`protocols/x402/upto/types.py`) field-for-field: camelCase JSON
+ * keys, amounts as base-10 u64 strings, timestamps as Unix seconds.
+ *
+ * PHP uses associative arrays at the wire boundary (same as Exact); this
+ * class only holds constants so every language SDK shares identical strings.
+ */
+final class Types
+{
+    /** The x402 scheme identifier for usage-based `upto` authorizations. */
+    public const SCHEME = 'upto';
+
+    /** Default forced-close delay, in seconds, for SVM payment channels. */
+    public const DEFAULT_WITHDRAW_DELAY_SECONDS = 900;
+
+    /**
+     * Settlement error when the metered actual exceeds the signed ceiling.
+     * Identical string to Rust/Go/Python for cross-language error parity.
+     */
+    public const ERROR_SETTLEMENT_EXCEEDS_AMOUNT = 'invalid_upto_svm_payload_settlement_exceeds_amount';
+
+    /** x402 protocol version this server emits for upto challenges. */
+    public const X402_VERSION = 2;
+
+    /** Default authorization window (seconds). */
+    public const DEFAULT_MAX_TIMEOUT_SECONDS = 300;
+
+    private function __construct()
+    {
+    }
+}

--- a/php/src/Protocols/X402/Upto/Verify.php
+++ b/php/src/Protocols/X402/Upto/Verify.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Protocols\X402\Upto;
+
+use PayKit\Exception\InvalidProofException;
+use PayKit\PayCore\PaymentChannels;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Programs\AssociatedTokenProgram;
+use SolanaPhpSdk\Programs\SystemProgram;
+
+/**
+ * Pure verification for the x402 `upto` payment-channel profile.
+ *
+ * No I/O: validates already-decoded structures and raises
+ * {@see InvalidProofException} on rejection. Ordered checks mirror Rust/Go/
+ * Python (`VerifyUptoPayload`, `validateUptoOpenInstruction`).
+ */
+final class Verify
+{
+    /**
+     * Parse a base-10 u64 amount string.
+     *
+     * @throws InvalidProofException
+     */
+    public static function parseBaseUnits(string $value, string $label): int
+    {
+        if ($value === '' || !preg_match('/^[0-9]+$/', $value)) {
+            throw new InvalidProofException("invalid upto {$label} " . var_export($value, true));
+        }
+        // Reject values that overflow PHP platform int or u64.
+        if (strlen($value) > 20 || (strlen($value) === 20 && $value > '18446744073709551615')) {
+            throw new InvalidProofException("upto {$label} {$value} does not fit in u64");
+        }
+        $parsed = (int) $value;
+        if ($parsed < 0) {
+            throw new InvalidProofException("upto {$label} {$parsed} does not fit in u64");
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Validate the client payload against the route-pinned requirement.
+     *
+     * @param array<string,mixed> $payload
+     * @param array<string,mixed> $requirements accepts[] entry
+     *
+     * @throws InvalidProofException
+     */
+    public static function verifyUptoPayload(
+        array $payload,
+        array $requirements,
+        string $receiverAuthorizer,
+        int $now,
+    ): void {
+        $maxAmount = self::parseBaseUnits((string) ($requirements['amount'] ?? ''), 'amount');
+        $signedMax = self::parseBaseUnits((string) ($payload['maxAmount'] ?? ''), 'maxAmount');
+        if ($signedMax !== $maxAmount) {
+            throw new InvalidProofException(
+                "amount mismatch: expected {$maxAmount}, got {$signedMax}",
+            );
+        }
+
+        $deposit = self::parseBaseUnits((string) ($payload['deposit'] ?? ''), 'deposit');
+        if ($deposit !== $maxAmount) {
+            throw new InvalidProofException(
+                "channel deposit {$deposit} must equal the authorized maximum {$maxAmount}",
+            );
+        }
+
+        $validAfter = (int) ($payload['validAfter'] ?? 0);
+        $expiresAt = (int) ($payload['expiresAt'] ?? 0);
+        if ($now < $validAfter) {
+            throw new InvalidProofException(
+                "authorization not yet active (validAfter {$validAfter} > now {$now})",
+            );
+        }
+        if ($expiresAt === 0 || $now >= $expiresAt) {
+            throw new InvalidProofException(
+                "authorization expired (expiresAt {$expiresAt} < now {$now})",
+            );
+        }
+
+        if (($payload['authorizedSigner'] ?? null) !== $receiverAuthorizer) {
+            throw new InvalidProofException(
+                'voucher authorized_signer must be the advertised receiver authorizer',
+            );
+        }
+    }
+
+    /**
+     * Enforce actual <= max at settlement.
+     *
+     * @throws InvalidProofException
+     */
+    public static function assertSettlementWithinCeiling(int $actual, int $maxAmount): void
+    {
+        if ($actual > $maxAmount) {
+            throw new InvalidProofException(Types::ERROR_SETTLEMENT_EXCEEDS_AMOUNT);
+        }
+    }
+
+    /**
+     * Validate the client-built channel-open instruction byte-for-byte.
+     *
+     * The open transaction must contain exactly one instruction targeting the
+     * payment-channels program with the open discriminator and the 14 accounts
+     * in the fixed program order.
+     *
+     * @param list<string>                                                                 $accountKeys base58 pubkeys
+     * @param list<array{programIdIndex: int, accounts: list<int>, data: string}>            $instructions
+     *
+     * @throws InvalidProofException
+     */
+    public static function validateUptoOpenInstruction(
+        array $accountKeys,
+        array $instructions,
+        PublicKey $programId,
+        PublicKey $feePayer,
+        PublicKey $receiverAuthorizer,
+        PublicKey $payer,
+        PublicKey $payee,
+        PublicKey $mint,
+        PublicKey $tokenProgram,
+        PublicKey $channelId,
+        int $maxAmount,
+        int $withdrawDelay,
+        string $payloadNonce,
+        string $payloadOpenSlot,
+        ?int $recentSlot,
+    ): void {
+        if (count($instructions) !== 1) {
+            throw new InvalidProofException(
+                'open transaction must contain exactly one instruction, found ' . count($instructions),
+            );
+        }
+        $ix = $instructions[0];
+        $programIndex = (int) $ix['programIdIndex'];
+        if ($programIndex >= count($accountKeys)) {
+            throw new InvalidProofException('open instruction program id out of range');
+        }
+        if ($accountKeys[$programIndex] !== (string) $programId) {
+            throw new InvalidProofException('open transaction targets an unexpected program');
+        }
+        $data = $ix['data'];
+        if ($data === '' || ord($data[0]) !== PaymentChannels::OPEN_INSTRUCTION_DISCRIMINATOR) {
+            throw new InvalidProofException('open transaction is not a channel-open instruction');
+        }
+
+        $indices = $ix['accounts'];
+
+        $accountAt = static function (int $pos, string $label) use ($indices, $accountKeys): string {
+            if ($pos >= count($indices) || $indices[$pos] >= count($accountKeys)) {
+                throw new InvalidProofException(
+                    "open transaction {$label} mismatch: expected account at slot {$pos}, got <none>",
+                );
+            }
+
+            return $accountKeys[$indices[$pos]];
+        };
+
+        $expect = static function (int $pos, PublicKey $want, string $label) use ($accountAt): void {
+            $got = $accountAt($pos, $label);
+            if ($got !== (string) $want) {
+                throw new InvalidProofException(
+                    "open transaction {$label} mismatch: expected {$want}, got {$got}",
+                );
+            }
+        };
+
+        [$payerToken] = PaymentChannels::findAssociatedTokenAddress($payer, $mint, $tokenProgram);
+        [$channelToken] = PaymentChannels::findAssociatedTokenAddress($channelId, $mint, $tokenProgram);
+        [$eventAuthority] = PaymentChannels::findEventAuthorityPda($programId);
+
+        $expect(0, $payer, 'payer');
+        $expect(1, $feePayer, 'rent_payer');
+        $expect(2, $payee, 'payee');
+        $expect(3, $mint, 'mint');
+        $expect(4, $receiverAuthorizer, 'authorized_signer');
+        $expect(5, $channelId, 'channel');
+        $expect(6, $payerToken, 'payer_token_account');
+        $expect(7, $channelToken, 'channel_token_account');
+        $expect(8, $tokenProgram, 'token_program');
+        $expect(9, new PublicKey(SystemProgram::PROGRAM_ID), 'system_program');
+        $expect(10, new PublicKey(PaymentChannels::RENT_SYSVAR_ID), 'rent_sysvar');
+        $expect(11, new PublicKey(AssociatedTokenProgram::PROGRAM_ID), 'associated_token_program');
+        $expect(12, $eventAuthority, 'event_authority');
+        $expect(13, $programId, 'self_program');
+
+        try {
+            $args = PaymentChannels::decodeOpenArgs($data);
+        } catch (\InvalidArgumentException $e) {
+            throw new InvalidProofException($e->getMessage(), 0, $e);
+        }
+
+        if ($payloadNonce !== (string) $args['salt']) {
+            throw new InvalidProofException(
+                "open salt {$args['salt']} does not match payload nonce " . var_export($payloadNonce, true),
+            );
+        }
+        if ($payloadOpenSlot !== (string) $args['openSlot']) {
+            throw new InvalidProofException(
+                "open slot {$args['openSlot']} does not match payload openSlot " . var_export($payloadOpenSlot, true),
+            );
+        }
+        if ($args['gracePeriod'] !== $withdrawDelay) {
+            throw new InvalidProofException(
+                "open withdraw delay {$args['gracePeriod']} must equal the advertised withdrawDelay {$withdrawDelay}",
+            );
+        }
+
+        [$derivedChannel] = PaymentChannels::findChannelPda(
+            $payer,
+            $payee,
+            $mint,
+            $receiverAuthorizer,
+            $args['salt'],
+            $args['openSlot'],
+            $programId,
+        );
+        if (!$derivedChannel->equals($channelId)) {
+            throw new InvalidProofException(
+                "open channel PDA {$channelId} != derived {$derivedChannel}",
+            );
+        }
+        if ($args['deposit'] !== $maxAmount) {
+            throw new InvalidProofException(
+                "open deposit {$args['deposit']} must equal the authorized maximum {$maxAmount}",
+            );
+        }
+        if ($recentSlot !== null) {
+            if ($args['openSlot'] > $recentSlot) {
+                throw new InvalidProofException(
+                    "open openSlot {$args['openSlot']} is ahead of the challenged recentSlot {$recentSlot}",
+                );
+            }
+            if ($recentSlot - $args['openSlot'] > PaymentChannels::OPEN_SLOT_WINDOW) {
+                throw new InvalidProofException(
+                    "open openSlot {$args['openSlot']} is outside the "
+                    . PaymentChannels::OPEN_SLOT_WINDOW
+                    . "-slot freshness window of the challenged recentSlot {$recentSlot}",
+                );
+            }
+        }
+    }
+}

--- a/php/src/Protocols/X402/Upto/Verify.php
+++ b/php/src/Protocols/X402/Upto/Verify.php
@@ -19,8 +19,15 @@ use SolanaPhpSdk\Programs\SystemProgram;
  */
 final class Verify
 {
+    /** Unsigned 64-bit maximum as a decimal string. */
+    private const U64_MAX = '18446744073709551615';
+
     /**
-     * Parse a base-10 u64 amount string.
+     * Parse a base-10 u64 amount string into a PHP int.
+     *
+     * Rejects non-digit input, values above u64 max, and values above
+     * {@see PHP_INT_MAX} so the cast cannot saturate/truncate (values in
+     * (PHP_INT_MAX, u64_max] would otherwise lose their wire value).
      *
      * @throws InvalidProofException
      */
@@ -29,16 +36,76 @@ final class Verify
         if ($value === '' || !preg_match('/^[0-9]+$/', $value)) {
             throw new InvalidProofException("invalid upto {$label} " . var_export($value, true));
         }
-        // Reject values that overflow PHP platform int or u64.
-        if (strlen($value) > 20 || (strlen($value) === 20 && $value > '18446744073709551615')) {
+        // Strip leading zeros for length/lexicographic compare (keep "0").
+        $normalized = ltrim($value, '0');
+        if ($normalized === '') {
+            $normalized = '0';
+        }
+        if (self::decimalGreaterThan($normalized, self::U64_MAX)) {
             throw new InvalidProofException("upto {$label} {$value} does not fit in u64");
         }
-        $parsed = (int) $value;
-        if ($parsed < 0) {
-            throw new InvalidProofException("upto {$label} {$parsed} does not fit in u64");
+        $maxPlatform = (string) PHP_INT_MAX;
+        if (self::decimalGreaterThan($normalized, $maxPlatform)) {
+            throw new InvalidProofException(
+                "upto {$label} {$value} does not fit in platform int (PHP_INT_MAX)",
+            );
         }
 
-        return $parsed;
+        return (int) $normalized;
+    }
+
+    /**
+     * Parse a strict base-10 integer (optional leading `-`) into a PHP int.
+     *
+     * Used for authorization timestamps so `"123abc"` cannot silently become
+     * `123` via a cast. Rejects values outside [PHP_INT_MIN, PHP_INT_MAX].
+     *
+     * @param mixed $value
+     *
+     * @throws InvalidProofException
+     */
+    public static function parseStrictInt(mixed $value, string $label): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (!is_string($value) || $value === '' || !preg_match('/^-?[0-9]+$/', $value)) {
+            throw new InvalidProofException(
+                "invalid upto {$label} " . var_export($value, true),
+            );
+        }
+        // Exact platform min string (e.g. "-9223372036854775808") before
+        // magnitude checks so we do not reject PHP_INT_MIN as > PHP_INT_MAX.
+        if ($value === (string) PHP_INT_MIN) {
+            return PHP_INT_MIN;
+        }
+        $negative = $value[0] === '-';
+        $digits = $negative ? substr($value, 1) : $value;
+        $normalized = ltrim($digits, '0');
+        if ($normalized === '') {
+            return 0;
+        }
+        if (self::decimalGreaterThan($normalized, (string) PHP_INT_MAX)) {
+            throw new InvalidProofException(
+                "upto {$label} {$value} does not fit in platform int",
+            );
+        }
+
+        return $negative ? -((int) $normalized) : (int) $normalized;
+    }
+
+    /**
+     * Lexicographic compare of non-negative decimal digit strings (no leading zeros).
+     */
+    private static function decimalGreaterThan(string $a, string $b): bool
+    {
+        $la = strlen($a);
+        $lb = strlen($b);
+        if ($la !== $lb) {
+            return $la > $lb;
+        }
+
+        return $a > $b;
     }
 
     /**
@@ -70,8 +137,8 @@ final class Verify
             );
         }
 
-        $validAfter = (int) ($payload['validAfter'] ?? 0);
-        $expiresAt = (int) ($payload['expiresAt'] ?? 0);
+        $validAfter = self::parseStrictInt($payload['validAfter'] ?? 0, 'validAfter');
+        $expiresAt = self::parseStrictInt($payload['expiresAt'] ?? 0, 'expiresAt');
         if ($now < $validAfter) {
             throw new InvalidProofException(
                 "authorization not yet active (validAfter {$validAfter} > now {$now})",
@@ -150,6 +217,11 @@ final class Verify
         }
 
         $indices = $ix['accounts'];
+        if (count($indices) !== 14) {
+            throw new InvalidProofException(
+                'open instruction must reference exactly 14 accounts, found ' . count($indices),
+            );
+        }
 
         $accountAt = static function (int $pos, string $label) use ($indices, $accountKeys): string {
             if ($pos >= count($indices) || $indices[$pos] >= count($accountKeys)) {

--- a/php/tests/PayCore/PaymentChannelsBuildersTest.php
+++ b/php/tests/PayCore/PaymentChannelsBuildersTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\PayCore;
+
+use PayKit\PayCore\PaymentChannels;
+use PHPUnit\Framework\TestCase;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Transaction\TransactionInstruction;
+
+/**
+ * Offline instruction-builder parity with Go paycore/paymentchannels.
+ */
+final class PaymentChannelsBuildersTest extends TestCase
+{
+    private PublicKey $payer;
+    private PublicKey $rentPayer;
+    private PublicKey $payee;
+    private PublicKey $mint;
+    private PublicKey $authorizedSigner;
+    private PublicKey $tokenProgram;
+
+    protected function setUp(): void
+    {
+        $this->payer = new PublicKey(str_repeat("\x01", 32));
+        $this->rentPayer = new PublicKey(str_repeat("\x02", 32));
+        $this->payee = new PublicKey(str_repeat("\x03", 32));
+        $this->mint = new PublicKey(str_repeat("\x04", 32));
+        $this->authorizedSigner = new PublicKey(str_repeat("\x05", 32));
+        $this->tokenProgram = new PublicKey(PaymentChannels::tokenProgramId());
+    }
+
+    public function testBuildOpenInstructionAccountOrderAndFlags(): void
+    {
+        $salt = 7;
+        $deposit = 100_000;
+        $grace = 900;
+        $openSlot = 4242;
+
+        $ix = PaymentChannels::buildOpenInstruction(
+            $this->payer,
+            $this->rentPayer,
+            $this->payee,
+            $this->mint,
+            $this->authorizedSigner,
+            $salt,
+            $deposit,
+            $grace,
+            $openSlot,
+            $this->tokenProgram,
+        );
+
+        self::assertInstanceOf(TransactionInstruction::class, $ix);
+        self::assertSame(PaymentChannels::PROGRAM_ID, (string) $ix->programId);
+        self::assertCount(14, $ix->accounts);
+
+        [$channel] = PaymentChannels::findChannelPda(
+            $this->payer,
+            $this->payee,
+            $this->mint,
+            $this->authorizedSigner,
+            $salt,
+            $openSlot,
+        );
+        [$payerToken] = PaymentChannels::findAssociatedTokenAddress(
+            $this->payer,
+            $this->mint,
+            $this->tokenProgram,
+        );
+        [$channelToken] = PaymentChannels::findAssociatedTokenAddress(
+            $channel,
+            $this->mint,
+            $this->tokenProgram,
+        );
+        [$eventAuthority] = PaymentChannels::findEventAuthorityPda();
+
+        $want = [
+            [(string) $this->payer, true, true],
+            [(string) $this->rentPayer, true, true],
+            [(string) $this->payee, false, false],
+            [(string) $this->mint, false, false],
+            [(string) $this->authorizedSigner, false, false],
+            [(string) $channel, false, true],
+            [(string) $payerToken, false, true],
+            [(string) $channelToken, false, true],
+            [PaymentChannels::tokenProgramId(), false, false],
+            [PaymentChannels::systemProgramId(), false, false],
+            [PaymentChannels::RENT_SYSVAR_ID, false, false],
+            [PaymentChannels::associatedTokenProgramId(), false, false],
+            [(string) $eventAuthority, false, false],
+            [PaymentChannels::PROGRAM_ID, false, false],
+        ];
+
+        foreach ($want as $i => [$pubkey, $signer, $writable]) {
+            $meta = $ix->accounts[$i];
+            self::assertSame($pubkey, (string) $meta->pubkey, "account[{$i}] pubkey");
+            self::assertSame($signer, $meta->isSigner, "account[{$i}] signer");
+            self::assertSame($writable, $meta->isWritable, "account[{$i}] writable");
+        }
+    }
+
+    public function testBuildOpenInstructionDataRoundTrip(): void
+    {
+        $salt = 7;
+        $deposit = 100_000;
+        $grace = 900;
+        $openSlot = 4242;
+
+        $ix = PaymentChannels::buildOpenInstruction(
+            $this->payer,
+            $this->rentPayer,
+            $this->payee,
+            $this->mint,
+            $this->authorizedSigner,
+            $salt,
+            $deposit,
+            $grace,
+            $openSlot,
+            $this->tokenProgram,
+        );
+
+        $encoded = PaymentChannels::encodeOpenInstructionData($salt, $deposit, $grace, $openSlot);
+        self::assertSame($encoded, $ix->data);
+        self::assertSame(33, strlen($ix->data));
+
+        $decoded = PaymentChannels::decodeOpenArgs($ix->data);
+        self::assertSame($salt, $decoded['salt']);
+        self::assertSame($deposit, $decoded['deposit']);
+        self::assertSame($grace, $decoded['gracePeriod']);
+        self::assertSame($openSlot, $decoded['openSlot']);
+    }
+
+    public function testBuildSettleAndSealVoucherlessIsSingleInstruction(): void
+    {
+        $channel = new PublicKey(str_repeat("\x09", 32));
+        $ixs = PaymentChannels::buildSettleAndSealInstructions(
+            $this->payee,
+            $channel,
+            $this->authorizedSigner,
+            null,
+            0,
+            0,
+        );
+        self::assertCount(1, $ixs);
+        $seal = $ixs[0];
+        self::assertSame(PaymentChannels::PROGRAM_ID, (string) $seal->programId);
+        self::assertCount(3, $seal->accounts);
+        self::assertTrue($seal->accounts[0]->isSigner);
+        self::assertFalse($seal->accounts[0]->isWritable);
+        self::assertFalse($seal->accounts[1]->isSigner);
+        self::assertTrue($seal->accounts[1]->isWritable);
+        self::assertSame(PaymentChannels::SYSVAR_INSTRUCTIONS, (string) $seal->accounts[2]->pubkey);
+        self::assertSame(
+            chr(PaymentChannels::SETTLE_AND_SEAL_DISCRIMINATOR) . "\x00",
+            $seal->data,
+        );
+    }
+
+    public function testBuildSettleAndSealWithVoucherPrependsEd25519(): void
+    {
+        $channel = new PublicKey(str_repeat("\x09", 32));
+        $signature = str_repeat("\xAB", 64);
+        $cumulative = 50_000;
+        $expiresAt = 1_700_000_000;
+
+        $ixs = PaymentChannels::buildSettleAndSealInstructions(
+            $this->payee,
+            $channel,
+            $this->authorizedSigner,
+            $signature,
+            $cumulative,
+            $expiresAt,
+        );
+        self::assertCount(2, $ixs);
+
+        $ed = $ixs[0];
+        self::assertSame(PaymentChannels::ED25519_PROGRAM_ID, (string) $ed->programId);
+        self::assertSame([], $ed->accounts);
+        self::assertSame(1, ord($ed->data[0]));
+        $message = PaymentChannels::voucherMessageBytes($channel, $cumulative, $expiresAt);
+        self::assertSame(112 + strlen($message), strlen($ed->data));
+        self::assertSame($this->authorizedSigner->toBytes(), substr($ed->data, 16, 32));
+        self::assertSame($signature, substr($ed->data, 48, 64));
+        self::assertSame($message, substr($ed->data, 112));
+
+        $seal = $ixs[1];
+        self::assertSame(
+            chr(PaymentChannels::SETTLE_AND_SEAL_DISCRIMINATOR) . "\x01",
+            $seal->data,
+        );
+    }
+
+    public function testBuildDistributeEmptyRecipients(): void
+    {
+        $channel = new PublicKey(str_repeat("\x0A", 32));
+        $ix = PaymentChannels::buildDistributeInstruction(
+            $channel,
+            $this->payer,
+            $this->rentPayer,
+            $this->payee,
+            $this->mint,
+            $this->tokenProgram,
+            [],
+        );
+
+        self::assertCount(11, $ix->accounts);
+        self::assertTrue($ix->accounts[0]->isWritable); // channel
+        self::assertTrue($ix->accounts[1]->isWritable); // payer
+        self::assertTrue($ix->accounts[2]->isWritable); // rentPayer
+        self::assertSame(
+            chr(PaymentChannels::DISTRIBUTE_DISCRIMINATOR) . "\x00\x00\x00\x00",
+            $ix->data,
+        );
+        self::assertSame(PaymentChannels::PROGRAM_ID, (string) $ix->programId);
+        self::assertSame(PaymentChannels::PROGRAM_ID, (string) $ix->accounts[10]->pubkey);
+    }
+
+    public function testBuildDistributeWithRecipientAppendsAta(): void
+    {
+        $channel = new PublicKey(str_repeat("\x0B", 32));
+        $recipient = new PublicKey(str_repeat("\x0C", 32));
+        $ix = PaymentChannels::buildDistributeInstruction(
+            $channel,
+            $this->payer,
+            $this->rentPayer,
+            $this->payee,
+            $this->mint,
+            $this->tokenProgram,
+            [['recipient' => $recipient, 'bps' => 10_000]],
+        );
+
+        self::assertCount(12, $ix->accounts);
+        [$recipientAta] = PaymentChannels::findAssociatedTokenAddress(
+            $recipient,
+            $this->mint,
+            $this->tokenProgram,
+        );
+        self::assertSame((string) $recipientAta, (string) $ix->accounts[11]->pubkey);
+        self::assertTrue($ix->accounts[11]->isWritable);
+        self::assertSame(1 + 4 + 32 + 2, strlen($ix->data));
+        self::assertSame(PaymentChannels::DISTRIBUTE_DISCRIMINATOR, ord($ix->data[0]));
+        self::assertSame(1, unpack('V', substr($ix->data, 1, 4))[1]);
+        self::assertSame($recipient->toBytes(), substr($ix->data, 5, 32));
+        self::assertSame(10_000, unpack('v', substr($ix->data, 37, 2))[1]);
+    }
+
+    public function testBuildEd25519RejectsBadSignatureLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        PaymentChannels::buildEd25519VerifyInstruction(
+            $this->authorizedSigner,
+            str_repeat("\x00", 32),
+            'msg',
+        );
+    }
+}

--- a/php/tests/Protocols/X402/Upto/EngineCosignTest.php
+++ b/php/tests/Protocols/X402/Upto/EngineCosignTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402\Upto;
+
+use PayKit\Config;
+use PayKit\Exception\InvalidProofException;
+use PayKit\Operator;
+use PayKit\PayCore\Network;
+use PayKit\Protocols\X402\Upto\Engine;
+use PayKit\Signer;
+use PayKit\Tests\PayCore\Rpc\FakeRpcGateway;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use SolanaPhpSdk\Keypair\Keypair;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Transaction\CompiledInstructionV0;
+use SolanaPhpSdk\Transaction\MessageV0;
+use SolanaPhpSdk\Transaction\VersionedTransaction;
+use SolanaPhpSdk\Util\Base58;
+
+/**
+ * Offline cosign + fee-payer binding coverage (mocked RPC, no Surfpool).
+ */
+final class EngineCosignTest extends TestCase
+{
+    public function testRequirePubkeyWrapsInvalidBase58(): void
+    {
+        $engine = $this->engine(new FakeRpcGateway());
+        $m = new ReflectionMethod(Engine::class, 'requirePubkey');
+        $m->setAccessible(true);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('invalid asset public key');
+        $m->invoke($engine, 'not-a-pubkey!!!', 'asset');
+    }
+
+    public function testCosignRejectsWrongFeePayerAtSlotZero(): void
+    {
+        $operator = Signer::generate();
+        $other = Keypair::generate();
+        $engine = $this->engine(new FakeRpcGateway(), $operator);
+
+        // Fee payer slot is someone else; operator cannot cosign this seat.
+        $txB64 = $this->partialOpenTxBase64($other, $other);
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('fee payer must be the advertised fee payer');
+        $engine->cosignAndBroadcastOpenTransaction($txB64);
+    }
+
+    public function testCosignAndBroadcastSucceedsWithMatchingFeePayer(): void
+    {
+        $operator = Signer::generate();
+        $payer = Keypair::generate();
+        $rpc = new FakeRpcGateway(signature: 'OpenSig1111111111111111111111111111111111111');
+        $engine = $this->engine($rpc, $operator, confirmationAttempts: 1, confirmationDelayMicros: 0);
+
+        $opKp = Keypair::fromSecretKey($operator->secretKey());
+        $txB64 = $this->partialOpenTxBase64($opKp, $payer);
+
+        $sig = $engine->cosignAndBroadcastOpenTransaction($txB64);
+        self::assertSame('OpenSig1111111111111111111111111111111111111', $sig);
+        self::assertCount(1, $rpc->sentTransactions);
+        self::assertNotSame('', $rpc->sentTransactions[0]);
+    }
+
+    public function testCosignBroadcastFailureSurfacesInvalidProof(): void
+    {
+        $operator = Signer::generate();
+        $payer = Keypair::generate();
+        $rpc = new FakeRpcGateway(
+            sendError: new \RuntimeException('rpc down'),
+        );
+        $engine = $this->engine($rpc, $operator, confirmationAttempts: 1, confirmationDelayMicros: 0);
+        $opKp = Keypair::fromSecretKey($operator->secretKey());
+        $txB64 = $this->partialOpenTxBase64($opKp, $payer);
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('open broadcast failed');
+        $engine->cosignAndBroadcastOpenTransaction($txB64);
+    }
+
+    /**
+     * Build a v0 open-shaped shell: fee payer first, payer second, both signers.
+     * Empty instructions — structural cosign only (full open ix covered offline
+     * by Verify + builders tests).
+     */
+    private function partialOpenTxBase64(Keypair $feePayer, Keypair $payer): string
+    {
+        $message = new MessageV0();
+        $message->numRequiredSignatures = 2;
+        $message->numReadonlySignedAccounts = 0;
+        $message->numReadonlyUnsignedAccounts = 0;
+        $message->staticAccountKeys = [
+            $feePayer->getPublicKey(),
+            $payer->getPublicKey(),
+        ];
+        $message->recentBlockhash = Base58::encode(str_repeat("\x02", 32));
+        $message->compiledInstructions = [];
+        $message->addressTableLookups = [];
+
+        $tx = new VersionedTransaction($message);
+        // Client only signs payer seat (index 1); fee payer slot left for cosign.
+        $tx->partialSign($payer);
+
+        return base64_encode($tx->serialize(verifySignatures: false));
+    }
+
+    private function engine(
+        FakeRpcGateway $rpc,
+        ?\PayKit\Signer\LocalSigner $operator = null,
+        int $confirmationAttempts = 40,
+        int $confirmationDelayMicros = 250_000,
+    ): Engine {
+        $operator ??= Signer::generate();
+        $config = new Config(
+            network: Network::SolanaDevnet,
+            operator: new Operator(
+                recipient: $operator->pubkey(),
+                signer: $operator,
+                feePayer: true,
+            ),
+            preflight: false,
+            rpcUrl: 'http://127.0.0.1:8899',
+        );
+
+        return new Engine(
+            $config,
+            chainHintsProvider: static fn (): array => [
+                'blockhash' => 'hint-blockhash',
+                'slot'      => '4242',
+            ],
+            rpc: $rpc,
+            confirmationAttempts: $confirmationAttempts,
+            confirmationDelayMicros: $confirmationDelayMicros,
+        );
+    }
+}

--- a/php/tests/Protocols/X402/Upto/EngineSettleTest.php
+++ b/php/tests/Protocols/X402/Upto/EngineSettleTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402\Upto;
+
+use PayKit\Config;
+use PayKit\Exception\InvalidProofException;
+use PayKit\Operator;
+use PayKit\PayCore\Network;
+use PayKit\PayCore\PaymentChannels;
+use PayKit\Protocols\X402\Upto\Engine;
+use PayKit\Signer;
+use PayKit\Tests\PayCore\Rpc\FakeRpcGateway;
+use PHPUnit\Framework\TestCase;
+use SolanaPhpSdk\Keypair\Keypair;
+use SolanaPhpSdk\Keypair\PublicKey;
+use SolanaPhpSdk\Transaction\VersionedTransaction;
+
+/**
+ * Offline settle_and_seal + distribute broadcast coverage (FakeRpcGateway).
+ */
+final class EngineSettleTest extends TestCase
+{
+    private const BLOCKHASH = '4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs';
+    private const MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+    public function testSettleVoucherlessIsSingleInstruction(): void
+    {
+        $operator = Signer::generate();
+        $rpc = new FakeRpcGateway(signature: 'SettleZero1111111111111111111111111111111111');
+        $engine = $this->engine($rpc, $operator);
+
+        $channel = $this->channelPda($operator);
+        $sig = $engine->settleAndSealAndBroadcast(
+            (string) $channel,
+            actualBaseUnits: 0,
+            maxBaseUnits: 100_000,
+            expiresAt: time() + 300,
+            recentBlockhash: self::BLOCKHASH,
+        );
+
+        self::assertSame('SettleZero1111111111111111111111111111111111', $sig);
+        self::assertCount(1, $rpc->sentTransactions);
+        $tx = VersionedTransaction::deserialize($rpc->sentTransactions[0]);
+        self::assertCount(1, $tx->message->compiledInstructions);
+        $ix = $tx->message->compiledInstructions[0];
+        self::assertSame(PaymentChannels::SETTLE_AND_SEAL_DISCRIMINATOR, ord($ix->data[0]));
+        self::assertSame(0, ord($ix->data[1])); // hasVoucher = 0
+    }
+
+    public function testSettleWithVoucherPrependsEd25519(): void
+    {
+        $operator = Signer::generate();
+        $rpc = new FakeRpcGateway(signature: 'SettleVoucher1111111111111111111111111111111');
+        $engine = $this->engine($rpc, $operator);
+
+        $channel = $this->channelPda($operator);
+        $actual = 50_000;
+        $sig = $engine->settleAndSealAndBroadcast(
+            (string) $channel,
+            actualBaseUnits: $actual,
+            maxBaseUnits: 100_000,
+            expiresAt: time() + 300,
+            recentBlockhash: self::BLOCKHASH,
+        );
+
+        self::assertSame('SettleVoucher1111111111111111111111111111111', $sig);
+        self::assertCount(1, $rpc->sentTransactions);
+        $tx = VersionedTransaction::deserialize($rpc->sentTransactions[0]);
+        self::assertCount(2, $tx->message->compiledInstructions);
+
+        $keys = array_map(static fn (PublicKey $k): string => (string) $k, $tx->message->staticAccountKeys);
+        $ed25519Idx = $tx->message->compiledInstructions[0]->programIdIndex;
+        $sealIdx = $tx->message->compiledInstructions[1]->programIdIndex;
+        self::assertSame(PaymentChannels::ED25519_PROGRAM_ID, $keys[$ed25519Idx]);
+        self::assertSame(PaymentChannels::PROGRAM_ID, $keys[$sealIdx]);
+        self::assertSame(1, ord($tx->message->compiledInstructions[1]->data[1])); // hasVoucher
+    }
+
+    public function testSettleRejectsAboveCeiling(): void
+    {
+        $operator = Signer::generate();
+        $engine = $this->engine(new FakeRpcGateway(), $operator);
+        $channel = $this->channelPda($operator);
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('invalid_upto_svm_payload_settlement_exceeds_amount');
+        $engine->settleAndSealAndBroadcast(
+            (string) $channel,
+            actualBaseUnits: 100_001,
+            maxBaseUnits: 100_000,
+            expiresAt: time() + 300,
+            recentBlockhash: self::BLOCKHASH,
+        );
+    }
+
+    public function testDistributeBroadcastsSingleInstruction(): void
+    {
+        $operator = Signer::generate();
+        $payer = Keypair::generate();
+        $rpc = new FakeRpcGateway(signature: 'Distribute111111111111111111111111111111111');
+        $engine = $this->engine($rpc, $operator);
+        $channel = $this->channelPda($operator);
+
+        $sig = $engine->distributeAndBroadcast(
+            (string) $channel,
+            payer: (string) $payer->getPublicKey(),
+            mint: self::MINT,
+            tokenProgram: PaymentChannels::tokenProgramId(),
+            recipients: [],
+            recentBlockhash: self::BLOCKHASH,
+        );
+
+        self::assertSame('Distribute111111111111111111111111111111111', $sig);
+        self::assertCount(1, $rpc->sentTransactions);
+        $tx = VersionedTransaction::deserialize($rpc->sentTransactions[0]);
+        self::assertCount(1, $tx->message->compiledInstructions);
+        $ix = $tx->message->compiledInstructions[0];
+        self::assertSame(PaymentChannels::DISTRIBUTE_DISCRIMINATOR, ord($ix->data[0]));
+        // fee payer is operator at static key 0
+        self::assertSame($operator->pubkey(), (string) $tx->message->staticAccountKeys[0]);
+    }
+
+    public function testDistributeWithRecipientAppendsAtaMeta(): void
+    {
+        $operator = Signer::generate();
+        $payer = Keypair::generate();
+        $recipient = Keypair::generate()->getPublicKey();
+        $rpc = new FakeRpcGateway(signature: 'DistributeRecip1111111111111111111111111111');
+        $engine = $this->engine($rpc, $operator);
+        $channel = $this->channelPda($operator);
+
+        $engine->distributeAndBroadcast(
+            (string) $channel,
+            payer: (string) $payer->getPublicKey(),
+            mint: self::MINT,
+            tokenProgram: PaymentChannels::tokenProgramId(),
+            recipients: [
+                ['recipient' => (string) $recipient, 'bps' => 10_000],
+            ],
+            recentBlockhash: self::BLOCKHASH,
+        );
+
+        $tx = VersionedTransaction::deserialize($rpc->sentTransactions[0]);
+        $ix = $tx->message->compiledInstructions[0];
+        // 11 fixed + 1 recipient ATA
+        self::assertCount(12, $ix->accountKeyIndexes);
+        // recipients_len = 1 in data after disc
+        self::assertSame(1, ord($ix->data[1]) | (ord($ix->data[2]) << 8) | (ord($ix->data[3]) << 16) | (ord($ix->data[4]) << 24));
+    }
+
+    public function testSettleBroadcastFailureIsInvalidProof(): void
+    {
+        $operator = Signer::generate();
+        $rpc = new FakeRpcGateway(sendError: new \RuntimeException('rpc down'));
+        $engine = $this->engine($rpc, $operator);
+        $channel = $this->channelPda($operator);
+
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('settle broadcast failed');
+        $engine->settleAndSealAndBroadcast(
+            (string) $channel,
+            actualBaseUnits: 0,
+            maxBaseUnits: 100_000,
+            expiresAt: time() + 300,
+            recentBlockhash: self::BLOCKHASH,
+        );
+    }
+
+    private function channelPda(\PayKit\Signer\LocalSigner $operator): PublicKey
+    {
+        $op = new PublicKey($operator->pubkey());
+        $mint = new PublicKey(self::MINT);
+        [$channel] = PaymentChannels::findChannelPda(
+            new PublicKey(str_repeat("\x11", 32)),
+            $op, // payee = operator for upto
+            $mint,
+            $op, // authorized signer
+            7,
+            4242,
+        );
+
+        return $channel;
+    }
+
+    private function engine(
+        FakeRpcGateway $rpc,
+        \PayKit\Signer\LocalSigner $operator,
+    ): Engine {
+        $config = new Config(
+            network: Network::SolanaDevnet,
+            operator: new Operator(
+                recipient: $operator->pubkey(),
+                signer: $operator,
+                feePayer: true,
+            ),
+            preflight: false,
+            rpcUrl: 'http://127.0.0.1:8899',
+        );
+
+        return new Engine(
+            $config,
+            chainHintsProvider: static fn (): array => [
+                'blockhash' => self::BLOCKHASH,
+                'slot'      => '4242',
+            ],
+            rpc: $rpc,
+            confirmationAttempts: 1,
+            confirmationDelayMicros: 0,
+        );
+    }
+}

--- a/php/tests/Protocols/X402/Upto/EngineTest.php
+++ b/php/tests/Protocols/X402/Upto/EngineTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402\Upto;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PayKit\Config;
+use PayKit\Gate;
+use PayKit\Operator;
+use PayKit\PayCore\Network;
+use PayKit\Price;
+use PayKit\Protocols\X402\Upto\Engine;
+use PayKit\Protocols\X402\Upto\Types;
+use PayKit\Signer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Challenge-shape coverage for the upto engine (no RPC / no on-chain).
+ */
+final class EngineTest extends TestCase
+{
+    public function testAcceptsEntryIsUptoSchemeWithOperatorSeats(): void
+    {
+        $engine = $this->engine();
+        $gate = new Gate(amount: Price::usd('0.10'));
+        $request = (new Psr17Factory())->createServerRequest('GET', '/usage');
+
+        $entry = $engine->acceptsEntry($gate, $request);
+
+        self::assertSame(Types::SCHEME, $entry['scheme']);
+        self::assertSame('x402', $entry['protocol']);
+        self::assertSame('100000', $entry['amount']);
+        self::assertArrayHasKey('extra', $entry);
+        $extra = $entry['extra'];
+        self::assertIsArray($extra);
+        self::assertSame($extra['feePayer'], $extra['receiverAuthorizer']);
+        self::assertNotSame('', $extra['feePayer']);
+        self::assertSame(Types::DEFAULT_WITHDRAW_DELAY_SECONDS, $extra['withdrawDelay']);
+        self::assertSame('hint-blockhash', $extra['recentBlockhash']);
+        self::assertSame('4242', $extra['recentSlot']);
+    }
+
+    public function testChallengeHeadersEmitPaymentRequiredBase64(): void
+    {
+        $engine = $this->engine();
+        $gate = new Gate(amount: Price::usd('0.10'));
+        $request = (new Psr17Factory())->createServerRequest('GET', '/usage');
+
+        $headers = $engine->challengeHeaders($gate, $request);
+        self::assertArrayHasKey('payment-required', $headers);
+        $raw = base64_decode($headers['payment-required'], true);
+        self::assertNotFalse($raw);
+        $body = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame(Types::X402_VERSION, $body['x402Version']);
+        self::assertSame(Types::SCHEME, $body['accepts'][0]['scheme']);
+        self::assertSame('/usage', $body['resource']['url']);
+    }
+
+    private function engine(): Engine
+    {
+        $signer = Signer::generate();
+        $config = new Config(
+            network: Network::SolanaDevnet,
+            operator: new Operator(
+                recipient: $signer->pubkey(),
+                signer: $signer,
+                feePayer: true,
+            ),
+            preflight: false,
+        );
+
+        return new Engine(
+            $config,
+            chainHintsProvider: static fn (): array => [
+                'blockhash' => 'hint-blockhash',
+                'slot'      => '4242',
+            ],
+        );
+    }
+}

--- a/php/tests/Protocols/X402/Upto/VerifyTest.php
+++ b/php/tests/Protocols/X402/Upto/VerifyTest.php
@@ -39,7 +39,78 @@ final class VerifyTest extends TestCase
         yield 'alpha' => ['abc'];
         yield 'negative' => ['-1'];
         yield 'decimal' => ['1.5'];
-        yield 'overflow' => [(string) (2 ** 64)];
+        // Explicit decimal: u64_max+1 (not (string)(2**64) which is scientific).
+        yield 'u64_overflow' => ['18446744073709551616'];
+        // Above PHP_INT_MAX on 64-bit (still within u64) must not saturate.
+        yield 'platform_overflow' => ['9223372036854775808'];
+    }
+
+    public function testParseStrictIntRejectsNonCanonical(): void
+    {
+        $this->expectException(InvalidProofException::class);
+        Verify::parseStrictInt('123abc', 'validAfter');
+    }
+
+    public function testParseStrictIntAcceptsIntAndDigitString(): void
+    {
+        self::assertSame(42, Verify::parseStrictInt(42, 'validAfter'));
+        self::assertSame(42, Verify::parseStrictInt('42', 'validAfter'));
+        self::assertSame(-5, Verify::parseStrictInt('-5', 'expiresAt'));
+    }
+
+    public function testDecodeOpenArgsRejectsTrailingBytes(): void
+    {
+        $data = PaymentChannels::encodeOpenInstructionData(7, self::MAX, 900, 4242);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('trailing bytes');
+        PaymentChannels::decodeOpenArgs($data . "\x00");
+    }
+
+    public function testDecodeOpenArgsRejectsNonEmptyRecipients(): void
+    {
+        // Build open data with recipients_len = 1 and no body → too short for
+        // entries, but decode rejects non-zero len before reading entries.
+        $base = PaymentChannels::encodeOpenInstructionData(7, self::MAX, 900, 4242);
+        // Last 4 bytes are recipients_len=0; rewrite to 1.
+        $data = substr($base, 0, 29) . "\x01\x00\x00\x00";
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('recipients length must be 0');
+        PaymentChannels::decodeOpenArgs($data);
+    }
+
+    public function testValidateOpenInstructionRequiresExactly14Accounts(): void
+    {
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('exactly 14 accounts');
+        $program = new PublicKey(PaymentChannels::PROGRAM_ID);
+        // 13 dummy static keys + program id at the end (programIdIndex = 13).
+        $keys = [];
+        for ($i = 1; $i <= 13; $i++) {
+            $keys[] = (string) new PublicKey(str_repeat(chr($i), 32));
+        }
+        $keys[] = (string) $program;
+        // Only 13 account metas — triggers the fixed-layout check.
+        Verify::validateUptoOpenInstruction(
+            $keys,
+            [[
+                'programIdIndex' => 13,
+                'accounts'       => range(0, 12),
+                'data'           => PaymentChannels::encodeOpenInstructionData(1, self::MAX, 900, 1),
+            ]],
+            $program,
+            new PublicKey($keys[1]),
+            new PublicKey($keys[4]),
+            new PublicKey($keys[0]),
+            new PublicKey($keys[2]),
+            new PublicKey($keys[3]),
+            new PublicKey($keys[8]),
+            new PublicKey($keys[5]),
+            self::MAX,
+            900,
+            '1',
+            '1',
+            null,
+        );
     }
 
     public function testVerifyUptoPayloadOk(): void

--- a/php/tests/Protocols/X402/Upto/VerifyTest.php
+++ b/php/tests/Protocols/X402/Upto/VerifyTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayKit\Tests\Protocols\X402\Upto;
+
+use PayKit\Exception\InvalidProofException;
+use PayKit\PayCore\PaymentChannels;
+use PayKit\Protocols\X402\Upto\Types;
+use PayKit\Protocols\X402\Upto\Verify;
+use PHPUnit\Framework\TestCase;
+use SolanaPhpSdk\Keypair\PublicKey;
+
+/**
+ * Offline pure-verifier coverage for x402 upto (payment-channel profile).
+ * Mirrors python/tests/test_pk_x402_upto_verifier.py payload checks.
+ */
+final class VerifyTest extends TestCase
+{
+    private const MAX = 100_000;
+    private const MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+    public function testParseBaseUnitsOk(): void
+    {
+        self::assertSame(100000, Verify::parseBaseUnits('100000', 'amount'));
+    }
+
+    /** @dataProvider badBaseUnits */
+    public function testParseBaseUnitsRejects(string $bad): void
+    {
+        $this->expectException(InvalidProofException::class);
+        Verify::parseBaseUnits($bad, 'amount');
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function badBaseUnits(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'alpha' => ['abc'];
+        yield 'negative' => ['-1'];
+        yield 'decimal' => ['1.5'];
+        yield 'overflow' => [(string) (2 ** 64)];
+    }
+
+    public function testVerifyUptoPayloadOk(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        Verify::verifyUptoPayload(
+            $this->payload($operator, $now),
+            $this->requirements($operator),
+            $operator,
+            $now,
+        );
+        $this->addToAssertionCount(1);
+    }
+
+    public function testVerifyUptoPayloadRejectsAmountMismatch(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['maxAmount'] = '1';
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('amount mismatch');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsDepositMismatch(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['deposit'] = '1';
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('channel deposit');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsExpired(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['expiresAt'] = $now - 1;
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('authorization expired');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsNotYetActive(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['validAfter'] = $now + 60;
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('not yet active');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testVerifyUptoPayloadRejectsWrongAuthorizer(): void
+    {
+        $operator = $this->operatorPubkey();
+        $now = time();
+        $payload = $this->payload($operator, $now);
+        $payload['authorizedSigner'] = '11111111111111111111111111111112';
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage('authorized_signer');
+        Verify::verifyUptoPayload($payload, $this->requirements($operator), $operator, $now);
+    }
+
+    public function testAssertSettlementWithinCeiling(): void
+    {
+        Verify::assertSettlementWithinCeiling(50_000, self::MAX);
+        $this->expectException(InvalidProofException::class);
+        $this->expectExceptionMessage(Types::ERROR_SETTLEMENT_EXCEEDS_AMOUNT);
+        Verify::assertSettlementWithinCeiling(self::MAX + 1, self::MAX);
+    }
+
+    public function testVoucherMessageBytesLayout(): void
+    {
+        $channel = new PublicKey(str_repeat("\x09", 32));
+        $got = PaymentChannels::voucherMessageBytes($channel, 42, 1234);
+        self::assertSame(50, strlen($got));
+        self::assertSame("\x56\x01", substr($got, 0, 2));
+        self::assertSame($channel->toBytes(), substr($got, 2, 32));
+        self::assertSame($this->leU64(42), substr($got, 34, 8));
+        self::assertSame($this->leI64(1234), substr($got, 42, 8));
+    }
+
+    public function testVoucherMessageBytesNegativeExpires(): void
+    {
+        $channel = new PublicKey(str_repeat("\x03", 32));
+        $got = PaymentChannels::voucherMessageBytes($channel, 7, -5);
+        self::assertSame(50, strlen($got));
+        self::assertSame($this->leI64(-5), substr($got, 42, 8));
+    }
+
+    public function testChannelPdaDeterministic(): void
+    {
+        $payer = new PublicKey(str_repeat("\x01", 32));
+        $payee = new PublicKey(str_repeat("\x02", 32));
+        $mint = new PublicKey(str_repeat("\x03", 32));
+        $signer = new PublicKey(str_repeat("\x04", 32));
+        [$a, $bumpA] = PaymentChannels::findChannelPda($payer, $payee, $mint, $signer, 99, 55_555);
+        [$b, $bumpB] = PaymentChannels::findChannelPda($payer, $payee, $mint, $signer, 99, 55_555);
+        self::assertTrue($a->equals($b));
+        self::assertSame($bumpA, $bumpB);
+        // Different openSlot → different channel.
+        [$c] = PaymentChannels::findChannelPda($payer, $payee, $mint, $signer, 99, 55_556);
+        self::assertFalse($a->equals($c));
+    }
+
+    public function testEncodeDecodeOpenArgsRoundTrip(): void
+    {
+        $data = PaymentChannels::encodeOpenInstructionData(7, self::MAX, 900, 4242);
+        $args = PaymentChannels::decodeOpenArgs($data);
+        self::assertSame(7, $args['salt']);
+        self::assertSame(self::MAX, $args['deposit']);
+        self::assertSame(900, $args['gracePeriod']);
+        self::assertSame(4242, $args['openSlot']);
+    }
+
+    /** @return array<string,mixed> */
+    private function requirements(string $operator): array
+    {
+        return [
+            'scheme'            => Types::SCHEME,
+            'network'           => 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+            'amount'            => (string) self::MAX,
+            'asset'             => self::MINT,
+            'payTo'             => $operator,
+            'maxTimeoutSeconds' => 300,
+            'extra'             => [
+                'decimals'           => 6,
+                'tokenProgram'       => PaymentChannels::tokenProgramId(),
+                'feePayer'           => $operator,
+                'receiverAuthorizer' => $operator,
+                'withdrawDelay'      => 900,
+                'recentBlockhash'    => '4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs',
+                'recentSlot'         => '4242',
+            ],
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function payload(string $operator, int $now): array
+    {
+        return [
+            'from'             => (string) new PublicKey(str_repeat("\x11", 32)),
+            'maxAmount'        => (string) self::MAX,
+            'expiresAt'        => $now + 300,
+            'validAfter'       => $now - 10,
+            'nonce'            => '7',
+            'channelId'        => '11111111111111111111111111111112',
+            'deposit'          => (string) self::MAX,
+            'authorizedSigner' => $operator,
+            'openSlot'         => '4242',
+        ];
+    }
+
+    private function operatorPubkey(): string
+    {
+        return (string) new PublicKey(str_repeat("\x0A", 32));
+    }
+
+    private function leU64(int $value): string
+    {
+        $out = '';
+        for ($i = 0; $i < 8; $i++) {
+            $out .= chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    private function leI64(int $value): string
+    {
+        return $this->leU64($value);
+    }
+}


### PR DESCRIPTION
## Summary

Last slice of the PHP SVM `upto` stack (#175): harness registration + CI leg for **php-x402-upto** server.

### Stack dependency

| PR | Role |
|----|------|
| #271 | Foundation (types/verify/challenge) |
| #272 | Instruction builders |
| #273 | Open cosign + broadcast |
| #274 | Settle + distribute broadcast |
| **this** | Harness + CI |

### Changes

1. **`harness/php-server/server.php`**
   - Protocol modes: `exact` | `upto` | `mpp` via `PAY_KIT_HARNESS_PROTOCOL`
   - `x402-upto`: `Upto\Engine` challenge → `verifyOpenAndBroadcast` → `settleAndSealAndBroadcast` → `distributeAndBroadcast`
   - Settlement header + `payment-response` body for matrix clients

2. **`implementations.ts`**
   - `php-x402-upto` server, `intents: ["x402-upto"]`, `reportsAs: "php"`, opt-in

3. **CI**
   - `php.yml` → `harness-php-x402-upto`
   - `harness.yml` → `php-x402-upto`
   - Env: `X402_HARNESS_CLIENTS=rust-x402-upto`, `X402_HARNESS_SERVERS=php-x402-upto`, scenario `x402-upto-basic` only
   - Payment-channels program build + Surfpool secret (same as kotlin/python upto)

### Explicitly out of scope

- PHP upto **client** harness fixture (server gap was the goal)
- `x402-upto-zero-actual` (still `serverIds: ["rust-x402-upto"]`)

Refs: #175, #271, #272, #273, #274