### PR TITLE
fix(x402): require decimals for SPL payments instead of defaulting to 6

### DIFF
--- a/rust/crates/kit/src/x402/client/exact/payment.rs
+++ b/rust/crates/kit/src/x402/client/exact/payment.rs
@@ -469,7 +469,13 @@ fn build_spl_instructions(
             )
         }))
         .map_err(|e| Error::Other(format!("Invalid token program: {e}")))?;
-    let decimals = requirements.decimals.unwrap_or(6);
+    // Mirror mpp::client::charge (Audit #42): `decimals` is required when
+    // `currency` is a mint address. Silently defaulting to 6 produced a
+    // TransferChecked that fails on-chain with MintDecimalsMismatch for every
+    // non-6-decimal mint (e.g. wrapped SOL, which has 9).
+    let decimals = requirements.decimals.ok_or_else(|| {
+        Error::Other("decimals is required for SPL token payments".into())
+    })?;
 
     let source_ata = get_associated_token_address(signer_pubkey, &mint, &token_program);
     let dest_ata = get_associated_token_address(recipient, &mint, &token_program);
@@ -603,6 +609,35 @@ mod tests {
             accepted: None,
             resource_info: None,
         }
+    }
+
+    #[test]
+    fn build_spl_rejects_missing_decimals() {
+        // Audit #42 (mirrors mpp::client::charge): `decimals` is required for
+        // SPL payments. Silently defaulting to 6 produced a TransferChecked
+        // that fails on-chain (MintDecimalsMismatch) for non-6-decimal mints.
+        let signer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        // Wrapped SOL (9 decimals) with `decimals` omitted from the challenge.
+        let spl = "So11111111111111111111111111111111111111112";
+        let mut requirements = test_requirements(spl);
+        requirements.decimals = None;
+
+        let mut instructions = vec![];
+        let err = build_spl_instructions(
+            &mut instructions,
+            &signer,
+            &recipient,
+            spl,
+            &requirements,
+            1_000_000,
+        )
+        .err()
+        .expect("missing decimals should be rejected");
+        assert!(
+            format!("{err}").contains("decimals is required"),
+            "got: {err}"
+        );
     }
 
     fn decode_tx(encoded: &str) -> VersionedTransaction {


### PR DESCRIPTION
## What

The x402 exact payment client defaults SPL `decimals` to 6 when a challenge omits it (`x402/client/exact/payment.rs`, `requirements.decimals.unwrap_or(6)`), so it emits a `TransferChecked` with the wrong decimals byte for any non-6-decimal mint.

## Why

`TransferChecked` carries a decimals byte that SPL Token compares against the mint's real decimals, returning `MintDecimalsMismatch` on any difference. For a challenge whose currency is a non-6-decimal mint (for example wrapped SOL, which has 9) with `decimals` absent, the client bakes in 6, so the payment transaction is guaranteed to fail on-chain. The fee-payer signature and fee are wasted and the payment never settles.

The MPP charge client already fixed the identical issue under Audit #42 (`mpp/client/charge.rs`), erroring when `decimals` is absent instead of defaulting to 6, with the note that defaulting "silently produced wrong-decimals transfers for non-6-decimal tokens." The x402 exact path was missed. The `decimals` field is also documented as required for SPL tokens in `x402/protocol/schemes/exact/types.rs`.

## Change

Require `decimals` on the SPL path and return an error when it is absent, mirroring the MPP charge client.

## Test

`build_spl_rejects_missing_decimals` mirrors the MPP Audit #42 test: it builds an SPL challenge (wrapped SOL) with `decimals` omitted and asserts the client rejects it instead of emitting a wrong-decimals `TransferChecked`. It fails before the change (the client silently emits decimals 6) and passes after.
