### PR TITLE
harness(session): Rust session client + session-basic rust-session matrix

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -119,6 +119,17 @@ jobs:
           MPP_HARNESS_CLIENTS: python-session
           MPP_HARNESS_SERVERS: python
         run: pnpm exec vitest run test/e2e.test.ts
+      # Phase 1a: TS session client against the wire-only Python session server
+      # (open → deliveries → commit → close). Unpins session-basic from
+      # Python-client-only isolation without requiring on-chain open submit.
+      - name: Focused TypeScript session client → Python session server
+        working-directory: harness
+        env:
+          MPP_HARNESS_INTENTS: session
+          MPP_HARNESS_SCENARIOS: session-basic
+          MPP_HARNESS_CLIENTS: typescript-session
+          MPP_HARNESS_SERVERS: python
+        run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
       - name: Focused TS-to-Python harness
         working-directory: harness
         env:

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -32,7 +32,7 @@ jobs:
       # cargo cache (key suffix "shared"), installs + typechecks the harness.
       - uses: ./.github/actions/setup-harness
         with:
-          cargo-bins: "paykit-harness-bins:mpp_harness_client,mpp_harness_server,x402_harness_client,x402_harness_server"
+          cargo-bins: "paykit-harness-bins:mpp_harness_client,mpp_harness_server,mpp_harness_session_client,x402_harness_client,x402_harness_server"
           cargo-cache-key: shared
       - name: Upload @solana/mpp dist
         uses: actions/upload-artifact@v7
@@ -128,6 +128,15 @@ jobs:
           MPP_HARNESS_INTENTS: session
           MPP_HARNESS_SCENARIOS: session-basic
           MPP_HARNESS_CLIENTS: typescript-session
+          MPP_HARNESS_SERVERS: python
+        run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
+      # Phase 1a: Rust session client against the same wire-only Python server.
+      - name: Focused Rust session client → Python session server
+        working-directory: harness
+        env:
+          MPP_HARNESS_INTENTS: session
+          MPP_HARNESS_SCENARIOS: session-basic
+          MPP_HARNESS_CLIENTS: rust-session
           MPP_HARNESS_SERVERS: python
         run: pnpm exec vitest run test/e2e.test.ts --testTimeout 180000
       - name: Focused TS-to-Python harness

