### PR TITLE
feat(mints): add devnet-only USDtest

### DIFF
--- a/rust/crates/kit/src/core/mints.rs
+++ b/rust/crates/kit/src/core/mints.rs
@@ -8,6 +8,9 @@
 pub const USDC_MAINNET: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 pub const USDC_DEVNET: &str = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 pub const USDC_TESTNET: &str = USDC_DEVNET;
+/// Devnet-only Token-2022 test dollar used for payment-channel integration and
+/// load testing. There is intentionally no mainnet or localnet alias.
+pub const USDTEST_DEVNET: &str = "6MJyWHwFpPsaTEuYarEz49ngtsSKPYn6yHqtJUW2a9St";
 pub const USDT_MAINNET: &str = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
 pub const USDG_MAINNET: &str = "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH";
 pub const USDG_DEVNET: &str = "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7";

--- a/rust/crates/kit/src/mpp/client/charge.rs
+++ b/rust/crates/kit/src/mpp/client/charge.rs
@@ -316,7 +316,7 @@ pub async fn build_prepared_charge(
         options.compute_budget.compute_unit_limit,
     ));
 
-    let mint = resolve_mint(currency, method_details.network.as_deref());
+    let mint = try_resolve_mint(currency, method_details.network.as_deref())?;
     let has_ata_creation_splits = splits
         .iter()
         .any(|split| split.ata_creation_required == Some(true));
@@ -435,13 +435,14 @@ pub async fn build_charge_transaction_with_options(
             // this straight to Pubkey::from_str, so a bare symbol would fail.
             // SOL (resolve_mint -> None) is already rejected by
             // validate_confidential_charge above; guard defensively anyway.
-            let mint =
-                resolve_mint(currency, method_details.network.as_deref()).ok_or_else(|| {
+            let mint = try_resolve_mint(currency, method_details.network.as_deref())?.ok_or_else(
+                || {
                     Error::InvalidConfig(
                         "confidential transfers require an SPL Token-2022 mint, not native SOL"
                             .into(),
                     )
-                })?;
+                },
+            )?;
             let blockhash = resolve_blockhash(rpc, method_details)?;
             return super::confidential::confidential_charge_payload(
                 signer,
@@ -937,8 +938,16 @@ fn transfer_checked_ix(
 /// mint string we don't recognize. Callers handling arbitrary mints MUST
 /// validate parseability separately; audit #27 calls out the docstring
 /// drift from "Some(mint_address)" alone.
+#[cfg(test)]
 fn resolve_mint<'a>(currency: &'a str, network: Option<&str>) -> Option<&'a str> {
     crate::mpp::protocol::solana::resolve_stablecoin_mint(currency, network)
+}
+
+fn try_resolve_mint<'a>(
+    currency: &'a str,
+    network: Option<&str>,
+) -> Result<Option<&'a str>, Error> {
+    crate::mpp::protocol::solana::try_resolve_stablecoin_mint(currency, network)
 }
 
 fn is_solana_charge_challenge_name(challenge: &PaymentChallenge) -> bool {

--- a/rust/crates/kit/src/mpp/client/session.rs
+++ b/rust/crates/kit/src/mpp/client/session.rs
@@ -36,7 +36,7 @@ use crate::mpp::protocol::intents::session::{
     SessionVoucherSigner, SignedVoucher, TopUpPayload, VoucherData, VoucherPayload,
     VoucherSignatureType, DEFAULT_SESSION_EXPIRES_AT,
 };
-use crate::mpp::protocol::solana::{default_token_program_for_currency, resolve_stablecoin_mint};
+use crate::mpp::protocol::solana::default_token_program_for_currency;
 
 /// Default payment-channel close grace period (seconds). Re-exported from
 /// `solana-pay-core` to preserve this crate's public path.
@@ -363,7 +363,7 @@ pub fn derive_payment_channel_open(
     let details = &request.method_details;
     let network = Some(details.network.as_str());
     let mint = parse_pubkey(
-        resolve_stablecoin_mint(&request.currency, network)
+        crate::mpp::protocol::solana::try_resolve_stablecoin_mint(&request.currency, network)?
             .ok_or_else(|| Error::Other("session payment channels require an SPL token".into()))?,
         "mint",
     )?;

--- a/rust/crates/kit/src/mpp/mod.rs
+++ b/rust/crates/kit/src/mpp/mod.rs
@@ -92,6 +92,7 @@ pub use protocol::intents::{
 
 pub use protocol::solana::{
     default_token_program_for_currency, mints, programs, resolve_stablecoin_mint,
+    try_resolve_stablecoin_mint,
 };
 
 // Store types

--- a/rust/crates/kit/src/mpp/protocol/solana.rs
+++ b/rust/crates/kit/src/mpp/protocol/solana.rs
@@ -68,6 +68,9 @@ pub fn default_rpc_url(network: &str) -> &'static str {
 /// Resolve a stablecoin symbol to a mint address for a network.
 ///
 /// Returns `None` for native SOL and passes through unknown symbols/mints.
+/// Call [`try_resolve_stablecoin_mint`] when the currency may be `USDtest` so
+/// unsupported networks produce an actionable error rather than reaching a
+/// later pubkey parser as an unknown symbol.
 pub fn resolve_stablecoin_mint<'a>(currency: &'a str, network: Option<&str>) -> Option<&'a str> {
     match currency.to_uppercase().as_str() {
         "SOL" => None,
@@ -76,6 +79,7 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, network: Option<&str>) -> 
             Some("testnet") => mints::USDC_TESTNET,
             _ => mints::USDC_MAINNET,
         }),
