### PR TITLE
harness(session): TypeScript session client + multi-client session-basic

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -119,6 +119,17 @@ jobs:
           MPP_HARNESS_CLIENTS: python-session
           MPP_HARNESS_SERVERS: python
         run: pnpm exec vitest run test/e2e.test.ts
+      # Phase 1a: TS session client against the wire-only Python session server
+      # (open → deliveries → commit → close). Unpins session-basic from
+      # Python-client-only isolation without requiring on-chain open submit.
+      - name: Focused TypeScript session client → Python session server
+        working-directory: harness
+        env:
+          MPP_HARNESS_INTENTS: session
+          MPP_HARNESS_SCENARIOS: session-basic
+          MPP_HARNESS_CLIENTS: typescript-session
+          MPP_HARNESS_SERVERS: python
+        run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
       - name: Focused TS-to-Python harness
         working-directory: harness
         env:

--- a/harness/src/fixtures/typescript/session-client.ts
+++ b/harness/src/fixtures/typescript/session-client.ts
@@ -1,0 +1,217 @@
+// TypeScript MPP `session` harness client.
+//
+// Mirrors harness/python-session-client/main.py against the wire-only session
+// server contract (Python harness SessionServer with accept-all open verify):
+//   GET resource → 402 WWW-Authenticate (session challenge)
+//   open credential → 200
+//   POST /__402/session/deliveries → reserve
+//   POST /__402/session/commit → voucher
+//   POST /__402/session/close → settlement header / reference
+//
+// Uses @solana/mpp client helpers only — no protocol reinvention.
+// Env: MPP_HARNESS_TARGET_URL (injected by harness), MPP_HARNESS_AMOUNT,
+// optional MPP_HARNESS_RPC_URL (unused for challenge-bound open blockhash).
+
+import { generateKeyPairSigner } from "@solana/kit";
+import {
+  createPaymentChannelSessionOpener,
+  selectSolanaSessionChallengeFromResponse,
+  serializeSessionCredential,
+  type SessionChallenge,
+  type SignedVoucher,
+} from "@solana/mpp/client";
+
+function baseUrlFromTarget(targetUrl: string): string {
+  const u = new URL(targetUrl);
+  return `${u.protocol}//${u.host}`;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function emitResult(parameters: {
+  ok: boolean;
+  status: number;
+  responseHeaders: Record<string, string>;
+  responseBody: unknown;
+  settlement?: string;
+  error?: string;
+}): void {
+  console.log(
+    JSON.stringify({
+      type: "result",
+      implementation: "typescript",
+      role: "client",
+      ok: parameters.ok,
+      status: parameters.status,
+      responseHeaders: parameters.responseHeaders,
+      responseBody: parameters.responseBody,
+      ...(parameters.settlement ? { settlement: parameters.settlement } : {}),
+      ...(parameters.error ? { error: parameters.error } : {}),
+    }),
+  );
+}
+
+function headersRecord(response: Response): Record<string, string> {
+  return Object.fromEntries(response.headers.entries());
+}
+
+async function main(): Promise<void> {
+  const targetUrl = process.env.MPP_HARNESS_TARGET_URL;
+  if (!targetUrl) {
+    throw new Error("MPP_HARNESS_TARGET_URL is required");
+  }
+  const amount = process.env.MPP_HARNESS_AMOUNT ?? "700";
+  const base = baseUrlFromTarget(targetUrl);
+  const reserveUrl = `${base}/__402/session/deliveries`;
+  const commitUrl = `${base}/__402/session/commit`;
+  const closeUrl = `${base}/__402/session/close`;
+
+  const probe = await fetch(targetUrl);
+  if (probe.status !== 402) {
+    emitResult({
+      ok: false,
+      status: probe.status,
+      responseHeaders: headersRecord(probe),
+      responseBody: await readJson(probe),
+      error: "expected 402 session challenge",
+    });
+    return;
+  }
+
+  const challenge = selectSolanaSessionChallengeFromResponse(probe) as SessionChallenge | null;
+  if (!challenge) {
+    emitResult({
+      ok: false,
+      status: probe.status,
+      responseHeaders: headersRecord(probe),
+      responseBody: await readJson(probe),
+      error: "no solana session challenge in WWW-Authenticate",
+    });
+    return;
+  }
+
+  // Client builds open against challenged blockhash/slot; harness server
+  // verifies wire shape only (Python accept-all) — no on-chain broadcast required.
+  const payer = await generateKeyPairSigner();
+  const opener = createPaymentChannelSessionOpener({ signer: payer });
+  // SessionOpener contract requires the original 402 response + fetch input;
+  // the payment-channel opener only consumes `challenge`.
+  const opened = await opener({
+    challenge,
+    input: targetUrl,
+    response: probe,
+  });
+  const openAuth = serializeSessionCredential({
+    challenge,
+    payload: opened.payload,
+  });
+
+  const openedResponse = await fetch(targetUrl, {
+    headers: { authorization: openAuth },
+  });
+  if (!openedResponse.ok) {
+    emitResult({
+      ok: false,
+      status: openedResponse.status,
+      responseHeaders: headersRecord(openedResponse),
+      responseBody: await readJson(openedResponse),
+      error: "session open rejected",
+    });
+    return;
+  }
+
+  const channelId = opened.session.channelId;
+  const reserveResponse = await fetch(reserveUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ sessionId: channelId, amount }),
+  });
+  const reserveBody = await readJson(reserveResponse);
+  if (
+    !reserveResponse.ok ||
+    typeof reserveBody !== "object" ||
+    reserveBody === null ||
+    !("deliveryId" in reserveBody)
+  ) {
+    emitResult({
+      ok: false,
+      status: reserveResponse.status,
+      responseHeaders: headersRecord(reserveResponse),
+      responseBody: reserveBody,
+      error: "session delivery reserve failed",
+    });
+    return;
+  }
+
+  const deliveryId = String((reserveBody as { deliveryId: unknown }).deliveryId);
+  const voucher: SignedVoucher = await opened.session.prepareIncrement(amount);
+  const commitResponse = await fetch(commitUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ deliveryId, voucher }),
+  });
+  const commitBody = await readJson(commitResponse);
+  if (!commitResponse.ok) {
+    emitResult({
+      ok: false,
+      status: commitResponse.status,
+      responseHeaders: headersRecord(commitResponse),
+      responseBody: commitBody,
+      error: "session commit failed",
+    });
+    return;
+  }
+  opened.session.recordVoucher(voucher);
+
+  const closeAuth = serializeSessionCredential({
+    challenge,
+    payload: {
+      action: "close",
+      channelId,
+      voucher,
+    },
+  });
+  const closeResponse = await fetch(closeUrl, {
+    method: "POST",
+    headers: { authorization: closeAuth },
+  });
+  const closeBody = await readJson(closeResponse);
+  let settlement = "";
+  if (typeof closeBody === "object" && closeBody !== null) {
+    const record = closeBody as Record<string, unknown>;
+    settlement = String(
+      record.reference ?? record.settledSignature ?? "",
+    );
+  }
+  const settlementHeader =
+    process.env.MPP_HARNESS_SETTLEMENT_HEADER ?? "x-session-settlement-signature";
+  if (!settlement) {
+    settlement = closeResponse.headers.get(settlementHeader) ?? "";
+  }
+
+  emitResult({
+    ok: closeResponse.ok,
+    status: closeResponse.status,
+    responseHeaders: headersRecord(closeResponse),
+    responseBody: closeBody,
+    settlement: settlement || undefined,
+  });
+}
+
+void main().catch(error => {
+  emitResult({
+    ok: false,
+    status: 0,
+    responseHeaders: {},
+    responseBody: null,
+    error: error instanceof Error ? error.message : String(error),
+  });
+});