--- a/harness/src/fixtures/typescript/session-client.ts
+++ b/harness/src/fixtures/typescript/session-client.ts
@@ -1,0 +1,217 @@
+// TypeScript MPP `session` harness client.
+//
+// Mirrors harness/python-session-client/main.py against the wire-only session
+// server contract (Python harness SessionServer with accept-all open verify):
+//   GET resource → 402 WWW-Authenticate (session challenge)
+//   open credential → 200
+//   POST /__402/session/deliveries → reserve
+//   POST /__402/session/commit → voucher
+//   POST /__402/session/close → settlement header / reference
+//
+// Uses @solana/mpp client helpers only — no protocol reinvention.
+// Env: MPP_HARNESS_TARGET_URL (injected by harness), MPP_HARNESS_AMOUNT,
+// optional MPP_HARNESS_RPC_URL (unused for challenge-bound open blockhash).
+
+import { generateKeyPairSigner } from "@solana/kit";
+import {
+  createPaymentChannelSessionOpener,
+  selectSolanaSessionChallengeFromResponse,
+  serializeSessionCredential,
+  type SessionChallenge,
+  type SignedVoucher,
+} from "@solana/mpp/client";
+
+function baseUrlFromTarget(targetUrl: string): string {
+  const u = new URL(targetUrl);
+  return `${u.protocol}//${u.host}`;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function emitResult(parameters: {
+  ok: boolean;
+  status: number;
+  responseHeaders: Record<string, string>;
+  responseBody: unknown;
+  settlement?: string;
+  error?: string;
+}): void {
+  console.log(
+    JSON.stringify({
+      type: "result",
+      implementation: "typescript",
+      role: "client",
+      ok: parameters.ok,
+      status: parameters.status,
+      responseHeaders: parameters.responseHeaders,
+      responseBody: parameters.responseBody,
+      ...(parameters.settlement ? { settlement: parameters.settlement } : {}),
+      ...(parameters.error ? { error: parameters.error } : {}),
+    }),
+  );
+}
+
+function headersRecord(response: Response): Record<string, string> {
+  return Object.fromEntries(response.headers.entries());
+}
+
+async function main(): Promise<void> {
+  const targetUrl = process.env.MPP_HARNESS_TARGET_URL;
+  if (!targetUrl) {
+    throw new Error("MPP_HARNESS_TARGET_URL is required");
+  }
+  const amount = process.env.MPP_HARNESS_AMOUNT ?? "700";
+  const base = baseUrlFromTarget(targetUrl);
+  const reserveUrl = `${base}/__402/session/deliveries`;
+  const commitUrl = `${base}/__402/session/commit`;
+  const closeUrl = `${base}/__402/session/close`;
+
+  const probe = await fetch(targetUrl);
+  if (probe.status !== 402) {
+    emitResult({
+      ok: false,
+      status: probe.status,
+      responseHeaders: headersRecord(probe),
+      responseBody: await readJson(probe),
+      error: "expected 402 session challenge",
+    });
+    return;
+  }
+
+  const challenge = selectSolanaSessionChallengeFromResponse(probe) as SessionChallenge | null;
+  if (!challenge) {
+    emitResult({
+      ok: false,
+      status: probe.status,
+      responseHeaders: headersRecord(probe),
+      responseBody: await readJson(probe),
+      error: "no solana session challenge in WWW-Authenticate",
+    });
+    return;
+  }
+
+  // Client builds open against challenged blockhash/slot; harness server
+  // verifies wire shape only (Python accept-all) — no on-chain broadcast required.
+  const payer = await generateKeyPairSigner();
+  const opener = createPaymentChannelSessionOpener({ signer: payer });
+  // SessionOpener contract requires the original 402 response + fetch input;
+  // the payment-channel opener only consumes `challenge`.
+  const opened = await opener({
+    challenge,
+    input: targetUrl,
+    response: probe,
+  });
+  const openAuth = serializeSessionCredential({
+    challenge,
+    payload: opened.payload,
+  });
+
+  const openedResponse = await fetch(targetUrl, {
+    headers: { authorization: openAuth },
+  });
+  if (!openedResponse.ok) {
+    emitResult({
+      ok: false,
+      status: openedResponse.status,
+      responseHeaders: headersRecord(openedResponse),
+      responseBody: await readJson(openedResponse),
+      error: "session open rejected",
+    });
+    return;
+  }
+
+  const channelId = opened.session.channelId;
+  const reserveResponse = await fetch(reserveUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ sessionId: channelId, amount }),
+  });
+  const reserveBody = await readJson(reserveResponse);
+  if (
+    !reserveResponse.ok ||
+    typeof reserveBody !== "object" ||
+    reserveBody === null ||
+    !("deliveryId" in reserveBody)
+  ) {
+    emitResult({
+      ok: false,
+      status: reserveResponse.status,
+      responseHeaders: headersRecord(reserveResponse),
+      responseBody: reserveBody,
+      error: "session delivery reserve failed",
+    });
+    return;
+  }
+
+  const deliveryId = String((reserveBody as { deliveryId: unknown }).deliveryId);
+  const voucher: SignedVoucher = await opened.session.prepareIncrement(amount);
+  const commitResponse = await fetch(commitUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ deliveryId, voucher }),
+  });
+  const commitBody = await readJson(commitResponse);
+  if (!commitResponse.ok) {
+    emitResult({
+      ok: false,
+      status: commitResponse.status,
+      responseHeaders: headersRecord(commitResponse),
+      responseBody: commitBody,
+      error: "session commit failed",
+    });
+    return;
+  }
+  opened.session.recordVoucher(voucher);
+
+  const closeAuth = serializeSessionCredential({
+    challenge,
+    payload: {
+      action: "close",
+      channelId,
+      voucher,
+    },
+  });
+  const closeResponse = await fetch(closeUrl, {
+    method: "POST",
+    headers: { authorization: closeAuth },
+  });
+  const closeBody = await readJson(closeResponse);
+  let settlement = "";
+  if (typeof closeBody === "object" && closeBody !== null) {
+    const record = closeBody as Record<string, unknown>;
+    settlement = String(
+      record.reference ?? record.settledSignature ?? "",
+    );
+  }
+  const settlementHeader =
+    process.env.MPP_HARNESS_SETTLEMENT_HEADER ?? "x-session-settlement-signature";
+  if (!settlement) {
+    settlement = closeResponse.headers.get(settlementHeader) ?? "";
+  }
+
+  emitResult({
+    ok: closeResponse.ok,
+    status: closeResponse.status,
+    responseHeaders: headersRecord(closeResponse),
+    responseBody: closeBody,
+    settlement: settlement || undefined,
+  });
+}
+
+void main().catch(error => {
+  emitResult({
+    ok: false,
+    status: 0,
+    responseHeaders: {},
+    responseBody: null,
+    error: error instanceof Error ? error.message : String(error),
+  });
+});