+        "USDTEST" if network == Some(NETWORK_DEVNET) => Some(mints::USDTEST_DEVNET),
         "USDT" => Some(mints::USDT_MAINNET),
         "USDG" => Some(match network {
             Some("devnet") => mints::USDG_DEVNET,
@@ -93,16 +97,37 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, network: Option<&str>) -> 
     }
 }
 
+/// Resolve a stablecoin symbol while enforcing network-specific availability.
+///
+/// `USDtest` exists on devnet only. An omitted network defaults to mainnet per
+/// the MPP specification and is rejected just like an explicit mainnet or
+/// localnet selection.
+pub fn try_resolve_stablecoin_mint<'a>(
+    currency: &'a str,
+    network: Option<&str>,
+) -> Result<Option<&'a str>, crate::mpp::error::Error> {
+    let is_usdtest = currency.eq_ignore_ascii_case("USDtest") || currency == mints::USDTEST_DEVNET;
+    if is_usdtest && network != Some(NETWORK_DEVNET) {
+        let actual = network.unwrap_or(DEFAULT_NETWORK);
+        return Err(crate::mpp::error::Error::InvalidConfig(format!(
+            "USDtest is devnet-only; set network to `devnet` (got `{actual}`)"
+        )));
+    }
+    Ok(resolve_stablecoin_mint(currency, network))
+}
+
 fn stablecoin_uses_token_2022(mint: &str) -> bool {
-    matches!(
-        mint,
-        mints::PYUSD_MAINNET
-            | mints::PYUSD_DEVNET
-            | mints::USDG_MAINNET
-            | mints::USDG_DEVNET
-            | mints::CASH_MAINNET
-            | mints::USDPT_MAINNET
-    )
+    mint.eq_ignore_ascii_case("USDtest")
+        || matches!(
+            mint,
+            mints::USDTEST_DEVNET
+                | mints::PYUSD_MAINNET
+                | mints::PYUSD_DEVNET
+                | mints::USDG_MAINNET
+                | mints::USDG_DEVNET
+                | mints::CASH_MAINNET
+                | mints::USDPT_MAINNET
+        )
 }
 
 /// Whether `mint` is a well-known stablecoin whose Token-2022 mint enables the
