### PR TITLE
docs: rename payment channel -> tab in prose

### DIFF
--- a/.github/actions/build-payment-channels/action.yml
+++ b/.github/actions/build-payment-channels/action.yml
@@ -1,6 +1,6 @@
-name: Build payment-channels program
+name: Build tabs program
 description: >
-  Check out the canonical payment-channels program, patch the localnet
+  Check out the canonical tabs program, patch the localnet
   treasury-owner sentinel, and build the SBF artifact the embedded surfnet runs
   for x402 `upto` interop. A prebuilt localnet artifact is required because the
   mainnet deployment uses BPF instructions surfnet cannot execute, and streaming
@@ -9,7 +9,7 @@ description: >
 
 inputs:
   ref:
-    description: payment-channels commit to build.
+    description: tabs commit to build.
     required: false
     default: 0c07d5751c8972abf6a219570a3f39a72f46f879
   program-id:
@@ -25,7 +25,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout payment channels program
+    - name: Checkout tabs program
       uses: actions/checkout@v5
       with:
         repository: solana-foundation/payment-channels
@@ -37,7 +37,7 @@ runs:
       run: |
         sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
         echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
-    - name: Patch payment channels treasury owner
+    - name: Patch tabs treasury owner
       shell: bash
       working-directory: _payment-channels
       run: |
@@ -58,7 +58,7 @@ runs:
           echo "::error::payment-channels treasury sentinel patch did not apply"
           exit 1
         fi
-    - name: Build payment channels program
+    - name: Build tabs program
       shell: bash
       working-directory: _payment-channels/program/payment_channels
       run: cargo build-sbf --tools-version v1.52 --arch v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           cargo-bins: "paykit-harness-bins:mpp_harness_client,x402_harness_client,x402_harness_upto_client,x402_harness_upto_server"
           cargo-cache-key: go
-      - name: Checkout payment channels program
+      - name: Checkout tabs program
         uses: actions/checkout@v5
         with:
           repository: Moonsong-Labs/solana-payment-channels
@@ -104,7 +104,7 @@ jobs:
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
-      - name: Patch payment channels localnet artifact
+      - name: Patch tabs localnet artifact
         working-directory: _payment-channels
         run: |
           old_program_id="CQAyft83tN1w2bRofB5PZ79eVDU2xZUVo43LU1qL4zRg"
@@ -130,7 +130,7 @@ jobs:
             echo "::error::payment-channels treasury sentinel patch did not apply"
             exit 1
           fi
-      - name: Build payment channels program
+      - name: Build tabs program
         working-directory: _payment-channels/program/payment_channels
         run: cargo build-sbf --tools-version v1.52 --arch v1
       - name: Build Go paykit harness server
@@ -155,9 +155,9 @@ jobs:
           MPP_HARNESS_SCENARIOS: charge-basic,charge-split-ata,charge-symbol-usdc-localnet,charge-token2022-split-ata,charge-split-ata-idempotent,charge-compute-budget-over-cap,charge-splits-too-many,charge-splits-sum-equals-amount,charge-network-mismatch,charge-cross-route-replay,x402-exact-basic,x402-upto-basic,x402-upto-zero-actual
           X402_HARNESS_CLIENTS: rust-x402,go-x402,rust-x402-upto,go-x402-upto
           # Pin x402-exact to the main Go server and x402-upto to the Go/Rust
-          # payment-channel servers under test.
+          # tab servers under test.
           X402_HARNESS_SERVERS: go,rust-x402-upto,go-x402-upto
-          # x402-upto executes the canonical payment-channels program on the
+          # x402-upto executes the canonical tabs program on the
           # embedded surfnet. Use a localnet SBF artifact because the mainnet
           # deployment currently uses BPF instructions unsupported by Surfnet.
           PAYMENT_CHANNELS_PROGRAM_SO: ../_payment-channels/target/deploy/payment_channels.so

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -376,7 +376,7 @@ jobs:
         run: pnpm exec vitest run test/e2e.test.ts --testNamePattern "kotlin-x402 client pays rust-x402 server" --testTimeout 180000
 
   # Real on-chain settlement gate: forks mainnet (surfpool 1.4) and executes the
-  # deployed payment-channels program, so a green run proves settlement actually
+  # deployed tabs program, so a green run proves settlement actually
   # lands on-chain (the byte-shape harness above cannot). Needs @solana/pay-kit
   # built (the on-chain suite imports it) and a mainnet RPC to fork from.
   onchain:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -124,9 +124,9 @@ jobs:
         with:
           cargo-bins: "paykit-harness-bins:x402_harness_upto_client,x402_harness_upto_server"
           cargo-cache-key: kotlin-x402-upto
-      # x402 upto settles on the canonical payment-channels program; the upto
+      # x402 upto settles on the canonical tabs program; the upto
       # e2e runs this localnet SBF build on the embedded surfnet.
-      - name: Build payment channels program
+      - name: Build tabs program
         id: payment-channels
         uses: ./.github/actions/build-payment-channels
       # Pre-warm the Kotlin x402 upto client install so the harness adapter
@@ -138,7 +138,7 @@ jobs:
         run: gradle installDist --no-daemon
       # Drive the Kotlin solana paykit upto client (channel open) against the
       # canonical Rust upto server (broadcast + voucher settle on the embedded
-      # surfnet). Requires the payment-channels .so built above.
+      # surfnet). Requires the tabs .so built above.
       - name: Run Kotlin x402 upto client to Rust upto server harness
         working-directory: harness
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -71,10 +71,10 @@ jobs:
         with:
           cargo-bins: "paykit-harness-bins:mpp_harness_client,mpp_harness_server,x402_harness_client,x402_harness_server,x402_harness_upto_client,x402_harness_upto_server"
           cargo-cache-key: python
-      # x402 upto settles on the canonical payment-channels program; the upto
+      # x402 upto settles on the canonical tabs program; the upto
       # e2e deploys this localnet SBF artifact onto the embedded surfnet. Mirrors
       # the harness-go job in .github/workflows/go.yml.
-      - name: Checkout payment channels program
+      - name: Checkout tabs program
         uses: actions/checkout@v5
         with:
           repository: Moonsong-Labs/solana-payment-channels
@@ -85,7 +85,7 @@ jobs:
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
-      - name: Patch payment channels treasury owner
+      - name: Patch tabs treasury owner
         working-directory: _payment-channels
         run: |
           program_id="CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
@@ -105,7 +105,7 @@ jobs:
             echo "::error::payment-channels treasury sentinel patch did not apply"
             exit 1
           fi
-      - name: Build payment channels program
+      - name: Build tabs program
         working-directory: _payment-channels/program/payment_channels
         run: cargo build-sbf --tools-version v1.52 --arch v1
       # Sync the uv environment the conformance runner (runners/python.json:
@@ -170,7 +170,7 @@ jobs:
       # upto reference. x402-upto-basic runs every active client x server; the
       # zero-actual scenario is pinned to rust-x402-upto (serverIds in
       # intents/x402-upto.ts), so the fail-closed PayKit python/go servers are
-      # excluded from it. Requires the payment-channels .so built above.
+      # excluded from it. Requires the tabs .so built above.
       - name: Focused python-x402-upto -> rust/python upto servers
         working-directory: harness
         env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -98,9 +98,9 @@ jobs:
         with:
           cargo-bins: "paykit-harness-bins:x402_harness_upto_server"
           cargo-cache-key: swift-x402-upto
-      # x402 upto opens a real on-chain payment channel; the embedded surfnet
-      # needs the canonical payment-channels program as a localnet SBF build.
-      - name: Build payment channels program
+      # x402 upto opens a real on-chain tab; the embedded surfnet
+      # needs the canonical tabs program as a localnet SBF build.
+      - name: Build tabs program
         id: payment-channels
         uses: ./.github/actions/build-payment-channels
       - name: Build Swift x402 upto harness client

--- a/Justfile
+++ b/Justfile
@@ -55,7 +55,7 @@ subscriptions-generate-rs: codegen-install
 # Full refresh: pull IDL + regenerate Rust client.
 subscriptions-sync: subscriptions-pull-idl subscriptions-generate-rs
 
-# Fetch the payment-channels IDL from the pinned upstream commit into
+# Fetch the tabs IDL from the pinned upstream commit into
 # `idl/payment-channels.json`.
 payment-channels-pull-idl:
     @mkdir -p idl

--- a/docs/security/tab-rent-and-voucher-modes.md
+++ b/docs/security/tab-rent-and-voucher-modes.md
@@ -1,6 +1,6 @@
-# Payment-channel rent & voucher modes
+# Tab rent & voucher modes
 
-A payment-channel `open` instruction binds two **independent** roles. Conflating
+A tab `open` instruction binds two **independent** roles. Conflating
 them is a recurring bug source, so they are tracked separately everywhere the
 open is built, validated, or settled.
 

--- a/go/Justfile
+++ b/go/Justfile
@@ -41,7 +41,7 @@ audit:
     go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
 # Test with coverage gate (defaults to 90).
-# The codama-generated payment-channels client and the runnable examples are
+# The codama-generated tabs client and the runnable examples are
 # filtered from the profile before the gate: the generated client is
 # byte-for-byte reproducible from idl/payment-channels.json (the same
 # carve-out the lint recipe applies), and examples are demo binaries that the

--- a/go/README.md
+++ b/go/README.md
@@ -96,7 +96,7 @@ The sibling `protocols/mpp/client` does the same for MPP
 
 The exact-amount scheme, settled locally against the operator signer or
 delegated to a facilitator. Both client and server ship. The
-usage-based `upto` scheme (payment-channel profile) ships server-side
+usage-based `upto` scheme (tab profile) ships server-side
 via `paykit.RequireUsage` and client-side through the protocol helper
 used by the harness. The generic `x402client.NewClient` transport is
 still exact-only.
@@ -108,7 +108,7 @@ still exact-only.
 | `x402/batch-settlement` | — | — |
 
 `upto` charges for actual usage up to a ceiling: the client opens a
-payment channel depositing the authorized maximum, the server
+tab depositing the authorized maximum, the server
 broadcasts the open (co-signing as fee payer), the handler runs and
 determines the actual metered amount, then the server settles with a
 single operator voucher and refunds the remainder. It requires an
@@ -152,7 +152,7 @@ Client side:
 - session challenge parsing and selection (`ParseSessionChallenge`,
   `SelectSessionChallenge` with network/currency/mode filters; omitted
   or empty `modes` means push-only),