--- a/harness/src/implementations.ts
+++ b/harness/src/implementations.ts
@@ -200,6 +200,25 @@ export const clientImplementations: ImplementationDefinition[] = [
     intents: ["session"],
   },
   {
+    id: "typescript-session",
+    label: "TypeScript @solana/mpp session client",
+    role: "client",
+    // Mirrors python-session-client (open → deliveries → commit → close)
+    // against the wire-only Python session server. Opt in via
+    // MPP_HARNESS_CLIENTS=typescript-session.
+    command: [
+      "pnpm",
+      "exec",
+      "node",
+      "--import",
+      "tsx",
+      "src/fixtures/typescript/session-client.ts",
+    ],
+    enabled: isEnabled("typescript-session", "MPP_HARNESS_CLIENTS", false),
+    intents: ["session"],
+    reportsAs: "typescript",
+  },
+  {
     id: "swift-x402",
     label: "Swift x402 exact client",
     role: "client",

--- a/harness/src/implementations.ts
+++ b/harness/src/implementations.ts
@@ -219,6 +219,28 @@ export const clientImplementations: ImplementationDefinition[] = [
     reportsAs: "typescript",
   },
   {
+    id: "rust-session",
+    label: "Rust solana-pay-kit session client",
+    role: "client",
+    // Mirrors python-session-client / typescript-session (open → deliveries →
+    // commit → close) against the wire-only Python session server. Opt in via
+    // MPP_HARNESS_CLIENTS=rust-session.
+    command: [
+      "cargo",
+      "run",
+      "--quiet",
+      "--manifest-path",
+      "../rust/Cargo.toml",
+      "-p",
+      "paykit-harness-bins",
+      "--bin",
+      "mpp_harness_session_client",
+    ],
+    enabled: isEnabled("rust-session", "MPP_HARNESS_CLIENTS", false),
+    intents: ["session"],
+    reportsAs: "rust",
+  },
+  {
     id: "swift-x402",
     label: "Swift x402 exact client",
     role: "client",

--- a/harness/src/intents/session.ts
+++ b/harness/src/intents/session.ts
@@ -14,7 +14,7 @@ export const sessionScenarios: readonly HarnessScenario[] = [
     // Phase 1a: multi-client against the wire-only Python session server.
     // TS/Rust high-level session() servers always submit open on-chain, so
     // they stay deferred until a Surfpool/program job (Phase 1a-server).
-    clientIds: ["python-session", "typescript-session"],
+    clientIds: ["python-session", "typescript-session", "rust-session"],
     serverIds: ["python"],
   },
 ] as const;

--- a/harness/src/intents/session.ts
+++ b/harness/src/intents/session.ts
@@ -11,7 +11,10 @@ export const sessionScenarios: readonly HarnessScenario[] = [
     resourcePath: "/session",
     settlementHeader: "x-session-settlement-signature",
     expectedStatus: 200,
-    clientIds: ["python-session"],
+    // Phase 1a: multi-client against the wire-only Python session server.
+    // TS/Rust high-level session() servers always submit open on-chain, so
+    // they stay deferred until a Surfpool/program job (Phase 1a-server).
+    clientIds: ["python-session", "typescript-session"],
     serverIds: ["python"],
   },
 ] as const;

--- a/rust/crates/harness-bins/Cargo.toml
+++ b/rust/crates/harness-bins/Cargo.toml
@@ -15,6 +15,8 @@ reqwest = { version = "0.12", features = ["json"] }
 # RPC and transaction types are imported by their own crate names.
 solana-rpc-client = { version = "4", default-features = false }
 solana-transaction = { version = "3", default-features = false }
+# Ephemeral session wallets (wire-only open; no funded key injection).
+solana-keypair = { version = "3.0" }
 
 [[bin]]
 name = "mpp_harness_client"
@@ -23,6 +25,10 @@ path = "src/bin/mpp_harness_client.rs"
 [[bin]]
 name = "mpp_harness_server"
 path = "src/bin/mpp_harness_server.rs"