@@ -122,6 +147,7 @@ pub fn is_known_stablecoin_mint(mint: &str) -> bool {
         mint,
         mints::USDC_MAINNET
             | mints::USDC_DEVNET
+            | mints::USDTEST_DEVNET
             | mints::USDT_MAINNET
             | mints::USDG_MAINNET
             | mints::USDG_DEVNET
@@ -282,6 +308,7 @@ mod tests {
 
         assert!(Pubkey::from_str(mints::USDC_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDC_DEVNET).is_ok());
+        assert!(Pubkey::from_str(mints::USDTEST_DEVNET).is_ok());
         assert!(Pubkey::from_str(mints::USDT_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_DEVNET).is_ok());
@@ -301,6 +328,16 @@ mod tests {
             resolve_stablecoin_mint("USDC", Some("devnet")),
             Some(mints::USDC_DEVNET)
         );
+        assert_eq!(
+            try_resolve_stablecoin_mint("USDtest", Some("devnet")).unwrap(),
+            Some(mints::USDTEST_DEVNET)
+        );
+        for network in [None, Some("mainnet"), Some("testnet"), Some("localnet")] {
+            let error = try_resolve_stablecoin_mint("usdtest", network).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+            let error = try_resolve_stablecoin_mint(mints::USDTEST_DEVNET, network).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+        }
         assert_eq!(
             resolve_stablecoin_mint("USDT", None),
             Some(mints::USDT_MAINNET)
@@ -326,6 +363,14 @@ mod tests {
 
     #[test]
     fn stablecoins_default_to_correct_token_program() {
+        assert_eq!(
+            default_token_program_for_currency("USDtest", Some("devnet")),
+            programs::TOKEN_2022_PROGRAM
+        );
+        assert_eq!(
+            default_token_program_for_currency(mints::USDTEST_DEVNET, Some("devnet")),
+            programs::TOKEN_2022_PROGRAM
+        );
         assert_eq!(
             default_token_program_for_currency("CASH", None),
             programs::TOKEN_2022_PROGRAM

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -144,7 +144,9 @@ fn resolve_server_token_program(
         return Ok(None);
     }
 
-    if let Some(mint) = crate::mpp::protocol::solana::resolve_stablecoin_mint(currency, network) {
+    if let Some(mint) =
+        crate::mpp::protocol::solana::try_resolve_stablecoin_mint(currency, network)?
+    {
         if crate::mpp::protocol::solana::is_known_stablecoin_mint(mint) {
             return Ok(Some(
                 crate::mpp::protocol::solana::default_token_program_for_currency(currency, network),
@@ -608,10 +610,10 @@ impl Mpp {
                 "ataCreationRequired requires an SPL token currency".into(),
             ));
         }
-        if crate::mpp::protocol::solana::resolve_stablecoin_mint(
+        if crate::mpp::protocol::solana::try_resolve_stablecoin_mint(
             &self.currency,
             Some(&self.network),
-        ) != Some(self.currency.as_str())
+        )? != Some(self.currency.as_str())
         {
             return Err(Error::InvalidConfig(
                 "ataCreationRequired requires currency to be an SPL token mint address".into(),
@@ -3105,7 +3107,8 @@ pub(crate) fn resolve_expected_mint(
     currency: &str,
     network: Option<&str>,
 ) -> Result<Pubkey, VerificationError> {
-    let Some(mint) = crate::mpp::protocol::solana::resolve_stablecoin_mint(currency, network)
+    let Some(mint) = crate::mpp::protocol::solana::try_resolve_stablecoin_mint(currency, network)
+        .map_err(|error| VerificationError::invalid_payload(error.to_string()))?
     else {
         return Err(VerificationError::invalid_payload(
             "SOL does not use an SPL mint".to_string(),

--- a/rust/crates/kit/src/mpp/server/html.rs
+++ b/rust/crates/kit/src/mpp/server/html.rs
@@ -90,7 +90,9 @@ pub fn challenge_to_html(challenge: &PaymentChallenge, _rpc_url: &str, _network:
         format!("{:.2}", amount_f)
     };
     let amount_display = match currency {
-        "USDC" | "USDT" | "USDG" | "PYUSD" | "CASH" => format!("${display_amount}"),
+        "USDC" | "USDT" | "USDTEST" | "USDG" | "PYUSD" | "CASH" => {
+            format!("${display_amount}")
+        }
         mints::USDC_MAINNET
         | mints::USDC_DEVNET
         | mints::USDT_MAINNET
@@ -98,7 +100,8 @@ pub fn challenge_to_html(challenge: &PaymentChallenge, _rpc_url: &str, _network:
         | mints::USDG_DEVNET
         | mints::PYUSD_MAINNET
         | mints::PYUSD_DEVNET
-        | mints::CASH_MAINNET => format!("${display_amount}"),
+        | mints::CASH_MAINNET
+        | mints::USDTEST_DEVNET => format!("${display_amount}"),
         c if c.to_lowercase() == "sol" => format!("{display_amount} SOL"),
         _ => format!("{display_amount} {}", &currency[..6.min(currency.len())]),
     };

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -35,7 +35,7 @@ use crate::mpp::protocol::intents::session::{
     SessionReceiptExtensions, SessionReceiptIntent, SessionRequest, SessionSplit, SignedVoucher,
     TopUpPayload, UsePayload, VoucherData, VoucherPayload, VoucherSignatureType,
 };
-use crate::mpp::protocol::solana::{default_token_program_for_currency, resolve_stablecoin_mint};
+use crate::mpp::protocol::solana::default_token_program_for_currency;
 use crate::mpp::store::{
     ChannelLifecycle, ChannelState, ChannelStore, CommittedDelivery, PendingDelivery, StoreError,
     CHANNEL_STATE_SCHEMA_VERSION,
@@ -2250,8 +2250,11 @@ fn parse_required_operator(operator: &str) -> Result<Pubkey> {
 }
 
 fn expected_payment_channel_mint(config: &SessionConfig) -> Result<Pubkey> {
-    let mint = resolve_stablecoin_mint(&config.currency, Some(config.network.as_str()))
-        .ok_or_else(|| Error::Other("payment-channel sessions require an SPL token".to_string()))?;
+    let mint = crate::mpp::protocol::solana::try_resolve_stablecoin_mint(
+        &config.currency,
+        Some(config.network.as_str()),
+    )?
+    .ok_or_else(|| Error::Other("payment-channel sessions require an SPL token".to_string()))?;
     parse_pubkey_field(mint, "currency")
 }
 
@@ -2371,6 +2374,16 @@ mod tests {
             idle_timeout_seconds: 300,
             ..SessionConfig::default()
         }
+    }
+
+    #[test]
+    fn usdtest_mainnet_challenge_is_rejected_before_rpc() {
+        let mut config = config(VoucherSigner::Client);
+        config.currency = "USDtest".to_string();
+        let server = SessionServer::new(config, MemoryChannelStore::new());
+
+        let error = server.build_challenge_request().unwrap_err();
+        assert!(error.to_string().contains("USDtest is devnet-only"));
     }
 
     fn state(channel_id: String, authorized_signer: String) -> ChannelState {

--- a/rust/crates/kit/src/x402/client/exact/payment.rs
+++ b/rust/crates/kit/src/x402/client/exact/payment.rs
@@ -14,9 +14,9 @@ use crate::x402::{
     error::Error,
     protocol::schemes::exact::{
         caip2_network_for_cluster, cluster_for_caip2_network, default_token_program_for_currency,
-        programs, resolve_stablecoin_mint, PaymentExtensions, PaymentPayload, PaymentProof,
-        PaymentRequiredEnvelope, PaymentRequirements, PaymentSignatureEnvelope, EXACT_SCHEME,
-        MAX_MEMO_BYTES, SOLANA_MAINNET,
+        programs, resolve_stablecoin_mint, try_resolve_stablecoin_mint, PaymentExtensions,
+        PaymentPayload, PaymentProof, PaymentRequiredEnvelope, PaymentRequirements,
+        PaymentSignatureEnvelope, EXACT_SCHEME, MAX_MEMO_BYTES, SOLANA_MAINNET,
     },
     PAYMENT_REQUIRED_HEADER, SOLANA_NETWORK, X402_V1_PAYMENT_REQUIRED_HEADER, X402_VERSION_V1,
     X402_VERSION_V2,
@@ -56,8 +56,11 @@ pub async fn build_payment(
     instructions.push(compute_unit_limit_ix(20_000));
     instructions.push(compute_unit_price_ix(1));
 
-    let cluster = requirements.cluster.as_deref();
-    let mint = resolve_mint(&requirements.currency, cluster);
+    let cluster = requirements
+        .cluster
+        .as_deref()
+        .or_else(|| cluster_for_caip2_network(&requirements.network));
+    let mint = try_resolve_mint(&requirements.currency, cluster)?;
 
     if let Some(mint_str) = mint {
         build_spl_instructions(
@@ -520,8 +523,16 @@ fn transfer_checked_ix(
 /// Resolve a currency to an optional mint address.
 ///
 /// Returns `None` for native SOL, or `Some(mint_address)` for SPL tokens.
+#[cfg(test)]
 fn resolve_mint<'a>(currency: &'a str, cluster: Option<&str>) -> Option<&'a str> {
     resolve_stablecoin_mint(currency, cluster)
+}
+
+fn try_resolve_mint<'a>(
+    currency: &'a str,
+    cluster: Option<&str>,
+) -> Result<Option<&'a str>, Error> {
+    try_resolve_stablecoin_mint(currency, cluster)
 }
 
 #[cfg(test)]

--- a/rust/crates/kit/src/x402/protocol/schemes/exact/types.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/exact/types.rs
@@ -84,6 +84,8 @@ pub fn is_native_sol(currency: &str) -> bool {
 /// Resolve a stablecoin symbol to a mint address for a cluster.
 ///
 /// Returns `None` for native SOL and passes through unknown symbols/mints.
+/// Call [`try_resolve_stablecoin_mint`] when the currency may be `USDtest` so
+/// unsupported clusters produce an actionable error.
 pub fn resolve_stablecoin_mint<'a>(currency: &'a str, cluster: Option<&str>) -> Option<&'a str> {
     if is_native_sol(currency) {
         return None;
@@ -94,6 +96,14 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, cluster: Option<&str>) -> 
             Some(SOLANA_TESTNET) | Some("testnet") => mints::USDC_TESTNET,
             _ => mints::USDC_MAINNET,
         }),
+        "USDTEST"
+            if matches!(
+                cluster,
+                Some(SOLANA_DEVNET) | Some("devnet") | Some("solana-devnet")
+            ) =>
+        {
+            Some(mints::USDTEST_DEVNET)
+        }
         "USDT" => Some(mints::USDT_MAINNET),
         "USDG" => Some(match cluster {
             Some(SOLANA_DEVNET) | Some("devnet") | Some("localnet") => mints::USDG_DEVNET,
@@ -110,6 +120,28 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, cluster: Option<&str>) -> 
     }
 }
 
+/// Resolve a stablecoin symbol while enforcing cluster-specific availability.
+///
+/// `USDtest` is intentionally available only on devnet. Omitted, mainnet,
+/// testnet, and localnet clusters are rejected.
+pub fn try_resolve_stablecoin_mint<'a>(
+    currency: &'a str,
+    cluster: Option<&str>,
+) -> Result<Option<&'a str>, crate::x402::Error> {
+    let is_devnet = matches!(
+        cluster,
+        Some(SOLANA_DEVNET) | Some("devnet") | Some("solana-devnet")
+    );
+    let is_usdtest = currency.eq_ignore_ascii_case("USDtest") || currency == mints::USDTEST_DEVNET;
+    if is_usdtest && !is_devnet {
+        let actual = cluster.unwrap_or("mainnet-beta");
+        return Err(crate::x402::Error::Other(format!(
+            "USDtest is devnet-only; set cluster to `devnet` (got `{actual}`)"
+        )));
+    }
+    Ok(resolve_stablecoin_mint(currency, cluster))
+}
+
 /// Reverse lookup: given a known mint address or stablecoin symbol, return
 /// the canonical symbol. Returns `None` for native SOL or unknown values.
 ///
@@ -123,12 +155,14 @@ pub fn stablecoin_symbol(currency_or_mint: &str) -> Option<&'static str> {
     let upper = currency_or_mint.to_uppercase();
     match upper.as_str() {
         "USDC" => Some("USDC"),
+        "USDTEST" => Some("USDTEST"),
         "USDT" => Some("USDT"),
         "USDG" => Some("USDG"),
         "PYUSD" => Some("PYUSD"),
         "CASH" => Some("CASH"),
         _ => match currency_or_mint {
             mints::USDC_MAINNET | mints::USDC_DEVNET => Some("USDC"),
+            mints::USDTEST_DEVNET => Some("USDTEST"),
             mints::USDT_MAINNET => Some("USDT"),
             mints::USDG_MAINNET | mints::USDG_DEVNET => Some("USDG"),
             mints::PYUSD_MAINNET | mints::PYUSD_DEVNET => Some("PYUSD"),
@@ -144,7 +178,7 @@ pub fn stablecoin_symbol(currency_or_mint: &str) -> Option<&'static str> {
 pub fn stablecoin_uses_token_2022(currency_or_mint: &str) -> bool {
     matches!(
         stablecoin_symbol(currency_or_mint),
-        Some("USDG") | Some("PYUSD") | Some("CASH")
+        Some("USDTEST") | Some("USDG") | Some("PYUSD") | Some("CASH")
     )
 }
 
@@ -727,6 +761,7 @@ mod tests {
 
         assert!(Pubkey::from_str(mints::USDC_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDC_DEVNET).is_ok());
+        assert!(Pubkey::from_str(mints::USDTEST_DEVNET).is_ok());
         assert!(Pubkey::from_str(mints::USDT_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_DEVNET).is_ok());
@@ -745,6 +780,21 @@ mod tests {
             resolve_stablecoin_mint("PYUSD", Some("devnet")),
             Some(mints::PYUSD_DEVNET)
         );
+        assert_eq!(
+            try_resolve_stablecoin_mint("USDtest", Some("devnet")).unwrap(),
+            Some(mints::USDTEST_DEVNET)
+        );
+        for cluster in [
+            None,
+            Some("mainnet-beta"),
+            Some("testnet"),
+            Some("localnet"),
+        ] {
+            let error = try_resolve_stablecoin_mint("usdtest", cluster).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+            let error = try_resolve_stablecoin_mint(mints::USDTEST_DEVNET, cluster).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+        }
         assert_eq!(
             resolve_stablecoin_mint("USDT", None),
             Some(mints::USDT_MAINNET)
@@ -766,6 +816,10 @@ mod tests {
 
     #[test]
     fn token_2022_stablecoins_default_to_token_2022() {
+        assert_eq!(
+            default_token_program_for_currency("USDtest", Some("devnet")),
+            programs::TOKEN_2022_PROGRAM
+        );
         assert_eq!(
             default_token_program_for_currency("USDC", None),
             programs::TOKEN_PROGRAM
@@ -811,7 +865,7 @@ mod tests {
 
     #[test]
     fn stablecoin_symbol_round_trips_symbols() {
-        for sym in ["USDC", "USDT", "USDG", "PYUSD", "CASH"] {
+        for sym in ["USDC", "USDT", "USDTEST", "USDG", "PYUSD", "CASH"] {
             assert_eq!(stablecoin_symbol(sym), Some(sym));
             assert_eq!(stablecoin_symbol(&sym.to_lowercase()), Some(sym));
         }
@@ -821,6 +875,7 @@ mod tests {
     fn stablecoin_symbol_resolves_known_mints() {
         assert_eq!(stablecoin_symbol(mints::USDC_MAINNET), Some("USDC"));
         assert_eq!(stablecoin_symbol(mints::USDC_DEVNET), Some("USDC"));
+        assert_eq!(stablecoin_symbol(mints::USDTEST_DEVNET), Some("USDTEST"));
         assert_eq!(stablecoin_symbol(mints::USDT_MAINNET), Some("USDT"));
         assert_eq!(stablecoin_symbol(mints::USDG_MAINNET), Some("USDG"));
         assert_eq!(stablecoin_symbol(mints::USDG_DEVNET), Some("USDG"));
@@ -843,6 +898,8 @@ mod tests {
         assert!(stablecoin_uses_token_2022("USDG"));
         assert!(stablecoin_uses_token_2022("PYUSD"));
         assert!(stablecoin_uses_token_2022("CASH"));
+        assert!(stablecoin_uses_token_2022("USDtest"));
+        assert!(stablecoin_uses_token_2022(mints::USDTEST_DEVNET));
         assert!(stablecoin_uses_token_2022(mints::USDG_MAINNET));
         assert!(stablecoin_uses_token_2022(mints::PYUSD_DEVNET));
         // Legacy stablecoins use the original SPL Token program.

--- a/rust/crates/kit/src/x402/server/batch_settlement.rs
+++ b/rust/crates/kit/src/x402/server/batch_settlement.rs
@@ -41,8 +41,7 @@ use crate::x402::protocol::schemes::batch_settlement::{
     PROFILE_PAYMENT_CHANNEL,
 };
 use crate::x402::protocol::schemes::exact::{
-    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency,
-    resolve_stablecoin_mint, ResourceInfo,
+    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency, ResourceInfo,
 };
 use crate::x402::server::upto::{
     cosign_operator_fee_payer, decode_transaction, validate_open_instruction,
@@ -152,6 +151,7 @@ impl X402BatchSettlement {
         }
         Pubkey::from_str(&config.recipient)
             .map_err(|e| Error::Other(format!("Invalid recipient pubkey: {e}")))?;
+        crate::x402::exact::try_resolve_stablecoin_mint(&config.currency, Some(&config.cluster))?;
         let operator = config.operator_signer.pubkey();
         let rpc_url = config
             .rpc_url
@@ -180,8 +180,11 @@ impl X402BatchSettlement {
     }
 
     fn mint(&self) -> Result<Pubkey, Error> {
-        let mint = resolve_stablecoin_mint(&self.config.currency, Some(&self.config.cluster))
-            .ok_or_else(|| Error::Other("batch-settlement requires an SPL token".into()))?;
+        let mint = crate::x402::exact::try_resolve_stablecoin_mint(
+            &self.config.currency,
+            Some(&self.config.cluster),
+        )?
+        .ok_or_else(|| Error::Other("batch-settlement requires an SPL token".into()))?;
         Pubkey::from_str(mint).map_err(|e| Error::Other(format!("invalid mint: {e}")))
     }
 

--- a/rust/crates/kit/src/x402/server/exact.rs
+++ b/rust/crates/kit/src/x402/server/exact.rs
@@ -141,6 +141,12 @@ impl X402 {
         }
         Pubkey::from_str(&config.recipient)
             .map_err(|e| Error::Other(format!("Invalid recipient pubkey: {e}")))?;
+        for currency in &config.currencies {
+            crate::x402::exact::try_resolve_stablecoin_mint(
+                &currency.currency,
+                Some(&config.network),
+            )?;
+        }
 
         let rpc_url = config
             .rpc_url
@@ -971,6 +977,18 @@ mod tests {
                 .collect(),
             ..config()
         }
+    }
+
+    #[test]
+    fn usdtest_mainnet_config_is_rejected() {
+        let mut config = multi_currency_config(&["USDtest"]);
+        config.network = "mainnet-beta".to_string();
+
+        let error = match X402::new(config) {
+            Ok(_) => panic!("USDtest must not be accepted on mainnet"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("USDtest is devnet-only"));
     }
 
     fn memory_signer(seed: u8) -> Box<dyn SolanaSigner> {

--- a/rust/crates/kit/src/x402/server/upto.rs
+++ b/rust/crates/kit/src/x402/server/upto.rs
@@ -37,8 +37,7 @@ use crate::core::payment_channels::generated::accounts::Channel;
 
 use crate::x402::error::Error;
 use crate::x402::protocol::schemes::exact::{
-    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency,
-    resolve_stablecoin_mint, ResourceInfo,
+    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency, ResourceInfo,
 };
 use crate::x402::protocol::schemes::upto::{
     assert_settlement_within_ceiling, verify_upto_payload, UptoExtra, UptoRequiredEnvelope,
@@ -188,6 +187,12 @@ impl X402Upto {
         if config.currencies.is_empty() {
             return Err(Error::Other("at least one currency is required".into()));
         }
+        for currency in &config.currencies {
+            crate::x402::exact::try_resolve_stablecoin_mint(
+                &currency.currency,
+                Some(&config.cluster),
+            )?;
+        }
         if let UptoPayout::Beneficiary { address } = &config.payout {
             Pubkey::from_str(address)
                 .map_err(|e| Error::Other(format!("Invalid recipient pubkey: {e}")))?;
@@ -268,8 +273,11 @@ impl X402Upto {
     /// Resolve the mint for a specific currency descriptor on the configured
     /// cluster.
     fn mint_for(&self, cc: &CurrencyConfig) -> Result<Pubkey, Error> {
-        let mint = resolve_stablecoin_mint(&cc.currency, Some(&self.config.cluster))
-            .ok_or_else(|| Error::Other("upto requires an SPL token (not native SOL)".into()))?;
+        let mint = crate::x402::exact::try_resolve_stablecoin_mint(
+            &cc.currency,
+            Some(&self.config.cluster),
+        )?
+        .ok_or_else(|| Error::Other("upto requires an SPL token (not native SOL)".into()))?;
         Pubkey::from_str(mint).map_err(|e| Error::Other(format!("invalid mint: {e}")))
     }
 


### PR DESCRIPTION
## Summary
- stack USDtest support on #283
- register the devnet USDtest Token-2022 mint in Rust
- resolve it in MPP and x402 while rejecting omitted, mainnet, testnet, and localnet networks
- select Token-2022 and recognize the mint across charge, session, and settlement paths

## Test Plan
- `cargo test --workspace --quiet` (891 passed, 5 ignored)
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings -A clippy::too_many_arguments`