### PR TITLE
feat(harness): session-multi-delivery cumulative watermark scenario

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -115,7 +115,7 @@ jobs:
         working-directory: harness
         env:
           MPP_HARNESS_INTENTS: session
-          MPP_HARNESS_SCENARIOS: session-basic
+          MPP_HARNESS_SCENARIOS: session-basic,session-multi-delivery
           MPP_HARNESS_CLIENTS: python-session
           MPP_HARNESS_SERVERS: python
         run: pnpm exec vitest run test/e2e.test.ts

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -128,7 +128,7 @@ jobs:
         working-directory: harness
         env:
           MPP_HARNESS_INTENTS: session
-          MPP_HARNESS_SCENARIOS: session-basic
+          MPP_HARNESS_SCENARIOS: session-basic,session-multi-delivery
           MPP_HARNESS_CLIENTS: python-session
           MPP_HARNESS_SERVERS: python
         run: pnpm exec vitest run test/e2e.test.ts

--- a/harness/python-session-client/main.py
+++ b/harness/python-session-client/main.py
@@ -82,7 +82,13 @@ def main() -> None:
     reserve_url = target.rsplit("/", 1)[0] + "/__402/session/deliveries"
     commit_url = target.rsplit("/", 1)[0] + "/__402/session/commit"
     close_url = target.rsplit("/", 1)[0] + "/__402/session/close"
+    # Per-increment amount (base units). Multi-delivery scenarios set
+    # MPP_HARNESS_DELIVERY_COUNT > 1 so the cumulative watermark advances
+    # count * amount before a single close.
     amount = os.environ.get("MPP_HARNESS_AMOUNT", "700")
+    delivery_count = int(os.environ.get("MPP_HARNESS_DELIVERY_COUNT", "1"))
+    if delivery_count < 1:
+        raise SystemExit("MPP_HARNESS_DELIVERY_COUNT must be >= 1")
 
     status, headers, raw = _request("GET", target)
     if status != 402:
@@ -106,27 +112,33 @@ def main() -> None:
         return
 
     channel_id = opener.session.channel_id_string
-    status, reserve_headers, reserve_raw = _request(
-        "POST",
-        reserve_url,
-        {"sessionId": channel_id, "amount": amount},
-    )
-    reserve_body = _json(reserve_raw)
-    if status != 200 or not isinstance(reserve_body, dict):
-        _result(status, reserve_headers, reserve_body)
-        return
+    voucher = None
+    increment = int(amount)
+    for _ in range(delivery_count):
+        status, reserve_headers, reserve_raw = _request(
+            "POST",
+            reserve_url,
+            {"sessionId": channel_id, "amount": amount},
+        )
+        reserve_body = _json(reserve_raw)
+        if status != 200 or not isinstance(reserve_body, dict):
+            _result(status, reserve_headers, reserve_body)
+            return
 
-    voucher = opener.session.prepare_increment(int(amount))
-    status, commit_headers, commit_raw = _request(
-        "POST",
-        commit_url,
-        {"deliveryId": reserve_body["deliveryId"], "voucher": voucher.to_dict()},
-    )
-    commit_body = _json(commit_raw)
-    if status != 200:
-        _result(status, commit_headers, commit_body)
-        return
-    opener.session.record_voucher(voucher)
+        voucher = opener.session.prepare_increment(increment)
+        status, commit_headers, commit_raw = _request(
+            "POST",
+            commit_url,
+            {"deliveryId": reserve_body["deliveryId"], "voucher": voucher.to_dict()},
+        )
+        commit_body = _json(commit_raw)
+        if status != 200:
+            _result(status, commit_headers, commit_body)
+            return
+        opener.session.record_voucher(voucher)
+
+    if voucher is None:
+        raise SystemExit("no voucher produced")
 
     close_auth = serialize_session_credential(
         challenge,

--- a/harness/src/intents/session.ts
+++ b/harness/src/intents/session.ts
@@ -14,4 +14,25 @@ export const sessionScenarios: readonly HarnessScenario[] = [
     clientIds: ["python-session"],
     serverIds: ["python"],
   },
+  // MPP session multi-delivery (cumulative watermark): N reserve/commit
+  // increments then a single close. Clients read MPP_HARNESS_DELIVERY_COUNT
+  // (default 1) and MPP_HARNESS_AMOUNT per increment. e2e sets count=3 for
+  // this scenario (3 × 700 = 2100 cumulative).
+  //
+  // PR-1 ships python-session only (the sole session harness client today).
+  // Expand clientIds to typescript-session / rust-session when those
+  // adapters land and implement the same DELIVERY_COUNT loop.
+  {
+    id: "session-multi-delivery",
+    intent: "session",
+    network: "localnet",
+    price: "0.0007",
+    amount: "700",
+    asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    resourcePath: "/session",
+    settlementHeader: "x-session-settlement-signature",
+    expectedStatus: 200,
+    clientIds: ["python-session"],
+    serverIds: ["python"],
+  },
 ] as const;