+
+[[bin]]
+name = "mpp_harness_session_client"
+path = "src/bin/mpp_harness_session_client.rs"
 
 [[bin]]
 name = "x402_harness_client"

--- a/rust/crates/harness-bins/src/bin/mpp_harness_session_client.rs
+++ b/rust/crates/harness-bins/src/bin/mpp_harness_session_client.rs
@@ -1,0 +1,329 @@
+//! MPP `session` harness client (wire-only path).
+//!
+//! Mirrors `harness/python-session-client` and the TypeScript
+//! `session-client.ts` fixture against the Python session server:
+//!
+//!   GET /session → 402 WWW-Authenticate (intent=session)
+//!   Authorization: Payment open → 200
+//!   POST /__402/session/deliveries → reserve
+//!   POST /__402/session/commit → voucher
+//!   POST /__402/session/close → settlement reference
+//!
+//! Status is **402 Payment Required**, not 401. Authorization scheme is
+//! `Payment <base64url>` (not `MPP credential=`). Env: `MPP_HARNESS_*`.
+
+use std::{
+    collections::HashMap,
+    env,
+    io::{self, Write},
+    process,
+};
+
+use serde_json::json;
+use solana_keypair::Keypair;
+use solana_pay_kit::mpp::client::{
+    create_payment_channel_session_opener, PaymentChannelSessionOpenOptions,
+};
+use solana_pay_kit::mpp::protocol::core::{format_authorization, PaymentCredential};
+use solana_pay_kit::mpp::protocol::intents::session::{
+    ClosePayload, SessionAction, SessionRequest,
+};
+use solana_pay_kit::mpp::{
+    parse_www_authenticate_all, AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER,
+};
+use solana_pay_kit::solana_keychain::memory::MemorySigner;
+use solana_pay_kit::solana_keychain::SolanaSigner;
+
+const DEFAULT_SETTLEMENT_HEADER: &str = "x-session-settlement-signature";
+
+/// Write a line to stdout, swallowing `BrokenPipe` (EPIPE) like the charge client.
+fn write_stdout_line(line: &str) {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    match writeln!(handle, "{line}") {
+        Ok(()) => {
+            let _ = handle.flush();
+        }
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => process::exit(0),
+        Err(err) => panic!("failed printing to stdout: {err}"),
+    }
+}
+
+fn emit_result(
+    ok: bool,
+    status: u16,
+    headers: HashMap<String, String>,
+    body: serde_json::Value,
+    settlement: Option<String>,
+    error: Option<String>,
+) {
+    let mut map = json!({
+        "type": "result",
+        "implementation": "rust",
+        "role": "client",
+        "ok": ok,
+        "status": status,
+        "responseHeaders": headers,
+        "responseBody": body,
+    });
+    if let Some(s) = settlement {
+        map["settlement"] = json!(s);
+    }
+    if let Some(e) = error {
+        map["error"] = json!(e);
+    }
+    write_stdout_line(&map.to_string());
+}
+
+fn random_memory_signer() -> Result<MemorySigner, Box<dyn std::error::Error + Send + Sync>> {
+    // Ephemeral harness wallets — no secret is injected for session-basic
+    // (Python/TS fixtures also generate throwaway keypairs).
+    let kp = Keypair::new();
+    Ok(MemorySigner::from_bytes(&kp.to_bytes())?)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Err(err) = run().await {
+        emit_result(
+            false,
+            0,
+            HashMap::new(),
+            serde_json::Value::Null,
+            None,
+            Some(err.to_string()),
+        );
+    }
+    Ok(())
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let target_url = read_required_env("MPP_HARNESS_TARGET_URL")?;
+    let amount: u64 = env::var("MPP_HARNESS_AMOUNT")
+        .unwrap_or_else(|_| "700".into())
+        .parse()
+        .map_err(|_| "MPP_HARNESS_AMOUNT must be a u64".to_string())?;
+    let settlement_header = env::var("MPP_HARNESS_SETTLEMENT_HEADER")
+        .unwrap_or_else(|_| DEFAULT_SETTLEMENT_HEADER.to_string());
+
+    let base = target_url
+        .rsplit_once('/')
+        .map(|(b, _)| b.to_string())
+        .unwrap_or_else(|| target_url.clone());
+    let reserve_url = format!("{base}/__402/session/deliveries");
+    let commit_url = format!("{base}/__402/session/commit");
+    let close_url = format!("{base}/__402/session/close");
+
+    let http = reqwest::Client::new();
+
+    // ── 1) Unauthenticated GET → expect 402 + session challenge ────────────
+    let first = http.get(&target_url).send().await?;
+    let first_status = first.status().as_u16();
+    // Keep multi-value headers as a Vec so every WWW-Authenticate is visible
+    // to parse_www_authenticate_all (HashMap would collapse duplicates).
+    let first_header_pairs = response_headers(first.headers())?;
+    let first_headers = headers_to_map(first_header_pairs.clone());
+    let first_body_raw = first.text().await?;
+    let first_body = parse_body(&first_body_raw);
+
+    if first_status != 402 {
+        emit_result(
+            false,
+            first_status,
+            first_headers,
+            first_body,
+            None,
+            Some("expected 402 session challenge".into()),
+        );
+        return Ok(());
+    }
+
+    let challenge_values = first_header_pairs
+        .iter()
+        .filter(|(name, _)| name == WWW_AUTHENTICATE_HEADER)
+        .map(|(_, value)| value.as_str());
+    let challenge = parse_www_authenticate_all(challenge_values)
+        .into_iter()
+        .filter_map(Result::ok)
+        .find(|c| c.method.as_str() == "solana" && c.intent.as_str() == "session")
+        .ok_or_else(|| "server did not return a solana/session Payment challenge".to_string())?;
+
+    let request: SessionRequest = challenge
+        .request
+        .decode()
+        .map_err(|e| format!("decode session challenge request: {e}"))?;
+
+    // ── 2) Build open action (client-built open tx; harness server wire-only) ─
+    let payer = random_memory_signer()?;
+    let session_signer: Box<dyn SolanaSigner> = Box::new(random_memory_signer()?);
+    let opened = create_payment_channel_session_opener(
+        &request,
+        &payer,
+        session_signer,
+        None, // use challenged recentBlockhash/slot
+        PaymentChannelSessionOpenOptions::default(),
+    )
+    .await
+    .map_err(|e| format!("create_payment_channel_session_opener: {e}"))?;
+
+    let open_auth = format_authorization(&PaymentCredential::new(
+        challenge.to_echo(),
+        &opened.action,
+    ))
+    .map_err(|e| format!("format open authorization: {e}"))?;
+
+    let open_resp = http
+        .get(&target_url)
+        .header(AUTHORIZATION_HEADER, &open_auth)
+        .send()
+        .await?;
+    let open_status = open_resp.status().as_u16();
+    let open_headers = headers_to_map(response_headers(open_resp.headers())?);
+    let open_body = parse_body(&open_resp.text().await?);
+    if !(200..300).contains(&open_status) {
+        emit_result(
+            false,
+            open_status,
+            open_headers,
+            open_body,
+            None,
+            Some("session open rejected".into()),
+        );
+        return Ok(());
+    }
+
+    let mut session = opened.session;
+    let channel_id = session.channel_id_str();
+
+    // ── 3) Reserve delivery ────────────────────────────────────────────────
+    let reserve_resp = http
+        .post(&reserve_url)
+        .json(&json!({ "sessionId": channel_id, "amount": amount.to_string() }))
+        .send()
+        .await?;
+    let reserve_status = reserve_resp.status().as_u16();
+    let reserve_headers = headers_to_map(response_headers(reserve_resp.headers())?);
+    let reserve_body = parse_body(&reserve_resp.text().await?);
+    let delivery_id = reserve_body
+        .get("deliveryId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    if !(200..300).contains(&reserve_status) || delivery_id.is_none() {
+        emit_result(
+            false,
+            reserve_status,
+            reserve_headers,
+            reserve_body,
+            None,
+            Some("session delivery reserve failed".into()),
+        );
+        return Ok(());
+    }
+    let delivery_id = delivery_id.unwrap();
+
+    // ── 4) Commit voucher ──────────────────────────────────────────────────
+    let voucher = session
+        .prepare_increment(amount)
+        .await
+        .map_err(|e| format!("prepare_increment: {e}"))?;
+    let commit_resp = http
+        .post(&commit_url)
+        .json(&json!({
+            "deliveryId": delivery_id,
+            "voucher": voucher,
+        }))
+        .send()
+        .await?;
+    let commit_status = commit_resp.status().as_u16();
+    let commit_headers = headers_to_map(response_headers(commit_resp.headers())?);
+    let commit_body = parse_body(&commit_resp.text().await?);
+    if !(200..300).contains(&commit_status) {
+        emit_result(
+            false,
+            commit_status,
+            commit_headers,
+            commit_body,
+            None,
+            Some("session commit failed".into()),
+        );
+        return Ok(());
+    }
+    session
+        .record_voucher(&voucher)
+        .map_err(|e| format!("record_voucher: {e}"))?;
+
+    // ── 5) Close with the committed voucher ────────────────────────────────
+    let close_action = SessionAction::Close(ClosePayload {
+        channel_id: channel_id.clone(),
+        authentication: None,
+        voucher: Some(voucher),
+    });
+    let close_auth = format_authorization(&PaymentCredential::new(
+        challenge.to_echo(),
+        &close_action,
+    ))
+    .map_err(|e| format!("format close authorization: {e}"))?;
+
+    let close_resp = http
+        .post(&close_url)
+        .header(AUTHORIZATION_HEADER, &close_auth)
+        .send()
+        .await?;
+    let close_status = close_resp.status().as_u16();
+    let close_headers = headers_to_map(response_headers(close_resp.headers())?);
+    let close_body_raw = close_resp.text().await?;
+    let close_body = parse_body(&close_body_raw);
+
+    let mut settlement = close_body
+        .get("reference")
+        .or_else(|| close_body.get("settledSignature"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_default();
+    if settlement.is_empty() {
+        settlement = close_headers
+            .get(&settlement_header)
+            .cloned()
+            .unwrap_or_default();
+    }
+
+    emit_result(
+        (200..300).contains(&close_status),
+        close_status,
+        close_headers,
+        close_body,
+        if settlement.is_empty() {
+            None
+        } else {
+            Some(settlement)
+        },
+        None,
+    );
+    Ok(())
+}
+
+fn parse_body(raw: &str) -> serde_json::Value {
+    serde_json::from_str(raw).unwrap_or_else(|_| json!(raw))
+}
+
+fn response_headers(
+    headers: &reqwest::header::HeaderMap,
+) -> Result<Vec<(String, String)>, Box<dyn std::error::Error + Send + Sync>> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            Ok((
+                name.as_str().to_ascii_lowercase(),
+                value.to_str()?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn headers_to_map(headers: Vec<(String, String)>) -> HashMap<String, String> {
+    headers.into_iter().collect()
+}
+
+fn read_required_env(name: &str) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    env::var(name).map_err(|_| format!("{name} is required").into())
+}


### PR DESCRIPTION
## Summary

Phase 1a extension of the MPP session harness: add a **Rust** wire-level session client and expand `session-basic` so `rust-session` exercises the same path as Python/TS against the wire-only Python session server.

**Depends on / stacks with [#276](https://github.com/solana-foundation/pay-kit/pull/276)** (TypeScript session client + multi-client `session-basic`). This branch includes that commit until #276 lands; review focus is the Rust adapter commit.

### Wire flow (corrected vs. naive 401/`MPP credential=` sketch)

Status is **402 Payment Required**, scheme **`Payment <base64url>`**, multi-step:

1. `GET /session` → 402 + `WWW-Authenticate` (`intent=session`)
2. Client builds open via `create_payment_channel_session_opener` (challenge-bound blockhash/slot)
3. Resubmit with `Authorization: Payment …` open action → 200
4. `POST /__402/session/deliveries` → reserve
5. `POST /__402/session/commit` → voucher
6. `POST /__402/session/close` → settlement reference

No on-chain broadcast in this scenario (Python accept-all open verify). Isolated from x402 upto stack (#271–#275).

### Changes

- `mpp_harness_session_client` bin (`paykit-harness-bins`)
- `rust-session` client adapter (`reportsAs: rust`)
- `session-basic` `clientIds`: `python-session` | `typescript-session` | **`rust-session`**
- CI: focused `rust-session` → `python` session-basic leg; prewarm bin in shared harness build

### Local verification

```
session-basic: rust-session client pays python server  ✓
```

## Test plan

- [x] `cargo check/build -p paykit-harness-bins --bin mpp_harness_session_client`
- [x] Local: `MPP_HARNESS_INTENTS=session MPP_HARNESS_SCENARIOS=session-basic MPP_HARNESS_CLIENTS=rust-session MPP_HARNESS_SERVERS=python pnpm exec vitest run test/e2e.test.ts`
- [x] CI: Harness Python job — Focused Rust session client → Python session server
- [ ] Confirm no interference with charge / x402 matrix legs