--- a/harness/src/implementations.ts
+++ b/harness/src/implementations.ts
@@ -200,6 +200,25 @@ export const clientImplementations: ImplementationDefinition[] = [
     intents: ["session"],
   },
   {
+    id: "typescript-session",
+    label: "TypeScript @solana/mpp session client",
+    role: "client",
+    // Mirrors python-session-client (open → deliveries → commit → close)
+    // against the wire-only Python session server. Opt in via
+    // MPP_HARNESS_CLIENTS=typescript-session.
+    command: [
+      "pnpm",
+      "exec",
+      "node",
+      "--import",
+      "tsx",
+      "src/fixtures/typescript/session-client.ts",
+    ],
+    enabled: isEnabled("typescript-session", "MPP_HARNESS_CLIENTS", false),
+    intents: ["session"],
+    reportsAs: "typescript",
+  },
+  {
     id: "swift-x402",
     label: "Swift x402 exact client",
     role: "client",

--- a/harness/src/intents/session.ts
+++ b/harness/src/intents/session.ts
@@ -11,7 +11,10 @@ export const sessionScenarios: readonly HarnessScenario[] = [
     resourcePath: "/session",
     settlementHeader: "x-session-settlement-signature",
     expectedStatus: 200,
-    clientIds: ["python-session"],
+    // Phase 1a: multi-client against the wire-only Python session server.
+    // TS/Rust high-level session() servers always submit open on-chain, so
+    // they stay deferred until a Surfpool/program job (Phase 1a-server).
+    clientIds: ["python-session", "typescript-session"],
     serverIds: ["python"],
   },
 ] as const;


### PR DESCRIPTION
## Summary

**MPP Session Harness Phase 1a** — break Python-only isolation for `session-basic` without reimplementing the session protocol.

### What ships

| Piece | Detail |
|--------|--------|
| `typescript-session` client | `harness/src/fixtures/typescript/session-client.ts` — mirrors `python-session-client` (open → deliveries → commit → close) via `@solana/mpp` |
| Scenario | `session-basic` `clientIds`: `python-session`, `typescript-session`; `serverIds`: still `python` |
| CI | `harness.yml`: focused **TS session client → Python session server** on `session-basic` |

### Explicit Phase 1a limits (locked)

- **No TS/Rust session servers yet.** High-level `session()` always **submits open on-chain** (`submitOpenTx` + post-confirm state). Python harness alone supports wire-only accept-all open verify.
- **No Rust session client bin yet** in this PR (next slice under same phase).
- **No lifecycle scenarios** (`multi-request`, `top-up`, `expire-settle`) — Phase 1b/2/3.
- **No on-chain settlement asserts** for session (existing e2e skip unchanged).

### How to run locally

```bash
# build @solana/mpp for harness file: dep
cd typescript && pnpm --filter @solana/mpp build
cd ../harness && pnpm install
MPP_HARNESS_INTENTS=session \
MPP_HARNESS_SCENARIOS=session-basic \
MPP_HARNESS_CLIENTS=typescript-session \
MPP_HARNESS_SERVERS=python \
# + standard MPP_HARNESS_RPC_URL / keys / mint from harness setup
pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
```

### Follow-ups

1. Rust session client process adapter (same wire flow)
2. Phase 1a-server: TS/Rust servers with Surfpool + payment-channels program (or SDK wire-only hooks)
3. Phase 1b: `session-invalid-revoked`, cross pairs once multi-server exists

Refs: MPP session harness integration spec (Phase 1a)