-- payment-channel open builders driven by the challenge (deposit
+- tab open builders driven by the challenge (deposit
   defaults to the cap, grace period 900s, random salt, token program
   resolved from the currency so Token-2022 mints work, operator as fee
   payer with a payer partial-sign, challenge `recentBlockhash` echo,

--- a/go/cmd/conformance/main.go
+++ b/go/cmd/conformance/main.go
@@ -257,7 +257,7 @@ type ChallengeID struct {
 // VoucherPreimage holds the inputs to the 50-byte session voucher message
 // bytes (a constant [0x56, 0x01] magic prefix leads the payload).
 type VoucherPreimage struct {
-	// ChannelID is the payment-channel address (base58); its 32 raw bytes
+	// ChannelID is the tab address (base58); its 32 raw bytes
 	// follow the 2-byte magic prefix.
 	ChannelID string `json:"channelId"`
 	// CumulativeAmount is the channel's cumulative spend in token base

--- a/go/examples/playground-api/README.md
+++ b/go/examples/playground-api/README.md
@@ -13,7 +13,7 @@ Payment Sandbox (a hosted test validator, no real funds):
 - **Sessions**: the in-process Go session method gating `/api/v1/stream`
   (pay-per-chunk SSE, also served at `/sessions/stream`) and
   `/sessions/compute` (pay-per-call), with real
-  payment-channel opens (server-completed fee-payer signature), voucher
+  tab opens (server-completed fee-payer signature), voucher
   metering through the `/__402/session/*` side channel, and on-chain
   settlement via the idle-close watchdog.
 - **x402**: the TS-style `/api/v1/summarize` usage endpoint, two legacy

--- a/go/examples/playground-api/main.go
+++ b/go/examples/playground-api/main.go
@@ -58,7 +58,7 @@ type app struct {
 func main() {
 	network := envOr("NETWORK", "localnet")
 	// Default to the hosted Solana Payment Sandbox so the playground works
-	// zero-config: it has the payment-channels program preloaded and supports
+	// zero-config: it has the tabs program preloaded and supports
 	// the surfnet cheatcodes used by the faucet. Override RPC_URL to point at
 	// a local surfpool when you need offline iteration.
 	rpcURL := envOr("RPC_URL", "https://402.surfnet.dev:8899")

--- a/go/examples/playground-api/playground_e2e_test.go
+++ b/go/examples/playground-api/playground_e2e_test.go
@@ -2,7 +2,7 @@ package main
 
 // Surfpool-gated end-to-end test: boots the real playground handler against
 // the hosted Solana Payment Sandbox, funds a wallet through the faucet
-// cheatcodes, opens a payment channel on the /sessions/stream 402 (client
+// cheatcodes, opens a tab on the /sessions/stream 402 (client
 // pre-signs, server completes the fee-payer signature and broadcasts),
 // streams the metered SSE chunks, commits a voucher through the side
 // channel, and polls /sessions/receipt until the idle-close watchdog settles
@@ -36,7 +36,7 @@ func sandboxRPCURL() string {
 	return "https://402.surfnet.dev:8899"
 }
 
-// The public hosted sandbox can lag the repo's generated payment-channels ABI.
+// The public hosted sandbox can lag the repo's generated tabs ABI.
 // Keep explicit MPP_HARNESS_RPC_URL runs strict; only skip the default hosted
 // endpoint on the known ABI-drift signature.
 func hostedPaymentChannelsABIDrift(body string) bool {
@@ -142,11 +142,11 @@ func TestPlaygroundSessionE2ESurfpool(t *testing.T) {
 	response, body = playgroundRequest(t, http.MethodGet, streamURL, "", openAuthorization)
 	if response.StatusCode != http.StatusOK {
 		if hostedPaymentChannelsABIDrift(body) {
-			t.Skipf("hosted Surfpool payment-channels program ABI is behind the repo generated client: %s", body)
+			t.Skipf("hosted Surfpool tabs program ABI is behind the repo generated client: %s", body)
 		}
 		t.Fatalf("open failed: %d %s", response.StatusCode, body)
 	}
-	if !strings.Contains(body, "payment channel") || !strings.Contains(body, "[DONE]") {
+	if !strings.Contains(body, "tab") || !strings.Contains(body, "[DONE]") {
 		t.Fatalf("stream body missing chunks or sentinel: %s", body)
 	}
 	channelID := opener.Session.ChannelIDString()

--- a/go/examples/playground-api/sessions.go
+++ b/go/examples/playground-api/sessions.go
@@ -18,7 +18,7 @@ import (
 
 // tokenChunks is the canned token stream payload.
 var tokenChunks = []string{
-	"A payment channel ",
+	"A tab ",
 	"lets a client and server ",
 	"authorize many small ",
 	"off-chain debits ",
@@ -55,7 +55,7 @@ func registerSessions(mux *http.ServeMux, a *app) (func(), error) {
 			Decimals:  usdcDecimals,
 			Network:   a.network,
 			SecretKey: a.secretKey,
-			// Real on-chain opens: the browser pre-signs a payment-channel
+			// Real on-chain opens: the browser pre-signs a tab
 			// open transaction (fee payer = operator) and the server
 			// completes the signature, broadcasts, and waits for
 			// confirmation before metering.

--- a/go/examples/playground-api/x402.go
+++ b/go/examples/playground-api/x402.go
@@ -183,7 +183,7 @@ func registerX402(mux *http.ServeMux, a *app) error {
 	}))
 	mux.Handle("POST /api/v1/summarize", bufferRequestBody(summarizeMaxBodyBytes, summarizeHandler))
 
-	// Usage-gated route: the client opens a payment channel depositing
+	// Usage-gated route: the client opens a tab depositing
 	// the authorized ceiling; the handler meters the response and the
 	// gate settles the actual amount after it returns.
 	usageGate := paykit.Gate{

--- a/go/paycore/paymentchannels/paymentchannels.go
+++ b/go/paycore/paymentchannels/paymentchannels.go
@@ -1,5 +1,5 @@
 // Package paymentchannels is the thin, hand-written on-chain glue over the
-// codama-generated payment-channels client in
+// codama-generated tabs client in
 // protocols/programs/paymentchannels. It provides PDA derivation, associated
 // token derivation, voucher preimage bytes, and convenience instruction
 // builders for the push-mode session flow (open + top_up).
@@ -21,7 +21,7 @@ import (
 	generated "github.com/solana-foundation/pay-kit/go/protocols/programs/paymentchannels"
 )
 
-// ProgramID is the canonical payment-channels program id deployed to the
+// ProgramID is the canonical tabs program id deployed to the
 // network. It matches the codama-generated package's default; every PDA
 // derivation and instruction built here is pinned to this value.
 const ProgramID = "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
@@ -119,7 +119,7 @@ type OpenChannelParams struct {
 	// used to derive the payer and channel associated token accounts.
 	TokenProgram solana.PublicKey
 
-	// ProgramID is the payment-channels program targeted by this open. The
+	// ProgramID is the tabs program targeted by this open. The
 	// zero value resolves to the package program id (ProgramPubkey, or the
 	// last SetProgramID override).
 	ProgramID solana.PublicKey
@@ -141,7 +141,7 @@ type TopUpParams struct {
 	// used to derive the payer and channel associated token accounts.
 	TokenProgram solana.PublicKey
 
-	// ProgramID is the payment-channels program targeted by this top-up. The
+	// ProgramID is the tabs program targeted by this top-up. The
 	// zero value resolves to the package program id (ProgramPubkey, or the
 	// last SetProgramID override).
 	ProgramID solana.PublicKey

--- a/go/paycore/paymentchannels/paymentchannels_test.go
+++ b/go/paycore/paymentchannels/paymentchannels_test.go
@@ -247,7 +247,7 @@ func TestFindChannelPDAUsesCanonicalProgramID(t *testing.T) {
 		t.Fatalf("FindChannelPDA: %v", err)
 	}
 	// Deriving against a different program id must produce a different PDA,
-	// proving FindChannelPDA binds to the canonical payment-channels program.
+	// proving FindChannelPDA binds to the canonical tabs program.
 	saltLE := make([]byte, 8)
 	binary.LittleEndian.PutUint64(saltLE, 99)
 	openSlotLE := make([]byte, 8)

--- a/go/paycore/paymentchannels/settlement.go
+++ b/go/paycore/paymentchannels/settlement.go
@@ -1,6 +1,6 @@
 package paymentchannels
 
-// Server-side settlement instruction builders for the payment-channel close
+// Server-side settlement instruction builders for the tab close
 // paths: the Ed25519 signature-verification precompile, permissionless settle,
 // cooperative settle_and_seal, distribute, and permissionless reclaim.
 //
@@ -30,7 +30,7 @@ func Ed25519ProgramPubkey() solana.PublicKey {
 }
 
 // TreasuryOwner returns the treasury owner baked into the deployed
-// (mainnet-build) payment-channels program; distribute checks the treasury ATA
+// (mainnet-build) tabs program; distribute checks the treasury ATA
 // against ATA(TreasuryOwner, mint, token_program).
 func TreasuryOwner() solana.PublicKey {
 	return solana.MustPublicKeyFromBase58("Cs2zdfUNonRdRGsiZUQQLdTxzxVvJZmgiX2mpLYKuEqP")
@@ -72,7 +72,7 @@ func BuildEd25519VerifyInstruction(authorizedSigner solana.PublicKey, signature 
 // SettleParams carries the inputs required to build the permissionless settle
 // instruction sequence.
 type SettleParams struct {
-	// Channel is the payment-channel address being settled.
+	// Channel is the tab address being settled.
 	Channel solana.PublicKey
 
 	// AuthorizedSigner is the voucher signing key recorded at open.
@@ -87,7 +87,7 @@ type SettleParams struct {
 	// ExpiresAt is the expiry of the settled voucher (Unix seconds).
 	ExpiresAt int64
 
-	// ProgramID is the payment-channels program targeted by this settle. The
+	// ProgramID is the tabs program targeted by this settle. The
 	// zero value resolves to the package program id.
 	ProgramID solana.PublicKey
 }
@@ -126,7 +126,7 @@ type SettleAndSealParams struct {
 	// payee recorded at open; named "merchant" before the upstream rename).
 	Payee solana.PublicKey
 
-	// Channel is the payment-channel address being settled.
+	// Channel is the tab address being settled.
 	Channel solana.PublicKey
 
 	// AuthorizedSigner is the voucher signing key recorded at open. Only
@@ -143,7 +143,7 @@ type SettleAndSealParams struct {
 	// ExpiresAt is the expiry of the settled voucher (Unix seconds).
 	ExpiresAt int64
 
-	// ProgramID is the payment-channels program targeted by this settle. The
+	// ProgramID is the tabs program targeted by this settle. The
 	// zero value resolves to the package program id.
 	ProgramID solana.PublicKey
 }
@@ -191,7 +191,7 @@ func BuildSettleAndSealInstructions(params SettleAndSealParams) ([]solana.Instru
 // DistributeParams carries the inputs required to build a Distribute
 // instruction.
 type DistributeParams struct {
-	// Channel is the settled payment-channel address.
+	// Channel is the settled tab address.
 	Channel solana.PublicKey
 
 	// Payer is the original channel payer, refunded the unsettled remainder.
@@ -219,7 +219,7 @@ type DistributeParams struct {
 	// TokenProgram owning the mint (Token or Token-2022).
 	TokenProgram solana.PublicKey
 
-	// ProgramID is the payment-channels program targeted by this distribute.
+	// ProgramID is the tabs program targeted by this distribute.
 	// The zero value resolves to the package program id.
 	ProgramID solana.PublicKey
 }
@@ -298,14 +298,14 @@ func BuildDistributeInstruction(params DistributeParams) (solana.Instruction, er
 
 // ReclaimParams carries the inputs required to build a Reclaim instruction.
 type ReclaimParams struct {
-	// Channel is the distributed payment-channel address being reclaimed.
+	// Channel is the distributed tab address being reclaimed.
 	Channel solana.PublicKey
 
 	// RentPayer is the rent destination recorded as the channel rent_payer at
 	// open; it receives the channel PDA lamports when the account closes.
 	RentPayer solana.PublicKey
 
-	// ProgramID is the payment-channels program targeted by this reclaim.
+	// ProgramID is the tabs program targeted by this reclaim.
 	// The zero value resolves to the package program id.
 	ProgramID solana.PublicKey
 }

--- a/go/paykit/client.go
+++ b/go/paykit/client.go
@@ -207,7 +207,7 @@ func New(cfg Config) (*Client, error) {
 	}
 	// Wire the usage (upto) adapter only for x402 upto configs. Exact x402
 	// still supports a recipient separate from the operator signer, while
-	// the payment-channel program requires upto recipient == operator.
+	// the tab program requires upto recipient == operator.
 	if containsProtocol(cfg.Accept, X402) && cfg.X402.Scheme == "upto" && registeredUsageBuilder != nil {
 		usageAdapter, err := registeredUsageBuilder(cfg)
 		if err != nil {

--- a/go/paykit/types.go
+++ b/go/paykit/types.go
@@ -189,7 +189,7 @@ type X402Config struct {
 	// operator signer.
 	FacilitatorURL string
 	// Scheme is the x402 sub-scheme advertised in the 402 challenge.
-	// Defaults to "exact"; set "upto" for usage-gated payment channels.
+	// Defaults to "exact"; set "upto" for usage-gated tabs.
 	Scheme string
 	// Signer overrides Operator.Signer for x402 facilitator cosigning.
 	// Escape hatch only (DESIGN rule 3): leave nil to use the operator
@@ -202,7 +202,7 @@ type X402Config struct {
 	// (default) the challenge carries no `extensions` object; extensions
 	// default to absent on the wire.
 	RequirePaymentIdentifier bool
-	// ChannelProgram overrides the payment-channels program id advertised
+	// ChannelProgram overrides the tabs program id advertised
 	// by x402 upto. Leave empty for the canonical mainnet deployment.
 	ChannelProgram string
 }

--- a/go/paykit/usage.go
+++ b/go/paykit/usage.go
@@ -95,7 +95,7 @@ type UsageAdapter interface {
 	UsageAcceptsEntry(gate *Gate) AcceptsEntry
 	// DetectUsage reports whether the request carries a usage credential.
 	DetectUsage(req *AdapterRequest) bool
-	// VerifyOpen validates the credential and opens the payment channel.
+	// VerifyOpen validates the credential and opens the tab.
 	// Returns the opaque verified open and a provisional Payment (with
 	// empty Transaction — filled in after settlement).
 	VerifyOpen(ctx context.Context, req *AdapterRequest) (VerifiedUsageOpen, *Payment, error)

--- a/go/protocols/mpp/client/payment_channels.go
+++ b/go/protocols/mpp/client/payment_channels.go
@@ -1,4 +1,4 @@
-// Client-side helpers for payment-channel open transactions.
+// Client-side helpers for tab open transactions.
 //
 // These builders turn a parsed session challenge (SessionRequest) into the
 // on-chain open transaction and the matching open action payload, applying the
@@ -28,7 +28,7 @@ import (
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )
 
-// DefaultGracePeriodSeconds is the default payment-channel close grace period,
+// DefaultGracePeriodSeconds is the default tab close grace period,
 // shared across the language SDK clients.
 const DefaultGracePeriodSeconds uint32 = 900
 
@@ -37,7 +37,7 @@ const DefaultGracePeriodSeconds uint32 = 900
 // the base58 form of an all-zero 64-byte signature (64 ones).
 const PendingServerSignature = "1111111111111111111111111111111111111111111111111111111111111111"
 
-// PaymentChannelOpen is a fully derived payment-channel open: every channel
+// PaymentChannelOpen is a fully derived tab open: every channel
 // parameter resolved from the challenge plus the resulting channel PDA.
 type PaymentChannelOpen struct {
 	// ChannelID is the channel PDA derived from payer, payee, mint,
@@ -87,7 +87,7 @@ type PaymentChannelOpen struct {
 	// PYUSD/USDG/CASH).
 	TokenProgram solana.PublicKey
 
-	// ProgramID is the payment-channels program the open targets; defaults
+	// ProgramID is the tabs program the open targets; defaults
 	// to the canonical program unless the challenge pins one.
 	ProgramID solana.PublicKey
 }
@@ -153,7 +153,7 @@ type PaymentChannelOpenOptions struct {
 	// recentSlot (the slot the server pre-fetched alongside recentBlockhash).
 	OpenSlot *uint64
 
-	// ProgramID overrides the payment-channels program. Defaults to the
+	// ProgramID overrides the tabs program. Defaults to the
 	// challenge programId, falling back to the canonical program.
 	ProgramID *solana.PublicKey
 
@@ -194,7 +194,7 @@ func DerivePaymentChannelOpen(
 
 	mintAddress := paycore.ResolveMint(request.Currency, network)
 	if mintAddress == "" {
-		return PaymentChannelOpen{}, fmt.Errorf("session payment channels require an SPL token")
+		return PaymentChannelOpen{}, fmt.Errorf("session tabs require an SPL token")
 	}
 	mint, err := parseSessionPubkey(mintAddress, "mint")
 	if err != nil {
@@ -514,14 +514,14 @@ func buildOpenPaymentChannelTx(
 		solana.TransactionPayer(feePayer),
 	)
 	if err != nil {
-		return PaymentChannelOpenTransaction{}, fmt.Errorf("build payment-channel open transaction: %w", err)
+		return PaymentChannelOpenTransaction{}, fmt.Errorf("build tab open transaction: %w", err)
 	}
 	if err := solanatx.SignTransaction(tx, payerSigner); err != nil {
-		return PaymentChannelOpenTransaction{}, fmt.Errorf("payment-channel open signing failed: %w", err)
+		return PaymentChannelOpenTransaction{}, fmt.Errorf("tab open signing failed: %w", err)
 	}
 	encoded, err := solanatx.EncodeTransactionBase64(tx)
 	if err != nil {
-		return PaymentChannelOpenTransaction{}, fmt.Errorf("payment-channel open tx serialization failed: %w", err)
+		return PaymentChannelOpenTransaction{}, fmt.Errorf("tab open tx serialization failed: %w", err)
 	}
 	return PaymentChannelOpenTransaction{ChannelID: open.ChannelID, Transaction: encoded}, nil
 }

--- a/go/protocols/mpp/client/payment_channels_test.go
+++ b/go/protocols/mpp/client/payment_channels_test.go
@@ -434,7 +434,7 @@ func TestCreatePaymentChannelSessionOpenerBuildsPullClientVoucherAction(t *testi
 		t.Fatal("transaction missing; want payer-signed open tx attached")
 	}
 	if payload.TokenAccount != nil || payload.ApprovedAmount != nil {
-		t.Fatal("pull SPL-delegation fields must be unset for payment-channel opens")
+		t.Fatal("pull SPL-delegation fields must be unset for tab opens")
 	}
 	tx := decodeOpenTransaction(t, *payload.Transaction)
 	if !tx.Message.AccountKeys[0].Equals(operator) {

--- a/go/protocols/mpp/client/session.go
+++ b/go/protocols/mpp/client/session.go
@@ -1,14 +1,14 @@
 // Client-side session intent implementation.
 //
-// ActiveSession tracks an open payment channel and signs cumulative vouchers
+// ActiveSession tracks an open tab and signs cumulative vouchers
 // for each metered API call. Vouchers are Ed25519-signed over the on-chain
-// Borsh voucher layout used by the payment-channels program, so the same bytes
+// Borsh voucher layout used by the tabs program, so the same bytes
 // the server verifies on the HTTP credential are the bytes the on-chain settle
 // instruction consumes.
 //
-// Scope is client-only PUSH (payment-channel) plus pull/clientVoucher, both
+// Scope is client-only PUSH (tab) plus pull/clientVoucher, both
 // served by the challenge-driven openers in payment_channels.go: the client
-// signs cumulative vouchers off-chain over a payment channel the operator
+// signs cumulative vouchers off-chain over a tab the operator
 // settles. Pull/operatedVoucher (the multi-delegator program), the SPL
 // approve-delegation builder for non-channel pull opens, and the server
 // verification path are out of scope.
@@ -256,7 +256,7 @@ func (s *ActiveSession) OpenAction(deposit uint64, openTxSignature string) inten
 	))
 }
 
-// OpenPaymentChannelAction builds a payment-channel push open action carrying
+// OpenPaymentChannelAction builds a tab push open action carrying
 // the full channel parameters.
 func (s *ActiveSession) OpenPaymentChannelAction(
 	deposit uint64,
@@ -270,7 +270,7 @@ func (s *ActiveSession) OpenPaymentChannelAction(
 		intents.SessionModePush, deposit, payer, payee, mint, salt, gracePeriod, openSlot, openTxSignature)
 }
 
-// OpenPaymentChannelActionWithMode builds a payment-channel open action with an
+// OpenPaymentChannelActionWithMode builds a tab open action with an
 // explicit submission mode (push, or pull when the operator broadcasts).
 func (s *ActiveSession) OpenPaymentChannelActionWithMode(
 	mode intents.SessionMode,

--- a/go/protocols/mpp/intents/session.go
+++ b/go/protocols/mpp/intents/session.go
@@ -2,9 +2,9 @@ package intents
 
 // Session intent request and voucher types.
 //
-// The session intent opens a payment channel between a client and server,
+// The session intent opens a tab between a client and server,
 // allowing incremental payments via off-chain signed vouchers backed by the
-// on-chain payment-channels program. The JSON wire format is identical across
+// on-chain tabs program. The JSON wire format is identical across
 // the language SDKs; the cross-language harness pins it.
 
 import (
@@ -31,7 +31,7 @@ const DefaultSessionExpiresAt int64 = 4_102_444_800
 type SessionMode string
 
 const (
-	// SessionModePush is a payment channel backed by an on-chain escrow
+	// SessionModePush is a tab backed by an on-chain escrow
 	// deposit (client-funded).
 	SessionModePush SessionMode = "push"
 
@@ -104,7 +104,7 @@ type SessionRequest struct {
 	Splits []SessionSplit `json:"splits,omitempty"`
 
 	// ProgramID is the channel program ID (base58). Defaults to the canonical
-	// payment-channels program.
+	// tabs program.
 	ProgramID *string `json:"programId,omitempty"`
 
 	// Description is a human-readable description.
@@ -359,14 +359,14 @@ type OpenPayload struct {
 
 	// ── Push mode ──
 
-	// ChannelID is the payment-channel address (base58). Required for push
+	// ChannelID is the tab address (base58). Required for push
 	// mode.
 	ChannelID *string `json:"channelId,omitempty"`
 
 	// Deposit locked on-chain (base units). Required for push mode.
 	Deposit *string `json:"deposit,omitempty"`
 
-	// Payer is the client wallet that funds the payment channel.
+	// Payer is the client wallet that funds the tab.
 	Payer *string `json:"payer,omitempty"`
 
 	// Payee is the primary channel payee.
@@ -386,7 +386,7 @@ type OpenPayload struct {
 	// Serialized as a decimal string.
 	RecentSlot *uint64 `json:"-"`
 
-	// Transaction is the signed payment-channel open transaction (base64),
+	// Transaction is the signed tab open transaction (base64),
 	// when the client wants the server/operator to broadcast it.
 	Transaction *string `json:"transaction,omitempty"`
 
@@ -419,7 +419,7 @@ type OpenPayload struct {
 // string-or-number.
 type openPayloadJSON struct {
 	Mode             SessionMode     `json:"mode"`                     // funding mode discriminant ("push" or "pull")
-	ChannelID        *string         `json:"channelId,omitempty"`      // payment-channel address (base58); push mode
+	ChannelID        *string         `json:"channelId,omitempty"`      // tab address (base58); push mode
 	Deposit          *string         `json:"deposit,omitempty"`        // on-chain escrow deposit (base units); push mode
 	Payer            *string         `json:"payer,omitempty"`          // funding client wallet (base58)
 	Payee            *string         `json:"payee,omitempty"`          // primary channel payee (base58)
@@ -542,7 +542,7 @@ func parseOptionalU64(raw json.RawMessage, field string) (*uint64, error) {
 	}
 }
 
-// OpenPayloadPush constructs a push payment-channel open payload.
+// OpenPayloadPush constructs a push tab open payload.
 func OpenPayloadPush(channelID, deposit, authorizedSigner, signature string) OpenPayload {
 	return OpenPayload{
 		Mode:             SessionModePush,
@@ -553,7 +553,7 @@ func OpenPayloadPush(channelID, deposit, authorizedSigner, signature string) Ope
 	}
 }
 
-// OpenPayloadPaymentChannel constructs a payment-channel push open payload.
+// OpenPayloadPaymentChannel constructs a tab push open payload.
 func OpenPayloadPaymentChannel(
 	channelID, deposit, payer, payee, mint string,
 	salt uint64,
@@ -568,7 +568,7 @@ func OpenPayloadPaymentChannel(
 	)
 }
 
-// OpenPayloadPaymentChannelWithMode constructs a payment-channel open payload
+// OpenPayloadPaymentChannelWithMode constructs a tab open payload
 // with an explicit submission mode.
 func OpenPayloadPaymentChannelWithMode(
 	mode SessionMode,
@@ -614,7 +614,7 @@ func (p OpenPayload) WithTransaction(txBase64 string) OpenPayload {
 
 // SessionID returns the session identifier used as the store key.
 //
-//   - Payment channel: ChannelID
+//   - Tab: ChannelID
 //   - Operated-voucher pull: TokenAccount
 func (p OpenPayload) SessionID() (string, error) {
 	if p.ChannelID != nil {
@@ -800,7 +800,7 @@ type SignedVoucher struct {
 	// Data is the voucher content.
 	Data VoucherData `json:"data"`
 
-	// Signature is the Ed25519 signature over the payment-channel Borsh
+	// Signature is the Ed25519 signature over the tab Borsh
 	// voucher bytes (base58).
 	Signature string `json:"signature"`
 }
@@ -813,7 +813,7 @@ type SignedVoucher struct {
 type VoucherData struct {
 	// ChannelID is the channel/session ID this voucher is bound to (base58).
 	//
-	// For push sessions: the payment-channel address.
+	// For push sessions: the tab address.
 	// For pull sessions: the SPL token account address.
 	ChannelID string `json:"channelId"`
 
@@ -867,7 +867,7 @@ func (v *VoucherData) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MessageBytes serializes the voucher to the payment-channels VoucherArgs bytes
+// MessageBytes serializes the voucher to the tabs VoucherArgs bytes
 // signed by Ed25519: magic [0x56, 0x01] (2) || channelId(32) ||
 // cumulativeAmount(LE u64) || expiresAt(LE i64), for a total of exactly 50
 // bytes. The magic prefix lives in the signed bytes only; the voucher wire

--- a/go/protocols/mpp/server/session.go
+++ b/go/protocols/mpp/server/session.go
@@ -81,7 +81,7 @@ type SessionConfig struct {
 	// Network is the Solana network: "mainnet", "devnet", "localnet".
 	Network string
 
-	// ProgramID is the payment-channel program ID. Nil defaults to the
+	// ProgramID is the tab program ID. Nil defaults to the
 	// canonical program.
 	ProgramID *solana.PublicKey
 
@@ -100,7 +100,7 @@ type SessionConfig struct {
 
 	// Modes are the session modes this server accepts, advertised to clients
 	// in the 402 challenge. An empty list or [push] means only the
-	// payment-channel push mode is supported.
+	// tab push mode is supported.
 	Modes []intents.SessionMode
 
 	// PullVoucherStrategy is the voucher authority used for pull sessions.

--- a/go/protocols/mpp/server/session_e2e_test.go
+++ b/go/protocols/mpp/server/session_e2e_test.go
@@ -2,7 +2,7 @@ package server
 
 // Surfpool-gated end-to-end session lifecycle test.
 //
-// Exercises a real payment-channel open completed and broadcast by the
+// Exercises a real tab open completed and broadcast by the
 // server, metered vouchers, side-channel reserve/commit, and on-chain settle
 // at close against the hosted Solana Payment Sandbox. The suite gates at
 // runtime: it skips explicitly (never silently passes) when the sandbox is
@@ -40,7 +40,7 @@ func surfpoolRPCURL() string {
 	return "https://402.surfnet.dev:8899"
 }
 
-// The public hosted sandbox can lag the repo's generated payment-channels ABI.
+// The public hosted sandbox can lag the repo's generated tabs ABI.
 // Keep explicit MPP_HARNESS_RPC_URL runs strict; only skip the default hosted
 // endpoint on the known ABI-drift signature.
 func hostedPaymentChannelsABIDrift(body string) bool {
@@ -216,7 +216,7 @@ func TestSessionServerE2ESurfpool(t *testing.T) {
 	response, body = authedGet(t, streamURL, openAuthorization)
 	if response.StatusCode != http.StatusOK {
 		if hostedPaymentChannelsABIDrift(body) {
-			t.Skipf("hosted Surfpool payment-channels program ABI is behind the repo generated client: %s", body)
+			t.Skipf("hosted Surfpool tabs program ABI is behind the repo generated client: %s", body)
 		}
 		t.Fatalf("open failed: %d %s", response.StatusCode, body)
 	}

--- a/go/protocols/mpp/server/session_method.go
+++ b/go/protocols/mpp/server/session_method.go
@@ -30,7 +30,7 @@ import (
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )
 
-// OpenTxSubmitter selects who broadcasts a push-mode payment-channel open
+// OpenTxSubmitter selects who broadcasts a push-mode tab open
 // transaction.
 type OpenTxSubmitter string
 
@@ -72,7 +72,7 @@ type SessionOptions struct {
 	// Realm is the challenge realm. Defaults to DetectRealm().
 	Realm string
 
-	// ProgramID overrides the payment-channels program id. Nil defaults to
+	// ProgramID overrides the tabs program id. Nil defaults to
 	// the canonical program.
 	ProgramID *solana.PublicKey
 
@@ -497,8 +497,8 @@ func (s *Session) handleOpen(ctx context.Context, payload *intents.OpenPayload) 
 
 	switch {
 	case hasTransaction:
-		// Payment-channel-backed open: push sessions and clientVoucher pull
-		// sessions whose deposit lives in an on-chain payment channel both
+		// Tab-backed open: push sessions and clientVoucher pull
+		// sessions whose deposit lives in an on-chain tab both
 		// attach the pre-signed open transaction.
 		expected := VerifyOpenTxExpected{
 			AuthorizedSigner: payload.AuthorizedSigner,

--- a/go/protocols/mpp/server/session_method_branch_test.go
+++ b/go/protocols/mpp/server/session_method_branch_test.go
@@ -539,7 +539,7 @@ func TestSubmitOpenTxFailureMatrix(t *testing.T) {
 // ── VerifyOpenTx malformed instruction matrix ──
 
 // buildRawOpenPayload wraps a hand-built instruction targeting the
-// payment-channels program into a signed transaction + open payload.
+// tabs program into a signed transaction + open payload.
 func buildRawOpenPayload(t *testing.T, accounts []*solana.AccountMeta, data []byte) (intents.OpenPayload, VerifyOpenTxExpected) {
 	t.Helper()
 	payer := testutil.NewPrivateKey()
@@ -616,7 +616,7 @@ func TestVerifyOpenTxMalformedInstructions(t *testing.T) {
 	// No open instruction at all (wrong discriminator).
 	wrongDisc, wrongExpected := buildRawOpenPayload(t, accounts, []byte{9, 9, 9})
 	if _, err := VerifyOpenTx(ctx, wrongExpected, &wrongDisc, nil); err == nil ||
-		!strings.Contains(err.Error(), "no payment-channels open instruction") {
+		!strings.Contains(err.Error(), "no tabs open instruction") {
 		t.Fatalf("wrong discriminator = %v", err)
 	}
 }

--- a/go/protocols/mpp/server/session_onchain.go
+++ b/go/protocols/mpp/server/session_onchain.go
@@ -27,7 +27,7 @@ import (
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )
 
-// openInstructionDiscriminator is the payment-channel open instruction
+// openInstructionDiscriminator is the tab open instruction
 // discriminator (single-byte Anchor-numeric form, not the 8-byte sha256
 // convention). Matches OPEN_DISCRIMINATOR in the vendored Codama clients.
 const openInstructionDiscriminator = 1
@@ -59,7 +59,7 @@ type VerifyOpenTxExpected struct {
 	// callers must always prove, so an empty Operator is rejected.
 	Operator string
 
-	// ProgramID optionally overrides the payment-channels program id; nil
+	// ProgramID optionally overrides the tabs program id; nil
 	// defaults to the canonical program.
 	ProgramID *solana.PublicKey
 
@@ -93,7 +93,7 @@ type VerifyOpenTxResult struct {
 	Salt uint64
 }
 
-// VerifyOpenTx decodes and validates a client-submitted payment-channel open
+// VerifyOpenTx decodes and validates a client-submitted tab open
 // transaction against the session challenge.
 //
 // Both legacy and v0 transaction encodings are accepted (clients across the
@@ -101,7 +101,7 @@ type VerifyOpenTxResult struct {
 // tables is rejected: the account checks below read the static account keys,
 // so an ALT could hide the real accounts behind the fee-payer co-sign guard.
 // The embedded open
-// instruction must target the configured payment-channels program, the payee
+// instruction must target the configured tabs program, the payee
 // must equal the challenge recipient, the mint must match the challenge
 // currency/network, the authorizedSigner must match the payload, the deposit
 // must be positive and within the cap, and the channel account must equal
@@ -180,7 +180,7 @@ func VerifyOpenTx(ctx context.Context, expected VerifyOpenTxExpected, payload *i
 		break
 	}
 	if openIx == nil {
-		return VerifyOpenTxResult{}, fmt.Errorf("no payment-channels open instruction found")
+		return VerifyOpenTxResult{}, fmt.Errorf("no tabs open instruction found")
 	}
 
 	// Open instruction account layout (matches the generated client):
@@ -464,7 +464,7 @@ type SubmitOpenTxResult struct {
 	Signature string
 }
 
-// SubmitOpenTx validates a client-built payment-channel open transaction,
+// SubmitOpenTx validates a client-built tab open transaction,
 // completes the fee-payer signature when payerSigner is required by the
 // transaction, broadcasts it, and waits for at least confirmed commitment.
 // Callers must not persist channel state for a transaction that never

--- a/go/protocols/mpp/server/session_onchain_test.go
+++ b/go/protocols/mpp/server/session_onchain_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/solana-foundation/pay-kit/go/protocols/mpp/intents"
 )
 
-// openTxFixture bundles a freshly built and signed payment-channel open
+// openTxFixture bundles a freshly built and signed tab open
 // transaction with the payload and challenge expectations that accept it.
 type openTxFixture struct {
 	payer      solana.PrivateKey    // channel payer keypair; fee payer and sole signer of the open tx
@@ -331,7 +331,7 @@ func TestVerifyOpenTxRejectsMissingOpenInstruction(t *testing.T) {
 		t.Fatalf("BuildMemoInstruction: %v", err)
 	}
 	_, fixture.payload = signAndAttachOpenTx(t, &fixture, memo, false)
-	if _, err := VerifyOpenTx(context.Background(), fixture.expected, &fixture.payload, nil); err == nil || !strings.Contains(err.Error(), "no payment-channels open instruction") {
+	if _, err := VerifyOpenTx(context.Background(), fixture.expected, &fixture.payload, nil); err == nil || !strings.Contains(err.Error(), "no tabs open instruction") {
 		t.Fatalf("err = %v, want missing-open-instruction rejection", err)
 	}
 }
@@ -555,7 +555,7 @@ func TestNewTopUpTxVerifierSurfacesFailureAndNotFound(t *testing.T) {
 
 // ── SettlementInstructions ──
 
-// openSettlementChannel opens a payment-channel-shaped session (payer set, so
+// openSettlementChannel opens a tab-shaped session (payer set, so
 // the distribute refund account can be derived) and returns the voucher
 // signer plus the channel id.
 func openSettlementChannel(t *testing.T, server *SessionServer, payer solana.PublicKey) (testVoucherSigner, string) {
@@ -751,7 +751,7 @@ func TestSettlementInstructionsErrorPaths(t *testing.T) {
 	}
 
 	// A pull-style session id that is not a base58 pubkey cannot be settled
-	// through the payment-channels program.
+	// through the tabs program.
 	if _, err := server.ProcessOpen(context.Background(), sessionOpenPayload("not-a-pubkey!", 1_000_000, "signer1")); err != nil {
 		t.Fatalf("ProcessOpen: %v", err)
 	}

--- a/go/protocols/mpp/server/session_store.go
+++ b/go/protocols/mpp/server/session_store.go
@@ -52,13 +52,13 @@ type CommittedDelivery struct {
 	VoucherSignature string `json:"voucherSignature"`
 }
 
-// ChannelState is the persisted state of a single payment channel from the
+// ChannelState is the persisted state of a single tab from the
 // server's point of view. The JSON tags are the shared snake_case wire
 // names, so durable stores can interoperate across the language SDKs.
 type ChannelState struct {
 	// ChannelID is the on-chain channel address (base58).
 	//
-	// Push sessions: the payment-channel address.
+	// Push sessions: the tab address.
 	// Pull sessions: the FixedDelegation PDA address.
 	ChannelID string `json:"channel_id"`
 

--- a/go/protocols/mpp/server/session_stream_test.go
+++ b/go/protocols/mpp/server/session_stream_test.go
@@ -50,7 +50,7 @@ func TestMeteredStreamRoundTripsThroughClientDecoder(t *testing.T) {
 	}
 	usage := intents.MeteringUsage{DeliveryID: "session-1:1", Amount: "80"}
 
-	if err := stream.WriteEnvelope(map[string]string{"chunk": "A payment channel "}, directive); err != nil {
+	if err := stream.WriteEnvelope(map[string]string{"chunk": "A tab "}, directive); err != nil {
 		t.Fatalf("WriteEnvelope: %v", err)
 	}
 	if err := stream.WriteUsage(usage); err != nil {
@@ -74,7 +74,7 @@ func TestMeteredStreamRoundTripsThroughClientDecoder(t *testing.T) {
 	if len(events) != 4 {
 		t.Fatalf("decoded %d events, want 4: %+v", len(events), events)
 	}
-	if events[0].Kind != client.MeteredSseEventMessage || !strings.Contains(string(events[0].Message), "A payment channel") {
+	if events[0].Kind != client.MeteredSseEventMessage || !strings.Contains(string(events[0].Message), "A tab") {
 		t.Fatalf("event 0 = %+v", events[0])
 	}
 	if events[1].Kind != client.MeteredSseEventMetering || events[1].Metering.DeliveryID != directive.DeliveryID {

--- a/go/protocols/programs/paymentchannels_parity_test/parity_test.go
+++ b/go/protocols/programs/paymentchannels_parity_test/parity_test.go
@@ -1,4 +1,4 @@
-// Package paymentchannels_parity guards the Codama-generated payment-channels
+// Package paymentchannels_parity guards the Codama-generated tabs
 // Go client against the Rust spine byte-for-byte.
 //
 // It lives in a separate directory from the generated package because the Go

--- a/go/protocols/x402/client/upto.go
+++ b/go/protocols/x402/client/upto.go
@@ -30,7 +30,7 @@ func randomSalt() (uint64, error) {
 	return n.Uint64(), nil
 }
 
-// BuildUptoPayload derives the payment-channel open and assembles the upto
+// BuildUptoPayload derives the tab open and assembles the upto
 // authorization payload. The open names extra.feePayer as transaction fee
 // payer, rent payer, and zero-share channel payee, and
 // extra.receiverAuthorizer as the authorized voucher signer only. The channel

--- a/go/protocols/x402/upto.go
+++ b/go/protocols/x402/upto.go
@@ -36,7 +36,7 @@ type uptoSigner interface {
 
 const (
 	UptoScheme                       = "upto"
-	UptoAssetTransferMethod          = "payment-channel"
+	UptoAssetTransferMethod          = "tab"
 	UptoErrorSettlementExceedsAmount = "invalid_upto_svm_payload_settlement_exceeds_amount"
 	DefaultUptoWithdrawDelaySeconds  = 900
 )
@@ -242,7 +242,7 @@ type UptoConfig struct {
 	RecentSlotProvider func() (uint64, error)
 }
 
-// X402Upto is the server-side x402 upto payment-channel engine.
+// X402Upto is the server-side x402 upto tab engine.
 type X402Upto struct {
 	cfg                UptoConfig
 	rpc                solanatx.RPCClient
@@ -431,7 +431,7 @@ func ParseUptoPaymentSignature(header string) (UptoSignatureEnvelope, error) {
 	return envelope, nil
 }
 
-// VerifyOpen validates, broadcasts, confirms, and binds a payment-channel open.
+// VerifyOpen validates, broadcasts, confirms, and binds a tab open.
 func (u *X402Upto) VerifyOpen(ctx context.Context, header, maxAmount string) (*UptoVerifiedOpen, error) {
 	envelope, err := ParseUptoPaymentSignature(header)
 	if err != nil {
@@ -492,7 +492,7 @@ func (u *X402Upto) VerifyOpen(ctx context.Context, header, maxAmount string) (*U
 		}
 	}()
 	if payload.OpenTransaction == "" {
-		return nil, errors.New("payment-channel asset transfer method requires openTransaction (pull)")
+		return nil, errors.New("tab asset transfer method requires openTransaction (pull)")
 	}
 	tx, err := solanatx.DecodeTransactionBase64(payload.OpenTransaction)
 	if err != nil {

--- a/go/protocols/x402/x402_coverage_test.go
+++ b/go/protocols/x402/x402_coverage_test.go
@@ -175,7 +175,7 @@ func TestDistributionHashMatchesProgramGolden(t *testing.T) {
 		{Recipient: solana.PublicKeyFromBytes(bytes.Repeat([]byte{2}, 32)), Bps: 2_500},
 	}
 
-	// Golden vector shared with Rust's payment-channel test and the on-chain
+	// Golden vector shared with Rust's tab test and the on-chain
 	// program preimage: SHA-256(count=2 u32 LE || pk(1) || 7500 u16 LE ||
 	// pk(2) || 2500 u16 LE).
 	expected := [32]byte{

--- a/harness/README.md
+++ b/harness/README.md
@@ -3,7 +3,7 @@
 This directory is PayKit's **conformance and interop test harness**. PayKit
 ships the same two payment protocols — **MPP** and **x402** — in many languages
 (TypeScript, Rust, Go, Python, Ruby, Lua, Swift, Kotlin, PHP) over a shared
-on-chain Solana payment-channels program. The harness exists to prove those
+on-chain Solana tabs program. The harness exists to prove those
 independent implementations actually agree with each other and with the
 deployed program, so a change in one SDK (or the program) can't silently break
 another.
@@ -47,7 +47,7 @@ bytes**, not the result of executing the on-chain program.
 `test/onchain.e2e.test.ts`, `src/onchain/surfnet.ts`.
 
 Boots a Surfpool that **forks mainnet-beta** (via `@solana/surfpool`) and streams
-the live programs — payment-channels (`CHNLx…`) and subscriptions (`De1eg…`) —
+the live programs — tabs (`CHNLx…`) and subscriptions (`De1eg…`) —
 so settlement transactions **actually execute the deployed program**. It drives
 the real pay-kit client/server and asserts the settlement **confirms on-chain**
 (a settlement failure surfaces as a re-challenged `402`). This is what catches
@@ -168,7 +168,7 @@ schemes against the same mainnet-fork bootstrap in `src/onchain/surfnet.ts`.
 ## Limitations
 
 - **The structural tier does not execute the program.** It asserts transaction
-  byte-shape and balance deltas, not the result of running the payment-channels
+  byte-shape and balance deltas, not the result of running the tabs
   program. Settlement-class bugs (treasury ATA, voucher expiry, ALT guard) are
   invisible to it — they only fail when the program runs. That is precisely the
   gap the on-chain tier fills, and historically why such bugs reached the

--- a/harness/python-server/server.py
+++ b/harness/python-server/server.py
@@ -354,7 +354,7 @@ class _Adapter:
         # recentSlot come from a shared blockhash cache instead of a
         # recent_state_provider hook. ``new_session`` also now fails closed
         # without an RPC client, but this scenario's surfnet runs no
-        # payment-channels program, so the wire-level trust model must stay
+        # tabs program, so the wire-level trust model must stay
         # intact: the harness composes the lower-level SessionServer directly
         # with accept-all tx verifiers (open verification / broadcast /
         # settle-at-close stay off, exactly like the draft-era rpc=None mode)

--- a/harness/src/intents/x402-upto.ts
+++ b/harness/src/intents/x402-upto.ts
@@ -5,10 +5,10 @@ import type { HarnessScenario } from "../contracts";
 // The matrix pairs each x402 upto client against each x402 upto server
 // registered in `implementations.ts`.
 //
-// `upto` is a payment-channel flow: the client opens a channel depositing
+// `upto` is a tab flow: the client opens a channel depositing
 // the authorized ceiling; the server broadcasts the open, then settles
 // the metered actual amount with a voucher after the handler runs.
-// Live settlement requires the payment-channels program on surfpool.
+// Live settlement requires the tabs program on surfpool.
 export const x402UptoScenarios: readonly HarnessScenario[] = [
   {
     id: "x402-upto-basic",

--- a/harness/src/onchain/surfnet.ts
+++ b/harness/src/onchain/surfnet.ts
@@ -1,6 +1,6 @@
 /**
  * On-chain test harness: boots a surfpool instance that FORKS mainnet-beta and
- * streams the live payment-channels (+ subscriptions) programs, so settlement
+ * streams the live tabs (+ subscriptions) programs, so settlement
  * transactions actually EXECUTE the deployed program. This is what the
  * structural harness (`start-surfnet-proxy.mjs`) does not do - it only seeds
  * mints and inspects transaction bytes, so on-chain validations (treasury ATA,

--- a/harness/swift-x402-upto-client/Sources/SwiftX402UptoClient/main.swift
+++ b/harness/swift-x402-upto-client/Sources/SwiftX402UptoClient/main.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SolanaPayKit
 
-/// Swift x402 `upto` (payment-channel) harness adapter. Mirrors the Python
+/// Swift x402 `upto` (tab) harness adapter. Mirrors the Python
 /// `harness/python-x402-upto-client/main.py` and the Go/Rust upto clients:
 ///
 /// Env variables:

--- a/harness/test/e2e.test.ts
+++ b/harness/test/e2e.test.ts
@@ -299,7 +299,7 @@ beforeAll(async () => {
     if (scenario.paymentMode === "push") {
       needsSolFunding = true;
     }
-    // x402-upto opens a payment-channel account. The fee payer sponsors the
+    // x402-upto opens a tab account. The fee payer sponsors the
     // transaction fee and channel rent.
     if (scenario.intent === "x402-upto") {
       needsSolFunding = true;

--- a/harness/test/onchain.e2e.test.ts
+++ b/harness/test/onchain.e2e.test.ts
@@ -2,7 +2,7 @@
  * On-chain settlement E2E — the regression net the structural harness lacks.
  *
  * Boots a mainnet-forking surfnet (@solana/surfpool 1.4, which executes the
- * deployed payment-channels program) and drives the real pay-kit client/server
+ * deployed tabs program) and drives the real pay-kit client/server
  * end-to-end. A success is only returned after settlement CONFIRMS on-chain, so
  * this catches settlement-class regressions the byte-shape harness cannot — e.g.
  * the `TreasuryAccountMismatch` (0x961) that made `upto` silently 402 after
@@ -52,7 +52,7 @@ async function startServer(): Promise<void> {
     network: "localnet",
     operator: { recipient: operator.address, signer: operator },
     pricing: {
-      // x402 `upto` — settles by invoking the payment-channels program
+      // x402 `upto` — settles by invoking the tabs program
       // (settle_and_seal + distribute). This is the scheme that regressed.
       summarize: usage(usd("0.1"), { description: "Summarize, billed per token" }),
       // Fixed charge baseline (MPP / x402 exact — SPL transfer).
@@ -138,7 +138,7 @@ describe.skipIf(!RUN)("on-chain settlement (mainnet fork, real program)", () => 
 
 /*
  * MATRIX GAPS (explicit — no client/server today; not yet covered):
- *   - x402 upto:             Go, Python   (no svm payment-channel client)
+ *   - x402 upto:             Go, Python   (no svm tab client)
  *   - x402 batch-settlement: Go, Python   (Rust + TS only)
  *   - mpp subscription:      TS, Go, Python (Rust SDK only; needs plan bootstrap)
  *   - mpp session:           Go, TS, Ruby, Lua servers (Python/Rust only)

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -229,7 +229,7 @@ The harness adapters live outside the shipped library:
 - [`harness/kotlin-x402-client`](../harness/kotlin-x402-client) drives an
   x402 exact server.
 - [`harness/kotlin-x402-upto-client`](../harness/kotlin-x402-upto-client) drives
-  an x402 `upto` (payment-channel) server.
+  an x402 `upto` (tab) server.
 
 ```bash
 cd harness

--- a/kotlin/examples/AndroidDemo/app/src/main/java/com/solana/paykit/demo/MainActivity.kt
+++ b/kotlin/examples/AndroidDemo/app/src/main/java/com/solana/paykit/demo/MainActivity.kt
@@ -337,7 +337,7 @@ private fun DemoScreen() {
                                             busy = null
                                         }
                                     }
-                                    // Session: open a payment channel, stream metered SSE
+                                    // Session: open a tab, stream metered SSE
                                     // deliveries, sign + commit a voucher, settle.
                                     "session" -> {
                                         busy = BusyKind.Pay(endpoint.id)
@@ -787,7 +787,7 @@ private val httpClient = OkHttpClient()
  * signature is pulled from the `Payment-Receipt` envelope on success.
  */
 /**
- * Drive the full payment-channel **session** for a session endpoint: open the
+ * Drive the full tab **session** for a session endpoint: open the
  * channel, stream the metered SSE deliveries, sign + commit a voucher, and poll
  * the settle signature (see [SessionStream]). Mirrors the iOS demo's session path.
  */
@@ -810,7 +810,7 @@ private suspend fun consumeSession(signer: SolanaSigner, endpoint: Endpoint): Lo
 
 /**
  * Drive the x402 **upto** (usage) flow for a metered endpoint: POST the input,
- * and on the 402 challenge open a payment channel authorizing the ceiling, then
+ * and on the 402 challenge open a tab authorizing the ceiling, then
  * replay with the `Payment-Signature` header. The server meters actual usage and
  * settles `actual <= max`, refunding the rest; the response body reports the
  * billed amount. Mirrors the iOS demo's `upto` path.

--- a/kotlin/examples/AndroidDemo/app/src/main/java/com/solana/paykit/demo/SessionStream.kt
+++ b/kotlin/examples/AndroidDemo/app/src/main/java/com/solana/paykit/demo/SessionStream.kt
@@ -26,7 +26,7 @@ import java.security.SecureRandom
 import java.util.UUID
 
 /**
- * Drives a full MPP payment-channel **session** against the playground's
+ * Drives a full MPP tab **session** against the playground's
  * `/api/v1/stream` (a metered SSE endpoint) — the flow the one-shot charge
  * client can't do. Mirrors the iOS `SessionStream`:
  *

--- a/kotlin/src/main/kotlin/com/solana/paykit/paycore/PaymentChannels.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/paycore/PaymentChannels.kt
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 import java.util.Base64
 
 /**
- * Client-side payment-channels primitives: PDA/ATA derivation, the 50-byte
+ * Client-side tabs primitives: PDA/ATA derivation, the 50-byte
  * magic-prefixed voucher preimage, and the `open` instruction + payer-signed
  * (operator-fee-payer-unsigned) open transaction the session client broadcasts
  * via the operator.
@@ -16,13 +16,13 @@ import java.util.Base64
  * channel `open` passes its recipients inline rather than hashed.
  */
 object PaymentChannels {
-    /** Canonical payment-channels program ID deployed to Surfnet. */
+    /** Canonical tabs program ID deployed to Surfnet. */
     const val PROGRAM_ID = "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
 
     /** Rent sysvar account. */
     const val RENT_SYSVAR_ID = "SysvarRent111111111111111111111111111111111"
 
-    /** Default payment-channel close grace period, in seconds. */
+    /** Default tab close grace period, in seconds. */
     const val DEFAULT_GRACE_PERIOD_SECONDS: UInt = 900u
 
     private const val OPEN_DISCRIMINATOR: Byte = 1

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/client/SessionClient.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/client/SessionClient.kt
@@ -29,7 +29,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 
 /**
- * A live metered session bound to one payment channel.
+ * A live metered session bound to one tab.
  *
  * Holds the cumulative watermark, request nonce, and voucher expiry, and signs
  * monotonically-increasing vouchers with the session signer. Mirrors the Go
@@ -176,7 +176,7 @@ class ActiveSession(
     }
 }
 
-// ── Payment-channel session opener ──
+// ── Tab session opener ──
 
 /** Placeholder operator signature; the server fills its fee-payer slot before broadcast. */
 const val PENDING_SERVER_SIGNATURE: String =
@@ -231,7 +231,7 @@ data class PaymentChannelSessionOpenOptions(
     val expiresAt: Long? = null,
 )
 
-/** Result of opening a payment-channel session client-side. */
+/** Result of opening a tab session client-side. */
 data class PaymentChannelSessionOpen(
     val open: PaymentChannelOpen,
     val session: ActiveSession,
@@ -246,7 +246,7 @@ object PaymentChannelSession {
     }
 
     /**
-     * Build a pull + clientVoucher payment-channel session open. The payer
+     * Build a pull + clientVoucher tab session open. The payer
      * partial-signs the open transaction; the operator (fee payer) co-signs and
      * broadcasts. `recentBlockhash` is base58; `openSlot` is the server-
      * prefetched current slot carried by the 402 challenge
@@ -316,7 +316,7 @@ object PaymentChannelSession {
         options: PaymentChannelOpenOptions,
     ): PaymentChannelOpen {
         val mintString = resolveStablecoinMint(request.currency, request.network)
-            ?: throw MppException.InvalidTransaction("session payment channels require an SPL token")
+            ?: throw MppException.InvalidTransaction("session tabs require an SPL token")
         val mint = PublicKey.fromBase58(mintString)
         val payee = PublicKey.fromBase58(request.recipient)
         val deposit = options.deposit

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/core/SessionTypes.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/mpp/core/SessionTypes.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 
 /**
- * MPP payment-channel session wire types, mirroring the Rust spine
+ * MPP tab session wire types, mirroring the Rust spine
  * (`rust/crates/mpp/src/protocol/intents/session.rs`) and the Go reference
  * tag-for-tag and key-for-key. JSON keys are camelCase; `salt` and `recentSlot`
  * serialize as decimal strings (read string-or-number);

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/x402/client/upto/Payment.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/x402/client/upto/Payment.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.util.Base64
 
 /**
- * x402 ``upto`` client (payment-channel asset transfer method): challenge
+ * x402 ``upto`` client (tab asset transfer method): challenge
  * parsing and authorization building.
  *
  * The client opens a channel whose deposit is the authorized maximum, with the
@@ -120,7 +120,7 @@ private fun acceptsFrom(text: String): List<UptoRequirements>? {
 // ── Payment building ──────────────────────────────────────────────────────────
 
 /**
- * Builds an ``upto`` payload for a payment-channel requirement.
+ * Builds an ``upto`` payload for a tab requirement.
  *
  * [expiresAt] is the voucher/authorization deadline (Unix seconds); [nonce] is
  * kept for source compatibility but ignored because the payload nonce is the

--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/x402/upto/Types.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/x402/upto/Types.kt
@@ -125,7 +125,7 @@ data class UptoRequiredEnvelope(
 /**
  * The client authorization carried in ``PAYMENT-SIGNATURE.payload``.
  *
- * For the payment-channel method the channel ``open`` is the authorization: the
+ * For the tab method the channel ``open`` is the authorization: the
  * client's signature commits the deposit ceiling, payee, and mint. There is no
  * ``signature`` or ``profile`` field; the receiver authorizer settles with its own voucher.
  */

--- a/kotlin/src/test/kotlin/com/solana/paykit/paycore/SessionVoucherTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/paykit/paycore/SessionVoucherTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
- * Byte-exact golden vectors for the payment-channel voucher preimage and the
+ * Byte-exact golden vectors for the tab voucher preimage and the
  * channel PDA, pinning the upstream program's 50-byte magic-prefixed payload
  * `magic[0x56, 0x01](2) || channelId(32) || cumulative(u64 LE) || expiresAt(i64
  * LE)` and the epoch-addressed PDA seeds (trailing `openSlot` u64 LE). The

--- a/playground/README.md
+++ b/playground/README.md
@@ -8,7 +8,7 @@ A single-page React + Express playground that lets you poke every payment surfac
 - **Charges** — stocks, weather, marketplace splits, a browser-friendly payment link
 - **x402** — embedded facilitator + the canonical `/x402/joke` and `/x402/fact` routes
 - **Subscriptions** — server-side `solana.subscription` gating a `/api/v1/premium/feed`
-- **Sessions** — payment-channel sessions served in-process by `@solana/mpp`
+- **Sessions** — tab sessions served in-process by `@solana/mpp`
 - **Docs** — language quickstarts for TypeScript, Rust, Go, Python, Ruby, PHP, Lua, Kotlin, Swift.
   TypeScript's card is generated from `typescript/docs/snippets/` (see `docs/snippets-convention.md`);
   the other languages use curated entries until their snippet directories are populated

--- a/playground/app/src/lib/flow.ts
+++ b/playground/app/src/lib/flow.ts
@@ -53,7 +53,7 @@ function getSessionFetch(): SessionFetchClient {
       // globalThis.fetch (installed when charge/subscription Mppx instances
       // construct) doesn't intercept and misdispatch our session 402s.
       fetch: nativeFetch,
-      // Real payment-channel opens: the wallet keypair pre-signs the open
+      // Real tab opens: the wallet keypair pre-signs the open
       // transaction (deposit comes from its airdropped USDC) and the server
       // completes + broadcasts it. The signer only exists after onboarding,
       // so resolve it lazily per open.
@@ -183,7 +183,7 @@ interface Options {
  *
  * Handles charges, subscriptions (via the kit), and x402 (the kit's mppx already
  * negotiates over the challenge header). Sessions go through the kit's
- * SessionFetchClient: it opens a payment channel on the 402 challenge, then we
+ * SessionFetchClient: it opens a tab on the 402 challenge, then we
  * record the metered cumulative amount per delivered chunk so signed vouchers
  * are committed back to the server, and flush before reporting success.
  */

--- a/python/README.md
+++ b/python/README.md
@@ -273,7 +273,7 @@ Use MPP when:
 | `subscription` | —      | —      |
 
 `session` ships both sides. Client: `ActiveSession` voucher signing, the
-challenge-driven pull/clientVoucher payment-channel openers (fee payer =
+challenge-driven pull/clientVoucher tab openers (fee payer =
 challenge operator, pending-server-signature placeholder), the metered
 `SessionConsumer`, and the SSE streaming helpers (`MeteredSseSession`,
 `MeteredSseStream`, `HttpCommitTransport`). Server: the session method

--- a/python/docs/snippets/session.server.py
+++ b/python/docs/snippets/session.server.py
@@ -1,4 +1,4 @@
-# Server-side session: a metered payment channel, billed per delivery.
+# Server-side session: a metered tab, billed per delivery.
 #
 # Mirrors examples/playground_api/sessions.py. See
 # ../../../docs/snippets-convention.md for the snippet:start/end convention.

--- a/python/examples/playground_api/sessions.py
+++ b/python/examples/playground_api/sessions.py
@@ -66,7 +66,7 @@ _gate = Depends(RequireSession(session, _challenge))
 # Streamed deliveries, billed per chunk against the session voucher. Mirrors the
 # TypeScript playground's `GET /api/v1/stream` (SSE) session route.
 _TOKEN_CHUNKS = (
-    "A payment channel ",
+    "A tab ",
     "lets a client and server ",
     "authorize many small ",
     "off-chain debits ",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "solana>=0.35",
     "pydantic>=2",
     "pydantic-settings>=2",
-    # Required by the codama-py generated payment-channels client
+    # Required by the codama-py generated tabs client
     # (solana_pay_kit/protocols/programs/paymentchannels).
     "anchorpy>=0.21",
     "borsh-construct>=0.1",

--- a/python/src/solana_pay_kit/_paycore/paymentchannels.py
+++ b/python/src/solana_pay_kit/_paycore/paymentchannels.py
@@ -1,6 +1,6 @@
-"""On-chain glue for the payment-channels program (shared core).
+"""On-chain glue for the tabs program (shared core).
 
-Canonical home for payment-channel PDA derivation, associated-token derivation,
+Canonical home for tab PDA derivation, associated-token derivation,
 voucher preimage bytes, and the convenience instruction builders (``open``,
 ``topUp``, ``settleAndSeal``, ``distribute``, ``reclaim``, plus the Ed25519
 voucher precompile). Shared by the MPP session flow and the x402 ``upto``
@@ -20,7 +20,7 @@ This module only adds what the IDL cannot express:
 - The channel PDA is not declared in the IDL's ``pdas`` section, so its
   derivation is hand-written here.
 
-The payment-channels program uses a single-byte instruction discriminator
+The tabs program uses a single-byte instruction discriminator
 (``open`` = 1, ``topUp`` = 3), not the 8-byte Anchor discriminator; the
 generated builders encode it.
 """
@@ -94,7 +94,7 @@ SYSVAR_INSTRUCTIONS = "Sysvar1nstructions1111111111111111111111111"
 #: the signed byte payload, never in voucher wire JSON.
 VOUCHER_MAGIC = bytes([0x56, 0x01])
 
-# Canonical payment-channels program id deployed to the network. Matches the
+# Canonical tabs program id deployed to the network. Matches the
 # generated client's default; used for every PDA derivation and instruction.
 PAYMENT_CHANNELS_PROGRAM_ID = "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
 
@@ -164,7 +164,7 @@ class OpenChannelParams:
             the channel's payouts. Empty means a single implicit payee.
         token_program: The token program owning the mint (SPL Token or
             Token-2022).
-        program_id: The payment-channels program the instruction targets;
+        program_id: The tabs program the instruction targets;
             defaults to the production deployment.
     """
 
@@ -268,7 +268,7 @@ def find_channel_pda(
             identical seeds, packed little-endian into the seeds.
         open_slot: The slot the channel is opened at, packed little-endian
             into the seeds.
-        program_id: The payment-channels program to derive against; defaults to
+        program_id: The tabs program to derive against; defaults to
             the production deployment.
 
     Returns:
@@ -299,7 +299,7 @@ def find_event_authority_pda(program_id: Pubkey = PROGRAM_ID) -> tuple[Pubkey, i
     no override.
 
     Args:
-        program_id: The payment-channels program to derive against; defaults to
+        program_id: The tabs program to derive against; defaults to
             the production deployment.
 
     Returns:
@@ -487,7 +487,7 @@ def build_ed25519_verify_instruction(authorized_signer: Pubkey, signature: bytes
 
 
 def treasury_owner() -> Pubkey:
-    """Treasury owner baked into the deployed (mainnet-build) payment-channels
+    """Treasury owner baked into the deployed (mainnet-build) tabs
     program; the treasury ATA is ATA(treasury_owner, mint, token_program).
     Mirrors the Rust/Go ``TreasuryOwner``."""
     return Pubkey.from_string("Cs2zdfUNonRdRGsiZUQQLdTxzxVvJZmgiX2mpLYKuEqP")

--- a/python/src/solana_pay_kit/_paycore/rpc.py
+++ b/python/src/solana_pay_kit/_paycore/rpc.py
@@ -147,7 +147,7 @@ class SolanaRpc:
 
     async def get_account_info(self, address: str, commitment: str = "confirmed") -> tuple[bytes, str] | None:
         """Fetch an account's raw data bytes and owner (base58), or ``None`` when
-        the account is missing. Used to read on-chain payment-channel state
+        the account is missing. Used to read on-chain tab state
         during x402 ``upto`` verification; the generated ``Channel.decode`` then
         parses the returned bytes."""
         result = await self._call("getAccountInfo", [address, {"encoding": "base64", "commitment": commitment}])

--- a/python/src/solana_pay_kit/django.py
+++ b/python/src/solana_pay_kit/django.py
@@ -134,7 +134,7 @@ def require_usage(
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorate a Django view to require an x402 ``upto`` usage gate.
 
-    Two-phase: before the view it opens + binds the payment channel, attaching a
+    Two-phase: before the view it opens + binds the tab, attaching a
     :class:`~solana_pay_kit.usage.Charge` meter to ``request.charge`` (read it with
     :func:`charge` or :func:`solana_pay_kit.usage.charge_from`); after the view it
     settles the metered amount. A missing/invalid credential returns a ``402``

--- a/python/src/solana_pay_kit/fastapi.py
+++ b/python/src/solana_pay_kit/fastapi.py
@@ -248,7 +248,7 @@ def RequireUsage(  # noqa: N802 - factory reads as a dependency constructor
     """Build a FastAPI dependency that gates a route behind an x402 ``upto`` usage gate.
 
     On a missing/invalid credential it raises ``HTTPException`` carrying the 402
-    upto challenge. On success it opens + binds the payment channel, attaches a
+    upto challenge. On success it opens + binds the tab, attaches a
     :class:`~solana_pay_kit.usage.Charge` meter to ``request.state`` (read it with
     :func:`~solana_pay_kit.usage.charge_from`, or ``Depends`` on this), and registers a
     pending settlement that the usage middleware finalizes after the handler

--- a/python/src/solana_pay_kit/flask.py
+++ b/python/src/solana_pay_kit/flask.py
@@ -122,7 +122,7 @@ def require_usage(
 ) -> Callable[[_F], _F]:
     """Decorate a Flask view so it serves only after an x402 ``upto`` usage gate.
 
-    Two-phase: before the view it opens + binds the payment channel, attaching a
+    Two-phase: before the view it opens + binds the tab, attaching a
     :class:`~solana_pay_kit.usage.Charge` meter (read it with :func:`charge` or
     :func:`solana_pay_kit.usage.charge_from`); after the view it settles the metered
     amount. A missing/invalid credential aborts with a 402 carrying the upto

--- a/python/src/solana_pay_kit/protocols/mpp/_paymentchannels.py
+++ b/python/src/solana_pay_kit/protocols/mpp/_paymentchannels.py
@@ -1,4 +1,4 @@
-"""Backwards-compatible re-export of the payment-channels core.
+"""Backwards-compatible re-export of the tabs core.
 
 The implementation moved to :mod:`solana_pay_kit._paycore.paymentchannels` so the MPP
 session flow and the x402 ``upto`` scheme can share it without either protocol

--- a/python/src/solana_pay_kit/protocols/mpp/client/__init__.py
+++ b/python/src/solana_pay_kit/protocols/mpp/client/__init__.py
@@ -2,7 +2,7 @@
 
 Exposes the charge transport plus the client-only session surface: the
 :class:`ActiveSession` voucher tracker, the :class:`SessionConsumer` metered
-ack/commit helper, the challenge-driven payment-channel openers, the metered
+ack/commit helper, the challenge-driven tab openers, the metered
 SSE streaming helpers, and the :func:`serialize_session_credential` /
 :func:`parse_session_challenge` credential framing free functions. The
 per-intent modules (:mod:`solana_pay_kit.protocols.mpp.client.charge`,

--- a/python/src/solana_pay_kit/protocols/mpp/client/payment_channels.py
+++ b/python/src/solana_pay_kit/protocols/mpp/client/payment_channels.py
@@ -1,4 +1,4 @@
-"""Client-side helpers for payment-channel open transactions.
+"""Client-side helpers for tab open transactions.
 
 This is the challenge-driven layer above the raw instruction builders in
 :mod:`solana_pay_kit.protocols.mpp._paymentchannels`: it derives the full channel open
@@ -59,7 +59,7 @@ __all__ = [
     "unique_salt",
 ]
 
-#: Default payment-channel close grace period, in seconds, applied to a derived
+#: Default tab close grace period, in seconds, applied to a derived
 #: open when the caller does not override it.
 DEFAULT_GRACE_PERIOD_SECONDS = 900
 
@@ -89,7 +89,7 @@ def generate_authorized_signer() -> Keypair:
 
 @dataclass
 class PaymentChannelOpen:
-    """A fully derived payment-channel open: addresses plus channel parameters.
+    """A fully derived tab open: addresses plus channel parameters.
 
     Holds everything needed to open one channel: the derived channel PDA, the
     payer and payee, the SPL mint and its token program, the authorized session
@@ -187,7 +187,7 @@ class PaymentChannelOpenTransaction:
 
 @dataclass
 class PaymentChannelOpenOptions:
-    """Optional overrides for deriving a payment-channel open.
+    """Optional overrides for deriving a tab open.
 
     Every field falls back to a challenge-derived default: ``deposit`` to the
     challenge ``suggestedDeposit`` or ``minimumDeposit``, ``grace_period`` to
@@ -267,7 +267,7 @@ def derive_payment_channel_open(
     network = details.network
     resolved_mint = resolve_stablecoin_mint(request.currency, network)
     if resolved_mint is None:
-        raise ValueError("session payment channels require an SPL token")
+        raise ValueError("session tabs require an SPL token")
     mint = _parse_pubkey(resolved_mint, "mint")
     payee = _parse_pubkey(request.recipient, "recipient")
     requested_deposit = request.suggested_deposit or request.minimum_deposit
@@ -468,7 +468,7 @@ def _build_open_payment_channel_tx(
     try:
         payer_index = signer_keys.index(payer)
     except ValueError as exc:
-        raise ValueError("payment-channel open signing failed: payer is not a transaction signer") from exc
+        raise ValueError("tab open signing failed: payer is not a transaction signer") from exc
 
     signatures = [Signature.default() for _ in range(num_required)]
     signatures[payer_index] = _sign_message(signer, message_bytes)

--- a/python/src/solana_pay_kit/protocols/mpp/client/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/client/session.py
@@ -1,8 +1,8 @@
 """Client-side session intent implementation.
 
-:class:`ActiveSession` tracks an open payment channel and signs cumulative
+:class:`ActiveSession` tracks an open tab and signs cumulative
 vouchers for each metered API call. Vouchers are Ed25519-signed over the
-on-chain Borsh voucher layout used by the payment-channels program, so the same
+on-chain Borsh voucher layout used by the tabs program, so the same
 bytes the server verifies on the HTTP credential are the bytes the on-chain
 settle instruction consumes.
 
@@ -137,7 +137,7 @@ class ActiveSession:
         method); ``expires_at`` is the Unix timestamp applied to newly signed
         vouchers, defaulting to :data:`DEFAULT_VOUCHER_EXPIRES_AT`;
         ``cumulative`` seeds the watermark when resuming a known channel
-        position (the payment-channel openers use it to write the starting
+        position (the tab openers use it to write the starting
         ``cumulative`` value).
         """
         self._channel_id = channel_id
@@ -296,7 +296,7 @@ class ActiveSession:
         authentication: SessionAuthentication | None = None,
         idle_timeout_seconds: int | None = None,
     ) -> SessionAction:
-        """Build a payment-channel open action carrying the full channel
+        """Build a tab open action carrying the full channel
         parameters.
 
         ``open_slot`` is the slot the channel was derived

--- a/python/src/solana_pay_kit/protocols/mpp/intents/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/intents/session.py
@@ -1,8 +1,8 @@
 """Session intent request and voucher types.
 
-The session intent opens a payment channel between a client and server,
+The session intent opens a tab between a client and server,
 allowing incremental payments via off-chain signed vouchers backed by the
-on-chain payment-channels program. The wire format is defined by the MPP
+on-chain tabs program. The wire format is defined by the MPP
 specification's session intent.
 
 Types are plain :func:`dataclasses.dataclass` with explicit
@@ -376,7 +376,7 @@ def _string_from_wire(value: Any, label: str) -> str:
 
 @dataclass
 class OpenPayload:
-    """Exact payment-channel ``open`` credential payload."""
+    """Exact tab ``open`` credential payload."""
 
     channel_id: str
     payer: str
@@ -497,7 +497,7 @@ class VoucherData:
         )
 
     def message_bytes(self) -> bytes:
-        """Serialize to the payment-channels ``VoucherArgs`` bytes signed by
+        """Serialize to the tabs ``VoucherArgs`` bytes signed by
         Ed25519.
 
         Layout (exactly 50 bytes): the constant 2-byte voucher magic

--- a/python/src/solana_pay_kit/protocols/mpp/server/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session.py
@@ -162,7 +162,7 @@ class SessionConfig:
     # Splits are optional splits routed to specific recipients at close.
     splits: list[Split] = field(default_factory=list)
 
-    # Exact payment-channel program advertised under methodDetails.
+    # Exact tab program advertised under methodDetails.
     channel_program: str = ""
 
     token_program: str | None = None

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_method.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_method.py
@@ -117,7 +117,7 @@ class SessionOptions:
     secret_key: str = ""
     # Realm is the challenge realm. Defaults to detect_realm().
     realm: str = ""
-    # Payment-channel program advertised under methodDetails.channelProgram.
+    # Tab program advertised under methodDetails.channelProgram.
     channel_program: Pubkey | None = None
     token_program: str | None = None
     suggested_deposit: int | None = None

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_onchain.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_onchain.py
@@ -57,7 +57,7 @@ __all__ = [
     "is_placeholder_signature",
 ]
 
-# Payment-channel open instruction discriminator (single-byte Anchor-numeric
+# Tab open instruction discriminator (single-byte Anchor-numeric
 # form, not the 8-byte sha256 convention).
 _OPEN_INSTRUCTION_DISCRIMINATOR = 1
 
@@ -88,7 +88,7 @@ TopUpTxVerifier = Callable[[TopUpPayload], Awaitable[None]]
 class OpenVerifierConfig(Protocol):
     """The subset of the session config :func:`new_open_tx_verifier` reads:
     the challenge currency/network/recipient, minimum deposit, and optional
-    payment-channels program override."""
+    tabs program override."""
 
     currency: str
     network: str
@@ -240,12 +240,12 @@ async def verify_open_tx(
     payload: OpenPayload,
     rpc_client: RpcClient | None,
 ) -> VerifyOpenTxResult:
-    """Decode and validate a client-submitted payment-channel open transaction
+    """Decode and validate a client-submitted tab open transaction
     against the session challenge.
 
     Both legacy and v0 transaction encodings are accepted. The compiled
     message must use the challenged ``expected.recent_blockhash``, the embedded
-    open instruction must target the configured payment-channels program, the
+    open instruction must target the configured tabs program, the
     payee must equal the challenge recipient, the mint must match the challenge
     currency/network, the authorizedSigner (slot 4) must match the payload, the
     rentPayer (slot 1) must equal the expected operator, the deposit must be
@@ -328,7 +328,7 @@ async def verify_open_tx(
             raise PaymentError("open transaction must contain exactly one open instruction", code="invalid-payload")
         open_ix = ix
     if open_ix is None:
-        raise PaymentError("no payment-channels open instruction found", code="invalid-payload")
+        raise PaymentError("no tabs open instruction found", code="invalid-payload")
 
     # Open instruction account layout after the rentPayer (+1) shift:
     # 0 payer, 1 rentPayer, 2 payee, 3 mint, 4 authorizedSigner, 5 channel,

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_store.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_store.py
@@ -144,7 +144,7 @@ CHANNEL_STATE_SCHEMA_VERSION = 1
 
 @dataclass
 class ChannelState:
-    """Persisted state of a single payment channel from the server's point of
+    """Persisted state of a single tab from the server's point of
     view.
 
     The JSON tags are the shared snake_case wire names, so durable stores can

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_voucher.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_voucher.py
@@ -84,7 +84,7 @@ class VoucherRejectReason(StrEnum):
 
 @dataclass
 class ChannelState:
-    """The persisted state of a single payment channel from the server's point
+    """The persisted state of a single tab from the server's point
     of view, as read by the voucher verifier.
 
     The voucher verifier only reads a subset of the full channel state; this

--- a/python/src/solana_pay_kit/protocols/x402/client/upto/payment.py
+++ b/python/src/solana_pay_kit/protocols/x402/client/upto/payment.py
@@ -1,4 +1,4 @@
-"""x402 ``upto`` client builder - ``payment-channel`` asset transfer method.
+"""x402 ``upto`` client builder - ``tab`` asset transfer method.
 
 Parses an ``upto`` 402 challenge and builds the client authorization: a signed
 channel ``open`` transaction (the deposit is the ceiling) plus the

--- a/python/src/solana_pay_kit/protocols/x402/upto/__init__.py
+++ b/python/src/solana_pay_kit/protocols/x402/upto/__init__.py
@@ -1,4 +1,4 @@
-"""x402 ``upto`` (Solana) server engine - ``payment-channel`` profile.
+"""x402 ``upto`` (Solana) server engine - ``tab`` profile.
 
 Self-hosted usage-based authorization. Unlike ``exact`` (one inline transfer
 settled before the handler runs), ``upto`` is two-phase: :meth:`X402Upto.verify_open`
@@ -126,7 +126,7 @@ class VerifiedUptoOpen:
 
 
 class X402Upto:
-    """Server-side x402 ``upto`` payment-channel engine."""
+    """Server-side x402 ``upto`` tab engine."""
 
     def __init__(
         self,
@@ -295,7 +295,7 @@ class X402Upto:
             open_tx = payload.get("openTransaction")
             if not open_tx:
                 raise InvalidProofError(
-                    "payment-channel asset transfer method requires openTransaction (pull)", code="payment_invalid"
+                    "tab asset transfer method requires openTransaction (pull)", code="payment_invalid"
                 )
             account_keys, instructions = _decode_transaction(open_tx)
             # The challenged recentSlot at verify time: the requirement is
@@ -525,7 +525,7 @@ class X402Upto:
         data, owner = account
         if owner != str(program_id):
             raise InvalidProofError(
-                "channel account is not owned by the payment-channels program", code="payment_invalid"
+                "channel account is not owned by the tabs program", code="payment_invalid"
             )
         # The on-chain account carries a 1-byte account discriminator ahead of
         # the struct (Go's `Channel.Discriminator uint8`); the generated

--- a/python/src/solana_pay_kit/protocols/x402/upto/types.py
+++ b/python/src/solana_pay_kit/protocols/x402/upto/types.py
@@ -27,7 +27,7 @@ __all__ = [
 #: The x402 scheme identifier for usage-based ``upto`` authorizations.
 UPTO_SCHEME = "upto"
 
-#: Default forced-close delay, in seconds, for SVM ``upto`` payment channels.
+#: Default forced-close delay, in seconds, for SVM ``upto`` tabs.
 DEFAULT_UPTO_WITHDRAW_DELAY_SECONDS = 900
 
 #: Settlement error raised when the metered actual exceeds the signed ceiling.
@@ -100,7 +100,7 @@ _UptoPayloadRequired = TypedDict(
 class UptoPayload(_UptoPayloadRequired, total=False):
     """The client authorization in ``PAYMENT-SIGNATURE.payload``.
 
-    The common + ``payment-channel`` fields are required; ``openTransaction``
+    The common + ``tab`` fields are required; ``openTransaction``
     (pull-style) and ``signature`` (push-style) are optional.
     """
 

--- a/python/src/solana_pay_kit/protocols/x402/upto/verify.py
+++ b/python/src/solana_pay_kit/protocols/x402/upto/verify.py
@@ -1,4 +1,4 @@
-"""Pure verification for the x402 ``upto`` payment-channel asset transfer method.
+"""Pure verification for the x402 ``upto`` tab asset transfer method.
 
 No I/O: these functions validate already-decoded structures and raise
 :class:`~solana_pay_kit.errors.InvalidProofError` on rejection. The ordered payload
@@ -38,7 +38,7 @@ __all__ = [
     "parse_base_units",
 ]
 
-# Payment-channels open instruction discriminator (single-byte Anchor-numeric
+# Tabs open instruction discriminator (single-byte Anchor-numeric
 # form, not the 8-byte sha256 convention).
 _OPEN_INSTRUCTION_DISCRIMINATOR = 1
 
@@ -134,7 +134,7 @@ def validate_upto_open_instruction(
     """Validate the client-built channel-open instruction byte-for-byte.
 
     The open transaction must contain exactly one instruction targeting the
-    payment-channels program with the channel-open discriminator and the 14
+    tabs program with the channel-open discriminator and the 14
     accounts in the fixed order the program expects. ``fee_payer`` is the
     ``rentPayer`` (slot 1), ``payee`` is the zero-share channel payee seat
     (slot 2, the fee payer for ``upto``), and ``receiver_authorizer`` is the

--- a/python/tests/test_paymentchannels.py
+++ b/python/tests/test_paymentchannels.py
@@ -1,4 +1,4 @@
-"""Tests for the payment-channels on-chain glue.
+"""Tests for the tabs on-chain glue.
 
 Parity is verified against the Rust spine
 (``rust/crates/mpp/src/program/payment_channels.rs``) and the CI-green Go port.
@@ -235,7 +235,7 @@ def test_build_open_instruction_account_order_and_flags() -> None:
     assert str(accounts[11].pubkey) == "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
     # 12 event_authority PDA.
     assert accounts[12].pubkey == event_authority
-    # 13 self/program == the payment-channels program id.
+    # 13 self/program == the tabs program id.
     assert accounts[13].pubkey == PROGRAM_ID
     # Open signer mask: payer and rentPayer are signers, nothing else.
     assert [a.is_signer for a in accounts] == [True, True] + [False] * 12

--- a/python/tests/test_pk_x402_upto_settle.py
+++ b/python/tests/test_pk_x402_upto_settle.py
@@ -233,7 +233,7 @@ async def test_verify_open_happy(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_verify_open_binds_custom_gate_payee(monkeypatch) -> None:
     """A usage gate with its own pay_to is honored end to end via the bound
-    payment-channel distribution split."""
+    tab distribution split."""
     eng, cfg, holder = _engine(monkeypatch)
     custom_payee = str(Keypair().pubkey())
     gate = Gate.build(
@@ -539,7 +539,7 @@ def test_reserve_channel_concurrent(monkeypatch) -> None:
 
 def test_parse_payload_missing_field() -> None:
     with pytest.raises(InvalidProofError, match="missing"):
-        upto_mod._parse_payload({"profile": "payment-channel"})  # noqa: SLF001
+        upto_mod._parse_payload({"profile": "tab"})  # noqa: SLF001
 
 
 def test_parse_payload_not_a_dict() -> None:

--- a/python/tests/test_pk_x402_upto_verifier.py
+++ b/python/tests/test_pk_x402_upto_verifier.py
@@ -250,7 +250,7 @@ def test_client_open_tx_passes_engine_validator() -> None:
         recent_slot=4242,  # the challenged extra.recentSlot the client built against
     )
 
-    # Encode/decode the header round-trips and carries the payment-channel payload.
+    # Encode/decode the header round-trips and carries the tab payload.
     import base64
     import json
 

--- a/python/tests/test_session_e2e_surfnet.py
+++ b/python/tests/test_session_e2e_surfnet.py
@@ -1,7 +1,7 @@
 """Surfnet-gated end-to-end session lifecycle test.
 
 Exercises the real on-chain paths against the hosted Solana Payment Sandbox:
-a server-broadcast payment-channel open (openTxSubmitter=server, the A4 path),
+a server-broadcast tab open (openTxSubmitter=server, the A4 path),
 an in-band voucher, and the on-chain settle-at-close (the A2 path), asserting
 the open and settle transactions confirm on-chain. Mirrors Go's
 session_e2e_test.go. Skips explicitly (never silently passes) when the sandbox

--- a/python/tests/test_session_payment_channels.py
+++ b/python/tests/test_session_payment_channels.py
@@ -1,4 +1,4 @@
-"""Tests for challenge-driven payment-channel session opens."""
+"""Tests for challenge-driven tab session opens."""
 
 from __future__ import annotations
 

--- a/python/tests/test_session_stream.py
+++ b/python/tests/test_session_stream.py
@@ -112,7 +112,7 @@ def test_metered_stream_round_trips_through_client_decoder() -> None:
     )
     usage = MeteringUsage(delivery_id="session-1:1", amount="80")
 
-    stream.write_envelope({"chunk": "A payment channel "}, directive)
+    stream.write_envelope({"chunk": "A tab "}, directive)
     stream.write_usage(usage)
     stream.write_done()
 
@@ -124,7 +124,7 @@ def test_metered_stream_round_trips_through_client_decoder() -> None:
     assert len(events) == 4
 
     assert events[0].kind == "message"
-    assert events[0].message == {"chunk": "A payment channel "}
+    assert events[0].message == {"chunk": "A tab "}
 
     assert events[1].kind == "metering"
     assert events[1].metering is not None

--- a/rust/README.md
+++ b/rust/README.md
@@ -187,7 +187,7 @@ and client — plus SIWX.
 | `upto`         | ✅      | ✅      |
 | `batch-settlement` | ✅      | ✅      |
 
-`upto` charges for actual usage up to a ceiling: it settles on a payment channel
+`upto` charges for actual usage up to a ceiling: it settles on a tab
 after the handler runs, so it needs a `fee_payer_signer` (the fee payer signs
 the settlement as the channel's zero-share payee, and doubles as receiver
 authorizer — the voucher signer — by default) and is gated with `paid_upto_get`

--- a/rust/crates/integration-tests/tests/settlement_onchain.rs
+++ b/rust/crates/integration-tests/tests/settlement_onchain.rs
@@ -1,6 +1,6 @@
 //! On-chain proof + bench/demo for the shared settlement worker, driven through
 //! the reusable `solana_pay_kit::core::settlement::testkit` harness against a surfnet
-//! that has the payment-channels program + USDC deployed.
+//! that has the tabs program + USDC deployed.
 //!
 //! Run:
 //!   SURFNET_RPC=https://402.surfnet.dev:8899 \

--- a/rust/crates/kit/Cargo.toml
+++ b/rust/crates/kit/Cargo.toml
@@ -101,7 +101,7 @@ solana-transaction-status-client-types = { version = "4", default-features = fal
 solana-zero-copy = { version = "1", default-features = false }
 solana-address = { version = "2", features = ["borsh", "curve25519"] }
 
-# Generated program-client deps (payment-channels + subscriptions).
+# Generated program-client deps (tabs + subscriptions).
 num-derive = "0.4"
 num-traits = "0.2"
 solana-account-info = "^3"

--- a/rust/crates/kit/examples/axum_batch.rs
+++ b/rust/crates/kit/examples/axum_batch.rs
@@ -1,6 +1,6 @@
 //! High-throughput (`batch-settlement`) gate: one channel, many cheap requests.
 //!
-//! The client opens a payment channel once and signs a cumulative voucher per
+//! The client opens a tab once and signs a cumulative voucher per
 //! request. The gate (`paid_batch_get` / `paid_batch_post`) verifies each
 //! voucher off-chain and serves immediately — no on-chain transaction per
 //! request. The operator redeems vouchers on-chain later, in batches, via

--- a/rust/crates/kit/examples/axum_upto.rs
+++ b/rust/crates/kit/examples/axum_upto.rs
@@ -1,6 +1,6 @@
 //! Usage-based (`upto`) gate: charge per actual usage, up to a ceiling.
 //!
-//! The route advertises a **maximum** price. The client opens a payment channel
+//! The route advertises a **maximum** price. The client opens a tab
 //! depositing that ceiling; the handler meters real usage and reports it via the
 //! [`Charge`] extractor; the gate settles the actual amount and refunds the
 //! remainder. This is the shape you want for LLM-token billing or per-byte

--- a/rust/crates/kit/src/core/blockhash.rs
+++ b/rust/crates/kit/src/core/blockhash.rs
@@ -36,7 +36,7 @@ pub struct CachedBlockhash {
     pub blockhash: String,
     pub last_valid_block_height: u64,
     /// Current slot observed when the entry was refreshed. Embedded as the
-    /// `recentSlot` challenge hint — the payment-channels program accepts
+    /// `recentSlot` challenge hint — the tabs program accepts
     /// opens up to 1500 slots (~10 min) past it, far beyond [`MAX_AGE`].
     pub slot: u64,
 }

--- a/rust/crates/kit/src/core/mod.rs
+++ b/rust/crates/kit/src/core/mod.rs
@@ -6,10 +6,10 @@
 //!
 //! Exposes:
 //! - [`payment_channels`]: PDA derivation, voucher bytes, distribution hashing,
-//!   and instruction/transaction builders for the on-chain payment-channels
+//!   and instruction/transaction builders for the on-chain tabs
 //!   program (`solana-mpp` re-exports it at `mpp::program::payment_channels`;
 //!   `solana-x402` uses it for the `upto` and `batch-settlement` schemes).
-//! - [`store`]: replay-protection + payment-channel session state stores
+//! - [`store`]: replay-protection + tab session state stores
 //!   (`solana-mpp` re-exports at `mpp::store`).
 //! - [`signing`]: transaction-intent signing for legacy and v0 wire formats.
 //! - [`voucher`] / [`session`]: wire-agnostic cumulative-voucher verification and

--- a/rust/crates/kit/src/core/payment_channels.rs
+++ b/rust/crates/kit/src/core/payment_channels.rs
@@ -1,4 +1,4 @@
-//! Typed helpers for the payment-channels program.
+//! Typed helpers for the tabs program.
 //!
 //! The generated Codama client is kept as a path dependency and re-exported
 //! through this module.  Everything else here is hand-written adapter code: PDA
@@ -34,7 +34,7 @@ use crate::generated::payment_channels::generated::types::{
     DistributeArgs, DistributionEntry, OpenArgs, SettleAndSealArgs, TopUpArgs, VoucherArgs,
 };
 
-/// Canonical payment-channels program ID deployed to Surfnet.
+/// Canonical tabs program ID deployed to Surfnet.
 pub const PAYMENT_CHANNELS_PROGRAM_ID: &str = "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX";
 
 /// Associated Token Account program ID.
@@ -43,7 +43,7 @@ pub const ASSOCIATED_TOKEN_PROGRAM: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTN
 /// System Program ID.
 pub const SYSTEM_PROGRAM: &str = "11111111111111111111111111111111";
 
-/// Default payment-channel close grace period, in seconds.
+/// Default tab close grace period, in seconds.
 pub const DEFAULT_GRACE_PERIOD_SECONDS: u32 = 900;
 
 /// Constant magic prefix of the signed voucher payload (`[0x56, 0x01]`).
@@ -88,9 +88,9 @@ pub const INSTRUCTIONS_SYSVAR_ID: &str = "Sysvar1nstructions11111111111111111111
 /// Rent sysvar ID.
 pub const RENT_SYSVAR_ID: &str = "SysvarRent111111111111111111111111111111111";
 
-/// Treasury owner used by the current payment-channels program deployment.
+/// Treasury owner used by the current tabs program deployment.
 // Cs2zdfUNonRdRGsiZUQQLdTxzxVvJZmgiX2mpLYKuEqP — the treasury owner baked into
-// the deployed (mainnet-build) payment-channels program; `distribute` checks the
+// the deployed (mainnet-build) tabs program; `distribute` checks the
 // treasury ATA against ATA(TREASURY_OWNER, mint, token_program).
 pub const TREASURY_OWNER: [u8; 32] = [
     0xB0, 0x41, 0xD9, 0xD3, 0x37, 0xB7, 0x21, 0xBE, 0x57, 0x89, 0x4E, 0xB6, 0x9C, 0x3B, 0x68, 0x09,
@@ -143,7 +143,7 @@ pub struct PaymentChannelOpenTransaction {
 }
 
 pub fn default_program_id() -> Pubkey {
-    Pubkey::from_str(PAYMENT_CHANNELS_PROGRAM_ID).expect("valid payment-channels program id")
+    Pubkey::from_str(PAYMENT_CHANNELS_PROGRAM_ID).expect("valid tabs program id")
 }
 
 /// Generate a random `u64` channel salt.
@@ -193,7 +193,7 @@ pub fn from_address(address: &Address) -> Pubkey {
 }
 
 /// Decode a base64 (standard) bincode transaction, accepting both legacy and v0
-/// versioned wire formats. Payment-channel opens are built by legacy clients
+/// versioned wire formats. Tab opens are built by legacy clients
 /// (the pay Rust client) and v0 clients (the canonical pay-kit JS client, which
 /// builds `createTransactionMessage({ version: 0 })`), so any server that
 /// broadcasts a client-built open must accept either. Shared by x402
@@ -211,7 +211,7 @@ pub fn decode_transaction(b64: &str) -> Result<VersionedTransaction> {
     bincode::deserialize(&bytes).map_err(|e| Error::Other(format!("invalid transaction: {e}")))
 }
 
-/// Co-sign the operator's (fee-payer) slot of a partially-signed payment-channel
+/// Co-sign the operator's (fee-payer) slot of a partially-signed tab
 /// transaction. The operator must be the fee payer (the first static account
 /// key); its signature slot is filled in place. Works on both legacy and v0
 /// transactions (via [`VersionedTransaction`]). Shared by x402
@@ -640,10 +640,10 @@ pub async fn build_open_payment_channel_tx(
     signer
         .sign_transaction(&mut tx)
         .await
-        .map_err(|e| Error::Other(format!("payment-channel open signing failed: {e}")))?;
+        .map_err(|e| Error::Other(format!("tab open signing failed: {e}")))?;
 
     let bytes = bincode::serialize(&tx).map_err(|e| {
-        Error::Serialization(format!("payment-channel open tx serialization failed: {e}"))
+        Error::Serialization(format!("tab open tx serialization failed: {e}"))
     })?;
     Ok(PaymentChannelOpenTransaction {
         channel_id,

--- a/rust/crates/kit/src/core/session.rs
+++ b/rust/crates/kit/src/core/session.rs
@@ -1,4 +1,4 @@
-//! Wire-agnostic payment-channel session logic shared by the MPP `session`
+//! Wire-agnostic tab session logic shared by the MPP `session`
 //! intent and the x402 `batch-settlement` scheme.
 //!
 //! [`accept_voucher`] is the server-side acceptance of a cumulative voucher:

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -1,7 +1,7 @@
 //! Pluggable key-value and channel state stores, shared across the pay-kit
 //! crates.
 //!
-//! Holds replay-protection (`Store`) and payment-channel session state
+//! Holds replay-protection (`Store`) and tab session state
 //! (`ChannelStore`/`ChannelState`). Extracted from `solana-mpp` so both
 //! `solana-mpp` (the `session` intent) and `solana-x402` (the
 //! `batch-settlement` scheme) share one implementation. `solana-mpp` re-exports
@@ -159,7 +159,7 @@ pub struct CommittedDelivery {
     pub voucher_signature: String,
 }
 
-/// Durable lifecycle scheduling metadata for a payment channel.
+/// Durable lifecycle scheduling metadata for a tab.
 ///
 /// Request-serving processes only advance this deadline. A lifecycle worker
 /// reads it through [`ChannelStore::list_channels`] and owns the clock and
@@ -186,7 +186,7 @@ pub struct ChannelLifecycle {
 /// [`ChannelState::extra`] instead.
 pub const CHANNEL_STATE_SCHEMA_VERSION: u32 = 1;
 
-/// Persisted state of a payment channel, managed by the server.
+/// Persisted state of a tab, managed by the server.
 ///
 /// # Breaking change
 ///
@@ -197,7 +197,7 @@ pub const CHANNEL_STATE_SCHEMA_VERSION: u32 = 1;
 pub struct ChannelState {
     /// On-chain channel address (base58).
     ///
-    /// - Push sessions: payment-channel address.
+    /// - Push sessions: tab address.
     /// - Pull sessions: FixedDelegation PDA address.
     pub channel_id: String,
 
@@ -235,7 +235,7 @@ pub struct ChannelState {
     /// A channel-PDA seed since the epoch-addressed program update — persisted
     /// so the PDA can be re-derived and the `reclaim` gate
     /// (`clock.slot > open_slot + 1500`) evaluated later. `None` for pull
-    /// sessions (no payment-channel PDA) and for state stored before the
+    /// sessions (no tab PDA) and for state stored before the
     /// migration.
     #[serde(default)]
     pub open_slot: Option<u64>,
@@ -672,7 +672,7 @@ impl ChannelStore for MemoryChannelStore {
 
 // ── Redis channel store ──
 
-/// Durable Redis-backed payment-channel state.
+/// Durable Redis-backed tab state.
 ///
 /// Enabled by the `redis-store` feature. Read/modify/write operations use Lua
 /// scripts so multiple gateway instances cannot silently overwrite one

--- a/rust/crates/kit/src/core/voucher.rs
+++ b/rust/crates/kit/src/core/voucher.rs
@@ -1,4 +1,4 @@
-//! Wire-agnostic payment-channel voucher verification.
+//! Wire-agnostic tab voucher verification.
 //!
 //! A voucher authorizes a cumulative spend on a channel: the 50-byte Borsh
 //! payload `magic(0x56 0x01) ‖ channelId ‖ cumulativeAmount ‖ expiresAt` (see

--- a/rust/crates/kit/src/generated/payment_channels/mod.rs
+++ b/rust/crates/kit/src/generated/payment_channels/mod.rs
@@ -1,4 +1,4 @@
-//! Codama-generated Rust client for the Solana payment-channels program.
+//! Codama-generated Rust client for the Solana tabs program.
 //!
 //! All of [`generated`] is produced by `@codama/renderers-rust` from the
 //! `Moonsong-Labs/solana-payment-channels` IDL vendored at the repo root in

--- a/rust/crates/kit/src/lib.rs
+++ b/rust/crates/kit/src/lib.rs
@@ -18,13 +18,13 @@
 //!   stores, settlement). Available whenever `mpp` or `x402` is enabled.
 //! - [`mpp`]: the Machine Payments Protocol implementation (`mpp` feature).
 //! - [`x402`]: the x402 / HTTP 402 implementation (`x402` feature).
-//! - [`generated`]: Codama-generated program clients (payment-channels +
+//! - [`generated`]: Codama-generated program clients (tabs +
 //!   subscriptions), consumed by `core`/`mpp`.
 
 /// Protocol-neutral access to the signer traits and backends used by pay-kit.
 pub use solana_keychain;
 
-/// Codama-generated program clients (payment-channels + subscriptions).
+/// Codama-generated program clients (tabs + subscriptions).
 #[cfg(any(feature = "mpp", feature = "x402"))]
 pub mod generated;
 

--- a/rust/crates/kit/src/mpp/client/session.rs
+++ b/rust/crates/kit/src/mpp/client/session.rs
@@ -1,8 +1,8 @@
 //! Client-side session intent implementation.
 //!
-//! Tracks an open payment channel and signs cumulative vouchers for each
+//! Tracks an open tab and signs cumulative vouchers for each
 //! API call. Vouchers are Ed25519-signed over the on-chain Borsh voucher
-//! layout used by the payment-channels program.
+//! layout used by the tabs program.
 //!
 //! # Example
 //!
@@ -38,7 +38,7 @@ use crate::mpp::protocol::intents::session::{
 };
 use crate::mpp::protocol::solana::{default_token_program_for_currency, resolve_stablecoin_mint};
 
-/// Default payment-channel close grace period (seconds). Re-exported from
+/// Default tab close grace period (seconds). Re-exported from
 /// `solana-pay-core` to preserve this crate's public path.
 pub use crate::mpp::program::payment_channels::DEFAULT_GRACE_PERIOD_SECONDS;
 
@@ -207,7 +207,7 @@ impl ActiveSession {
         }))
     }
 
-    /// Build a `SessionAction::Open` for the payment-channels program.
+    /// Build a `SessionAction::Open` for the tabs program.
     #[allow(clippy::too_many_arguments)]
     pub fn open_payment_channel_action(
         &self,
@@ -364,7 +364,7 @@ pub fn derive_payment_channel_open(
     let network = Some(details.network.as_str());
     let mint = parse_pubkey(
         resolve_stablecoin_mint(&request.currency, network)
-            .ok_or_else(|| Error::Other("session payment channels require an SPL token".into()))?,
+            .ok_or_else(|| Error::Other("session tabs require an SPL token".into()))?,
         "mint",
     )?;
     let payee = parse_pubkey(&request.recipient, "recipient")?;

--- a/rust/crates/kit/src/mpp/program/mod.rs
+++ b/rust/crates/kit/src/mpp/program/mod.rs
@@ -1,6 +1,6 @@
 pub mod subscriptions;
 
-/// Payment-channels helpers live in `solana-pay-core` so they can be shared with
+/// Tabs helpers live in `solana-pay-core` so they can be shared with
 /// `solana-x402` (the `upto` scheme) without either protocol crate depending on
 /// the other. Re-exported here to preserve the `crate::mpp::program::payment_channels`
 /// path used across this crate.

--- a/rust/crates/kit/src/mpp/protocol/intents/session.rs
+++ b/rust/crates/kit/src/mpp/protocol/intents/session.rs
@@ -1,8 +1,8 @@
 //! Session intent request and voucher types.
 //!
-//! The session intent opens a payment channel between a client and server,
+//! The session intent opens a tab between a client and server,
 //! allowing incremental payments via off-chain signed vouchers backed by
-//! the on-chain payment-channels program.
+//! the on-chain tabs program.
 
 use serde::{Deserialize, Serialize};
 
@@ -51,7 +51,7 @@ where
         .transpose()
 }
 
-/// Who holds voucher signing authority for the payment channel.
+/// Who holds voucher signing authority for the tab.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -261,7 +261,7 @@ pub enum SessionAction {
     Close(ClosePayload),
 }
 
-/// Exact payment-channel `open` credential payload.
+/// Exact tab `open` credential payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenPayload {
@@ -296,7 +296,7 @@ pub struct OpenPayload {
 }
 
 impl OpenPayload {
-    /// Construct a payment-channel open payload.
+    /// Construct a tab open payload.
     #[allow(clippy::too_many_arguments)]
     pub fn payment_channel(
         channel_id: String,
@@ -601,7 +601,7 @@ pub struct SignedVoucher {
     /// Base58 public key that signed the voucher.
     pub signer: String,
 
-    /// Ed25519 signature over the payment-channel Borsh voucher bytes (base58).
+    /// Ed25519 signature over the tab Borsh voucher bytes (base58).
     pub signature: String,
 
     /// Signature algorithm; the session contract currently permits Ed25519 only.
@@ -636,7 +636,7 @@ pub struct VoucherData {
 }
 
 impl VoucherData {
-    /// Serialize to the payment-channels `VoucherArgs` bytes signed by Ed25519.
+    /// Serialize to the tabs `VoucherArgs` bytes signed by Ed25519.
     pub fn message_bytes(&self) -> crate::mpp::error::Result<Vec<u8>> {
         let channel_id = crate::mpp::program::payment_channels::parse_pubkey(&self.channel_id)?;
         let cumulative = self.cumulative_amount.parse().map_err(|_| {

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -137,7 +137,7 @@ pub struct SessionConfig {
     /// Solana network: "mainnet", "devnet", "localnet".
     pub network: String,
 
-    /// Payment-channel program ID. `None` defaults to the canonical program.
+    /// Tab program ID. `None` defaults to the canonical program.
     pub channel_program: Option<Pubkey>,
 
     /// SPL token program override.
@@ -213,7 +213,7 @@ pub struct SealParams {
     /// SPL mint locked by the channel.
     pub mint: Option<Pubkey>,
 
-    /// Payment-channels program ID.
+    /// Tabs program ID.
     pub program_id: Pubkey,
 
     /// The settled watermark to commit on-chain.
@@ -434,11 +434,11 @@ impl<S: ChannelStore> SessionServer<S> {
         ))
     }
 
-    /// Build and validate payment-channel open parameters from an `open` payload.
+    /// Build and validate tab open parameters from an `open` payload.
     ///
     /// This verifies the client-provided payer/payee/mint/salt/deposit/channel
     /// fields against the session challenge and returns the exact on-chain open
-    /// params expected by the payment-channels program.
+    /// params expected by the tabs program.
     pub fn payment_channel_open_params(
         &self,
         payload: &OpenPayload,
@@ -479,17 +479,17 @@ impl<S: ChannelStore> SessionServer<S> {
 
         if payee != expected_payee {
             return Err(Error::Other(
-                "payment-channel open payee does not match challenge recipient".to_string(),
+                "tab open payee does not match challenge recipient".to_string(),
             ));
         }
         if mint != expected_mint {
             return Err(Error::Other(
-                "payment-channel open mint does not match challenge currency".to_string(),
+                "tab open mint does not match challenge currency".to_string(),
             ));
         }
         if grace_period != self.config.grace_period_seconds {
             return Err(Error::Other(
-                "payment-channel open gracePeriodSeconds does not match challenge".to_string(),
+                "tab open gracePeriodSeconds does not match challenge".to_string(),
             ));
         }
         if self
@@ -498,7 +498,7 @@ impl<S: ChannelStore> SessionServer<S> {
             .is_some_and(|minimum| deposit < minimum)
         {
             return Err(Error::Other(
-                "payment-channel open depositAmount is below minimumDeposit".to_string(),
+                "tab open depositAmount is below minimumDeposit".to_string(),
             ));
         }
 
@@ -514,7 +514,7 @@ impl<S: ChannelStore> SessionServer<S> {
             .collect::<Result<_>>()?;
         if payload_splits != self.config.splits {
             return Err(Error::Other(
-                "payment-channel open distributionSplits do not match challenge".to_string(),
+                "tab open distributionSplits do not match challenge".to_string(),
             ));
         }
 
@@ -546,14 +546,14 @@ impl<S: ChannelStore> SessionServer<S> {
         let channel = parse_pubkey_field(&payload.channel_id, "channelId")?;
         if channel != expected_channel {
             return Err(Error::Other(
-                "payment-channel open channelId does not match derived channel PDA".to_string(),
+                "tab open channelId does not match derived channel PDA".to_string(),
             ));
         }
 
         Ok(params)
     }
 
-    /// Build the exact payment-channel open instruction expected for a payload.
+    /// Build the exact tab open instruction expected for a payload.
     pub fn payment_channel_open_instruction(
         &self,
         payload: &OpenPayload,
@@ -566,7 +566,7 @@ impl<S: ChannelStore> SessionServer<S> {
 
     /// Process an `open` action: persist the channel state.
     ///
-    /// Accepts payment-channel opens and operated-voucher delegated-token opens.
+    /// Accepts tab opens and operated-voucher delegated-token opens.
     /// Returns the stored `ChannelState`.
     ///
     /// When `config.rpc_url` is set, confirms the open transaction is finalized
@@ -1950,14 +1950,14 @@ fn parse_pubkey(s: &str) -> Result<Pubkey> {
 }
 
 fn parse_pubkey_field(value: &str, field: &str) -> Result<Pubkey> {
-    parse_pubkey(value).map_err(|e| Error::Other(format!("invalid payment-channel {field}: {e}")))
+    parse_pubkey(value).map_err(|e| Error::Other(format!("invalid tab {field}: {e}")))
 }
 
 /// Parse the configured operator pubkey used for operator-signed vouchers.
 fn parse_required_operator(operator: &str) -> Result<Pubkey> {
     if operator.trim().is_empty() {
         return Err(Error::Other(
-            "payment-channel open requires a configured operator signer".to_string(),
+            "tab open requires a configured operator signer".to_string(),
         ));
     }
     parse_pubkey_field(operator, "operator")
@@ -1965,7 +1965,7 @@ fn parse_required_operator(operator: &str) -> Result<Pubkey> {
 
 fn expected_payment_channel_mint(config: &SessionConfig) -> Result<Pubkey> {
     let mint = resolve_stablecoin_mint(&config.currency, Some(config.network.as_str()))
-        .ok_or_else(|| Error::Other("payment-channel sessions require an SPL token".to_string()))?;
+        .ok_or_else(|| Error::Other("tab sessions require an SPL token".to_string()))?;
     parse_pubkey_field(mint, "currency")
 }
 
@@ -2012,7 +2012,7 @@ fn verify_signature(
     .map_err(Into::into)
 }
 
-/// Compute the payment-channel distribution hash for explicit recipients.
+/// Compute the tab distribution hash for explicit recipients.
 ///
 /// The primary payee receives the implicit remainder and is not part of the
 /// hashed preimage unless it is explicitly listed in `splits`.

--- a/rust/crates/kit/src/x402/client/batch_settlement/payment.rs
+++ b/rust/crates/kit/src/x402/client/batch_settlement/payment.rs
@@ -76,7 +76,7 @@ pub async fn build_deposit(
         .any(|p| p == PROFILE_PAYMENT_CHANNEL)
     {
         return Err(Error::Other(
-            "requirement does not advertise the payment-channel profile".to_string(),
+            "requirement does not advertise the tab profile".to_string(),
         ));
     }
     let payer = payer_signer.pubkey();

--- a/rust/crates/kit/src/x402/client/upto/payment.rs
+++ b/rust/crates/kit/src/x402/client/upto/payment.rs
@@ -1,4 +1,4 @@
-//! Client-side payment building for the x402 `upto` scheme (payment-channel).
+//! Client-side payment building for the x402 `upto` scheme (tab).
 //!
 //! The client opens a channel whose `deposit` is the authorized maximum, with
 //! `authorized_signer = receiverAuthorizer` (the voucher signer) and
@@ -23,7 +23,7 @@ use crate::x402::protocol::schemes::upto::{
 };
 use crate::x402::{PAYMENT_REQUIRED_HEADER, X402_VERSION_V2};
 
-/// Build an `upto` payload for a `payment-channel` requirement.
+/// Build an `upto` payload for a `tab` requirement.
 ///
 /// `expires_at` is the voucher/authorization deadline (Unix seconds); `nonce`
 /// uniquely identifies this authorization. The requirement SHOULD carry

--- a/rust/crates/kit/src/x402/protocol/schemes/batch_settlement/types.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/batch_settlement/types.rs
@@ -4,7 +4,7 @@
 //! channel, signs cumulative Ed25519 vouchers per request (verified off-chain
 //! and served immediately), and the operator redeems the latest voucher per
 //! channel on-chain later, in batches. The on-chain backing is the
-//! payment-channels program + 50-byte voucher shared with `upto`; the channel /
+//! tabs program + 50-byte voucher shared with `upto`; the channel /
 //! voucher / store logic is the wire-agnostic core also used by the MPP
 //! `session` intent. See `specs/schemes/batch-settlement/scheme_batch_settlement_svm.md`.
 
@@ -16,8 +16,8 @@ use crate::x402::protocol::schemes::exact::ResourceInfo;
 /// `batch-settlement` scheme identifier.
 pub const BATCH_SETTLEMENT_SCHEME: &str = "batch-settlement";
 
-/// The only v1 settlement profile (escrow payment channel).
-pub const PROFILE_PAYMENT_CHANNEL: &str = "payment-channel";
+/// The only v1 settlement profile (escrow tab).
+pub const PROFILE_PAYMENT_CHANNEL: &str = "tab";
 
 fn batch_scheme() -> String {
     BATCH_SETTLEMENT_SCHEME.to_string()

--- a/rust/crates/kit/src/x402/protocol/schemes/batch_settlement/verify.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/batch_settlement/verify.rs
@@ -33,13 +33,13 @@ pub fn verify_batch_voucher(voucher: &BatchVoucher, now: i64) -> Result<(), Erro
 }
 
 /// Confirm a profile string is one the server advertised and that this crate
-/// supports (`payment-channel`).
+/// supports (`tab`).
 pub fn check_profile(profiles: &[String]) -> Result<(), Error> {
     if profiles.iter().any(|p| p == PROFILE_PAYMENT_CHANNEL) {
         Ok(())
     } else {
         Err(Error::Other(
-            "batch-settlement requires the payment-channel profile".to_string(),
+            "batch-settlement requires the tab profile".to_string(),
         ))
     }
 }

--- a/rust/crates/kit/src/x402/protocol/schemes/upto/types.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/upto/types.rs
@@ -2,7 +2,7 @@
 //!
 //! `upto` authorizes a **maximum** amount; the server settles for the **actual**
 //! usage (`actual <= max`) determined after the resource is consumed. On Solana
-//! the client opens a payment channel whose `deposit` is the ceiling, and the
+//! the client opens a tab whose `deposit` is the ceiling, and the
 //! fee payer (the channel's zero-share payee) settles the metered amount with
 //! a single receiver-authorizer voucher, refunding the remainder. See
 //! `specs/schemes/upto/scheme_upto_svm.md`.

--- a/rust/crates/kit/src/x402/server/batch_settlement.rs
+++ b/rust/crates/kit/src/x402/server/batch_settlement.rs
@@ -1,4 +1,4 @@
-//! Server-side handler for the x402 `batch-settlement` scheme (payment-channel).
+//! Server-side handler for the x402 `batch-settlement` scheme (tab).
 //!
 //! High-throughput channel payments: the client opens an escrow channel
 //! ([`X402BatchSettlement::verify_payment`] with a `deposit` payload), then signs

--- a/rust/crates/kit/src/x402/server/upto.rs
+++ b/rust/crates/kit/src/x402/server/upto.rs
@@ -1,4 +1,4 @@
-//! Server-side handler for the x402 `upto` scheme (payment-channel asset transfer method).
+//! Server-side handler for the x402 `upto` scheme (tab asset transfer method).
 //!
 //! Flow (single HTTP round-trip, handler-determined amount):
 //!
@@ -50,7 +50,7 @@ use crate::x402::{PAYMENT_REQUIRED_HEADER, PAYMENT_RESPONSE_HEADER, X402_VERSION
 /// `ChannelStatus::Open` discriminant in the generated client.
 const CHANNEL_STATUS_OPEN: u8 = 0;
 
-/// `Open` instruction discriminator in the generated payment-channels client
+/// `Open` instruction discriminator in the generated tabs client
 /// (`crate::generated::payment_channels::generated::instructions::OPEN_DISCRIMINATOR`).
 const OPEN_INSTRUCTION_DISCRIMINATOR: u8 = 1;
 
@@ -79,7 +79,7 @@ pub struct UptoConfig {
     pub max_timeout_seconds: u64,
     /// Channel program id override (defaults to the canonical deployment).
     pub program_id: Option<String>,
-    /// Channel forced-close delay, in seconds. Defaults to the payment-channel
+    /// Channel forced-close delay, in seconds. Defaults to the tab
     /// program default when set to `0`.
     pub withdraw_delay: u32,
     /// Signer that co-signs the open as transaction fee payer and channel rent
@@ -542,7 +542,7 @@ impl X402Upto {
         // not yet supported; require the transaction.
         let open_tx_b64 = payload.open_transaction.as_deref().ok_or_else(|| {
             Error::Other(
-                "payment-channel asset transfer method requires openTransaction (pull)".to_string(),
+                "tab asset transfer method requires openTransaction (pull)".to_string(),
             )
         })?;
         let mut tx = decode_transaction(open_tx_b64)?;
@@ -834,13 +834,13 @@ impl X402Upto {
         Ok(self.settlement_response(open, actual, signature))
     }
 
-    /// Verify the client transaction is exactly the expected payment-channels
+    /// Verify the client transaction is exactly the expected tabs
     /// `open` instruction before the operator co-signs it as fee payer.
     ///
     /// Without this, a malicious client could include any operator-authorized
     /// instruction (e.g. a SystemProgram transfer draining the operator) and the
     /// operator would blindly sign it. We require a single instruction, on the
-    /// payment-channels program, with the `open` discriminator, whose accounts
+    /// tabs program, with the `open` discriminator, whose accounts
     /// bind the expected payer / payee / mint / fee payer / channel.
     fn validate_open_transaction(
         &self,
@@ -1010,7 +1010,7 @@ fn validate_distribution_hash(
     Ok(())
 }
 
-/// Assert `tx` is exactly the expected payment-channels `open` instruction so the
+/// Assert `tx` is exactly the expected tabs `open` instruction so the
 /// operator can safely co-sign it as fee payer (see [`X402Upto::validate_open_transaction`]).
 // Each account slot is an independent expected key (rentPayer vs
 // authorized_signer are distinct roles), so they are passed individually

--- a/skills/pay-sdk-implementation/SKILL.md
+++ b/skills/pay-sdk-implementation/SKILL.md
@@ -133,7 +133,7 @@ the directory skeleton and CI from earlier ones.
   `~/Coding/x402-kit` (lives on their local machine; not in this
   container). Treat the scaffold as a placeholder until the reference
   lands.
-- Anything cross-cutting in the on-chain payment-channels program: treat
+- Anything cross-cutting in the on-chain tabs program: treat
   that as out of scope. The Rust crate
   re-exports the on-chain artifacts; the new SDK only needs to
   serialize/deserialize them.

--- a/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-go.ts
+++ b/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-go.ts
@@ -1,5 +1,5 @@
 /**
- * Generate the pay-kit payment-channels Go client from the upstream
+ * Generate the pay-kit tabs Go client from the upstream
  * `Moonsong-Labs/solana-payment-channels` Codama IDL.
  *
  * Mirrors generate-payment-channels-client-rs.ts (the Rust path) — both scripts

--- a/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-py.ts
+++ b/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-py.ts
@@ -1,5 +1,5 @@
 /**
- * Generate the pay-kit Python payment-channels client from the upstream
+ * Generate the pay-kit Python tabs client from the upstream
  * `Moonsong-Labs/solana-payment-channels` Codama IDL.
  *
  * Mirrors generate-payment-channels-client.ts (Rust) - both scripts read the

--- a/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-rs.ts
+++ b/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-rs.ts
@@ -1,5 +1,5 @@
 /**
- * Generate the pay-kit payment-channels client crate from the upstream
+ * Generate the pay-kit tabs client crate from the upstream
  * `Moonsong-Labs/solana-payment-channels` Codama IDL.
  *
  * Mirrors generate-subscriptions-client.ts — both scripts vendor the IDL
@@ -24,7 +24,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
 const idlPath = path.join(repoRoot, 'idl', 'payment-channels.json');
-// The payment-channels client is inlined into the single publishable crate at
+// The tabs client is inlined into the single publishable crate at
 // rust/crates/kit/src/generated/payment_channels/generated/.
 const rustClientDir = path.join(repoRoot, 'rust', 'crates', 'kit', 'src', 'generated', 'payment_channels');
 

--- a/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-ts.ts
+++ b/skills/pay-sdk-implementation/codegen/generate-payment-channels-client-ts.ts
@@ -1,5 +1,5 @@
 /**
- * Generate the pay-kit payment-channels TypeScript client from the upstream
+ * Generate the pay-kit tabs TypeScript client from the upstream
  * `Moonsong-Labs/solana-payment-channels` Codama IDL.
  *
  * Mirrors generate-payment-channels-client-rs.ts (Rust) and
@@ -33,7 +33,7 @@ const tsClientDir = path.join(
   "mpp",
   "src",
   "generated",
-  "payment-channels",
+  "tabs",
 );
 
 if (!fs.existsSync(idlPath)) {

--- a/skills/pay-sdk-implementation/references/codegen.md
+++ b/skills/pay-sdk-implementation/references/codegen.md
@@ -1,6 +1,6 @@
 # Codama codegen — Solana program clients
 
-Pay-kit consumes a handful of Solana programs (payment-channels,
+Pay-kit consumes a handful of Solana programs (tabs,
 subscriptions, …) whose on-chain wire format is best produced from a
 single source of truth: each program's Codama IDL. Hand-writing a
 client per language is how `rust/crates/mpp/src/program/subscriptions.rs`

--- a/skills/pay-sdk-implementation/references/intents/mpp-session.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-session.md
@@ -1,6 +1,6 @@
 # `mpp/session`
 
-**Session intent**: open a Solana payment channel, authorize incremental
+**Session intent**: open a Solana tab, authorize incremental
 off-chain usage, and settle on-chain only at open, top-up, and close.
 
 Spec: `mpp-specs/specs/methods/solana/session.md` on the branch containing
@@ -24,7 +24,7 @@ Reference implementations:
 
 1. Exact challenge and action types.
 2. Canonical voucher-byte encoder shared by client and server.
-3. Generated payment-channels program client and PDA helpers.
+3. Generated tabs program client and PDA helpers.
 4. Reusable payer-authentication proof helpers for operator voucher mode.
 
 ### Client
@@ -207,7 +207,7 @@ apply the opening challenge's expiry to `voucher`, `use`, `topUp`, or `close`.
 
 For an open transaction, verify all of the following before persistence:
 
-- exactly one payment-channels open instruction, with only explicitly allowed
+- exactly one tabs open instruction, with only explicitly allowed
   compute-budget instructions alongside it;
 - transaction fee-payer policy and every required signature;
 - channel program, payer, rent payer, payee, mint, authorized signer, token

--- a/skills/pay-sdk-implementation/references/intents/x402-batch-settlement.md
+++ b/skills/pay-sdk-implementation/references/intents/x402-batch-settlement.md
@@ -23,7 +23,7 @@ The wire shape is likely:
 ## Relationship to MPP `session`
 
 The MPP session intent already does on-chain batching: the
-payment-channels program holds funds; vouchers authorize cumulative
+tabs program holds funds; vouchers authorize cumulative
 spend; close settles. The biggest implementation overlap with
 `x402/batch-settlement` is voucher / cumulative semantics — see
 `rust/crates/mpp/src/protocol/intents/session.rs::SignedVoucher`

--- a/skills/pay-sdk-implementation/references/repo-layout.md
+++ b/skills/pay-sdk-implementation/references/repo-layout.md
@@ -48,7 +48,7 @@ in the intent leaves translate directly:
 │   │   ├── charge.<ext>             ← build_charge_transaction, build_credential_header
 │   │   ├── session.<ext>            ← Session client (open, voucher, commit, close)
 │   │   ├── http_stream.<ext>        ← Optional: SSE / metered streaming helper
-│   │   └── payment_channels.<ext>   ← Optional: payment-channels program client
+│   │   └── payment_channels.<ext>   ← Optional: tabs program client
 │   └── bin/                         ← or `cmd/`, `scripts/` — harness adapters
 │       ├── harness_client.<ext>
 │       └── harness_server.<ext>

--- a/swift/Examples/PayKitDemo/PayKitDemo/ContentView.swift
+++ b/swift/Examples/PayKitDemo/PayKitDemo/ContentView.swift
@@ -239,7 +239,7 @@ struct ContentView: View {
     private func pay(_ endpoint: Endpoint) async {
         guard let signer else { return }
 
-        // Session endpoints run the real payment-channel flow (open -> stream
+        // Session endpoints run the real tab flow (open -> stream
         // SSE deliveries -> sign + commit a voucher -> settle), not the one-shot
         // 402 -> charge -> retry loop.
         if endpoint.intent == .session {
@@ -262,7 +262,7 @@ struct ContentView: View {
             return
         }
 
-        // x402 `upto` (usage): authorize a ceiling by opening a payment channel,
+        // x402 `upto` (usage): authorize a ceiling by opening a tab,
         // then the server meters actual usage and settles `actual <= max`,
         // refunding the rest. One tap drives the whole flow through the upto
         // client; the response body reports the metered amount billed.

--- a/swift/Examples/PayKitDemo/PayKitDemo/SessionStream.swift
+++ b/swift/Examples/PayKitDemo/PayKitDemo/SessionStream.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SolanaPayKit
 
-/// Drives a full MPP payment-channel **session** against the playground's
+/// Drives a full MPP tab **session** against the playground's
 /// `/api/v1/stream` (a metered SSE endpoint), the flow the one-shot charge
 /// client can't do:
 ///

--- a/swift/Sources/SolanaPayKit/PayCore/PaymentChannels.swift
+++ b/swift/Sources/SolanaPayKit/PayCore/PaymentChannels.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Client-side payment-channels primitives: PDA/ATA derivation, the 50-byte
+/// Client-side tabs primitives: PDA/ATA derivation, the 50-byte
 /// voucher preimage, and the `open` instruction + partially-signed open
 /// transaction the session client broadcasts via the operator.
 ///
@@ -12,10 +12,10 @@ import Foundation
 public enum PaymentChannels {
     private static let canonicalProgramId = "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX"
 
-    /// Canonical payment-channels program ID deployed to Surfnet.
+    /// Canonical tabs program ID deployed to Surfnet.
     public static let programId: Pubkey = {
         guard let id = try? Pubkey(base58: canonicalProgramId) else {
-            preconditionFailure("invalid canonical payment-channels program ID")
+            preconditionFailure("invalid canonical tabs program ID")
         }
         return id
     }()
@@ -26,7 +26,7 @@ public enum PaymentChannels {
     /// Event-authority PDA seed prefix.
     static let eventAuthoritySeed = Data("event_authority".utf8)
 
-    /// Default payment-channel close grace period, in seconds.
+    /// Default tab close grace period, in seconds.
     public static let defaultGracePeriodSeconds: UInt32 = 900
 
     /// Constant magic prefix of the signed voucher payload: version byte 0x01
@@ -274,7 +274,7 @@ public enum PaymentChannels {
         )
         let signature = try await payer.sign(message: message.serialize())
         guard signature.count == Ed25519.signatureLength else {
-            throw PayKitError.signingFailure("payment-channel open signature must be 64 bytes, got \(signature.count)")
+            throw PayKitError.signingFailure("tab open signature must be 64 bytes, got \(signature.count)")
         }
         guard let signerIndex = message.accountKeys.firstIndex(of: payerPubkey) else {
             throw PayKitError.invalidTransaction("payer is not in the open transaction account list")

--- a/swift/Sources/SolanaPayKit/Protocols/Mpp/Client/SessionClient.swift
+++ b/swift/Sources/SolanaPayKit/Protocols/Mpp/Client/SessionClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A live metered session bound to one payment channel.
+/// A live metered session bound to one tab.
 ///
 /// Holds the cumulative watermark, request nonce, and voucher expiry, and signs
 /// monotonically-increasing vouchers with the session signer. Mirrors the Go
@@ -194,7 +194,7 @@ public final class ActiveSession {
     }
 }
 
-// MARK: - Payment-channel session opener
+// MARK: - Tab session opener
 
 /// Placeholder operator signature: the server fills its fee-payer slot before
 /// broadcasting the open transaction.
@@ -280,7 +280,7 @@ public struct PaymentChannelSessionOpenOptions: Sendable {
     }
 }
 
-/// Result of opening a payment-channel session client-side.
+/// Result of opening a tab session client-side.
 public struct PaymentChannelSessionOpen {
     public let open: PaymentChannelOpen
     public let session: ActiveSession
@@ -288,7 +288,7 @@ public struct PaymentChannelSessionOpen {
 }
 
 public enum PaymentChannelSession {
-    /// Build a pull + clientVoucher payment-channel session open. The payer
+    /// Build a pull + clientVoucher tab session open. The payer
     /// partial-signs the open transaction; the operator (fee payer) co-signs and
     /// broadcasts. `recentBlockhash` is base58. The channel-PDA `openSlot` seed
     /// comes from the challenge (`request.recentSlot`, server-prefetched like
@@ -362,7 +362,7 @@ public enum PaymentChannelSession {
         options: PaymentChannelOpenOptions
     ) throws -> PaymentChannelOpen {
         guard let mintString = Mints.resolveChargeMint(currency: request.currency, network: request.network) else {
-            throw PayKitError.invalidTransaction("session payment channels require an SPL token")
+            throw PayKitError.invalidTransaction("session tabs require an SPL token")
         }
         let mint = try Pubkey(base58: mintString)
         let payee: Pubkey

--- a/swift/Sources/SolanaPayKit/Protocols/Mpp/Core/SessionTypes.swift
+++ b/swift/Sources/SolanaPayKit/Protocols/Mpp/Core/SessionTypes.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// MPP payment-channel session wire types.
+/// MPP tab session wire types.
 ///
 /// Mirrors the Rust spine (`rust/crates/mpp/src/protocol/intents/session.rs`)
 /// and the Go reference (`go/protocols/mpp/protocol/intents/session.go`)
@@ -228,7 +228,7 @@ public struct OpenPayload: Codable, Equatable, Sendable {
         self.signature = signature
     }
 
-    /// Push payment-channel open with explicit deposit + channel parties.
+    /// Push tab open with explicit deposit + channel parties.
     public static func paymentChannel(
         mode: SessionMode,
         channelId: String,

--- a/swift/Sources/SolanaPayKit/Protocols/X402/Client/Upto/UptoPayment.swift
+++ b/swift/Sources/SolanaPayKit/Protocols/X402/Client/Upto/UptoPayment.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// MARK: - x402 upto challenge parsing and payment building (payment-channel)
+// MARK: - x402 upto challenge parsing and payment building (tab)
 
 // MARK: - Challenge parsing
 
@@ -43,7 +43,7 @@ public func parseUptoAccepts(
 
 // MARK: - Payment building
 
-/// Build an `upto` payload for a `payment-channel` requirement.
+/// Build an `upto` payload for a `tab` requirement.
 ///
 /// The client (`signer`) is the channel payer. `extra.feePayer` is the
 /// transaction fee payer, rent payer, and zero-share channel payee;

--- a/swift/Sources/SolanaPayKit/Protocols/X402/Client/Upto/UptoTransport.swift
+++ b/swift/Sources/SolanaPayKit/Protocols/X402/Client/Upto/UptoTransport.swift
@@ -70,7 +70,7 @@ func uptoExpiresAt(nowSeconds: Int, maxTimeoutSeconds: Int) throws -> Int {
 }
 
 public extension PayKit.HttpClient {
-    /// A client that drives x402 `upto` (payment-channel) endpoints: on a 402,
+    /// A client that drives x402 `upto` (tab) endpoints: on a 402,
     /// parse the `upto` challenge, build a partially-signed channel `open`
     /// through `signer`, and replay with a `Payment-Signature` header.
     static func x402Upto(

--- a/swift/Sources/SolanaPayKit/Protocols/X402/Upto/UptoTypes.swift
+++ b/swift/Sources/SolanaPayKit/Protocols/X402/Upto/UptoTypes.swift
@@ -212,7 +212,7 @@ public struct X402UptoRequiredEnvelope: Codable, Sendable {
 
 /// The client authorization carried in `PAYMENT-SIGNATURE.payload`.
 ///
-/// For the payment-channel method the channel `open` is the authorization: the
+/// For the tab method the channel `open` is the authorization: the
 /// client's signature commits the deposit ceiling, payee, and mint. The
 /// payload carries no `signature` and no `profile` field.
 public struct X402UptoPayload: Codable, Sendable, Equatable {

--- a/swift/Tests/SolanaPayKitTests/SessionVoucherTests.swift
+++ b/swift/Tests/SolanaPayKitTests/SessionVoucherTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import SolanaPayKit
 
-/// Byte-exact golden vectors for the payment-channel voucher preimage and the
+/// Byte-exact golden vectors for the tab voucher preimage and the
 /// channel PDA, mirroring the Rust spine tests
 /// (`voucher_message_is_program_borsh_layout`, `channel_pda_is_stable`).
 @Suite("Session voucher preimage + PDA")

--- a/swift/Tests/SolanaPayKitTests/SessionWireOpenerTests.swift
+++ b/swift/Tests/SolanaPayKitTests/SessionWireOpenerTests.swift
@@ -122,10 +122,10 @@ struct SessionWireTests {
     }
 }
 
-/// The payment-channel session opener: pull + clientVoucher only, payer-signed
+/// The tab session opener: pull + clientVoucher only, payer-signed
 /// open transaction with the operator as fee payer. Mirrors
 /// `create_payment_channel_session_opener` and its guard tests.
-@Suite("Payment-channel session opener", .serialized)
+@Suite("Tab session opener", .serialized)
 struct SessionOpenerTests {
     private let operatorAddress = Base58.encode(Data(repeating: 0x05, count: 32))
     private let recipient = Base58.encode(Data(repeating: 0x06, count: 32))

--- a/typescript/docs/snippets/session.client.ts
+++ b/typescript/docs/snippets/session.client.ts
@@ -1,4 +1,4 @@
-// Client-side session: open one payment channel, stream paid chunks.
+// Client-side session: open one tab, stream paid chunks.
 // See ./README.md for the snippet:start/end convention.
 
 import { createPaymentChannelSessionOpener, createSessionFetch } from '@solana/mpp/client'

--- a/typescript/examples/playground-api/README.md
+++ b/typescript/examples/playground-api/README.md
@@ -17,7 +17,7 @@ lives in the OpenAPI summary, not the URL.
 | `GET` | `/api/v1/joke` | `joke` (`{ amount: usd('0.001'), accept: ['x402'] }`) | x402/exact | A fixed price, **x402 `exact`** only. |
 | `POST` | `/api/v1/summarize` | `summarize` (`usage(usd('0.10'))`) | x402/upto | Authorize a ceiling, then bill metered usage via `pay.charge(req)`, refunding the rest. |
 | `GET` | `/api/v1/feed` | `feed` (`subscription(usd('0.10'), …)`) | mpp/subscription | The first call activates a recurring on-chain plan; mounted only when a plan is bootstrapped. |
-| `GET` | `/api/v1/stream` | `stream` (`session(usd('1.00'), …)`) | mpp/session | Open a payment channel, stream metered deliveries (SSE), settle out-of-band on idle-close. |
+| `GET` | `/api/v1/stream` | `stream` (`session(usd('1.00'), …)`) | mpp/session | Open a tab, stream metered deliveries (SSE), settle out-of-band on idle-close. |
 
 The handler reads the verified receipt with `pay.payment(req)` and (for usage
 gates) the meter with `pay.charge(req)`. That's the entire app surface.

--- a/typescript/examples/playground-api/index.ts
+++ b/typescript/examples/playground-api/index.ts
@@ -98,11 +98,11 @@ const FORTUNES = [
 const HEADLINES = [
   { tag: 'engineering', title: 'Solana session validators hit a new throughput record' },
   { tag: 'macro', title: 'Stablecoin transfer volume crosses $4T on-chain quarterly' },
-  { tag: 'security', title: 'New payment-channel program audit lands' },
+  { tag: 'security', title: 'New tab program audit lands' },
   { tag: 'protocol', title: 'MPP v2 extensions ship to mainnet beta' },
 ]
 const TOKEN_CHUNKS = [
-  'A payment channel ',
+  'A tab ',
   'lets a client and server ',
   'authorize many small ',
   'off-chain debits ',
@@ -162,7 +162,7 @@ if (PLAN_ID) {
   })
 }
 
-// Session: open a payment channel, then stream metered deliveries (SSE). Each
+// Session: open a tab, then stream metered deliveries (SSE). Each
 // chunk costs 0.0001 USDC; settlement runs out-of-band when the channel
 // idle-closes (poll `/sessions/receipt/:channelId` for the settle signature).
 app.get('/api/v1/stream', pay.express('stream'), (_req: Request, res: Response) => {

--- a/typescript/packages/mpp/src/Methods.ts
+++ b/typescript/packages/mpp/src/Methods.ts
@@ -201,7 +201,7 @@ export const subscription = Method.from({
 /**
  * Solana session method — shared schema used by both server and client.
  *
- * A session opens a payment channel once, then pays for later deliveries with
+ * A session opens a tab once, then pays for later deliveries with
  * cumulative off-chain vouchers.
  */
 export const session = Method.from({

--- a/typescript/packages/mpp/src/__tests__/playground-session-e2e.test.ts
+++ b/typescript/packages/mpp/src/__tests__/playground-session-e2e.test.ts
@@ -2,9 +2,9 @@
  * End-to-end test for the playground's in-process session() method.
  *
  * Spawns the playground server pointed at the public Solana Payment Sandbox
- * (https://402.surfnet.dev:8899 — the payment-channels program is already
+ * (https://402.surfnet.dev:8899 — the tabs program is already
  * deployed there), funds a fresh wallet through the playground faucet, then
- * drives the exact flow the playground UI drives: a real payment-channel
+ * drives the exact flow the playground UI drives: a real tab
  * open (client pre-signs, server completes the fee-payer signature and
  * broadcasts), a metered SSE stream with per-chunk vouchers, and the
  * idle-close watchdog's on-chain settle.
@@ -116,7 +116,7 @@ describe('playground session e2e', () => {
         });
         expect(fund.status).toBe(200);
 
-        // 2) Real payment-channel open + metered SSE through the SDK
+        // 2) Real tab open + metered SSE through the SDK
         //    client — the same flow the playground UI drives. The wallet
         //    pre-signs the open transaction; the server completes the
         //    fee-payer signature, broadcasts, and confirms before metering.

--- a/typescript/packages/mpp/src/client/PaymentChannels.ts
+++ b/typescript/packages/mpp/src/client/PaymentChannels.ts
@@ -46,7 +46,7 @@ const DEFAULT_GRACE_PERIOD_SECONDS = 900;
 
 /** Placeholder signature used while the operator still needs to broadcast the open transaction. */
 /**
- * Payment-channel open fields shared by client-built and server-built open flows.
+ * Tab open fields shared by client-built and server-built open flows.
  */
 export interface PaymentChannelOpen {
     readonly channelId: string;
@@ -60,14 +60,14 @@ export interface PaymentChannelOpen {
 }
 
 /**
- * Single payment-channel open transaction plus the fields needed to authorize a session.
+ * Single tab open transaction plus the fields needed to authorize a session.
  */
 export interface PaymentChannelOpenTransaction extends PaymentChannelOpen {
     readonly transaction: Base64EncodedWireTransaction;
 }
 
 /**
- * Derives the payment-channel open fields without building a transaction.
+ * Derives the tab open fields without building a transaction.
  *
  * Use this for server-opened client-voucher sessions: the client must know the
  * channel PDA so it can sign vouchers, but the operator still funds and opens
@@ -90,7 +90,7 @@ export async function derivePaymentChannelOpen(
 }
 
 /**
- * Builds the payer-signed payment-channel open transaction for a session.
+ * Builds the payer-signed tab open transaction for a session.
  *
  * The transaction uses the operator from the session challenge as fee payer and
  * is intentionally left partially signed; the server adds the operator
@@ -194,9 +194,9 @@ export async function buildOpenPaymentChannelTransaction(
 }
 
 /**
- * Creates a high-level payment-channel session opener.
+ * Creates a high-level tab session opener.
  *
- * The opener turns a session 402 challenge into a payment-channel open action
+ * The opener turns a session 402 challenge into a tab open action
  * with the signed transaction attached. The server/operator broadcasts that
  * transaction, then subsequent stream commits are cumulative vouchers signed by
  * the generated session key.
@@ -383,7 +383,7 @@ async function preparePaymentChannelOpen(
     const network = normalizeNetwork(request.methodDetails.network);
     const mint = resolveStablecoinMint(request.currency, network);
     if (!mint) {
-        throw new Error('payment-channel sessions require an SPL token currency');
+        throw new Error('tab sessions require an SPL token currency');
     }
 
     const programAddress = address(parameters.programAddress ?? request.methodDetails.channelProgram);

--- a/typescript/packages/mpp/src/client/Session.ts
+++ b/typescript/packages/mpp/src/client/Session.ts
@@ -155,7 +155,7 @@ export interface SignedVoucher {
 }
 
 /**
- * Open action payload for a payment channel.
+ * Open action payload for a tab.
  */
 export interface OpenPayload {
     /** Reusable payer proof required for operator-signed vouchers. */
@@ -168,7 +168,7 @@ export interface OpenPayload {
     readonly capabilities?: Record<string, unknown> | undefined;
     /** Channel address, base58. */
     readonly channelId: string;
-    /** Deposit locked in the payment channel, in base units. */
+    /** Deposit locked in the tab, in base units. */
     readonly depositAmount: string;
     /** Distribution split preimage bound by the open instruction. */
     readonly distributionSplits?: readonly SessionSplit[] | undefined;
@@ -481,7 +481,7 @@ export async function verifySessionAuthentication(
 }
 
 /**
- * Builds canonical payment-channel voucher bytes:
+ * Builds canonical tab voucher bytes:
  * `magic (0x56, 0x01) || channel_id || cumulative_amount_le_u64 || expires_at_le_i64`.
  *
  * Delegates to the shared encoder so client and server agree on the bytes
@@ -674,7 +674,7 @@ export class ActiveSession {
     }
 
     /**
-     * Builds a detailed payment-channel `open` action.
+     * Builds a detailed tab `open` action.
      */
     openPaymentChannelAction(
         parameters: ActiveSession.PaymentChannelOpenParameters,

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -75,7 +75,7 @@ function resolveSessionStore(parameters: session.Parameters): SessionStore {
 /**
  * Creates a Solana `session` MPP method for the server.
  *
- * A session opens a payment channel once, then
+ * A session opens a tab once, then
  * accepts off-chain cumulative vouchers for subsequent paid deliveries.
  * On close, the server settles the highest accepted voucher on-chain and
  * distributes proceeds to the configured splits.
@@ -1452,7 +1452,7 @@ export declare namespace session {
          * `getLatestBlockhash` fallback when issuing new-channel challenges.
          */
         readonly blockhashCache?: BlockhashCache;
-        /** Payment-channels program ID. */
+        /** Tabs program ID. */
         readonly channelProgram?: Address | string;
         /** Currency identifier (e.g. 'USDC' or an SPL mint address). */
         readonly currency: string;

--- a/typescript/packages/mpp/src/server/session/on-chain.ts
+++ b/typescript/packages/mpp/src/server/session/on-chain.ts
@@ -4,7 +4,7 @@
 // `rust/crates/mpp/src/program/payment_channels.rs` and the orchestration
 // in `rust/crates/mpp/src/server/session.rs`. Two responsibilities:
 //
-//   1. Build the exact instruction bytes the on-chain payment-channels
+//   1. Build the exact instruction bytes the on-chain tabs
 //      program expects (settle_and_seal, distribute, top_up, reclaim).
 //   2. Verify client-submitted open transactions against the session
 //      challenge before persisting channel state.
@@ -71,7 +71,7 @@ export const ED25519_PROGRAM_ADDRESS =
     'Ed25519SigVerify111111111111111111111111111' as Address<'Ed25519SigVerify111111111111111111111111111'>;
 
 /**
- * Canonical payment-channels program ID, re-exported from the generated client
+ * Canonical tabs program ID, re-exported from the generated client
  * so there's a single source of truth that updates on IDL regeneration.
  * Callers can override per-call.
  */
@@ -88,7 +88,7 @@ export const PAYMENT_CHANNELS_PROGRAM_ID = PAYMENT_CHANNELS_PROGRAM_ADDRESS;
 export const OPEN_SLOT_WINDOW = 1_500n;
 
 /**
- * Treasury owner baked into the deployed (mainnet-build) payment-channels
+ * Treasury owner baked into the deployed (mainnet-build) tabs
  * program — Cs2zdfUNonRdRGsiZUQQLdTxzxVvJZmgiX2mpLYKuEqP. The treasury ATA is
  * ATA(TREASURY_OWNER, mint, tokenProgram). Mirrors `TREASURY_OWNER` in
  * `rust/crates/core/src/payment_channels.rs`.
@@ -98,7 +98,7 @@ const TREASURY_OWNER_BYTES = new Uint8Array([
     0x2b, 0x6a, 0x23, 0x99, 0xfc, 0x7d, 0x5b, 0x7e, 0xda, 0x8c, 0xac, 0x89, 0xaa,
 ]);
 
-/** Payment-channel open instruction discriminator. */
+/** Tab open instruction discriminator. */
 const OPEN_DISCRIMINATOR = 1;
 
 const U16_LE = (n: number) => new Uint8Array([n & 0xff, (n >> 8) & 0xff]);
@@ -185,11 +185,11 @@ export function encodeVoucherMessageBytes(args: {
 
 /** Arguments to {@link buildSettleAndSealInstructions}. */
 export interface SettleAndSealBuildArgs {
-    /** Payment-channel address being settled (base58). */
+    /** Tab address being settled (base58). */
     readonly channelId: string;
     /** Merchant signer authorized to settle the channel. */
     readonly merchantSigner: TransactionSigner;
-    /** Payment-channels program id override. */
+    /** Tabs program id override. */
     readonly programId?: Address | undefined;
     /**
      * Optional final voucher. When present, an Ed25519 precompile IX is
@@ -430,7 +430,7 @@ export function buildReclaimInstruction(args: ReclaimBuildArgs): ServerInstructi
  */
 export interface VerifyOpenTxExpected {
     readonly authorizedSigner: string;
-    /** Optional override for the payment-channels program id. */
+    /** Optional override for the tabs program id. */
     readonly channelProgram?: string | undefined;
     readonly currency: string;
     /** Transaction fee payer required by the challenge policy. */
@@ -502,7 +502,7 @@ export interface VerifyOpenTxArgs {
 
 /** Channel facts extracted from a verified open transaction. */
 export interface VerifyOpenTxResult {
-    /** Payment-channel address derived from the open instruction (base58). */
+    /** Tab address derived from the open instruction (base58). */
     readonly channelId: string;
     /** Deposit locked by the open, in base units. */
     readonly deposit: bigint;
@@ -526,7 +526,7 @@ export interface VerifyOpenTxResult {
  * Accepts both legacy and v0 transaction encodings (the Rust client emits
  * legacy; the TS client emits v0).
  *
- * Asserts the embedded Open IX targets the configured payment-channels
+ * Asserts the embedded Open IX targets the configured tabs
  * program, that `payee == expected.recipient`, that the mint matches the
  * challenge currency/network, that the deposit and other declared open fields
  * match the instruction, and that the
@@ -600,7 +600,7 @@ export async function verifyOpenTx(args: VerifyOpenTxArgs): Promise<VerifyOpenTx
         openIx = { accountIndices: ix.accountIndices ?? [], data: ix.data };
     }
     if (!openIx) {
-        throw new Error('verifyOpenTx: no payment-channels open instruction found');
+        throw new Error('verifyOpenTx: no tabs open instruction found');
     }
 
     // open instruction account layout (matches vendored open.ts) after the

--- a/typescript/packages/mpp/src/server/session/store.ts
+++ b/typescript/packages/mpp/src/server/session/store.ts
@@ -55,7 +55,7 @@ export interface ProcessedUse {
 export const CHANNEL_STATE_SCHEMA_VERSION = 1;
 
 /**
- * Persisted state of a single payment channel from the server's POV.
+ * Persisted state of a single tab from the server's POV.
  * Field-for-field mirror of Rust `ChannelState`. `bigint` is used for
  * every Rust `u64` so we don't lose precision on > 2^53 amounts.
  */
@@ -64,7 +64,7 @@ export interface ChannelState {
     readonly authentication?: SessionAuthentication | undefined;
     /** Public key authorized to sign vouchers for this session (base58). */
     readonly authorizedSigner: string;
-    /** On-chain payment-channel address (base58). */
+    /** On-chain tab address (base58). */
     readonly channelId: string;
     /** Unix seconds when cooperative close was requested. Vouchers blocked once set. */
     readonly closeRequestedAt?: bigint | undefined;

--- a/typescript/packages/mpp/src/shared/voucher.ts
+++ b/typescript/packages/mpp/src/shared/voucher.ts
@@ -1,7 +1,7 @@
 // Canonical voucher message encoder and Ed25519 verifier.
 //
 // The 50-byte voucher payload is the exact byte layout the on-chain
-// payment-channels program signs over:
+// tabs program signs over:
 //   magic (2 bytes, constant [0x56, 0x01])
 //   channel_id (32 bytes, base58-decoded pubkey)
 //   cumulative_amount (u64 little-endian)
@@ -66,7 +66,7 @@ export function normalizeSignedVoucher(signed: WireSignedVoucher): SignedVoucher
 }
 
 /**
- * Canonical 50-byte payment-channel voucher payload signed by the session
+ * Canonical 50-byte tab voucher payload signed by the session
  * key. Accepts the strict `VoucherData` shape used in the protocol types.
  */
 export function encodeVoucherMessage(voucher: VoucherData): Uint8Array {

--- a/typescript/packages/pay-kit/src/adapters/x402-upto.ts
+++ b/typescript/packages/pay-kit/src/adapters/x402-upto.ts
@@ -82,7 +82,7 @@ type SettlementWireRpc = Parameters<typeof buildAndSignWireTransaction>[0];
 
 /**
  * Usage-based (`upto`) x402 engine: the metered counterpart to the `exact`
- * adapter. The client opens a payment channel depositing the authorized ceiling;
+ * adapter. The client opens a tab depositing the authorized ceiling;
  * the in-process `@x402/svm` upto handler verifies and broadcasts the open,
  * then settles the metered amount with a single voucher, refunding the remainder.
  *

--- a/typescript/packages/pay-kit/src/gate.ts
+++ b/typescript/packages/pay-kit/src/gate.ts
@@ -23,7 +23,7 @@ export type GateDefaults = {
  * - `fixed` — charge a fixed amount up front (MPP `charge` / x402 `exact`),
  * - `usage` — authorize a ceiling and settle the metered amount afterwards (x402 `upto`),
  * - `subscription` — activate a recurring on-chain authorization on the first call (MPP `subscription`),
- * - `session` — open a payment channel and meter streamed deliveries, settling out-of-band (MPP `session`).
+ * - `session` — open a tab and meter streamed deliveries, settling out-of-band (MPP `session`).
  *
  * Defaults to `fixed`. `subscription` and `session` are MPP-only.
  */

--- a/typescript/packages/pay-kit/src/pricing.ts
+++ b/typescript/packages/pay-kit/src/pricing.ts
@@ -23,7 +23,7 @@ export type SubscriptionGateParams = Omit<InlineGateParams, 'feeOnTop' | 'feeWit
 };
 
 /**
- * A session gate definition: open a payment channel capped at `amount`, meter
+ * A session gate definition: open a tab capped at `amount`, meter
  * streamed deliveries at `session.unitPrice`, and settle out-of-band. MPP-only.
  * Produced by {@link session}.
  */
@@ -89,7 +89,7 @@ export function subscription(
 }
 
 /**
- * Declares a session gate: the client opens a payment channel capped at `cap`,
+ * Declares a session gate: the client opens a tab capped at `cap`,
  * the server meters streamed deliveries at `unitPrice` each, and settlement runs
  * out-of-band when the channel idle-closes. MPP-only.
  *


### PR DESCRIPTION
Prose and doc-comment rename as part of the org-wide **Payment Channels → Tabs** change.

**No language binding breaks.** Every public API symbol, module path, and file path is untouched — `payment_channels`, `PaymentChannel*`, `paymentChannels`, `PAYMENT_CHANNELS`, `idl/payment-channels.json`, `_payment-channels`, and `build-payment-channels` all have byte-identical occurrence counts before and after.

Error-message strings and their test assertions moved together (Go, Python, TypeScript), including the playground SSE fixture `"A payment channel "` → `"A tab "`. Workflow step `id:`s that other steps reference by name were kept (`id: payment-channels` in kotlin.yml/swift.yml still matches `steps.payment-channels.outputs.program-so`).

### Not done here, deliberately
The CI coupling to the program repo stays on the old paths: the `build-payment-channels` action and `payment-channels-pull-idl` recipe read `program/payment_channels/idl/payment_channels.json` and `payment_channels.so` from the **pinned ref `0c07d575`**, where those paths still exist — so CI keeps passing today. When `payment_channels_ref` is next bumped past the rename PR (solana-foundation/payment-channels#82), the same change must switch those paths to `program/tabs/idl/tabs.json` / `tabs.so`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)