--- a/harness/test/e2e.test.ts
+++ b/harness/test/e2e.test.ts
@@ -914,6 +914,13 @@ function environmentForScenario(
     }
   } else if (scenario.intent === "session") {
     env.PAY_KIT_HARNESS_PROTOCOL = "session";
+    // Multi-delivery cumulative watermark: three increments of amount before
+    // a single close. session-basic (and any other session scenario) leave
+    // the default MPP_HARNESS_DELIVERY_COUNT=1 so one reserve/commit remains.
+    if (scenario.id === "session-multi-delivery") {
+      env.MPP_HARNESS_DELIVERY_COUNT = "3";
+      env.MPP_HARNESS_AMOUNT = "700";
+    }
   } else {
     env.PAY_KIT_HARNESS_PROTOCOL = "mpp";
   }

--- a/harness/test/intent-selection.test.ts
+++ b/harness/test/intent-selection.test.ts
@@ -84,7 +84,7 @@ describe("harness scenario selection", () => {
   it("returns session scenarios when explicitly requested", () => {
     expect(
       selectHarnessScenarios("session", undefined).map((scenario) => scenario.id),
-    ).toEqual(["session-basic"]);
+    ).toEqual(["session-basic", "session-multi-delivery"]);
   });
 
   it("returns x402-upto scenarios when explicitly requested", () => {


### PR DESCRIPTION
## Summary

Phase 1b PR-1: multi-delivery MPP session harness scenario.

- New scenario `session-multi-delivery`: 3 delivery increments @ 700 base units (cumulative watermark **2100**) then a single close.
- `python-session-client` respects `MPP_HARNESS_DELIVERY_COUNT` (default `1`) and `MPP_HARNESS_AMOUNT` so `session-basic` stays single-delivery.
- e2e sets `MPP_HARNESS_DELIVERY_COUNT=3` only for `session-multi-delivery`.
- CI (`harness.yml`, `python.yml`) runs `session-basic,session-multi-delivery`.

## Scope note

Blueprint listed `typescript-session` / `rust-session` clients. Those harness adapters do not exist yet (only `python-session` is registered). This PR ships the multi-delivery contract on the working python path; expand `clientIds` when those clients land and implement the same delivery loop.

## Verification

- [x] `python-session` ↔ `python` server: `session-multi-delivery` green (local e2e)
- [x] `python-session` ↔ `python` server: `session-basic` still green
- [x] `intent-selection` includes both session scenarios
- [ ] typescript-session / rust-session: deferred until adapters exist

Local:
```
MPP_HARNESS_INTENTS=session \
MPP_HARNESS_SCENARIOS=session-basic,session-multi-delivery \
MPP_HARNESS_CLIENTS=python-session \
MPP_HARNESS_SERVERS=python \
pnpm exec vitest run test/e2e.test.ts
# ✓ session-basic  ~2.6s
# ✓ session-multi-delivery  ~1.4s
```

## Test plan

- [x] intent-selection unit tests
- [x] focused session e2e (basic + multi-delivery)
- [ ] CI harness/python focused session job