### PR TITLE
fix(session): confirm channel transactions sooner

### DIFF
--- a/harness/python-server/server.py
+++ b/harness/python-server/server.py
@@ -389,6 +389,14 @@ class _Adapter:
                 return None
             return (blockhash, slot)
 
+        def _current_slot() -> int:
+            _, slot = _fetch_recent_state_sync(self.rpc_url)
+            if slot is None:
+                raise ValueError("session harness RPC did not return a current slot")
+            return slot
+
+        config.current_slot_provider = _current_slot
+
         core = SessionServer(config, MemoryChannelStore()).with_blockhash_cache(_blockhash_cache)
         self.session_method = Session(
             core=core,

--- a/python/protocol_conformance_runner.py
+++ b/python/protocol_conformance_runner.py
@@ -137,6 +137,12 @@ def _receipt_to_canonical(rcpt: Receipt) -> dict[str, Any]:
         "reference": rcpt.reference,
         "challengeId": rcpt.challenge_id,
         "externalId": rcpt.external_id,
+        "intent": rcpt.intent,
+        "acceptedCumulative": rcpt.accepted_cumulative,
+        "spent": rcpt.spent,
+        "idleTimeoutSeconds": rcpt.idle_timeout_seconds,
+        "txHash": rcpt.tx_hash,
+        "refunded": rcpt.refunded,
     }
     return _drop_empty(out)
 
@@ -186,6 +192,9 @@ def _credential_from_canonical(obj: dict[str, Any]) -> PaymentCredential:
 
 
 def _receipt_from_canonical(obj: dict[str, Any]) -> Receipt:
+    idle_timeout_seconds = obj.get("idleTimeoutSeconds")
+    if isinstance(idle_timeout_seconds, bool) or not isinstance(idle_timeout_seconds, int):
+        idle_timeout_seconds = None
     return Receipt(
         status=str(obj.get("status", "")),
         method=str(obj.get("method", "")),
@@ -193,6 +202,12 @@ def _receipt_from_canonical(obj: dict[str, Any]) -> Receipt:
         reference=str(obj.get("reference", "")),
         challenge_id=str(obj.get("challengeId", "")),
         external_id=str(obj.get("externalId", "")),
+        intent=str(obj.get("intent", "")),
+        accepted_cumulative=str(obj.get("acceptedCumulative", "")),
+        spent=str(obj.get("spent", "")),
+        idle_timeout_seconds=idle_timeout_seconds,
+        tx_hash=str(obj.get("txHash", "")),
+        refunded=str(obj.get("refunded", "")),
     )
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solana-pay-kit"
-version = "0.6.0"
+version = "0.7.0"
 description = "Building blocks for Agentic payments (x402, MPP, AP2)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/src/solana_pay_kit/protocols/mpp/core/headers.py
+++ b/python/src/solana_pay_kit/protocols/mpp/core/headers.py
@@ -229,14 +229,41 @@ def parse_receipt(header: str) -> Receipt:
     if not _ISO8601_RE.match(timestamp):
         raise ParseError(f"Invalid ISO-8601 timestamp in receipt: {timestamp!r}")
 
-    return Receipt(
+    idle_timeout_seconds = data.get("idleTimeoutSeconds")
+    if idle_timeout_seconds is not None and (
+        isinstance(idle_timeout_seconds, bool) or not isinstance(idle_timeout_seconds, int) or idle_timeout_seconds < 0
+    ):
+        raise ParseError("'idleTimeoutSeconds' in receipt must be a non-negative integer")
+
+    receipt = Receipt(
         status=str(data["status"]),
         method=str(data["method"]),
         timestamp=timestamp,
         reference=str(data["reference"]),
         challenge_id=str(data.get("challengeId", "")),
         external_id=str(data.get("externalId", "")),
+        intent=str(data.get("intent", "")),
+        accepted_cumulative=str(data.get("acceptedCumulative", "")),
+        spent=str(data.get("spent", "")),
+        idle_timeout_seconds=idle_timeout_seconds,
+        tx_hash=str(data.get("txHash", "")),
+        refunded=str(data.get("refunded", "")),
     )
+    if receipt.intent == "session":
+        for field, value in (
+            ("acceptedCumulative", receipt.accepted_cumulative),
+            ("spent", receipt.spent),
+            ("idleTimeoutSeconds", receipt.idle_timeout_seconds),
+        ):
+            if value is None or value == "":
+                raise ParseError(f"Missing '{field}' in session receipt")
+        for field, value in (
+            ("acceptedCumulative", receipt.accepted_cumulative),
+            ("spent", receipt.spent),
+        ):
+            if not value.isascii() or not value.isdigit():
+                raise ParseError(f"'{field}' in session receipt must be a decimal string")
+    return receipt
 
 
 def format_receipt(receipt: Receipt) -> str:
@@ -250,6 +277,18 @@ def format_receipt(receipt: Receipt) -> str:
     }
     if receipt.external_id:
         data["externalId"] = receipt.external_id
+    if receipt.intent:
+        data["intent"] = receipt.intent
+    if receipt.accepted_cumulative:
+        data["acceptedCumulative"] = receipt.accepted_cumulative
+    if receipt.spent:
+        data["spent"] = receipt.spent
+    if receipt.idle_timeout_seconds is not None:
+        data["idleTimeoutSeconds"] = receipt.idle_timeout_seconds
+    if receipt.tx_hash:
+        data["txHash"] = receipt.tx_hash
+    if receipt.refunded:
+        data["refunded"] = receipt.refunded
     return encode_json(data)
 
 

--- a/python/src/solana_pay_kit/protocols/mpp/core/types.py
+++ b/python/src/solana_pay_kit/protocols/mpp/core/types.py
@@ -181,6 +181,12 @@ class Receipt:
     reference: str
     challenge_id: str = ""
     external_id: str = ""
+    intent: str = ""
+    accepted_cumulative: str = ""
+    spent: str = ""
+    idle_timeout_seconds: int | None = None
+    tx_hash: str = ""
+    refunded: str = ""
 
     def is_success(self) -> bool:
         """Return True if the receipt indicates success."""

--- a/python/src/solana_pay_kit/protocols/mpp/intents/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/intents/session.py
@@ -431,6 +431,8 @@ class OpenPayload:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> OpenPayload:
+        if "bump" in data:
+            raise ValueError("open payload must not include bump")
         salt = _u64_from_wire(data.get("salt"), "salt")
         open_slot = _u64_from_wire(data.get("openSlot"), "openSlot")
         if salt is None or open_slot is None:

--- a/python/src/solana_pay_kit/protocols/mpp/server/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session.py
@@ -26,6 +26,9 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
 
+from solders.pubkey import Pubkey  # type: ignore[import-untyped]
+
+from solana_pay_kit._paycore.mints import resolve_stablecoin_mint
 from solana_pay_kit._paycore.paymentchannels import OPEN_SLOT_WINDOW
 from solana_pay_kit.protocols.mpp.core.types import PaymentChallenge
 from solana_pay_kit.protocols.mpp.intents.session import (
@@ -208,6 +211,10 @@ class SessionConfig:
     # process_top_up raises the deposit.
     verify_top_up_tx: SessionTxVerifier[TopUpPayload] | None = None
 
+    # Current slot source used to reject opens that have aged out since the
+    # challenge was issued. It may return the slot directly or awaitably.
+    current_slot_provider: Callable[[], Awaitable[int] | int] | None = None
+
 
 @dataclass
 class DeliveryRequest:
@@ -381,7 +388,7 @@ class SessionServer:
         )
         return SessionRequest(
             amount=str(self._config.amount),
-            currency=self._config.currency,
+            currency=self._wire_currency(),
             recipient=self._config.recipient,
             method_details=details,
             minimum_deposit=(str(self._config.minimum_deposit) if self._config.minimum_deposit is not None else None),
@@ -417,6 +424,26 @@ class SessionServer:
         raise ValueError(
             "session challenge requires recentBlockhash/recentSlot; configure a blockhash cache or an RPC client"
         )
+
+    def _wire_currency(self) -> str:
+        mint = resolve_stablecoin_mint(self._config.currency, self._config.network)
+        if mint is None:
+            raise ValueError("session currency must be an SPL token mint; use wrapped SOL instead of SOL")
+        return mint
+
+    async def _current_cluster_slot(self) -> int:
+        provider = self._config.current_slot_provider
+        try:
+            if provider is not None:
+                value = provider()
+                if isinstance(value, Awaitable):
+                    return int(await value)
+                return int(value)
+            if self._rpc is not None:
+                return int(await self._rpc.get_slot())
+        except Exception as exc:
+            raise ValueError(f"failed to fetch current cluster slot for session open: {exc}") from exc
+        raise ValueError("open freshness validation requires an RPC current-slot provider")
 
     @staticmethod
     def _open_context(challenge: PaymentChallenge) -> SessionOpenContext:
@@ -500,6 +527,26 @@ class SessionServer:
                 f"window of the challenged recentSlot {context.recent_slot}"
             )
 
+        existing = await self._store.get_channel(session_id)
+        if existing is None:
+            current_slot = await self._current_cluster_slot()
+            if payload.open_slot > current_slot:
+                raise ValueError(
+                    f"open openSlot {payload.open_slot} is ahead of the current cluster slot {current_slot}"
+                )
+            if current_slot - payload.open_slot > OPEN_SLOT_WINDOW:
+                raise ValueError(
+                    f"open openSlot {payload.open_slot} is outside the {OPEN_SLOT_WINDOW}-slot freshness "
+                    f"window of the current cluster slot {current_slot}"
+                )
+
+        try:
+            authorized_signer = Pubkey.from_string(payload.authorized_signer)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"invalid authorizedSigner: {exc}") from exc
+        if not authorized_signer.is_on_curve():
+            raise ValueError("open authorizedSigner must be an on-curve Ed25519 public key")
+
         if self._config.voucher_signer == "operator" and payload.authorized_signer != self._config.operator:
             raise ValueError("operator voucher signing requires authorizedSigner to match the operator")
 
@@ -518,7 +565,6 @@ class SessionServer:
                 raise ValueError("invalid session authentication signature")
 
         authentication = payload.authentication.to_dict() if payload.authentication is not None else None
-        existing = await self._store.get_channel(session_id)
         if existing is not None:
             if existing.sealed:
                 raise ValueError(f"channel {session_id} is already sealed")
@@ -677,7 +723,7 @@ class SessionServer:
         await self._store.update_channel(payload.channel_id, mutator)
         return result[0]
 
-    async def verify_voucher(self, payload: VoucherPayload) -> int:
+    async def verify_voucher(self, payload: VoucherPayload, amount: int | None = None) -> int:
         """Verify a voucher, advance the watermark, and return the new
         cumulative.
 
@@ -697,6 +743,9 @@ class SessionServer:
                 f"channelId {voucher.data.channel_id!r}"
             )
         channel_id = voucher.data.channel_id
+        price = self._config.amount if amount is None else amount
+        if price <= 0 or price > _U64_MAX:
+            raise ValueError("voucher amount must be a positive u64")
 
         state = await self._store.get_channel(channel_id)
         if state is None:
@@ -719,9 +768,6 @@ class SessionServer:
             # Surface the stable reject tag ahead of the detail
             # ("<reason>: <detail>").
             raise ValueError(f"{result.reason}: {result.detail}")
-        if result.status == VoucherVerifyStatus.REPLAYED:
-            return result.new_cumulative
-
         new_cumulative = result.new_cumulative
         new_signature = result.new_signature
         new_expires_at = result.new_expires_at
@@ -735,20 +781,18 @@ class SessionServer:
                 raise ValueError(f"channel {channel_id} is already sealed")
             if current.close_requested_at is not None:
                 raise ValueError(f"channel {channel_id} close is pending; no further vouchers accepted")
-            # Idempotent replay inside the mutator.
-            if (
-                new_cumulative == current.cumulative
-                and current.highest_voucher_signature is not None
-                and current.highest_voucher_signature == new_signature
-            ):
-                return current
+            replayed = result.status == VoucherVerifyStatus.REPLAYED and new_cumulative == current.cumulative
             # Concurrent watermark advancement check.
-            if new_cumulative <= current.cumulative:
+            if not replayed and new_cumulative <= current.cumulative:
                 raise ValueError("concurrent update: watermark advanced")
+            if new_cumulative - current.spent_amount < price:
+                raise ValueError("insufficient authorized voucher availability")
             nxt = current.clone()
-            nxt.cumulative = new_cumulative
-            nxt.highest_voucher_signature = new_signature
-            nxt.highest_voucher_expires_at = new_expires_at
+            if not replayed:
+                nxt.cumulative = new_cumulative
+                nxt.highest_voucher_signature = new_signature
+                nxt.highest_voucher_expires_at = new_expires_at
+            nxt.spent_amount += price
             nxt.last_activity_at = int(time.time() * 1000)
             return nxt
 
@@ -876,7 +920,7 @@ class SessionServer:
                 delivery_id=delivery_id,
                 session_id=session_id,
                 amount=str(amount),
-                currency=self._config.currency,
+                currency=self._wire_currency(),
                 sequence=sequence,
                 expires_at=expires_at,
             )
@@ -981,6 +1025,7 @@ class SessionServer:
             # recheck (and the post-restart reconcile) closes a channel that is
             # actively paying through the metered-delivery flow.
             nxt.last_activity_at = int(time.time() * 1000)
+            nxt.spent_amount += actual_amount
             nxt.committed_deliveries.append(
                 CommittedDelivery(
                     delivery_id=delivery_id,

--- a/python/src/solana_pay_kit/protocols/mpp/server/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session.py
@@ -785,13 +785,18 @@ class SessionServer:
             # Concurrent watermark advancement check.
             if not replayed and new_cumulative <= current.cumulative:
                 raise ValueError("concurrent update: watermark advanced")
+            nxt = current.clone()
+            if replayed:
+                # An idempotent replay of the already-accepted highest voucher
+                # must not deliver additional service or debit spent_amount
+                # again — the client already paid for it.
+                nxt.last_activity_at = int(time.time() * 1000)
+                return nxt
             if new_cumulative - current.spent_amount < price:
                 raise ValueError("insufficient authorized voucher availability")
-            nxt = current.clone()
-            if not replayed:
-                nxt.cumulative = new_cumulative
-                nxt.highest_voucher_signature = new_signature
-                nxt.highest_voucher_expires_at = new_expires_at
+            nxt.cumulative = new_cumulative
+            nxt.highest_voucher_signature = new_signature
+            nxt.highest_voucher_expires_at = new_expires_at
             nxt.spent_amount += price
             nxt.last_activity_at = int(time.time() * 1000)
             return nxt

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_method.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_method.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
 from solders.pubkey import Pubkey  # type: ignore[import-untyped]
 
@@ -36,6 +36,7 @@ from solana_pay_kit._paycore.errors import (
     PaymentError,
     payment_required_response,
 )
+from solana_pay_kit._paycore.mints import resolve_stablecoin_mint
 from solana_pay_kit._paycore.solana import MAX_SPLITS
 from solana_pay_kit.protocols.mpp._paymentchannels import PROGRAM_ID
 from solana_pay_kit.protocols.mpp.core.expires import minutes
@@ -63,7 +64,7 @@ from solana_pay_kit.protocols.mpp.server.session_onchain import (
     new_top_up_tx_verifier,
     settle_and_seal_channel,
 )
-from solana_pay_kit.protocols.mpp.server.session_store import ChannelStore, MemoryChannelStore
+from solana_pay_kit.protocols.mpp.server.session_store import ChannelState, ChannelStore, MemoryChannelStore
 from solana_pay_kit.signer import LocalSigner
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,12 @@ _SECRET_KEY_ENV_VAR = "MPP_SECRET_KEY"
 _U64_MAX = (1 << 64) - 1
 # Watchdog retry delay after a failed idle-close settle.
 _SETTLE_RETRY_SECONDS = 60.0
+
+
+class SessionRpcClient(RpcClient, Protocol):
+    """RPC surface required by session challenge and open validation."""
+
+    async def get_slot(self, commitment: str = ...) -> int: ...
 
 
 class _AlreadySealed(Exception):
@@ -110,7 +117,7 @@ class SessionOptions:
     # Currency identifier (e.g. "USDC" or an SPL mint address). Default USDC.
     currency: str = ""
     # Decimals is the token decimals. Default 6.
-    decimals: int = 0
+    decimals: int | None = None
     # Network is the Solana network. Default "mainnet".
     network: str = ""
     # SecretKey is the challenge HMAC secret. Defaults to MPP_SECRET_KEY.
@@ -135,7 +142,7 @@ class SessionOptions:
     # Store is the pluggable channel store. Defaults to in-memory.
     store: ChannelStore | None = None
     # RPC is required: session funding verification always fails closed.
-    rpc: RpcClient | None = None
+    rpc: SessionRpcClient | None = None
     # Signer is the operator/merchant local signer that funds and signs the
     # on-chain settle-at-close (and the server-broadcast open) transactions.
     # None (or no RPC) leaves close a pure state-flip with settledSignature unset.
@@ -188,14 +195,24 @@ def _parse_session_u64(value: str, name: str) -> int:
     return parsed
 
 
-def _success_receipt(reference: str, challenge_id: str, external_id: str) -> Receipt:
+def _success_receipt(state: ChannelState, challenge_id: str, external_id: str) -> Receipt:
     """Build a success receipt for a session action."""
-    return Receipt.success(
+    if state.idle_timeout_seconds is None:
+        raise ValueError(f"channel {state.channel_id} is missing its negotiated idle timeout")
+    receipt = Receipt.success(
         method="solana",
-        reference=reference,
+        reference=state.channel_id,
         challenge_id=challenge_id,
         external_id=external_id,
     )
+    receipt.intent = "session"
+    receipt.accepted_cumulative = str(state.cumulative)
+    receipt.spent = str(state.spent_amount)
+    receipt.idle_timeout_seconds = state.idle_timeout_seconds
+    receipt.tx_hash = state.settled_signature or ""
+    if state.sealed:
+        receipt.refunded = str(state.deposit - state.cumulative)
+    return receipt
 
 
 class Session:
@@ -221,7 +238,7 @@ class Session:
         self._secret_key = secret_key
         self._realm = realm
         self._amount = amount
-        self._currency = currency
+        self._currency = resolve_stablecoin_mint(currency, network) or currency
         self._recipient = recipient
         self._network = network
         self._rpc = rpc
@@ -312,20 +329,27 @@ class Session:
         if action.open is not None:
             if challenge.is_expired():
                 raise ChallengeExpiredError(f"challenge expired at {challenge.expires}")
-            reference = await self._handle_open(action.open, challenge=challenge)
+            channel_id = await self._handle_open(action.open, challenge=challenge)
         elif action.use is not None:
-            reference = await self._handle_use(action.use, challenge.id, idempotency_key, int(request.amount))
+            await self._handle_use(action.use, challenge.id, idempotency_key, int(request.amount))
+            channel_id = action.use.channel_id
         elif action.voucher is not None:
-            reference = await self._handle_voucher(action.voucher)
+            await self._handle_voucher(action.voucher, int(request.amount))
+            channel_id = action.voucher.channel_id
         elif action.top_up is not None:
-            reference = await self._handle_top_up(action.top_up)
+            await self._handle_top_up(action.top_up)
+            channel_id = action.top_up.channel_id
         elif action.close is not None:
-            reference = await self._handle_close(action.close)
+            await self._handle_close(action.close)
+            channel_id = action.close.channel_id
         else:
             raise PaymentError("unknown session action", code="invalid-payload")
 
         external_id = request.external_id or ""
-        return _success_receipt(reference, credential.challenge.id, external_id)
+        state = await self._core.store().get_channel(channel_id)
+        if state is None:
+            raise PaymentError(f"channel {channel_id} not found after session action", code="invalid-payload")
+        return _success_receipt(state, credential.challenge.id, external_id)
 
     async def handle(
         self,
@@ -436,12 +460,12 @@ class Session:
         await self._touch(payload.channel_id)
         return f"{payload.channel_id}:{voucher.data.cumulative_amount}:{voucher.signature}"
 
-    async def _handle_voucher(self, payload: VoucherPayload) -> str:
+    async def _handle_voucher(self, payload: VoucherPayload, amount: int | None = None) -> str:
         """Verify a cumulative voucher and advance the watermark. The receipt
         reference is "<channelId>:<cumulative>"."""
         channel_id = payload.voucher.data.channel_id
         try:
-            cumulative = await self._core.verify_voucher(payload)
+            cumulative = await self._core.verify_voucher(payload, self._amount if amount is None else amount)
         except ValueError as exc:
             raise PaymentError(str(exc), code="invalid-payload") from exc
         await self._touch(channel_id)
@@ -473,11 +497,19 @@ class Session:
         # The idle watchdog may only forget the channel once the settle
         # attempt is behind us: after a failed settle it is the sole actor
         # left that can re-drive the close.
-        if self._lifecycle is not None:
-            self._lifecycle.remove_channel(payload.channel_id)
+        await self._finish_settle_lifecycle(channel_id, settled)
         # On a successful settle the reference is the on-chain signature; without
         # a signer/RPC the close is a state-flip and the channel id stands in.
         return settled or payload.channel_id
+
+    async def _finish_settle_lifecycle(self, channel_id: str, settled: str | None) -> None:
+        if self._lifecycle is None:
+            return
+        state = await self._core.store().get_channel(channel_id)
+        if settled is not None or state is None or state.sealed or state.settled_signature is not None:
+            self._lifecycle.remove_channel(channel_id)
+        elif self._signer is not None and self._rpc is not None:
+            self._lifecycle.touch(channel_id, _SETTLE_RETRY_SECONDS)
 
     async def _settle_channel(self, channel_id: str) -> str | None:
         """Settle and seal the channel on-chain, returning the settlement
@@ -487,8 +519,6 @@ class Session:
         """
         if self._signer is None or self._rpc is None:
             return None
-
-        from solana_pay_kit.protocols.mpp.server.session_store import ChannelState
 
         # Atomic settle-in-progress guard: claim the channel under the
         # per-channel store lock so a concurrent close retry or idle-watchdog
@@ -575,8 +605,6 @@ class Session:
         """
         import time
 
-        from solana_pay_kit.protocols.mpp.server.session_store import ChannelState
-
         due = False
         remaining: float | None = None
 
@@ -608,7 +636,8 @@ class Session:
             if remaining is not None and self._lifecycle is not None:
                 self._lifecycle.touch(channel_id, remaining)
             if due:
-                await self._settle_channel(channel_id)
+                settled = await self._settle_channel(channel_id)
+                await self._finish_settle_lifecycle(channel_id, settled)
         except Exception:
             logging.getLogger(__name__).warning("idle-close settle failed for channel %s", channel_id, exc_info=True)
             # Re-arm the timer: after a failed settle the watchdog is the
@@ -661,12 +690,15 @@ def new_session(options: SessionOptions) -> Session:
         raise PaymentError("missing secret key", code="invalid-config")
 
     currency = options.currency or "USDC"
-    decimals = options.decimals or 6
+    decimals = 6 if options.decimals is None else options.decimals
+    if isinstance(decimals, bool) or not 0 <= decimals <= 9:
+        raise PaymentError("decimals must be an integer from 0 to 9", code="invalid-config")
     network = options.network or "mainnet"
     realm = options.realm or detect_realm()
 
     if options.rpc is None:
         raise PaymentError("session requires an RPC client for funding verification", code="invalid-config")
+    rpc = options.rpc
     if options.voucher_signer not in ("client", "operator"):
         raise PaymentError("voucherSigner must be 'client' or 'operator'", code="invalid-config")
     if options.voucher_signer == "operator" and options.signer is None:
@@ -700,26 +732,27 @@ def new_session(options: SessionOptions) -> Session:
         operator_signer=(options.signer.keypair if options.voucher_signer == "operator" and options.signer else None),
         idle_timeout_options_seconds=options.idle_timeout_options_seconds,
         idle_timeout_seconds=options.idle_timeout_seconds,
+        current_slot_provider=lambda: rpc.get_slot(),
     )
     config.verify_open_tx = new_open_tx_verifier(
         config,
-        options.rpc,
+        rpc,
         fee_payer_signer=(options.signer.keypair if options.fee_payer and options.signer else None),
     )
-    config.verify_top_up_tx = new_top_up_tx_verifier(config, store, options.rpc)
+    config.verify_top_up_tx = new_top_up_tx_verifier(config, store, rpc)
     # The RPC doubles as the fallback source of the challenge's
     # recentBlockhash/recentSlot; hosts can avoid the per-402 round-trip by
     # sharing a cache via ``session.core().with_blockhash_cache(...)``.
-    core = SessionServer(config, store, rpc=options.rpc)
+    core = SessionServer(config, store, rpc=rpc)
     session = Session(
         core=core,
         secret_key=secret_key,
         realm=realm,
         amount=options.amount,
-        currency=currency,
+        currency=(resolve_stablecoin_mint(currency, network) or currency),
         recipient=options.recipient,
         network=network,
-        rpc=options.rpc,
+        rpc=rpc,
         lifecycle=None,
         signer=options.signer,
     )

--- a/python/tests/test_headers.py
+++ b/python/tests/test_headers.py
@@ -294,6 +294,35 @@ class TestReceipt:
         with pytest.raises(ParseError):
             parse_receipt(bad)
 
+    def test_session_extension_roundtrip(self):
+        receipt = Receipt(
+            status="success",
+            method="solana",
+            timestamp="2024-01-01T00:00:00Z",
+            reference="channel-id",
+            intent="session",
+            accepted_cumulative="250",
+            spent="100",
+            idle_timeout_seconds=300,
+            tx_hash="settle-signature",
+            refunded="750",
+        )
+        parsed = parse_receipt(format_receipt(receipt))
+        assert parsed == receipt
+
+    def test_session_receipt_requires_extension_fields(self):
+        header = encode_json(
+            {
+                "intent": "session",
+                "method": "solana",
+                "reference": "channel-id",
+                "status": "success",
+                "timestamp": "2024-01-01T00:00:00Z",
+            }
+        )
+        with pytest.raises(ParseError, match="acceptedCumulative"):
+            parse_receipt(header)
+
 
 class TestCRLFRejection:
     """L11 lock: header parameter values MUST reject CR or LF.

--- a/python/tests/test_playground_api.py
+++ b/python/tests/test_playground_api.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from examples.playground_api import sessions
 from examples.playground_api.app import app
 
 
 @pytest.fixture
 def client() -> TestClient:
+    sessions.session.core().with_blockhash_cache(lambda: ("4vJ9JU1bJJQpUgJ8V6hYz7xXKz4F2tN6aBrZEcD3xKhs", 1))
     return TestClient(app)
 
 

--- a/python/tests/test_protocol_conformance_runner.py
+++ b/python/tests/test_protocol_conformance_runner.py
@@ -1,0 +1,48 @@
+"""Tests for the mpp-protocol conformance runner's canonical receipt ABI.
+
+Exercises ``protocol_conformance_runner.py`` the same way the cross-language
+harness does (see ``harness/protocol-runners/python.json``): spawn it and
+speak the stdin/stdout adapter ABI, rather than importing it directly.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_RUNNER = Path(__file__).resolve().parent.parent / "protocol_conformance_runner.py"
+
+
+def _dispatch(op: str, input_: dict) -> dict:
+    proc = subprocess.run(
+        [sys.executable, str(_RUNNER)],
+        input=json.dumps({"op": op, "input": input_}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_session_receipt_format_parse_roundtrip():
+    session_receipt = {
+        "status": "success",
+        "method": "solana",
+        "timestamp": "2026-01-29T12:00:30Z",
+        "reference": "0xabc",
+        "intent": "session",
+        "acceptedCumulative": "500000",
+        "spent": "125000",
+        "idleTimeoutSeconds": 300,
+        "txHash": "5x7y9z",
+        "refunded": "0",
+    }
+
+    formatted = _dispatch("receipt.format", session_receipt)
+    assert formatted["success"] is True
+
+    parsed = _dispatch("receipt.parse", {"header": formatted["result"]["header"]})
+    assert parsed["success"] is True
+    assert parsed["result"] == session_receipt

--- a/python/tests/test_session_intent.py
+++ b/python/tests/test_session_intent.py
@@ -162,6 +162,9 @@ def test_open_payload_uses_exact_string_amount_and_slot_fields() -> None:
     assert wire["openSlot"] == "42"
     assert wire["gracePeriodSeconds"] == 900
     assert OpenPayload.from_dict(wire) == payload
+
+    with pytest.raises(ValueError, match="must not include bump"):
+        OpenPayload.from_dict({**wire, "bump": 255})
     for stale in ("deposit", "recentSlot", "programId", "mode"):
         assert stale not in wire
 

--- a/python/tests/test_session_method.py
+++ b/python/tests/test_session_method.py
@@ -59,10 +59,15 @@ class _Rpc:
 
         return _Resp()
 
+    async def get_slot(self, commitment: str = "confirmed") -> int:
+        del commitment
+        return CHALLENGED_SLOT
+
 
 def _core(config: SessionConfig, store: MemoryChannelStore | None = None) -> SessionServer:
     """A SessionServer whose challenges serve the pinned open-transaction
     context from a blockhash cache."""
+    config.current_slot_provider = config.current_slot_provider or (lambda: CHALLENGED_SLOT)
     return SessionServer(config, store if store is not None else MemoryChannelStore()).with_blockhash_cache(
         lambda: (CHALLENGED_BLOCKHASH, CHALLENGED_SLOT)
     )
@@ -222,6 +227,7 @@ async def test_operator_use_survives_challenge_expiry_and_is_idempotent() -> Non
             authorized_signer=str(operator.pubkey()),
             payer=str(payer.pubkey()),
             deposit=1_000,
+            idle_timeout_seconds=300,
             opening_challenge_id=challenge.id,
             authentication=authentication.to_dict(),
             voucher_signer="operator",
@@ -390,7 +396,11 @@ async def test_verify_dispatches_client_voucher_top_up_and_close() -> None:
             payload=SessionAction.voucher_action(_voucher_payload(voucher(100))).to_dict(),
         )
     )
-    assert voucher_receipt.reference == f"{RECIPIENT}:100"
+    assert voucher_receipt.reference == RECIPIENT
+    assert voucher_receipt.intent == "session"
+    assert voucher_receipt.accepted_cumulative == "100"
+    assert voucher_receipt.spent == "25"
+    assert voucher_receipt.idle_timeout_seconds == 300
     top_up_receipt = await session.verify_credential(
         PaymentCredential(
             challenge=challenge.to_echo(),
@@ -432,6 +442,7 @@ async def test_handle_accepts_valid_operator_use_header() -> None:
             authorized_signer=str(operator.pubkey()),
             payer=str(payer.pubkey()),
             deposit=1_000,
+            idle_timeout_seconds=300,
             opening_challenge_id=challenge.id,
             authentication=authentication.to_dict(),
             voucher_signer="operator",
@@ -637,3 +648,34 @@ async def test_idle_close_redrives_a_stranded_settle() -> None:
     session._lifecycle_reconciled = False
     await session._reconcile_lifecycle()
     assert settled_spy.touches == []
+
+
+async def test_idle_close_rearms_when_another_settle_is_in_flight() -> None:
+    store = MemoryChannelStore()
+    core = SessionServer(
+        SessionConfig(recipient=RECIPIENT, amount=25, currency="USDC", network="localnet"),
+        store,
+    )
+    await store.update_channel(
+        RECIPIENT,
+        lambda _: ChannelState(
+            channel_id=RECIPIENT,
+            authorized_signer=RECIPIENT,
+            payer=RECIPIENT,
+            deposit=1_000,
+            idle_timeout_seconds=60,
+            last_activity_at=0,
+            close_requested_at=1,
+            settling=True,
+        ),
+    )
+    session = _session(core)
+    session._signer = object()  # type: ignore[assignment]
+    session._rpc = object()  # type: ignore[assignment]
+    spy = _LifecycleSpy()
+    session._lifecycle = spy  # type: ignore[assignment]
+
+    await session._close_on_idle(RECIPIENT)
+
+    assert spy.removed == []
+    assert spy.touches == [(RECIPIENT, 60.0)]

--- a/python/tests/test_session_routes.py
+++ b/python/tests/test_session_routes.py
@@ -39,6 +39,7 @@ def _config() -> SessionConfig:
         network="localnet",
         channel_program=str(Keypair.from_seed(bytes([8] * 32)).pubkey()),
         grace_period_seconds=900,
+        current_slot_provider=lambda: 1,
     )
 
 
@@ -171,7 +172,7 @@ async def test_deliveries_reserves_and_shares_store() -> None:
     assert resp.status == 200
     assert resp.body["deliveryId"] == f"{channel_id}:1"
     assert resp.body["sequence"] == 1
-    assert resp.body["currency"] == "USDC"
+    assert resp.body["currency"] == "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
     assert resp.body["amount"] == "200"
 
 

--- a/python/tests/test_session_server.py
+++ b/python/tests/test_session_server.py
@@ -352,9 +352,11 @@ async def test_client_voucher_advances_watermark_and_replays_idempotently() -> N
     server, _, _ = await _server()
     voucher = _voucher(100)
     assert await server.verify_voucher(_voucher_payload(voucher)) == 100
+    # The replay must not double-debit: spent_amount reflects only the one
+    # fresh acceptance, not the replay that followed it.
     assert await server.verify_voucher(_voucher_payload(voucher)) == 100
     state = await server.store().get_channel(CHANNEL)
-    assert state is not None and state.cumulative == 100 and state.spent_amount == 50
+    assert state is not None and state.cumulative == 100 and state.spent_amount == 25
 
 
 async def test_voucher_action_channel_id_must_match_the_signed_voucher() -> None:

--- a/python/tests/test_session_server.py
+++ b/python/tests/test_session_server.py
@@ -8,7 +8,9 @@ from dataclasses import replace
 
 import pytest
 from solders.keypair import Keypair  # type: ignore[import-untyped]
+from solders.pubkey import Pubkey  # type: ignore[import-untyped]
 
+from solana_pay_kit._paycore.paymentchannels import OPEN_SLOT_WINDOW
 from solana_pay_kit.protocols.mpp._paymentchannels import PROGRAM_ID
 from solana_pay_kit.protocols.mpp.core.types import PaymentChallenge
 from solana_pay_kit.protocols.mpp.intents.session import (
@@ -44,6 +46,7 @@ CHALLENGED_SLOT = 42
 def _core(config: SessionConfig) -> SessionServer:
     """A SessionServer whose challenges serve the pinned open-transaction
     context from a blockhash cache (no RPC round-trip)."""
+    config.current_slot_provider = config.current_slot_provider or (lambda: CHALLENGED_SLOT)
     return SessionServer(config, MemoryChannelStore()).with_blockhash_cache(
         lambda: (CHALLENGED_BLOCKHASH, CHALLENGED_SLOT)
     )
@@ -76,6 +79,7 @@ def _config(*, operator: bool = False) -> SessionConfig:
         operator_signer=OPERATOR if operator else None,
         idle_timeout_options_seconds=[30, 300],
         idle_timeout_seconds=300,
+        current_slot_provider=lambda: CHALLENGED_SLOT,
     )
 
 
@@ -219,8 +223,6 @@ async def test_open_binds_open_slot_to_challenged_recent_slot() -> None:
         await server.process_open(ahead, challenge)
 
     # An openSlot staler than the 1500-slot freshness window is rejected.
-    from solana_pay_kit._paycore.paymentchannels import OPEN_SLOT_WINDOW
-
     stale_challenge_config = _config()
     stale_challenge_config.verify_open_tx = verify
     stale = PaymentChallenge.with_secret_key(
@@ -246,6 +248,26 @@ async def test_open_binds_open_slot_to_challenged_recent_slot() -> None:
     earlier.open_slot = CHALLENGED_SLOT - 1
     state = await server.process_open(earlier, challenge)
     assert state.open_slot == CHALLENGED_SLOT - 1
+
+
+async def test_open_checks_current_slot_and_authorized_signer_curve() -> None:
+    config = _config()
+
+    async def verify(_: OpenPayload, __: object) -> None:
+        return None
+
+    config.verify_open_tx = verify
+    challenge = await _challenge(config)
+    config.current_slot_provider = lambda: CHALLENGED_SLOT + OPEN_SLOT_WINDOW + 1
+    with pytest.raises(ValueError, match="freshness window of the current cluster slot"):
+        await SessionServer(config, MemoryChannelStore()).process_open(_open(config, challenge), challenge)
+
+    config.current_slot_provider = lambda: CHALLENGED_SLOT
+    off_curve, _ = Pubkey.find_program_address([b"session-test"], Pubkey.from_string(str(PROGRAM_ID)))
+    payload = _open(config, challenge)
+    payload.authorized_signer = str(off_curve)
+    with pytest.raises(ValueError, match="on-curve Ed25519"):
+        await SessionServer(config, MemoryChannelStore()).process_open(payload, challenge)
 
 
 async def test_open_rejects_challenge_without_open_transaction_context() -> None:
@@ -332,7 +354,7 @@ async def test_client_voucher_advances_watermark_and_replays_idempotently() -> N
     assert await server.verify_voucher(_voucher_payload(voucher)) == 100
     assert await server.verify_voucher(_voucher_payload(voucher)) == 100
     state = await server.store().get_channel(CHANNEL)
-    assert state is not None and state.cumulative == 100
+    assert state is not None and state.cumulative == 100 and state.spent_amount == 50
 
 
 async def test_voucher_action_channel_id_must_match_the_signed_voucher() -> None:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "solana-pay-kit"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anchorpy" },

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       thor (~> 1.0)
     docile (1.4.1)
     ed25519 (1.4.0)
-    json (2.20.0)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -128,7 +128,7 @@ CHECKSUMS
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
-  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/rust/crates/integration-tests/tests/charge_integration.rs
+++ b/rust/crates/integration-tests/tests/charge_integration.rs
@@ -339,16 +339,13 @@ async fn sol_charge_wrong_recipient_rejected_before_broadcast() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
-async fn sol_charge_identical_retry_is_idempotent() {
-    // PayKit Slice 1 changed this test's expectation. Ed25519 signing is
-    // deterministic, so replaying an already-signed pull-mode credential
-    // reproduces the exact same on-chain signature. Before Slice 1's
-    // challenge-scoped `ChargeReplayStore`, that meant an identical retry —
-    // e.g. because the client never saw the first HTTP response — hit
-    // `consume_signature`'s "already consumed" error instead of returning
-    // the receipt it already earned: replay-safe, but not
-    // response-loss-idempotent. Slice 1 makes the identical retry succeed
-    // and return the SAME signature.
+async fn sol_charge_identical_retry_is_rejected() {
+    // Ed25519 signing is deterministic, so replaying an already-signed
+    // pull-mode credential reproduces the exact same on-chain signature.
+    // The challenge-scoped `ChargeReplayStore` recognizes that before
+    // `consume_signature` would otherwise surface a bare internal error,
+    // and rejects it with the canonical `signature_consumed` code instead —
+    // the same reject TypeScript and Ruby emit for a resettled credential.
     let recipient = Keypair::new();
     let Some(surfnet) = start_surfnet_or_skip().await else {
         return;
@@ -397,18 +394,20 @@ async fn sol_charge_identical_retry_is_idempotent() {
         .unwrap();
     assert_eq!(first.status.to_string(), "success");
 
-    // Identical retry — must return the SAME receipt instead of erroring.
-    let second = mpp
+    // Identical retry — must reject with the canonical signature-consumed
+    // code, not silently re-settle or succeed a second time.
+    let second_err = mpp
         .verify_credential_with_expected(
             &solana_pay_kit::mpp::parse_authorization(&auth).unwrap(),
             &expected,
         )
         .await
-        .unwrap();
-    assert_eq!(second.status.to_string(), "success");
-    assert_eq!(
-        second.reference, first.reference,
-        "identical retry must return the same settlement signature"
+        .unwrap_err();
+    assert_eq!(second_err.code, Some("signature-consumed"));
+    assert!(
+        second_err.message.contains(&first.reference),
+        "reject message should reference the already-settled signature, got: {}",
+        second_err.message
     );
 }
 

--- a/rust/crates/integration-tests/tests/charge_integration.rs
+++ b/rust/crates/integration-tests/tests/charge_integration.rs
@@ -339,7 +339,16 @@ async fn sol_charge_wrong_recipient_rejected_before_broadcast() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
-async fn sol_charge_replay_rejected() {
+async fn sol_charge_identical_retry_is_idempotent() {
+    // PayKit Slice 1 changed this test's expectation. Ed25519 signing is
+    // deterministic, so replaying an already-signed pull-mode credential
+    // reproduces the exact same on-chain signature. Before Slice 1's
+    // challenge-scoped `ChargeReplayStore`, that meant an identical retry —
+    // e.g. because the client never saw the first HTTP response — hit
+    // `consume_signature`'s "already consumed" error instead of returning
+    // the receipt it already earned: replay-safe, but not
+    // response-loss-idempotent. Slice 1 makes the identical retry succeed
+    // and return the SAME signature.
     let recipient = Keypair::new();
     let Some(surfnet) = start_surfnet_or_skip().await else {
         return;
@@ -369,7 +378,6 @@ async fn sol_charge_replay_rejected() {
         .await
         .unwrap();
 
-    // First: success.
     let expected = expected_charge(
         "1000000",
         "SOL",
@@ -378,30 +386,29 @@ async fn sol_charge_replay_rejected() {
         9,
         None,
     );
-    let receipt = mpp
+
+    // First presentation: settles on-chain.
+    let first = mpp
         .verify_credential_with_expected(
             &solana_pay_kit::mpp::parse_authorization(&auth).unwrap(),
             &expected,
         )
         .await
         .unwrap();
-    assert_eq!(receipt.status.to_string(), "success");
+    assert_eq!(first.status.to_string(), "success");
 
-    // Replay: rejected — either by the replay store (signature-consumed)
-    // or by the network itself (duplicate transaction).
-    let err = mpp
+    // Identical retry — must return the SAME receipt instead of erroring.
+    let second = mpp
         .verify_credential_with_expected(
             &solana_pay_kit::mpp::parse_authorization(&auth).unwrap(),
             &expected,
         )
         .await
-        .unwrap_err();
-    assert!(
-        err.message.contains("consumed")
-            || err.message.contains("already been processed")
-            || err.code == Some("signature-consumed"),
-        "Expected replay rejection, got: {}",
-        err.message
+        .unwrap();
+    assert_eq!(second.status.to_string(), "success");
+    assert_eq!(
+        second.reference, first.reference,
+        "identical retry must return the same settlement signature"
     );
 }
 

--- a/rust/crates/kit/Cargo.toml
+++ b/rust/crates/kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-pay-kit"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Building blocks for Agentic payments (x402, MPP, AP2)"
 license = "MIT"

--- a/rust/crates/kit/src/core/mints.rs
+++ b/rust/crates/kit/src/core/mints.rs
@@ -8,6 +8,9 @@
 pub const USDC_MAINNET: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 pub const USDC_DEVNET: &str = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 pub const USDC_TESTNET: &str = USDC_DEVNET;
+/// Devnet-only Token-2022 test dollar used for payment-channel integration and
+/// load testing. There is intentionally no mainnet or localnet alias.
+pub const USDTEST_DEVNET: &str = "6MJyWHwFpPsaTEuYarEz49ngtsSKPYn6yHqtJUW2a9St";
 pub const USDT_MAINNET: &str = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
 pub const USDG_MAINNET: &str = "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH";
 pub const USDG_DEVNET: &str = "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7";

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -9,7 +9,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
-#[cfg(feature = "redis-store")]
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Default time to retain a finalized channel record for reconciliation,
@@ -133,6 +133,230 @@ impl Store for MemoryStore {
                 }
             }
         })
+    }
+}
+
+// ── Charge replay / idempotency store ──
+//
+// PayKit's original charge replay guard
+// (`solana-charge:consumed:<signature>`, see
+// `mpp::server::charge::Mpp::consume_signature`) is replay-safe — the same
+// final signature can never be reserved twice — but not
+// response-loss-idempotent: if a client's HTTP response is lost after a
+// successful settlement, retrying the identical credential recomputes the
+// same Ed25519 signature (signing is deterministic) and then fails at
+// `consume_signature` instead of returning the receipt it already earned.
+// `ChargeReplayStore` adds a second, challenge-scoped record that a retried
+// presentation of the SAME credential can look up and short-circuit on,
+// instead of erroring — see the PayKit Slice 1 plan's "pay-api safety and
+// idempotency" section.
+
+/// Default time a charge-settlement record is retained for idempotent
+/// replay once it reaches a terminal (`Confirmed`/`Failed`) state. Chosen to
+/// exceed Solana's transaction-history retention and typical client resume
+/// windows; a Redis-backed [`Store`] should set this as the key's TTL.
+pub const DEFAULT_CHARGE_RECORD_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// How long a charge record may sit in [`ChargeRecordState::Reserved`]
+/// before a fresh presentation of the same challenge id + digest is allowed
+/// to reclaim it.
+///
+/// Guards against a process that reserved a settlement and then crashed (or
+/// hung) before calling `mark_confirmed`/`mark_failed`: without this lease,
+/// that challenge id would be stuck returning `InProgress` forever.
+pub const CHARGE_RESERVATION_LEASE: Duration = Duration::from_secs(2 * 60);
+
+/// Settlement state of a [`ChargeRecord`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChargeRecordState {
+    /// A caller has claimed this challenge id and is (or was) attempting to
+    /// settle it. No final signature yet.
+    Reserved,
+    /// Settlement succeeded; `final_signature` is authoritative.
+    Confirmed,
+    /// Settlement failed terminally; `failure_reason` explains why.
+    Failed,
+}
+
+/// A durable record of one charge-settlement attempt, keyed by challenge id.
+///
+/// See the module-level "Charge replay / idempotency store" docs above.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ChargeRecord {
+    pub challenge_id: String,
+    /// Digest over everything that must match for a retry to be considered
+    /// "the same" settlement attempt (in `mpp::server::charge`, this is
+    /// computed over the challenge id, the expected request, and the
+    /// presented credential payload). This module treats it as an opaque
+    /// caller-supplied string.
+    pub normalized_request_digest: String,
+    pub final_signature: Option<String>,
+    pub failure_reason: Option<String>,
+    pub state: ChargeRecordState,
+    pub updated_at: i64,
+    pub expires_at: i64,
+}
+
+/// Outcome of [`ChargeReplayStore::reserve`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChargeReservation {
+    /// First presentation of this challenge id + digest (or a prior
+    /// reservation's lease expired). The caller now owns this record and
+    /// MUST eventually call `mark_confirmed` or `mark_failed` — no other
+    /// concurrent caller can also receive `Reserved` for the same key.
+    Reserved,
+    /// An earlier presentation with the same digest already confirmed.
+    /// Return `final_signature` to the caller instead of re-settling.
+    AlreadyConfirmed { final_signature: String },
+    /// An earlier presentation with the same digest already failed
+    /// terminally.
+    AlreadyFailed { reason: String },
+    /// An earlier presentation with the same digest is still being settled
+    /// (or its owner crashed before the lease expired). The caller must NOT
+    /// settle again; it should ask the client to retry shortly.
+    InProgress,
+    /// The same challenge id was presented with a DIFFERENT digest — a
+    /// different request or credential is trying to reuse this challenge.
+    Conflict,
+}
+
+fn charge_record_key(challenge_id: &str) -> String {
+    format!("solana-charge:record:{challenge_id}")
+}
+
+fn now_unix() -> i64 {
+    time::OffsetDateTime::now_utc().unix_timestamp()
+}
+
+/// Idempotent charge-settlement ledger built on top of a plain [`Store`].
+///
+/// Only the caller that receives [`ChargeReservation::Reserved`] from
+/// [`Self::reserve`] may call [`Self::mark_confirmed`] or
+/// [`Self::mark_failed`] for that challenge id — every other concurrent
+/// caller is turned away with `InProgress` or `Conflict` before doing any
+/// settlement work. That invariant is what lets `mark_confirmed`/
+/// `mark_failed` use a plain read-then-write instead of a compare-and-swap:
+/// there is never more than one writer per key between a `Reserved` outcome
+/// and its matching `mark_*` call.
+#[derive(Clone)]
+pub struct ChargeReplayStore {
+    store: Arc<dyn Store>,
+}
+
+impl ChargeReplayStore {
+    pub fn new(store: Arc<dyn Store>) -> Self {
+        Self { store }
+    }
+
+    /// Reserve `challenge_id` for settlement, or classify an existing
+    /// record. See [`ChargeReservation`] for the possible outcomes.
+    pub async fn reserve(
+        &self,
+        challenge_id: &str,
+        normalized_request_digest: &str,
+        lease: Duration,
+    ) -> Result<ChargeReservation, StoreError> {
+        let key = charge_record_key(challenge_id);
+        let now = now_unix();
+        let fresh = ChargeRecord {
+            challenge_id: challenge_id.to_string(),
+            normalized_request_digest: normalized_request_digest.to_string(),
+            final_signature: None,
+            failure_reason: None,
+            state: ChargeRecordState::Reserved,
+            updated_at: now,
+            expires_at: now + lease.as_secs() as i64,
+        };
+        let fresh_value =
+            serde_json::to_value(&fresh).map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        if self.store.put_if_absent(&key, fresh_value.clone()).await? {
+            return Ok(ChargeReservation::Reserved);
+        }
+
+        let existing = self.store.get(&key).await?.ok_or_else(|| {
+            StoreError::Internal("charge record vanished after put_if_absent conflict".into())
+        })?;
+        let existing: ChargeRecord = serde_json::from_value(existing)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        if existing.normalized_request_digest != normalized_request_digest {
+            return Ok(ChargeReservation::Conflict);
+        }
+
+        match existing.state {
+            ChargeRecordState::Confirmed => Ok(ChargeReservation::AlreadyConfirmed {
+                final_signature: existing.final_signature.unwrap_or_default(),
+            }),
+            ChargeRecordState::Failed => Ok(ChargeReservation::AlreadyFailed {
+                reason: existing.failure_reason.unwrap_or_default(),
+            }),
+            ChargeRecordState::Reserved if existing.expires_at <= now => {
+                // The prior reservation's lease expired — presumed abandoned
+                // (e.g. the process that reserved it crashed before
+                // confirming or failing). Reclaim it via `put` (not
+                // `put_if_absent`, which would fail since the key exists).
+                self.store.put(&key, fresh_value).await?;
+                Ok(ChargeReservation::Reserved)
+            }
+            ChargeRecordState::Reserved => Ok(ChargeReservation::InProgress),
+        }
+    }
+
+    /// Transition a reserved record to `Confirmed`. Only the caller that
+    /// received `Reserved` from `reserve` for this `challenge_id` may call
+    /// this — see struct docs.
+    pub async fn mark_confirmed(
+        &self,
+        challenge_id: &str,
+        final_signature: &str,
+    ) -> Result<(), StoreError> {
+        self.settle(
+            challenge_id,
+            ChargeRecordState::Confirmed,
+            Some(final_signature.to_string()),
+            None,
+        )
+        .await
+    }
+
+    /// Transition a reserved record to `Failed`. Only the caller that
+    /// received `Reserved` from `reserve` for this `challenge_id` may call
+    /// this — see struct docs.
+    pub async fn mark_failed(&self, challenge_id: &str, reason: &str) -> Result<(), StoreError> {
+        self.settle(
+            challenge_id,
+            ChargeRecordState::Failed,
+            None,
+            Some(reason.to_string()),
+        )
+        .await
+    }
+
+    async fn settle(
+        &self,
+        challenge_id: &str,
+        state: ChargeRecordState,
+        final_signature: Option<String>,
+        failure_reason: Option<String>,
+    ) -> Result<(), StoreError> {
+        let key = charge_record_key(challenge_id);
+        let existing = self.store.get(&key).await?.ok_or_else(|| {
+            StoreError::Internal(format!(
+                "cannot settle charge record `{challenge_id}`: no reservation found"
+            ))
+        })?;
+        let mut record: ChargeRecord = serde_json::from_value(existing)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+        record.state = state;
+        record.final_signature = final_signature;
+        record.failure_reason = failure_reason;
+        record.updated_at = now_unix();
+        record.expires_at = record.updated_at + DEFAULT_CHARGE_RECORD_RETENTION.as_secs() as i64;
+        let value =
+            serde_json::to_value(&record).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        self.store.put(&key, value).await
     }
 }
 
@@ -1160,6 +1384,178 @@ mod tests {
             .await
             .unwrap());
         assert_eq!(store.get("k").await.unwrap(), Some(v));
+    }
+
+    // ── ChargeReplayStore ──
+
+    fn replay_store() -> ChargeReplayStore {
+        ChargeReplayStore::new(Arc::new(MemoryStore::new()))
+    }
+
+    #[tokio::test]
+    async fn charge_replay_reserve_first_presentation_wins() {
+        let store = replay_store();
+        let outcome = store
+            .reserve("chal-1", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(outcome, ChargeReservation::Reserved);
+    }
+
+    #[tokio::test]
+    async fn charge_replay_reserve_identical_retry_while_in_progress_does_not_settle_again() {
+        let store = replay_store();
+        store
+            .reserve("chal-2", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+
+        // Still reserved (not yet confirmed/failed) — a second identical
+        // presentation must not be allowed to settle again.
+        let outcome = store
+            .reserve("chal-2", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(outcome, ChargeReservation::InProgress);
+    }
+
+    #[tokio::test]
+    async fn charge_replay_identical_retry_after_confirmation_returns_same_signature() {
+        let store = replay_store();
+        store
+            .reserve("chal-3", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        store.mark_confirmed("chal-3", "sig-abc").await.unwrap();
+
+        // Response-loss-idempotent: an identical retry after the first
+        // settled must return the SAME signature instead of erroring or
+        // re-settling.
+        let outcome = store
+            .reserve("chal-3", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            ChargeReservation::AlreadyConfirmed {
+                final_signature: "sig-abc".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn charge_replay_identical_retry_after_failure_returns_same_reason() {
+        let store = replay_store();
+        store
+            .reserve("chal-4", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        store
+            .mark_failed("chal-4", "simulation failed")
+            .await
+            .unwrap();
+
+        let outcome = store
+            .reserve("chal-4", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            ChargeReservation::AlreadyFailed {
+                reason: "simulation failed".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn charge_replay_conflicting_digest_under_same_challenge_id_errors() {
+        let store = replay_store();
+        store
+            .reserve("chal-5", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+
+        // A different request/credential trying to reuse the same
+        // challenge id must be rejected, whether the original is still
+        // in flight...
+        let outcome = store
+            .reserve("chal-5", "digest-b", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(outcome, ChargeReservation::Conflict);
+
+        // ...or already confirmed.
+        store.mark_confirmed("chal-5", "sig-abc").await.unwrap();
+        let outcome = store
+            .reserve("chal-5", "digest-b", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(outcome, ChargeReservation::Conflict);
+    }
+
+    #[tokio::test]
+    async fn charge_replay_expired_reservation_is_reclaimed() {
+        let store = replay_store();
+        // A lease of zero is immediately expired, simulating a process that
+        // reserved and then crashed before confirming or failing.
+        store
+            .reserve("chal-6", "digest-a", Duration::from_secs(0))
+            .await
+            .unwrap();
+
+        let outcome = store
+            .reserve("chal-6", "digest-a", CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        assert_eq!(outcome, ChargeReservation::Reserved);
+    }
+
+    #[tokio::test]
+    async fn charge_replay_mark_confirmed_without_reservation_errors() {
+        let store = replay_store();
+        let err = store
+            .mark_confirmed("never-reserved", "sig-abc")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::Internal(_)));
+    }
+
+    // Concurrency regression: race N tasks reserving the SAME challenge
+    // id + digest together. Exactly one may win `Reserved`; every other
+    // task must observe `InProgress` — never a second `Reserved`, which
+    // would mean two callers both think they own the settlement and could
+    // double-broadcast.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn charge_replay_concurrent_identical_reserve_wins_exactly_once() {
+        const TASKS: usize = 16;
+        let store = Arc::new(replay_store());
+        let barrier = Arc::new(tokio::sync::Barrier::new(TASKS));
+
+        let mut handles = Vec::with_capacity(TASKS);
+        for _ in 0..TASKS {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .reserve("chal-concurrent", "digest-a", CHARGE_RESERVATION_LEASE)
+                    .await
+                    .unwrap()
+            }));
+        }
+
+        let mut reserved = 0usize;
+        let mut in_progress = 0usize;
+        for handle in handles {
+            match handle.await.expect("task panicked") {
+                ChargeReservation::Reserved => reserved += 1,
+                ChargeReservation::InProgress => in_progress += 1,
+                other => panic!("unexpected outcome: {other:?}"),
+            }
+        }
+
+        assert_eq!(reserved, 1, "exactly one task may reserve the challenge");
+        assert_eq!(in_progress, TASKS - 1, "every other task must back off");
     }
 
     #[test]

--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -141,15 +141,14 @@ impl Store for MemoryStore {
 // PayKit's original charge replay guard
 // (`solana-charge:consumed:<signature>`, see
 // `mpp::server::charge::Mpp::consume_signature`) is replay-safe — the same
-// final signature can never be reserved twice — but not
-// response-loss-idempotent: if a client's HTTP response is lost after a
-// successful settlement, retrying the identical credential recomputes the
-// same Ed25519 signature (signing is deterministic) and then fails at
-// `consume_signature` instead of returning the receipt it already earned.
-// `ChargeReplayStore` adds a second, challenge-scoped record that a retried
-// presentation of the SAME credential can look up and short-circuit on,
-// instead of erroring — see the PayKit Slice 1 plan's "pay-api safety and
-// idempotency" section.
+// final signature can never be reserved twice — but produces the wrong
+// error for a retry: Ed25519 signing is deterministic, so replaying an
+// already-signed credential recomputes the same final signature and hits
+// `consume_signature`'s generic internal error instead of the canonical
+// `signature_consumed` reject every SDK is supposed to emit for a resettled
+// credential. `ChargeReplayStore` adds a second, challenge-scoped record
+// that a retried presentation of the SAME credential can look up and
+// reject against directly, without attempting to resettle.
 
 /// Default time a charge-settlement record is retained for idempotent
 /// replay once it reaches a terminal (`Confirmed`/`Failed`) state. Chosen to

--- a/rust/crates/kit/src/mpp/client/charge.rs
+++ b/rust/crates/kit/src/mpp/client/charge.rs
@@ -14,7 +14,8 @@ use crate::mpp::protocol::core::{
 };
 use crate::mpp::protocol::intents::ChargeRequest;
 use crate::mpp::protocol::solana::{
-    programs, CredentialPayload, MethodDetails, Split, MAX_MEMO_BYTES,
+    check_transaction_packet_size, programs, CredentialPayload, MethodDetails, Split,
+    MAX_CLIENT_COMPUTE_UNIT_PRICE_MICROLAMPORTS, MAX_MEMO_BYTES, SOLANA_MAX_COMPUTE_UNIT_LIMIT,
 };
 
 /// Build a charge transaction from challenge parameters.
@@ -68,6 +69,55 @@ pub struct BuildChargeTransactionOptions {
     /// auto-pay agent meant for one network from being lured into
     /// signing a transaction for another.
     pub expected_network: Option<String>,
+    /// PayKit Slice 1: bounded compute-unit price/limit for the prepared
+    /// transaction. Defaults match the historical hardcoded budget (1
+    /// micro-lamport, 200,000 CU) — existing callers see no behavior change
+    /// unless they opt into different values.
+    pub compute_budget: ComputeBudgetOptions,
+}
+
+/// Bounded compute-budget parameters for a prepared charge transaction.
+///
+/// Defaults match PayKit's historical hardcoded charge-transaction budget
+/// (1 micro-lamport price, 200,000 CU limit), so existing callers see no
+/// behavior change unless they opt into different values. See
+/// [`Self::validate`] for the bounds enforced on non-default values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComputeBudgetOptions {
+    /// `SetComputeUnitPrice`, in micro-lamports.
+    pub compute_unit_price_micro_lamports: u64,
+    /// `SetComputeUnitLimit`, in compute units.
+    pub compute_unit_limit: u32,
+}
+
+impl Default for ComputeBudgetOptions {
+    fn default() -> Self {
+        Self {
+            compute_unit_price_micro_lamports: 1,
+            compute_unit_limit: 200_000,
+        }
+    }
+}
+
+impl ComputeBudgetOptions {
+    /// Reject a compute-unit limit above Solana's real per-transaction
+    /// ceiling, and a compute-unit price above a generous client-side
+    /// sanity ceiling, before either is ever compiled into an instruction.
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.compute_unit_limit > SOLANA_MAX_COMPUTE_UNIT_LIMIT {
+            return Err(Error::Other(format!(
+                "compute_unit_limit {} exceeds Solana's per-transaction ceiling of {SOLANA_MAX_COMPUTE_UNIT_LIMIT}",
+                self.compute_unit_limit
+            )));
+        }
+        if self.compute_unit_price_micro_lamports > MAX_CLIENT_COMPUTE_UNIT_PRICE_MICROLAMPORTS {
+            return Err(Error::Other(format!(
+                "compute_unit_price_micro_lamports {} exceeds the client-side sanity ceiling of {MAX_CLIENT_COMPUTE_UNIT_PRICE_MICROLAMPORTS}",
+                self.compute_unit_price_micro_lamports
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Options for selecting one Solana charge challenge from a challenge set.
@@ -112,6 +162,218 @@ fn resolve_blockhash(rpc: &RpcClient, method_details: &MethodDetails) -> Result<
             .map(|(hash, _last_valid_block_height)| hash)
             .map_err(|e| Error::Rpc(e.to_string()))
     }
+}
+
+/// An unsigned, fully-compiled charge transaction plus the metadata a
+/// caller needs to size-check and eventually sign it.
+///
+/// Returned by [`build_prepared_charge`]. `build_charge_transaction_with_options`
+/// signs the transaction inside this struct rather than duplicating the
+/// signing logic — see its implementation. Deliberately decoupled from
+/// `PaymentChallenge`/`ChargeRequest` (it takes plain, already-decoded
+/// parameters): a future direct `pay push` CSV batch path can reuse the
+/// same underlying instruction-building primitives
+/// ([`build_spl_transfer_batch_instructions`]) without depending on this
+/// crate's challenge/credential wire types.
+#[derive(Debug, Clone)]
+pub struct PreparedCharge {
+    /// The compiled, unsigned transaction. Its `signatures` vec is already
+    /// sized to `num_required_signatures` (all-zero placeholders), so its
+    /// serialized length equals the length after signing — see
+    /// [`check_transaction_packet_size`](crate::mpp::protocol::solana::check_transaction_packet_size).
+    pub transaction: Transaction,
+    /// The fee payer compiled into `transaction` — the signer's own pubkey
+    /// unless the challenge specified a server-side fee payer.
+    pub fee_payer: Pubkey,
+    /// The blockhash compiled into `transaction`.
+    pub blockhash: Hash,
+}
+
+/// One entry in an ordered SPL-token transfer batch: who receives it, how
+/// much (base units), whether its associated token account must be created
+/// (idempotently) before the transfer, and an optional memo emitted right
+/// after this entry's transfer.
+#[derive(Debug, Clone)]
+pub struct TransferEntry {
+    pub recipient: Pubkey,
+    pub amount: u64,
+    pub ata_creation_required: bool,
+    pub memo: Option<String>,
+}
+
+/// Build the idempotent-ATA-create + `transfer_checked` instructions for an
+/// ordered batch of SPL-token transfers, all funded from one source ATA
+/// under one authority.
+///
+/// This is the single place that constructs SPL-transfer-batch
+/// instructions: the MPP charge builder (`build_spl_instructions`) adapts
+/// its primary-transfer-plus-splits shape onto this, and a future direct
+/// `pay push` CSV batch path can call it directly (subject to the same
+/// packet-size limit — see
+/// [`check_transaction_packet_size`](crate::mpp::protocol::solana::check_transaction_packet_size)).
+///
+/// Does NOT include compute-budget instructions — callers that want a
+/// compute-budget preamble (like [`build_prepared_charge`]) push it
+/// themselves, since that is a whole-transaction concern, not a
+/// per-transfer-batch one.
+pub fn build_spl_transfer_batch_instructions(
+    authority: &Pubkey,
+    mint: &Pubkey,
+    token_program: &Pubkey,
+    decimals: u8,
+    fee_payer: &Pubkey,
+    entries: &[TransferEntry],
+) -> Result<Vec<Instruction>, Error> {
+    let mut instructions = Vec::with_capacity(entries.len() * 3);
+    let source_ata = get_associated_token_address(authority, mint, token_program);
+
+    for entry in entries {
+        let dest_ata = get_associated_token_address(&entry.recipient, mint, token_program);
+
+        if entry.ata_creation_required {
+            instructions.push(create_associated_token_account_idempotent(
+                fee_payer,
+                &entry.recipient,
+                mint,
+                token_program,
+            ));
+        }
+
+        instructions.push(transfer_checked_ix(
+            token_program,
+            &source_ata,
+            mint,
+            &dest_ata,
+            authority,
+            entry.amount,
+            decimals,
+        ));
+
+        push_memo_instruction(&mut instructions, entry.memo.as_deref())?;
+    }
+
+    Ok(instructions)
+}
+
+/// Build the unsigned message for a non-confidential Solana charge: one
+/// primary transfer plus any validated splits, compiled against a resolved
+/// blockhash. This is the prepared-message half of
+/// `build_charge_transaction_with_options` — see [`PreparedCharge`].
+///
+/// Takes the signer's public key rather than a `SolanaSigner`: preparing
+/// and size-checking a charge message never needs to touch a wallet's
+/// secret key, only the eventual `sign_transaction` call does.
+///
+/// Confidential charges are NOT handled here — a confidential charge
+/// settles via a multi-transaction bundle, not a single prepared message.
+/// Callers must branch on `method_details.confidential` before calling this
+/// (see `build_charge_transaction_with_options` for the reference branch).
+pub async fn build_prepared_charge(
+    signer_pubkey: Pubkey,
+    rpc: &RpcClient,
+    total_amount: u64,
+    currency: &str,
+    recipient: &str,
+    method_details: &MethodDetails,
+    options: &BuildChargeTransactionOptions,
+) -> Result<PreparedCharge, Error> {
+    let splits = method_details.splits.as_deref().unwrap_or(&[]);
+    if splits.len() > crate::mpp::protocol::solana::MAX_SPLITS {
+        return Err(Error::TooManySplits);
+    }
+
+    let splits_total = crate::mpp::protocol::solana::checked_sum_split_amounts(splits)
+        .ok_or(Error::SplitsExceedAmount)?;
+    let primary_amount = total_amount
+        .checked_sub(splits_total)
+        .ok_or(Error::SplitsExceedAmount)?;
+    if primary_amount == 0 {
+        return Err(Error::SplitsExceedAmount);
+    }
+
+    let recipient_pubkey =
+        Pubkey::from_str(recipient).map_err(|e| Error::Other(format!("Invalid recipient: {e}")))?;
+
+    let use_fee_payer =
+        method_details.fee_payer.unwrap_or(false) && method_details.fee_payer_key.is_some();
+
+    let fee_payer_pubkey = if use_fee_payer {
+        let key = method_details.fee_payer_key.as_ref().unwrap();
+        Some(Pubkey::from_str(key).map_err(|e| Error::Other(format!("Invalid fee payer: {e}")))?)
+    } else {
+        None
+    };
+
+    // PayKit Slice 1: bounded compute-unit price/limit instead of the
+    // historical hardcoded 1 micro-lamport / 200,000 units.
+    options.compute_budget.validate()?;
+
+    let mut instructions = Vec::new();
+    instructions.push(compute_unit_price_ix(
+        options.compute_budget.compute_unit_price_micro_lamports,
+    ));
+    instructions.push(compute_unit_limit_ix(
+        options.compute_budget.compute_unit_limit,
+    ));
+
+    let mint = resolve_mint(currency, method_details.network.as_deref());
+    let has_ata_creation_splits = splits
+        .iter()
+        .any(|split| split.ata_creation_required == Some(true));
+
+    if has_ata_creation_splits {
+        let Some(mint_str) = mint else {
+            return Err(Error::Other(
+                "ataCreationRequired requires an SPL token charge".into(),
+            ));
+        };
+        if mint_str != currency {
+            return Err(Error::Other(
+                "ataCreationRequired requires currency to be an SPL token mint address".into(),
+            ));
+        }
+    }
+
+    if let Some(mint_str) = mint {
+        build_spl_instructions(
+            &mut instructions,
+            &signer_pubkey,
+            &recipient_pubkey,
+            rpc,
+            mint_str,
+            method_details,
+            primary_amount,
+            options.external_id.as_deref(),
+            splits,
+            fee_payer_pubkey.as_ref(),
+            options.allow_unknown_token_2022,
+        )?;
+    } else {
+        build_sol_instructions(
+            &mut instructions,
+            &signer_pubkey,
+            &recipient_pubkey,
+            primary_amount,
+            options.external_id.as_deref(),
+            splits,
+        )?;
+    }
+
+    let blockhash = resolve_blockhash(rpc, method_details)?;
+
+    let fee_payer = fee_payer_pubkey.unwrap_or(signer_pubkey);
+    let message = Message::new_with_blockhash(&instructions, Some(&fee_payer), &blockhash);
+    let transaction = Transaction::new_unsigned(message);
+
+    // PayKit Slice 1: reject an oversized unsigned transaction before it is
+    // ever handed to a signer.
+    check_transaction_packet_size(&transaction)?;
+
+    Ok(PreparedCharge {
+        transaction,
+        fee_payer,
+        blockhash,
+    })
 }
 
 pub async fn build_charge_transaction_with_options(
@@ -202,91 +464,22 @@ pub async fn build_charge_transaction_with_options(
         }
     }
 
-    let splits = method_details.splits.as_deref().unwrap_or(&[]);
-    if splits.len() > crate::mpp::protocol::solana::MAX_SPLITS {
-        return Err(Error::TooManySplits);
-    }
-
-    let splits_total = crate::mpp::protocol::solana::checked_sum_split_amounts(splits)
-        .ok_or(Error::SplitsExceedAmount)?;
-    let primary_amount = total_amount
-        .checked_sub(splits_total)
-        .ok_or(Error::SplitsExceedAmount)?;
-    if primary_amount == 0 {
-        return Err(Error::SplitsExceedAmount);
-    }
-
+    // PayKit Slice 1: build the unsigned prepared message, then sign it —
+    // this is the only place in the non-confidential path that calls
+    // `signer.sign_transaction`.
     let signer_pubkey = signer.pubkey();
+    let prepared = build_prepared_charge(
+        signer_pubkey,
+        rpc,
+        total_amount,
+        currency,
+        recipient,
+        method_details,
+        &options,
+    )
+    .await?;
 
-    let recipient_pubkey =
-        Pubkey::from_str(recipient).map_err(|e| Error::Other(format!("Invalid recipient: {e}")))?;
-
-    let use_fee_payer =
-        method_details.fee_payer.unwrap_or(false) && method_details.fee_payer_key.is_some();
-
-    let fee_payer_pubkey = if use_fee_payer {
-        let key = method_details.fee_payer_key.as_ref().unwrap();
-        Some(Pubkey::from_str(key).map_err(|e| Error::Other(format!("Invalid fee payer: {e}")))?)
-    } else {
-        None
-    };
-
-    let mut instructions = Vec::new();
-
-    // Compute budget.
-    instructions.push(compute_unit_price_ix(1));
-    instructions.push(compute_unit_limit_ix(200_000));
-
-    let mint = resolve_mint(currency, method_details.network.as_deref());
-    let has_ata_creation_splits = splits
-        .iter()
-        .any(|split| split.ata_creation_required == Some(true));
-
-    if has_ata_creation_splits {
-        let Some(mint_str) = mint else {
-            return Err(Error::Other(
-                "ataCreationRequired requires an SPL token charge".into(),
-            ));
-        };
-        if mint_str != currency {
-            return Err(Error::Other(
-                "ataCreationRequired requires currency to be an SPL token mint address".into(),
-            ));
-        }
-    }
-
-    if let Some(mint_str) = mint {
-        build_spl_instructions(
-            &mut instructions,
-            &signer_pubkey,
-            &recipient_pubkey,
-            rpc,
-            mint_str,
-            method_details,
-            primary_amount,
-            options.external_id.as_deref(),
-            splits,
-            fee_payer_pubkey.as_ref(),
-            options.allow_unknown_token_2022,
-        )?;
-    } else {
-        build_sol_instructions(
-            &mut instructions,
-            &signer_pubkey,
-            &recipient_pubkey,
-            primary_amount,
-            options.external_id.as_deref(),
-            splits,
-        )?;
-    }
-
-    // Build and sign.
-    let blockhash = resolve_blockhash(rpc, method_details)?;
-
-    let actual_fee_payer = fee_payer_pubkey.unwrap_or(signer_pubkey);
-    let message = Message::new_with_blockhash(&instructions, Some(&actual_fee_payer), &blockhash);
-    let mut tx = Transaction::new_unsigned(message);
-
+    let mut tx = prepared.transaction;
     signer
         .sign_transaction(&mut tx)
         .await
@@ -577,42 +770,26 @@ fn build_spl_instructions(
         Error::Other("methodDetails.decimals is required for SPL charges (spec §7.2)".into())
     })?;
 
-    let source_ata = get_associated_token_address(signer_pubkey, &mint, &token_program);
-
     let payer = fee_payer.copied().unwrap_or(*signer_pubkey);
 
-    let add_spl_transfer = |instructions: &mut Vec<Instruction>,
-                            dest_owner: &Pubkey,
-                            transfer_amount: u64,
-                            create_ata: bool|
-     -> Result<(), Error> {
-        let dest_ata = get_associated_token_address(dest_owner, &mint, &token_program);
-
-        if create_ata {
-            instructions.push(create_associated_token_account_idempotent(
-                &payer,
-                dest_owner,
-                &mint,
-                &token_program,
-            ));
-        }
-
-        instructions.push(transfer_checked_ix(
-            &token_program,
-            &source_ata,
-            &mint,
-            &dest_ata,
-            signer_pubkey,
-            transfer_amount,
-            decimals,
-        ));
-
-        Ok(())
-    };
-
-    add_spl_transfer(instructions, recipient, primary_amount, false)?;
-    push_memo_instruction(instructions, external_id)?;
-
+    // PayKit Slice 1: adapt the primary-transfer-plus-splits shape onto the
+    // generic batch builder instead of constructing instructions here
+    // directly, so both this (MPP charge) path and a future direct
+    // `pay push` path share one instruction-building implementation. The
+    // primary transfer is entry 0 and never auto-creates its own ATA (the
+    // charge builder has never created the primary recipient's ATA — see
+    // PayKit Slice 1 plan); each split becomes a subsequent entry carrying
+    // its own `ata_creation_required` flag and memo. This preserves the
+    // exact instruction order the pre-refactor implementation produced:
+    // primary transfer, then external_id memo, then per split [ATA-create
+    // if flagged, transfer, memo if present].
+    let mut entries = Vec::with_capacity(1 + splits.len());
+    entries.push(TransferEntry {
+        recipient: *recipient,
+        amount: primary_amount,
+        ata_creation_required: false,
+        memo: external_id.map(str::to_string),
+    });
     for split in splits {
         let split_recipient = Pubkey::from_str(&split.recipient)
             .map_err(|e| Error::Other(format!("Invalid split recipient: {e}")))?;
@@ -626,14 +803,23 @@ fn build_spl_instructions(
         // with N dust splits × ATA rent. Spec §7.2 says the client MUST
         // include the ATA-create ix when `ataCreationRequired` is true;
         // it does not authorize creation otherwise.
-        add_spl_transfer(
-            instructions,
-            &split_recipient,
-            split_amount,
-            split.ata_creation_required == Some(true),
-        )?;
-        push_memo_instruction(instructions, split.memo.as_deref())?;
+        entries.push(TransferEntry {
+            recipient: split_recipient,
+            amount: split_amount,
+            ata_creation_required: split.ata_creation_required == Some(true),
+            memo: split.memo.clone(),
+        });
     }
+
+    let batch = build_spl_transfer_batch_instructions(
+        signer_pubkey,
+        &mint,
+        &token_program,
+        decimals,
+        &payer,
+        &entries,
+    )?;
+    instructions.extend(batch);
 
     Ok(())
 }
@@ -1916,6 +2102,465 @@ mod tests {
         let err = resolve_token_program(&rpc, &mint, &md);
         assert!(err.is_err());
         assert!(format!("{}", err.unwrap_err()).contains("Unsupported token program"));
+    }
+
+    // ── ComputeBudgetOptions ──
+
+    #[test]
+    fn compute_budget_options_default_matches_historical_hardcoded_values() {
+        let opts = ComputeBudgetOptions::default();
+        assert_eq!(opts.compute_unit_price_micro_lamports, 1);
+        assert_eq!(opts.compute_unit_limit, 200_000);
+        opts.validate().expect("default must be within bounds");
+    }
+
+    #[test]
+    fn compute_budget_options_rejects_limit_above_solana_ceiling() {
+        let opts = ComputeBudgetOptions {
+            compute_unit_price_micro_lamports: 1,
+            compute_unit_limit: SOLANA_MAX_COMPUTE_UNIT_LIMIT + 1,
+        };
+        let err = opts.validate().unwrap_err();
+        assert!(format!("{err}").contains("exceeds Solana's per-transaction ceiling"));
+    }
+
+    #[test]
+    fn compute_budget_options_rejects_price_above_client_sanity_ceiling() {
+        let opts = ComputeBudgetOptions {
+            compute_unit_price_micro_lamports: MAX_CLIENT_COMPUTE_UNIT_PRICE_MICROLAMPORTS + 1,
+            compute_unit_limit: 200_000,
+        };
+        let err = opts.validate().unwrap_err();
+        assert!(format!("{err}").contains("exceeds the client-side sanity ceiling"));
+    }
+
+    #[test]
+    fn compute_budget_options_accepts_exact_ceilings() {
+        let opts = ComputeBudgetOptions {
+            compute_unit_price_micro_lamports: MAX_CLIENT_COMPUTE_UNIT_PRICE_MICROLAMPORTS,
+            compute_unit_limit: SOLANA_MAX_COMPUTE_UNIT_LIMIT,
+        };
+        opts.validate()
+            .expect("exact ceiling values must be accepted");
+    }
+
+    // ── build_spl_transfer_batch_instructions (generic SPL batch builder) ──
+
+    fn batch_test_fixture() -> (Pubkey, Pubkey, Pubkey, Pubkey) {
+        (
+            Pubkey::new_unique(),                               // authority
+            Pubkey::from_str(USDC_MINT).unwrap(),               // mint
+            Pubkey::from_str(programs::TOKEN_PROGRAM).unwrap(), // token_program
+            Pubkey::new_unique(),                               // fee_payer
+        )
+    }
+
+    #[test]
+    fn spl_transfer_batch_empty_entries_is_empty() {
+        let (authority, mint, token_program, fee_payer) = batch_test_fixture();
+        let ixs = build_spl_transfer_batch_instructions(
+            &authority,
+            &mint,
+            &token_program,
+            6,
+            &fee_payer,
+            &[],
+        )
+        .unwrap();
+        assert!(ixs.is_empty());
+    }
+
+    #[test]
+    fn spl_transfer_batch_orders_ata_create_before_its_own_transfer_only_when_flagged() {
+        let (authority, mint, token_program, fee_payer) = batch_test_fixture();
+        let entries = vec![
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 100,
+                ata_creation_required: false,
+                memo: None,
+            },
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 200,
+                ata_creation_required: true,
+                memo: None,
+            },
+        ];
+        let ixs = build_spl_transfer_batch_instructions(
+            &authority,
+            &mint,
+            &token_program,
+            6,
+            &fee_payer,
+            &entries,
+        )
+        .unwrap();
+
+        // entry 0 (unflagged): transfer only.
+        // entry 1 (flagged): ATA-create immediately before its own transfer.
+        assert_eq!(ixs.len(), 3);
+        let token_program_id = Pubkey::from_str(programs::TOKEN_PROGRAM).unwrap();
+        let ata_program = Pubkey::from_str(programs::ASSOCIATED_TOKEN_PROGRAM).unwrap();
+        assert_eq!(ixs[0].program_id, token_program_id, "entry 0 transfer");
+        assert_eq!(ixs[1].program_id, ata_program, "entry 1 ata-create");
+        assert_eq!(ixs[2].program_id, token_program_id, "entry 1 transfer");
+    }
+
+    #[test]
+    fn spl_transfer_batch_emits_transfer_checked_per_entry_with_correct_amounts_and_decimals() {
+        let (authority, mint, token_program, fee_payer) = batch_test_fixture();
+        let entries = vec![
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 111,
+                ata_creation_required: false,
+                memo: None,
+            },
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 222,
+                ata_creation_required: false,
+                memo: None,
+            },
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 333,
+                ata_creation_required: false,
+                memo: None,
+            },
+        ];
+        let ixs = build_spl_transfer_batch_instructions(
+            &authority,
+            &mint,
+            &token_program,
+            9,
+            &fee_payer,
+            &entries,
+        )
+        .unwrap();
+        assert_eq!(ixs.len(), 3);
+        for (ix, entry) in ixs.iter().zip(entries.iter()) {
+            assert_eq!(ix.data[0], 12u8, "TransferChecked discriminator");
+            let amount = u64::from_le_bytes(ix.data[1..9].try_into().unwrap());
+            assert_eq!(amount, entry.amount);
+            assert_eq!(ix.data[9], 9, "decimals");
+        }
+    }
+
+    #[test]
+    fn spl_transfer_batch_emits_memo_only_when_present() {
+        let (authority, mint, token_program, fee_payer) = batch_test_fixture();
+        let entries = vec![
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 1,
+                ata_creation_required: false,
+                memo: Some("hi".to_string()),
+            },
+            TransferEntry {
+                recipient: Pubkey::new_unique(),
+                amount: 2,
+                ata_creation_required: false,
+                memo: None,
+            },
+        ];
+        let ixs = build_spl_transfer_batch_instructions(
+            &authority,
+            &mint,
+            &token_program,
+            6,
+            &fee_payer,
+            &entries,
+        )
+        .unwrap();
+        // entry 0: transfer + memo. entry 1: transfer only.
+        assert_eq!(ixs.len(), 3);
+        assert_eq!(
+            ixs[1].program_id,
+            Pubkey::from_str(programs::MEMO_PROGRAM).unwrap()
+        );
+        assert_eq!(ixs[1].data, b"hi");
+    }
+
+    #[test]
+    fn spl_transfer_batch_ata_create_is_paid_by_fee_payer_and_targets_entry_owner() {
+        let (authority, mint, token_program, fee_payer) = batch_test_fixture();
+        let recipient = Pubkey::new_unique();
+        let entries = vec![TransferEntry {
+            recipient,
+            amount: 1,
+            ata_creation_required: true,
+            memo: None,
+        }];
+        let ixs = build_spl_transfer_batch_instructions(
+            &authority,
+            &mint,
+            &token_program,
+            6,
+            &fee_payer,
+            &entries,
+        )
+        .unwrap();
+        assert_eq!(ixs.len(), 2);
+        assert_eq!(ixs[0].accounts[0].pubkey, fee_payer);
+        assert_eq!(ixs[0].accounts[2].pubkey, recipient);
+    }
+
+    #[test]
+    fn spl_transfer_batch_rejects_oversized_memo() {
+        let (authority, mint, token_program, fee_payer) = batch_test_fixture();
+        let entries = vec![TransferEntry {
+            recipient: Pubkey::new_unique(),
+            amount: 1,
+            ata_creation_required: false,
+            memo: Some("x".repeat(567)),
+        }];
+        let err = build_spl_transfer_batch_instructions(
+            &authority,
+            &mint,
+            &token_program,
+            6,
+            &fee_payer,
+            &entries,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("memo cannot exceed 566 bytes"));
+    }
+
+    // ── build_prepared_charge (deliverable 1: prepared unsigned message) ──
+
+    #[tokio::test]
+    async fn build_prepared_charge_returns_unsigned_transaction() {
+        let signer_pk = Pubkey::new_unique();
+        let rpc = dummy_rpc();
+        let md = MethodDetails {
+            recent_blockhash: Some(ZERO_HASH.to_string()),
+            ..Default::default()
+        };
+        let prepared = build_prepared_charge(
+            signer_pk,
+            &rpc,
+            1_000_000,
+            "SOL",
+            RECIPIENT,
+            &md,
+            &BuildChargeTransactionOptions::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(prepared.fee_payer, signer_pk);
+        // Every signature slot is present but unsigned (all-zero).
+        assert!(prepared
+            .transaction
+            .signatures
+            .iter()
+            .all(|sig| *sig == solana_signature::Signature::default()));
+    }
+
+    #[tokio::test]
+    async fn build_charge_transaction_signs_the_prepared_message() {
+        // Deliverable 4: the credential builder must sign the SAME message
+        // `build_prepared_charge` produces, not a separately constructed one.
+        let signer = make_signer();
+        let rpc = dummy_rpc();
+        let md = MethodDetails {
+            recent_blockhash: Some(ZERO_HASH.to_string()),
+            ..Default::default()
+        };
+        let prepared = build_prepared_charge(
+            signer.pubkey(),
+            &rpc,
+            1_000_000,
+            "SOL",
+            RECIPIENT,
+            &md,
+            &BuildChargeTransactionOptions::default(),
+        )
+        .await
+        .unwrap();
+        let expected_message_bytes = prepared.transaction.message.serialize();
+
+        let payload =
+            build_charge_transaction(signer.as_ref(), &rpc, "1000000", "SOL", RECIPIENT, &md)
+                .await
+                .unwrap();
+        let CredentialPayload::Transaction { transaction } = payload else {
+            panic!("expected transaction payload");
+        };
+        let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, transaction)
+            .unwrap();
+        let signed_tx: Transaction = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(signed_tx.message.serialize(), expected_message_bytes);
+        assert_ne!(
+            signed_tx.signatures[0],
+            solana_signature::Signature::default(),
+            "the prepared message must actually get signed"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_prepared_charge_rejects_oversized_batch() {
+        // Deliverable 6 wired into deliverable 1: a batch large enough to
+        // exceed PACKET_DATA_SIZE must be rejected before signing.
+        let signer_pk = Pubkey::new_unique();
+        let rpc = dummy_rpc();
+        // MAX_SPLITS (8) splits, each with a near-max-length memo, comfortably
+        // exceeds the 1232-byte packet limit.
+        let splits: Vec<Split> = (0..8)
+            .map(|_| Split {
+                recipient: Pubkey::new_unique().to_string(),
+                amount: "1".to_string(),
+                ata_creation_required: Some(true),
+                label: None,
+                memo: Some("x".repeat(500)),
+            })
+            .collect();
+        let md = MethodDetails {
+            recent_blockhash: Some(ZERO_HASH.to_string()),
+            token_program: Some(programs::TOKEN_PROGRAM.to_string()),
+            decimals: Some(6),
+            splits: Some(splits),
+            ..Default::default()
+        };
+        let err = build_prepared_charge(
+            signer_pk,
+            &rpc,
+            1_000_000_000,
+            USDC_MINT,
+            RECIPIENT,
+            &md,
+            &BuildChargeTransactionOptions::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, crate::mpp::Error::TransactionTooLarge { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_prepared_charge_uses_configured_compute_budget() {
+        let signer_pk = Pubkey::new_unique();
+        let rpc = dummy_rpc();
+        let md = MethodDetails {
+            recent_blockhash: Some(ZERO_HASH.to_string()),
+            ..Default::default()
+        };
+        let options = BuildChargeTransactionOptions {
+            compute_budget: ComputeBudgetOptions {
+                compute_unit_price_micro_lamports: 12_345,
+                compute_unit_limit: 55_555,
+            },
+            ..Default::default()
+        };
+        let prepared =
+            build_prepared_charge(signer_pk, &rpc, 1_000_000, "SOL", RECIPIENT, &md, &options)
+                .await
+                .unwrap();
+
+        let price_ix = &prepared.transaction.message.instructions[0];
+        let limit_ix = &prepared.transaction.message.instructions[1];
+        let price = u64::from_le_bytes(price_ix.data[1..9].try_into().unwrap());
+        let limit = u32::from_le_bytes(limit_ix.data[1..5].try_into().unwrap());
+        assert_eq!(price, 12_345);
+        assert_eq!(limit, 55_555);
+    }
+
+    #[tokio::test]
+    async fn build_prepared_charge_rejects_out_of_bounds_compute_budget() {
+        let signer_pk = Pubkey::new_unique();
+        let rpc = dummy_rpc();
+        let md = MethodDetails {
+            recent_blockhash: Some(ZERO_HASH.to_string()),
+            ..Default::default()
+        };
+        let options = BuildChargeTransactionOptions {
+            compute_budget: ComputeBudgetOptions {
+                compute_unit_price_micro_lamports: 1,
+                compute_unit_limit: SOLANA_MAX_COMPUTE_UNIT_LIMIT + 1,
+            },
+            ..Default::default()
+        };
+        let err =
+            build_prepared_charge(signer_pk, &rpc, 1_000_000, "SOL", RECIPIENT, &md, &options)
+                .await
+                .unwrap_err();
+        assert!(format!("{err}").contains("exceeds Solana's per-transaction ceiling"));
+    }
+
+    // ── MPP charge builder shape regression (deliverable 3) ──
+    //
+    // Proves the charge builder produces the exact same instruction shape
+    // after being adapted onto `build_spl_transfer_batch_instructions` as it
+    // did before: compute budget, primary transfer (no ATA create), ATA
+    // create only for the flagged split, split transfer, split memo — in
+    // that order.
+
+    #[tokio::test]
+    async fn build_charge_spl_with_fee_payer_and_split_ata_creation_produces_expected_shape() {
+        let signer = make_signer();
+        let rpc = dummy_rpc();
+        let fee_payer = Pubkey::new_unique();
+        let split_recipient = Pubkey::new_unique();
+        let md = MethodDetails {
+            recent_blockhash: Some(ZERO_HASH.to_string()),
+            token_program: Some(programs::TOKEN_PROGRAM.to_string()),
+            decimals: Some(6),
+            fee_payer: Some(true),
+            fee_payer_key: Some(fee_payer.to_string()),
+            splits: Some(vec![Split {
+                recipient: split_recipient.to_string(),
+                amount: "50000".to_string(),
+                ata_creation_required: Some(true),
+                label: None,
+                memo: Some("tip".to_string()),
+            }]),
+            ..Default::default()
+        };
+        let payload = build_charge_transaction_with_options(
+            signer.as_ref(),
+            &rpc,
+            "1000000",
+            USDC_MINT,
+            RECIPIENT,
+            &md,
+            BuildChargeTransactionOptions::default(),
+        )
+        .await
+        .unwrap();
+        let CredentialPayload::Transaction { transaction } = payload else {
+            panic!("expected transaction payload");
+        };
+        let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, transaction)
+            .unwrap();
+        let tx: Transaction = bincode::deserialize(&bytes).unwrap();
+
+        let program_id_of = |idx: usize| -> Pubkey {
+            let compiled = &tx.message.instructions[idx];
+            tx.message.account_keys[compiled.program_id_index as usize]
+        };
+
+        let compute_budget_program =
+            Pubkey::from_str("ComputeBudget111111111111111111111111111111").unwrap();
+        let token_program_id = Pubkey::from_str(programs::TOKEN_PROGRAM).unwrap();
+        let ata_program = Pubkey::from_str(programs::ASSOCIATED_TOKEN_PROGRAM).unwrap();
+        let memo_program = Pubkey::from_str(programs::MEMO_PROGRAM).unwrap();
+
+        assert_eq!(
+            tx.message.instructions.len(),
+            6,
+            "unexpected instruction count"
+        );
+        assert_eq!(program_id_of(0), compute_budget_program, "cu price");
+        assert_eq!(program_id_of(1), compute_budget_program, "cu limit");
+        assert_eq!(program_id_of(2), token_program_id, "primary transfer");
+        assert_eq!(program_id_of(3), ata_program, "split ata create");
+        assert_eq!(program_id_of(4), token_program_id, "split transfer");
+        assert_eq!(program_id_of(5), memo_program, "split memo");
+        assert_eq!(tx.message.instructions[5].data, b"tip");
     }
 
     // ── build_spl_instructions ──

--- a/rust/crates/kit/src/mpp/client/charge.rs
+++ b/rust/crates/kit/src/mpp/client/charge.rs
@@ -316,7 +316,7 @@ pub async fn build_prepared_charge(
         options.compute_budget.compute_unit_limit,
     ));
 
-    let mint = resolve_mint(currency, method_details.network.as_deref());
+    let mint = try_resolve_mint(currency, method_details.network.as_deref())?;
     let has_ata_creation_splits = splits
         .iter()
         .any(|split| split.ata_creation_required == Some(true));
@@ -435,13 +435,14 @@ pub async fn build_charge_transaction_with_options(
             // this straight to Pubkey::from_str, so a bare symbol would fail.
             // SOL (resolve_mint -> None) is already rejected by
             // validate_confidential_charge above; guard defensively anyway.
-            let mint =
-                resolve_mint(currency, method_details.network.as_deref()).ok_or_else(|| {
+            let mint = try_resolve_mint(currency, method_details.network.as_deref())?.ok_or_else(
+                || {
                     Error::InvalidConfig(
                         "confidential transfers require an SPL Token-2022 mint, not native SOL"
                             .into(),
                     )
-                })?;
+                },
+            )?;
             let blockhash = resolve_blockhash(rpc, method_details)?;
             return super::confidential::confidential_charge_payload(
                 signer,
@@ -937,8 +938,16 @@ fn transfer_checked_ix(
 /// mint string we don't recognize. Callers handling arbitrary mints MUST
 /// validate parseability separately; audit #27 calls out the docstring
 /// drift from "Some(mint_address)" alone.
+#[cfg(test)]
 fn resolve_mint<'a>(currency: &'a str, network: Option<&str>) -> Option<&'a str> {
     crate::mpp::protocol::solana::resolve_stablecoin_mint(currency, network)
+}
+
+fn try_resolve_mint<'a>(
+    currency: &'a str,
+    network: Option<&str>,
+) -> Result<Option<&'a str>, Error> {
+    crate::mpp::protocol::solana::try_resolve_stablecoin_mint(currency, network)
 }
 
 fn is_solana_charge_challenge_name(challenge: &PaymentChallenge) -> bool {

--- a/rust/crates/kit/src/mpp/client/charge.rs
+++ b/rust/crates/kit/src/mpp/client/charge.rs
@@ -69,7 +69,7 @@ pub struct BuildChargeTransactionOptions {
     /// auto-pay agent meant for one network from being lured into
     /// signing a transaction for another.
     pub expected_network: Option<String>,
-    /// PayKit Slice 1: bounded compute-unit price/limit for the prepared
+    /// Bounded compute-unit price/limit for the prepared
     /// transaction. Defaults match the historical hardcoded budget (1
     /// micro-lamport, 200,000 CU) — existing callers see no behavior change
     /// unless they opt into different values.
@@ -304,7 +304,7 @@ pub async fn build_prepared_charge(
         None
     };
 
-    // PayKit Slice 1: bounded compute-unit price/limit instead of the
+    // Bounded compute-unit price/limit instead of the
     // historical hardcoded 1 micro-lamport / 200,000 units.
     options.compute_budget.validate()?;
 
@@ -365,7 +365,7 @@ pub async fn build_prepared_charge(
     let message = Message::new_with_blockhash(&instructions, Some(&fee_payer), &blockhash);
     let transaction = Transaction::new_unsigned(message);
 
-    // PayKit Slice 1: reject an oversized unsigned transaction before it is
+    // Reject an oversized unsigned transaction before it is
     // ever handed to a signer.
     check_transaction_packet_size(&transaction)?;
 
@@ -464,7 +464,7 @@ pub async fn build_charge_transaction_with_options(
         }
     }
 
-    // PayKit Slice 1: build the unsigned prepared message, then sign it —
+    // Build the unsigned prepared message, then sign it —
     // this is the only place in the non-confidential path that calls
     // `signer.sign_transaction`.
     let signer_pubkey = signer.pubkey();
@@ -772,13 +772,13 @@ fn build_spl_instructions(
 
     let payer = fee_payer.copied().unwrap_or(*signer_pubkey);
 
-    // PayKit Slice 1: adapt the primary-transfer-plus-splits shape onto the
+    // Adapt the primary-transfer-plus-splits shape onto the
     // generic batch builder instead of constructing instructions here
     // directly, so both this (MPP charge) path and a future direct
     // `pay push` path share one instruction-building implementation. The
     // primary transfer is entry 0 and never auto-creates its own ATA (the
-    // charge builder has never created the primary recipient's ATA — see
-    // PayKit Slice 1 plan); each split becomes a subsequent entry carrying
+    // charge builder has never created the primary recipient's ATA); each
+    // split becomes a subsequent entry carrying
     // its own `ata_creation_required` flag and memo. This preserves the
     // exact instruction order the pre-refactor implementation produced:
     // primary transfer, then external_id memo, then per split [ATA-create

--- a/rust/crates/kit/src/mpp/client/session.rs
+++ b/rust/crates/kit/src/mpp/client/session.rs
@@ -36,7 +36,7 @@ use crate::mpp::protocol::intents::session::{
     SessionVoucherSigner, SignedVoucher, TopUpPayload, VoucherData, VoucherPayload,
     VoucherSignatureType, DEFAULT_SESSION_EXPIRES_AT,
 };
-use crate::mpp::protocol::solana::{default_token_program_for_currency, resolve_stablecoin_mint};
+use crate::mpp::protocol::solana::default_token_program_for_currency;
 
 /// Default payment-channel close grace period (seconds). Re-exported from
 /// `solana-pay-core` to preserve this crate's public path.
@@ -363,7 +363,7 @@ pub fn derive_payment_channel_open(
     let details = &request.method_details;
     let network = Some(details.network.as_str());
     let mint = parse_pubkey(
-        resolve_stablecoin_mint(&request.currency, network)
+        crate::mpp::protocol::solana::try_resolve_stablecoin_mint(&request.currency, network)?
             .ok_or_else(|| Error::Other("session payment channels require an SPL token".into()))?,
         "mint",
     )?;

--- a/rust/crates/kit/src/mpp/error.rs
+++ b/rust/crates/kit/src/mpp/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
     #[error("Challenge ID mismatch — not issued by this server")]
     ChallengeMismatch,
 
-    /// PayKit Slice 1: a prepared unsigned transaction's serialized size
+    /// A prepared unsigned transaction's serialized size
     /// exceeds Solana's packet limit
     /// (`mpp::protocol::solana::PACKET_DATA_SIZE`). Raised by
     /// `mpp::protocol::solana::check_transaction_packet_size` so callers can

--- a/rust/crates/kit/src/mpp/error.rs
+++ b/rust/crates/kit/src/mpp/error.rs
@@ -58,6 +58,14 @@ pub enum Error {
     #[error("Challenge ID mismatch — not issued by this server")]
     ChallengeMismatch,
 
+    /// PayKit Slice 1: a prepared unsigned transaction's serialized size
+    /// exceeds Solana's packet limit
+    /// (`mpp::protocol::solana::PACKET_DATA_SIZE`). Raised by
+    /// `mpp::protocol::solana::check_transaction_packet_size` so callers can
+    /// reject an oversized transaction before ever signing it.
+    #[error("Prepared transaction is {size} bytes, exceeding Solana's {limit}-byte packet limit")]
+    TransactionTooLarge { size: usize, limit: usize },
+
     #[error("{0}")]
     Other(String),
 }

--- a/rust/crates/kit/src/mpp/mod.rs
+++ b/rust/crates/kit/src/mpp/mod.rs
@@ -92,6 +92,7 @@ pub use protocol::intents::{
 
 pub use protocol::solana::{
     default_token_program_for_currency, mints, programs, resolve_stablecoin_mint,
+    try_resolve_stablecoin_mint,
 };
 
 // Store types

--- a/rust/crates/kit/src/mpp/mod.rs
+++ b/rust/crates/kit/src/mpp/mod.rs
@@ -82,11 +82,11 @@ pub use protocol::intents::{
     AuthenticateMethodDetails, AuthenticatePayload, AuthenticateRequest, ChargeRequest,
     ClosePayload, CommitPayload, CommitReceipt, CommitStatus, MeteredEnvelope, MeteringDirective,
     MeteringUsage, OpenPayload, SessionAction, SessionAuthentication, SessionAuthenticationType,
-    SessionMethodDetails, SessionRequest, SessionSplit, SessionVoucherSigner, SignedVoucher,
-    SubscriptionAction, SubscriptionPeriodUnit, SubscriptionReceiptExtensions, SubscriptionRequest,
-    TopUpPayload, UsePayload, VoucherData, VoucherPayload, VoucherSignatureType,
-    DEFAULT_SESSION_EXPIRES_AT, MAX_IDLE_TIMEOUT_SECONDS, RESOURCE_SCHEME_HTTP,
-    RESOURCE_SCHEME_SOLANA_SESSION, RESOURCE_SCHEME_SOLANA_SUBSCRIPTION,
+    SessionMethodDetails, SessionReceiptExtensions, SessionReceiptIntent, SessionRequest,
+    SessionSplit, SessionVoucherSigner, SignedVoucher, SubscriptionAction, SubscriptionPeriodUnit,
+    SubscriptionReceiptExtensions, SubscriptionRequest, TopUpPayload, UsePayload, VoucherData,
+    VoucherPayload, VoucherSignatureType, DEFAULT_SESSION_EXPIRES_AT, MAX_IDLE_TIMEOUT_SECONDS,
+    RESOURCE_SCHEME_HTTP, RESOURCE_SCHEME_SOLANA_SESSION, RESOURCE_SCHEME_SOLANA_SUBSCRIPTION,
     SESSION_AUTHENTICATION_DOMAIN, SIGNATURE_SCHEME_SIWMPP, SIGNATURE_TYPE_ED25519, SIWMPP_VERSION,
 };
 

--- a/rust/crates/kit/src/mpp/mod.rs
+++ b/rust/crates/kit/src/mpp/mod.rs
@@ -96,8 +96,10 @@ pub use protocol::solana::{
 
 // Store types
 pub use store::{
-    ChannelState, ChannelStore, CommittedDelivery, MemoryChannelStore, MemoryStore,
-    PendingDelivery, Store, StoreError, CHANNEL_STATE_SCHEMA_VERSION,
+    ChannelState, ChannelStore, ChargeRecord, ChargeRecordState, ChargeReplayStore,
+    ChargeReservation, CommittedDelivery, MemoryChannelStore, MemoryStore, PendingDelivery, Store,
+    StoreError, CHANNEL_STATE_SCHEMA_VERSION, CHARGE_RESERVATION_LEASE,
+    DEFAULT_CHARGE_RECORD_RETENTION,
 };
 
 // Re-export crates callers need to use with the charge builder.

--- a/rust/crates/kit/src/mpp/protocol/core/challenge.rs
+++ b/rust/crates/kit/src/mpp/protocol/core/challenge.rs
@@ -360,14 +360,12 @@ impl Receipt {
 ///
 /// On the wire the variant is untagged — the JSON shape is the union of
 /// [`Receipt`]'s base fields plus any intent-specific extension fields.
-/// Deserialisation tries `Subscription` first (it carries the strict
-/// superset of fields) and falls back to `Charge` when extension fields
-/// are absent.
+/// Deserialisation tries the extension-bearing variants before falling back
+/// to `Charge` when intent-specific fields are absent.
 ///
-/// This enum is the breaking change from v0.6: every caller of
-/// [`super::parse_receipt`] / [`super::format_receipt`] now handles the
-/// variant explicitly.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Callers of [`super::parse_receipt`] / [`super::format_receipt`] handle the
+/// intent variant explicitly.
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum ReceiptKind {
     /// Subscription activation receipt — base receipt plus the
@@ -382,8 +380,75 @@ pub enum ReceiptKind {
         #[serde(flatten)]
         extensions: crate::mpp::protocol::intents::SubscriptionReceiptExtensions,
     },
+    /// Payment-channel session receipt — base receipt plus the fields required
+    /// by `draft-solana-session-00`.
+    Session {
+        #[serde(flatten)]
+        base: Receipt,
+        #[serde(flatten)]
+        extensions: crate::mpp::protocol::intents::SessionReceiptExtensions,
+    },
     /// One-shot charge receipt — the original `Receipt` shape.
     Charge(Receipt),
+}
+
+impl<'de> Deserialize<'de> for ReceiptKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct SessionReceiptWire {
+            #[serde(flatten)]
+            base: Receipt,
+            #[serde(flatten)]
+            extensions: crate::mpp::protocol::intents::SessionReceiptExtensions,
+        }
+
+        #[derive(Deserialize)]
+        struct SubscriptionReceiptWire {
+            #[serde(flatten)]
+            base: Receipt,
+            #[serde(flatten)]
+            extensions: crate::mpp::protocol::intents::SubscriptionReceiptExtensions,
+        }
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let is_session = value.get("intent").and_then(serde_json::Value::as_str) == Some("session")
+            || ["acceptedCumulative", "spent", "idleTimeoutSeconds"]
+                .iter()
+                .any(|field| value.get(field).is_some());
+        if is_session {
+            let wire: SessionReceiptWire =
+                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            return Ok(Self::Session {
+                base: wire.base,
+                extensions: wire.extensions,
+            });
+        }
+
+        let is_subscription = [
+            "subscriptionId",
+            "planId",
+            "periodIndex",
+            "periodStartTs",
+            "periodEndTs",
+        ]
+        .iter()
+        .any(|field| value.get(field).is_some());
+        if is_subscription {
+            let wire: SubscriptionReceiptWire =
+                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            return Ok(Self::Subscription {
+                base: wire.base,
+                extensions: wire.extensions,
+            });
+        }
+
+        serde_json::from_value(value)
+            .map(Self::Charge)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 impl ReceiptKind {
@@ -392,6 +457,7 @@ impl ReceiptKind {
         match self {
             ReceiptKind::Charge(r) => r,
             ReceiptKind::Subscription { base, .. } => base,
+            ReceiptKind::Session { base, .. } => base,
         }
     }
 
@@ -403,7 +469,17 @@ impl ReceiptKind {
     ) -> Option<&crate::mpp::protocol::intents::SubscriptionReceiptExtensions> {
         match self {
             ReceiptKind::Subscription { extensions, .. } => Some(extensions),
-            ReceiptKind::Charge(_) => None,
+            ReceiptKind::Charge(_) | ReceiptKind::Session { .. } => None,
+        }
+    }
+
+    /// Return the session extensions when this is a session receipt.
+    pub fn session_extensions(
+        &self,
+    ) -> Option<&crate::mpp::protocol::intents::SessionReceiptExtensions> {
+        match self {
+            ReceiptKind::Session { extensions, .. } => Some(extensions),
+            ReceiptKind::Charge(_) | ReceiptKind::Subscription { .. } => None,
         }
     }
 

--- a/rust/crates/kit/src/mpp/protocol/core/headers.rs
+++ b/rust/crates/kit/src/mpp/protocol/core/headers.rs
@@ -238,8 +238,8 @@ pub fn format_authorization(credential: &PaymentCredential) -> Result<String, Er
 /// Parse a Payment-Receipt header into a [`ReceiptKind`].
 ///
 /// The wire shape is base64url-encoded JSON. The untagged enum is parsed
-/// with the more-specific `Subscription` variant tried first; falls back
-/// to `Charge` for receipts without subscription extension fields.
+/// with extension-bearing variants tried first; falls back to `Charge` for
+/// receipts without intent-specific fields.
 pub fn parse_receipt(header: &str) -> Result<ReceiptKind, Error> {
     let token = header.trim();
     if token.len() > MAX_TOKEN_LEN {
@@ -270,8 +270,8 @@ pub fn parse_receipt(header: &str) -> Result<ReceiptKind, Error> {
 ///
 /// Uses JCS (RFC 8785) canonicalization before base64url encoding
 /// as required by the spec. Both variants serialise as a flat JSON
-/// object — subscription receipts carry the union of base + extension
-/// fields side-by-side.
+/// object — subscription and session receipts carry the union of base plus
+/// extension fields side-by-side.
 pub fn format_receipt(receipt: &ReceiptKind) -> Result<String, Error> {
     let json = serde_json_canonicalizer::to_string(receipt)
         .map_err(|e| Error::Other(format!("JCS serialization failed: {e}")))?;
@@ -439,7 +439,9 @@ mod tests {
         let parsed = parse_receipt(&header).unwrap();
         match parsed {
             ReceiptKind::Charge(r) => assert_eq!(r.reference, "5UfDuX..."),
-            ReceiptKind::Subscription { .. } => panic!("expected Charge variant"),
+            ReceiptKind::Subscription { .. } | ReceiptKind::Session { .. } => {
+                panic!("expected Charge variant")
+            }
         }
     }
 
@@ -483,10 +485,66 @@ mod tests {
                     Some("2026-07-14T12:00:00Z")
                 );
             }
-            ReceiptKind::Charge(_) => {
+            ReceiptKind::Charge(_) | ReceiptKind::Session { .. } => {
                 panic!("untagged enum must prefer Subscription when extension fields are present")
             }
         }
+    }
+
+    #[test]
+    fn receipt_roundtrip_session_carries_required_extensions() {
+        use crate::mpp::protocol::intents::{SessionReceiptExtensions, SessionReceiptIntent};
+
+        let base = Receipt {
+            status: ReceiptStatus::Success,
+            method: "solana".into(),
+            timestamp: "2026-08-11T14:00:00Z".to_string(),
+            reference: "7Y5session".to_string(),
+            challenge_id: "ch-session".to_string(),
+        };
+        let header = format_receipt(&ReceiptKind::Session {
+            base,
+            extensions: SessionReceiptExtensions {
+                intent: SessionReceiptIntent::Session,
+                accepted_cumulative: 125,
+                spent: 100,
+                idle_timeout_seconds: 300,
+                tx_hash: Some("5settlement".to_string()),
+                refunded: Some(25),
+            },
+        })
+        .unwrap();
+
+        match parse_receipt(&header).unwrap() {
+            ReceiptKind::Session { base, extensions } => {
+                assert_eq!(base.reference, "7Y5session");
+                assert_eq!(extensions.intent, SessionReceiptIntent::Session);
+                assert_eq!(extensions.accepted_cumulative, 125);
+                assert_eq!(extensions.spent, 100);
+                assert_eq!(extensions.idle_timeout_seconds, 300);
+                assert_eq!(extensions.tx_hash.as_deref(), Some("5settlement"));
+                assert_eq!(extensions.refunded, Some(25));
+            }
+            ReceiptKind::Charge(_) | ReceiptKind::Subscription { .. } => {
+                panic!("expected Session variant")
+            }
+        }
+    }
+
+    #[test]
+    fn receipt_parse_rejects_incomplete_session_extensions() {
+        let raw = r#"{
+            "status": "success",
+            "method": "solana",
+            "intent": "session",
+            "timestamp": "2026-08-11T14:00:00Z",
+            "reference": "7Y5session",
+            "acceptedCumulative": "125",
+            "spent": "100"
+        }"#;
+        use crate::mpp::protocol::core::base64url_encode;
+        let header = base64url_encode(raw.as_bytes());
+        assert!(parse_receipt(&header).is_err());
     }
 
     #[test]

--- a/rust/crates/kit/src/mpp/protocol/intents/mod.rs
+++ b/rust/crates/kit/src/mpp/protocol/intents/mod.rs
@@ -15,9 +15,10 @@ pub use session::{
     resolve_idle_timeout_seconds, validate_idle_timeout_options, ClosePayload, CommitPayload,
     CommitReceipt, CommitStatus, MeteredEnvelope, MeteringDirective, MeteringUsage, OpenPayload,
     SessionAction, SessionAuthentication, SessionAuthenticationType, SessionMethodDetails,
-    SessionRequest, SessionSplit, SessionVoucherSigner, SignedVoucher, TopUpPayload, UsePayload,
-    VoucherData, VoucherPayload, VoucherSignatureType, DEFAULT_SESSION_EXPIRES_AT,
-    MAX_IDLE_TIMEOUT_SECONDS, SESSION_AUTHENTICATION_DOMAIN,
+    SessionReceiptExtensions, SessionReceiptIntent, SessionRequest, SessionSplit,
+    SessionVoucherSigner, SignedVoucher, TopUpPayload, UsePayload, VoucherData, VoucherPayload,
+    VoucherSignatureType, DEFAULT_SESSION_EXPIRES_AT, MAX_IDLE_TIMEOUT_SECONDS,
+    SESSION_AUTHENTICATION_DOMAIN,
 };
 pub use subscription::{
     ActivatePayload, SubscriptionAction, SubscriptionMethodDetails, SubscriptionPeriodUnit,

--- a/rust/crates/kit/src/mpp/protocol/intents/session.rs
+++ b/rust/crates/kit/src/mpp/protocol/intents/session.rs
@@ -263,7 +263,7 @@ pub enum SessionAction {
 
 /// Exact payment-channel `open` credential payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OpenPayload {
     pub channel_id: String,
     pub payer: String,
@@ -293,6 +293,47 @@ pub struct OpenPayload {
     pub transaction: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<serde_json::Value>,
+}
+
+/// Literal intent discriminator required on Solana session receipts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionReceiptIntent {
+    /// The receipt records a payment-channel session action.
+    #[serde(rename = "session")]
+    Session,
+}
+
+/// Fields added to the standard receipt for every session action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionReceiptExtensions {
+    /// Intent discriminator; always serializes as `"session"`.
+    pub intent: SessionReceiptIntent,
+    /// Highest cumulative voucher accepted by the server, in base units.
+    #[serde(
+        deserialize_with = "deserialize_u64_from_string",
+        serialize_with = "serialize_u64_as_string"
+    )]
+    pub accepted_cumulative: u64,
+    /// Total value already consumed by delivered work, in base units.
+    #[serde(
+        deserialize_with = "deserialize_u64_from_string",
+        serialize_with = "serialize_u64_as_string"
+    )]
+    pub spent: u64,
+    /// Effective inactivity threshold negotiated for the channel.
+    pub idle_timeout_seconds: u32,
+    /// Settlement transaction signature returned by a close action, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_hash: Option<String>,
+    /// Amount returned to the payer after distribution, when known.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_u64_from_string",
+        serialize_with = "serialize_opt_u64_as_string"
+    )]
+    pub refunded: Option<u64>,
 }
 
 impl OpenPayload {
@@ -743,6 +784,29 @@ mod tests {
             let encoded = serde_json::to_string(&action).unwrap();
             let _: SessionAction = serde_json::from_str(&encoded).unwrap();
         }
+    }
+
+    #[test]
+    fn open_payload_rejects_wire_bump() {
+        let open = OpenPayload::payment_channel(
+            "channel".to_string(),
+            "100".to_string(),
+            "payer".to_string(),
+            "payee".to_string(),
+            "mint".to_string(),
+            7,
+            900,
+            42,
+            "signer".to_string(),
+            "transaction".to_string(),
+        );
+        let mut value = serde_json::to_value(open).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("bump".to_string(), serde_json::json!(255));
+        let error = serde_json::from_value::<OpenPayload>(value).unwrap_err();
+        assert!(error.to_string().contains("unknown field `bump`"));
     }
 
     #[test]

--- a/rust/crates/kit/src/mpp/protocol/solana.rs
+++ b/rust/crates/kit/src/mpp/protocol/solana.rs
@@ -144,7 +144,7 @@ pub fn default_token_program_for_currency(currency: &str, network: Option<&str>)
     }
 }
 
-// ── PayKit Slice 1: prepared-transaction bounds ──
+// ── Prepared-transaction bounds ──
 //
 // Shared numeric ceilings for the prepared charge/message builder in
 // `mpp::client::charge` (`ComputeBudgetOptions`, `check_transaction_packet_size`).

--- a/rust/crates/kit/src/mpp/protocol/solana.rs
+++ b/rust/crates/kit/src/mpp/protocol/solana.rs
@@ -144,6 +144,72 @@ pub fn default_token_program_for_currency(currency: &str, network: Option<&str>)
     }
 }
 
+// ── PayKit Slice 1: prepared-transaction bounds ──
+//
+// Shared numeric ceilings for the prepared charge/message builder in
+// `mpp::client::charge` (`ComputeBudgetOptions`, `check_transaction_packet_size`).
+// Kept here rather than in `mpp::client::charge` because a future direct
+// `pay push` batch path (outside this crate) is expected to enforce the same
+// bounds without depending on the charge/challenge builder module.
+
+/// Solana's hard per-transaction compute-unit ceiling (the runtime rejects
+/// any `SetComputeUnitLimit` above this).
+///
+/// Hardcoded rather than imported: `solana-compute-budget-interface` is
+/// resolved elsewhere in this workspace's `Cargo.lock` (pulled in by
+/// unrelated SVM-runtime crates) but is not a dependency of this crate, and
+/// taking it on would pull in the SVM runtime for one `u32` constant. This
+/// value is a stable Solana network protocol invariant, not implementation
+/// detail that could silently drift underneath us.
+pub const SOLANA_MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+/// A generous client-side sanity ceiling for `SetComputeUnitPrice`
+/// (micro-lamports), applied by
+/// `mpp::client::charge::ComputeBudgetOptions::validate`. Not a protocol
+/// limit — just a guard against a caller accidentally passing an absurd
+/// priority fee that would massively overpay. Matches the anti-abuse ceiling
+/// PayKit's server side already applies to client-paid charges
+/// (`mpp::server::charge::MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`).
+pub const MAX_CLIENT_COMPUTE_UNIT_PRICE_MICROLAMPORTS: u64 = 5_000_000;
+
+/// Maximum serialized byte size of a Solana transaction, i.e. the
+/// `solana-packet` crate's `PACKET_DATA_SIZE` (minimum IPv6 MTU of `1280`
+/// minus a `40`-byte IPv6 header minus an `8`-byte UDP header). Solana's
+/// networking stack rejects any transaction whose wire size exceeds this.
+///
+/// Duplicated here instead of depending on the `solana-packet` crate (also
+/// only reachable transitively elsewhere in this workspace's `Cargo.lock`,
+/// not a dependency of this crate) because the formula is a fixed IPv6/UDP
+/// protocol invariant, not implementation detail — value and derivation
+/// match `solana_packet::PACKET_DATA_SIZE` exactly (`1232`).
+pub const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
+
+/// Reject a transaction whose serialized size exceeds Solana's packet limit
+/// ([`PACKET_DATA_SIZE`]) before it is signed.
+///
+/// `bincode`-serializes `tx` exactly as it would be sent over the wire.
+/// Calling this on an *unsigned* transaction built with the correct number
+/// of (zeroed) signature slots — e.g. via `Transaction::new_unsigned` —
+/// gives the same length as after signing, since Ed25519 signatures are a
+/// fixed 64 bytes: callers can reject an oversized prepared message before
+/// ever touching a signer.
+pub fn check_transaction_packet_size(
+    tx: &solana_transaction::Transaction,
+) -> Result<usize, crate::mpp::error::Error> {
+    let size = bincode::serialize(tx)
+        .map_err(|e| {
+            crate::mpp::error::Error::Other(format!("Failed to measure transaction size: {e}"))
+        })?
+        .len();
+    if size > PACKET_DATA_SIZE {
+        return Err(crate::mpp::error::Error::TransactionTooLarge {
+            size,
+            limit: PACKET_DATA_SIZE,
+        });
+    }
+    Ok(size)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -743,6 +809,97 @@ mod tests {
             .err()
             .expect("splits rejected");
         assert!(format!("{err}").contains("splits"), "got: {err}");
+    }
+
+    // ── check_transaction_packet_size ──
+
+    fn instruction_with_data_len(len: usize) -> solana_instruction::Instruction {
+        solana_instruction::Instruction {
+            program_id: solana_pubkey::Pubkey::new_unique(),
+            accounts: vec![],
+            data: vec![0u8; len],
+        }
+    }
+
+    fn unsigned_tx_with_instruction(
+        ix: solana_instruction::Instruction,
+    ) -> solana_transaction::Transaction {
+        let payer = solana_pubkey::Pubkey::new_unique();
+        let message = solana_message::Message::new_with_blockhash(
+            &[ix],
+            Some(&payer),
+            &solana_hash::Hash::default(),
+        );
+        solana_transaction::Transaction::new_unsigned(message)
+    }
+
+    #[test]
+    fn check_transaction_packet_size_accepts_small_transaction() {
+        let tx = unsigned_tx_with_instruction(instruction_with_data_len(10));
+        let size = check_transaction_packet_size(&tx).expect("small tx must be accepted");
+        assert!(size < PACKET_DATA_SIZE);
+    }
+
+    #[test]
+    fn check_transaction_packet_size_rejects_oversized_transaction() {
+        let tx = unsigned_tx_with_instruction(instruction_with_data_len(PACKET_DATA_SIZE + 200));
+        let err = check_transaction_packet_size(&tx).expect_err("oversized tx must be rejected");
+        match err {
+            crate::mpp::error::Error::TransactionTooLarge { size, limit } => {
+                assert!(size > limit);
+                assert_eq!(limit, PACKET_DATA_SIZE);
+            }
+            other => panic!("expected TransactionTooLarge, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_transaction_packet_size_boundary_exact_limit_accepted_one_more_byte_rejected() {
+        // Find the exact instruction-data padding that lands the serialized
+        // transaction exactly on PACKET_DATA_SIZE by direct measurement,
+        // incrementing one byte at a time. bincode's length-prefix encoding
+        // is not a fixed width, so a padding length computed from a single
+        // "fixed overhead" measurement (assuming +1 byte of data == +1
+        // serialized byte) is not reliable near varint-width boundaries.
+        let mut pad = 0usize;
+        let mut size = bincode::serialize(&unsigned_tx_with_instruction(
+            instruction_with_data_len(pad),
+        ))
+        .unwrap()
+        .len();
+        assert!(
+            size < PACKET_DATA_SIZE,
+            "test assumption violated: base size {size} already >= limit"
+        );
+        while size < PACKET_DATA_SIZE {
+            pad += 1;
+            size = bincode::serialize(&unsigned_tx_with_instruction(instruction_with_data_len(
+                pad,
+            )))
+            .unwrap()
+            .len();
+        }
+        assert_eq!(
+            size, PACKET_DATA_SIZE,
+            "expected to land exactly on the limit"
+        );
+
+        let exact_tx = unsigned_tx_with_instruction(instruction_with_data_len(pad));
+        assert!(
+            check_transaction_packet_size(&exact_tx).is_ok(),
+            "exactly at the limit must be accepted"
+        );
+
+        let over_tx = unsigned_tx_with_instruction(instruction_with_data_len(pad + 1));
+        let over_size = bincode::serialize(&over_tx).unwrap().len();
+        assert!(
+            over_size > PACKET_DATA_SIZE,
+            "expected the next byte to push size strictly over the limit"
+        );
+        assert!(
+            check_transaction_packet_size(&over_tx).is_err(),
+            "one byte over the limit must be rejected"
+        );
     }
 }
 

--- a/rust/crates/kit/src/mpp/protocol/solana.rs
+++ b/rust/crates/kit/src/mpp/protocol/solana.rs
@@ -68,6 +68,9 @@ pub fn default_rpc_url(network: &str) -> &'static str {
 /// Resolve a stablecoin symbol to a mint address for a network.
 ///
 /// Returns `None` for native SOL and passes through unknown symbols/mints.
+/// Call [`try_resolve_stablecoin_mint`] when the currency may be `USDtest` so
+/// unsupported networks produce an actionable error rather than reaching a
+/// later pubkey parser as an unknown symbol.
 pub fn resolve_stablecoin_mint<'a>(currency: &'a str, network: Option<&str>) -> Option<&'a str> {
     match currency.to_uppercase().as_str() {
         "SOL" => None,
@@ -76,6 +79,7 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, network: Option<&str>) -> 
             Some("testnet") => mints::USDC_TESTNET,
             _ => mints::USDC_MAINNET,
         }),
+        "USDTEST" if network == Some(NETWORK_DEVNET) => Some(mints::USDTEST_DEVNET),
         "USDT" => Some(mints::USDT_MAINNET),
         "USDG" => Some(match network {
             Some("devnet") => mints::USDG_DEVNET,
@@ -93,16 +97,37 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, network: Option<&str>) -> 
     }
 }
 
+/// Resolve a stablecoin symbol while enforcing network-specific availability.
+///
+/// `USDtest` exists on devnet only. An omitted network defaults to mainnet per
+/// the MPP specification and is rejected just like an explicit mainnet or
+/// localnet selection.
+pub fn try_resolve_stablecoin_mint<'a>(
+    currency: &'a str,
+    network: Option<&str>,
+) -> Result<Option<&'a str>, crate::mpp::error::Error> {
+    let is_usdtest = currency.eq_ignore_ascii_case("USDtest") || currency == mints::USDTEST_DEVNET;
+    if is_usdtest && network != Some(NETWORK_DEVNET) {
+        let actual = network.unwrap_or(DEFAULT_NETWORK);
+        return Err(crate::mpp::error::Error::InvalidConfig(format!(
+            "USDtest is devnet-only; set network to `devnet` (got `{actual}`)"
+        )));
+    }
+    Ok(resolve_stablecoin_mint(currency, network))
+}
+
 fn stablecoin_uses_token_2022(mint: &str) -> bool {
-    matches!(
-        mint,
-        mints::PYUSD_MAINNET
-            | mints::PYUSD_DEVNET
-            | mints::USDG_MAINNET
-            | mints::USDG_DEVNET
-            | mints::CASH_MAINNET
-            | mints::USDPT_MAINNET
-    )
+    mint.eq_ignore_ascii_case("USDtest")
+        || matches!(
+            mint,
+            mints::USDTEST_DEVNET
+                | mints::PYUSD_MAINNET
+                | mints::PYUSD_DEVNET
+                | mints::USDG_MAINNET
+                | mints::USDG_DEVNET
+                | mints::CASH_MAINNET
+                | mints::USDPT_MAINNET
+        )
 }
 
 /// Whether `mint` is a well-known stablecoin whose Token-2022 mint enables the
@@ -122,6 +147,7 @@ pub fn is_known_stablecoin_mint(mint: &str) -> bool {
         mint,
         mints::USDC_MAINNET
             | mints::USDC_DEVNET
+            | mints::USDTEST_DEVNET
             | mints::USDT_MAINNET
             | mints::USDG_MAINNET
             | mints::USDG_DEVNET
@@ -282,6 +308,7 @@ mod tests {
 
         assert!(Pubkey::from_str(mints::USDC_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDC_DEVNET).is_ok());
+        assert!(Pubkey::from_str(mints::USDTEST_DEVNET).is_ok());
         assert!(Pubkey::from_str(mints::USDT_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_DEVNET).is_ok());
@@ -301,6 +328,16 @@ mod tests {
             resolve_stablecoin_mint("USDC", Some("devnet")),
             Some(mints::USDC_DEVNET)
         );
+        assert_eq!(
+            try_resolve_stablecoin_mint("USDtest", Some("devnet")).unwrap(),
+            Some(mints::USDTEST_DEVNET)
+        );
+        for network in [None, Some("mainnet"), Some("testnet"), Some("localnet")] {
+            let error = try_resolve_stablecoin_mint("usdtest", network).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+            let error = try_resolve_stablecoin_mint(mints::USDTEST_DEVNET, network).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+        }
         assert_eq!(
             resolve_stablecoin_mint("USDT", None),
             Some(mints::USDT_MAINNET)
@@ -326,6 +363,14 @@ mod tests {
 
     #[test]
     fn stablecoins_default_to_correct_token_program() {
+        assert_eq!(
+            default_token_program_for_currency("USDtest", Some("devnet")),
+            programs::TOKEN_2022_PROGRAM
+        );
+        assert_eq!(
+            default_token_program_for_currency(mints::USDTEST_DEVNET, Some("devnet")),
+            programs::TOKEN_2022_PROGRAM
+        );
         assert_eq!(
             default_token_program_for_currency("CASH", None),
             programs::TOKEN_2022_PROGRAM

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -2043,7 +2043,7 @@ pub(crate) fn decode_compute_budget_op(ix: &CompiledInstruction) -> Option<Compu
     }
 }
 
-fn validate_compute_budget_instruction(
+pub(crate) fn validate_compute_budget_instruction(
     ix: &CompiledInstruction,
     fee_sponsored: bool,
 ) -> Result<(), VerificationError> {

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -944,8 +944,15 @@ impl Mpp {
             .map_err(|e| VerificationError::new(format!("Store error: {e}")))?
         {
             ChargeReservation::AlreadyConfirmed { final_signature } => {
+                // "already consumed" is load-bearing: canonical-code
+                // classifiers (this harness's `classify_canonical_code` and
+                // its TS/Python/Ruby counterparts) pattern-match error text
+                // rather than reading `VerificationError::code` directly, so
+                // the wording has to agree with `consume_signature`'s
+                // "Transaction signature already consumed" message below.
                 return Err(VerificationError::signature_consumed(format!(
-                    "Challenge {challenge_id} was already settled (tx {final_signature})"
+                    "Transaction signature already consumed — challenge {challenge_id} was \
+                     already settled (tx {final_signature})"
                 )));
             }
             ChargeReservation::AlreadyFailed { reason } => {

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -920,19 +920,20 @@ impl Mpp {
             ));
         }
 
-        // ── Idempotent replay (response-loss-idempotent, not just replay-safe) ──
+        // ── Idempotent replay guard ──
         //
         // `consume_signature` (used inside `settle_payload` below) prevents
-        // the same on-chain signature from ever being reserved twice, but it
-        // is not response-loss-idempotent: Ed25519 signing is deterministic,
-        // so a client retry of an already-signed pull-mode credential
-        // reproduces the exact same final signature and would simply fail
-        // `consume_signature` instead of returning the receipt it already
-        // earned. Reserve on the challenge id BEFORE doing any settlement
-        // work so an identical retry — including one whose original HTTP
-        // response never reached the client — returns the same result
-        // instead of erroring. See the PayKit Slice 1 plan's "pay-api
-        // safety and idempotency" section.
+        // the same on-chain signature from ever being reserved twice, but on
+        // its own it produces the wrong outcome for a pull-mode retry:
+        // Ed25519 signing is deterministic, so replaying an already-signed
+        // credential reproduces the exact same final signature and used to
+        // fail `consume_signature`'s "already consumed" check with a bare
+        // internal error instead of the canonical reject every other SDK
+        // emits. Reserve on the challenge id BEFORE doing any settlement
+        // work so a credential that was already settled is recognized here
+        // and rejected with the same `signature_consumed` code TypeScript
+        // and Ruby use — resubmitting a completed charge is a reject, not a
+        // silent success, per the cross-SDK harness contract.
         let challenge_id = credential.challenge.id.clone();
         let digest = normalized_request_digest(&challenge_id, request, &payload)?;
         let charge_store = self.charge_replay_store();
@@ -942,11 +943,9 @@ impl Mpp {
             .map_err(|e| VerificationError::new(format!("Store error: {e}")))?
         {
             ChargeReservation::AlreadyConfirmed { final_signature } => {
-                return Ok(Receipt::success(
-                    METHOD_NAME,
-                    &final_signature,
-                    challenge_id,
-                ));
+                return Err(VerificationError::signature_consumed(format!(
+                    "Challenge {challenge_id} was already settled (tx {final_signature})"
+                )));
             }
             ChargeReservation::AlreadyFailed { reason } => {
                 return Err(VerificationError::new(reason));
@@ -1807,7 +1806,7 @@ fn expected_ata_creation_policy(
     })
 }
 
-/// PayKit Slice 1: compute a stable digest over everything that must match
+/// Compute a stable digest over everything that must match
 /// for a retried credential to be treated as "the same" settlement attempt —
 /// the challenge id (so an unrelated challenge with coincidentally matching
 /// request fields can't collide), the caller-supplied expected request, and
@@ -3286,7 +3285,7 @@ impl VerificationError {
         )
     }
 
-    /// PayKit Slice 1: a different request or credential tried to reuse a
+    /// A different request or credential tried to reuse a
     /// challenge id that already has an in-flight or settled record with a
     /// different [normalized digest](normalized_request_digest).
     pub fn challenge_conflict(msg: impl Into<String>) -> Self {
@@ -3298,7 +3297,7 @@ impl VerificationError {
         )
     }
 
-    /// PayKit Slice 1: an identical credential is already being settled by
+    /// An identical credential is already being settled by
     /// another in-flight request (or its owner crashed before its
     /// reservation lease expired). Retryable — the caller should back off
     /// and retry; a settled result will then be returned idempotently.
@@ -6715,7 +6714,7 @@ mod tests {
         assert_eq!(after.unwrap_err().code, Some("signature-consumed"));
     }
 
-    // ── PayKit Slice 1: idempotent replay wired into verify() ──
+    // ── Idempotent replay wired into verify() ──
     //
     // These pre-seed the challenge-scoped `ChargeReplayStore` directly
     // (rather than driving a real broadcast, which needs live RPC) to prove
@@ -6726,7 +6725,7 @@ mod tests {
     // distinguishable error, so the test is self-validating.
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn verify_identical_retry_after_confirmation_short_circuits_without_resettling() {
+    async fn verify_identical_retry_after_confirmation_rejects_without_resettling() {
         let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
         let mpp = Mpp::new(Config {
             recipient: TEST_RECIPIENT.to_string(),
@@ -6760,14 +6759,19 @@ mod tests {
             .await
             .unwrap();
 
-        // The retry must return the pre-confirmed signature without
-        // attempting real settlement.
-        let receipt = mpp
+        // The retry must reject with the canonical signature-consumed code,
+        // referencing the pre-confirmed signature, without attempting real
+        // settlement.
+        let err = mpp
             .verify_credential_with_expected(&cred, &expected)
             .await
-            .unwrap();
-        assert!(receipt.is_success());
-        assert_eq!(receipt.reference, "already-settled-signature");
+            .unwrap_err();
+        assert_eq!(err.code, Some("signature-consumed"));
+        assert!(
+            err.message.contains("already-settled-signature"),
+            "reject message should reference the already-settled signature, got: {}",
+            err.message
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -935,7 +935,8 @@ impl Mpp {
         // and Ruby use — resubmitting a completed charge is a reject, not a
         // silent success, per the cross-SDK harness contract.
         let challenge_id = credential.challenge.id.clone();
-        let digest = normalized_request_digest(&challenge_id, request, &payload)?;
+        let digest =
+            normalized_request_digest(&challenge_id, credential.challenge.request.raw(), &payload)?;
         let charge_store = self.charge_replay_store();
         match charge_store
             .reserve(&challenge_id, &digest, CHARGE_RESERVATION_LEASE)
@@ -1809,27 +1810,41 @@ fn expected_ata_creation_policy(
 /// Compute a stable digest over everything that must match
 /// for a retried credential to be treated as "the same" settlement attempt —
 /// the challenge id (so an unrelated challenge with coincidentally matching
-/// request fields can't collide), the caller-supplied expected request, and
+/// request fields can't collide), the credential's own encoded request, and
 /// the credential payload actually presented.
 ///
+/// Hashes `credential.challenge.request.raw()` — the encoded request the
+/// credential itself carries and that was HMAC-bound at challenge issuance —
+/// not the caller-supplied `expected` `ChargeRequest`. A route handler is
+/// free to reconstruct `expected` fresh on every call (e.g. re-deriving a
+/// challenge to read off its `ChargeRequest` shape), and that reconstruction
+/// can legitimately embed a volatile field never covered by
+/// `compare_expected_to_request`'s payment-constraining comparison — a
+/// pre-fetched blockhash is the concrete case (see `charge_with_options`).
+/// Hashing that value directly turns "the same credential resubmitted twice
+/// in quick succession" into two different digests purely because the
+/// caller's derived `expected` drifted between calls, which then falsely
+/// rejects the retry as a conflicting request rather than recognizing it as
+/// identical. The credential's own raw request never changes between
+/// resubmits of the same credential, so it is deterministic where the
+/// caller-supplied `expected` value cannot be.
+///
 /// `serde_json::to_vec`'s field order is fixed by each type's struct
-/// definition, so this is deterministic for equal inputs across processes —
-/// sufficient for an idempotency key. It is not used for any cryptographic
-/// purpose: the HMAC challenge id already authenticates the challenge
-/// itself; this digest only distinguishes "identical retry" from
-/// "different request/credential reusing the same challenge id".
+/// definition, so hashing `payload` is deterministic for equal inputs across
+/// processes — sufficient for an idempotency key. None of this is used for
+/// any cryptographic purpose: the HMAC challenge id already authenticates
+/// the challenge itself; this digest only distinguishes "identical retry"
+/// from "different request/credential reusing the same challenge id".
 fn normalized_request_digest(
     challenge_id: &str,
-    request: &ChargeRequest,
+    encoded_request: &str,
     payload: &CredentialPayload,
 ) -> Result<String, VerificationError> {
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
     hasher.update(challenge_id.as_bytes());
-    hasher.update(serde_json::to_vec(request).map_err(|e| {
-        VerificationError::new(format!("Failed to hash request for idempotency check: {e}"))
-    })?);
+    hasher.update(encoded_request.as_bytes());
     hasher.update(serde_json::to_vec(payload).map_err(|e| {
         VerificationError::new(format!(
             "Failed to hash credential payload for idempotency check: {e}"
@@ -6748,7 +6763,9 @@ mod tests {
         // response-loss scenario: the first HTTP response never reached the
         // client, but the settlement itself already happened.
         let payload: CredentialPayload = serde_json::from_value(cred.payload.clone()).unwrap();
-        let digest = normalized_request_digest(&cred.challenge.id, &expected, &payload).unwrap();
+        let digest =
+            normalized_request_digest(&cred.challenge.id, cred.challenge.request.raw(), &payload)
+                .unwrap();
         let replay_store = ChargeReplayStore::new(store.clone());
         replay_store
             .reserve(&cred.challenge.id, &digest, CHARGE_RESERVATION_LEASE)
@@ -6819,30 +6836,94 @@ mod tests {
 
     #[test]
     fn normalized_request_digest_is_deterministic_and_input_sensitive() {
-        let request = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "USDC".to_string(),
-            recipient: Some(TEST_RECIPIENT.to_string()),
-            ..Default::default()
-        };
+        let encoded_request = "encoded-request-a";
         let payload = CredentialPayload::Signature {
             signature: "sig-a".to_string(),
         };
 
-        let d1 = normalized_request_digest("chal-1", &request, &payload).unwrap();
-        let d2 = normalized_request_digest("chal-1", &request, &payload).unwrap();
+        let d1 = normalized_request_digest("chal-1", encoded_request, &payload).unwrap();
+        let d2 = normalized_request_digest("chal-1", encoded_request, &payload).unwrap();
         assert_eq!(d1, d2, "same inputs must hash identically");
 
-        let d3 = normalized_request_digest("chal-2", &request, &payload).unwrap();
+        let d3 = normalized_request_digest("chal-2", encoded_request, &payload).unwrap();
         assert_ne!(d1, d3, "a different challenge id must change the digest");
 
         let other_payload = CredentialPayload::Signature {
             signature: "sig-b".to_string(),
         };
-        let d4 = normalized_request_digest("chal-1", &request, &other_payload).unwrap();
+        let d4 = normalized_request_digest("chal-1", encoded_request, &other_payload).unwrap();
         assert_ne!(
             d1, d4,
             "a different credential payload must change the digest"
+        );
+
+        let d5 = normalized_request_digest("chal-1", "encoded-request-b", &payload).unwrap();
+        assert_ne!(d1, d5, "a different encoded request must change the digest");
+    }
+
+    // Regression test for the bug this fix closes: a route handler that
+    // reconstructs its `expected` `ChargeRequest` fresh on every call (e.g.
+    // `charge_with_options` embedding a freshly pre-fetched blockhash in
+    // `methodDetails`) must not make an identical credential resubmit hash
+    // to a different digest just because the caller-supplied `expected`
+    // drifted between the two calls.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_identical_retry_is_stable_even_when_callers_expected_request_drifts() {
+        let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+        let mpp = Mpp::new(Config {
+            recipient: TEST_RECIPIENT.to_string(),
+            challenge_binding_secret: Some(TEST_SECRET.to_string()),
+            store: Some(store.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let challenge = mpp.charge("0.10").unwrap();
+        let cred = PaymentCredential {
+            challenge: challenge.to_echo(),
+            source: None,
+            payload: serde_json::json!({"type": "signature", "signature": "not-a-real-signature"}),
+        };
+        let payload: CredentialPayload = serde_json::from_value(cred.payload.clone()).unwrap();
+        let digest =
+            normalized_request_digest(&cred.challenge.id, cred.challenge.request.raw(), &payload)
+                .unwrap();
+
+        // Pre-seed as if an earlier call already confirmed this credential
+        // on-chain.
+        let replay_store = ChargeReplayStore::new(store.clone());
+        replay_store
+            .reserve(&cred.challenge.id, &digest, CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        replay_store
+            .mark_confirmed(&cred.challenge.id, "already-settled-signature")
+            .await
+            .unwrap();
+
+        // A route handler that reconstructs `expected` fresh per call (e.g.
+        // re-deriving a challenge via `charge_with_options`, whose method
+        // details embed a freshly pre-fetched blockhash) can legitimately
+        // hand `verify_credential_with_expected` an `expected` that differs
+        // from the one used on the original call — `compare_expected_to_request`
+        // doesn't check `methodDetails.blockhash` for exactly this reason.
+        // The retry must still be recognized as the same settlement attempt.
+        let mut expected: ChargeRequest = challenge.request.decode().unwrap();
+        let mut details = expected
+            .method_details
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({}));
+        details["blockhash"] = serde_json::json!("a-different-blockhash-than-original-issuance");
+        expected.method_details = Some(details);
+
+        let err = mpp
+            .verify_credential_with_expected(&cred, &expected)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.code,
+            Some("signature-consumed"),
+            "a drifted `expected` must not turn an identical retry into a false conflict"
         );
     }
 

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -144,7 +144,9 @@ fn resolve_server_token_program(
         return Ok(None);
     }
 
-    if let Some(mint) = crate::mpp::protocol::solana::resolve_stablecoin_mint(currency, network) {
+    if let Some(mint) =
+        crate::mpp::protocol::solana::try_resolve_stablecoin_mint(currency, network)?
+    {
         if crate::mpp::protocol::solana::is_known_stablecoin_mint(mint) {
             return Ok(Some(
                 crate::mpp::protocol::solana::default_token_program_for_currency(currency, network),
@@ -608,10 +610,10 @@ impl Mpp {
                 "ataCreationRequired requires an SPL token currency".into(),
             ));
         }
-        if crate::mpp::protocol::solana::resolve_stablecoin_mint(
+        if crate::mpp::protocol::solana::try_resolve_stablecoin_mint(
             &self.currency,
             Some(&self.network),
-        ) != Some(self.currency.as_str())
+        )? != Some(self.currency.as_str())
         {
             return Err(Error::InvalidConfig(
                 "ataCreationRequired requires currency to be an SPL token mint address".into(),
@@ -3105,7 +3107,8 @@ pub(crate) fn resolve_expected_mint(
     currency: &str,
     network: Option<&str>,
 ) -> Result<Pubkey, VerificationError> {
-    let Some(mint) = crate::mpp::protocol::solana::resolve_stablecoin_mint(currency, network)
+    let Some(mint) = crate::mpp::protocol::solana::try_resolve_stablecoin_mint(currency, network)
+        .map_err(|error| VerificationError::invalid_payload(error.to_string()))?
     else {
         return Err(VerificationError::invalid_payload(
             "SOL does not use an SPL mint".to_string(),

--- a/rust/crates/kit/src/mpp/server/charge.rs
+++ b/rust/crates/kit/src/mpp/server/charge.rs
@@ -51,7 +51,9 @@ use crate::mpp::protocol::intents::ChargeRequest;
 use crate::mpp::protocol::solana::{
     default_rpc_url, programs, CredentialPayload, MethodDetails, Split, MAX_MEMO_BYTES,
 };
-use crate::mpp::store::{MemoryStore, Store};
+use crate::mpp::store::{
+    ChargeReplayStore, ChargeReservation, MemoryStore, Store, CHARGE_RESERVATION_LEASE,
+};
 
 const SECRET_KEY_ENV_VAR: &str = "MPP_SECRET_KEY";
 const METHOD_NAME: &str = "solana";
@@ -918,22 +920,108 @@ impl Mpp {
             ));
         }
 
+        // ── Idempotent replay (response-loss-idempotent, not just replay-safe) ──
+        //
+        // `consume_signature` (used inside `settle_payload` below) prevents
+        // the same on-chain signature from ever being reserved twice, but it
+        // is not response-loss-idempotent: Ed25519 signing is deterministic,
+        // so a client retry of an already-signed pull-mode credential
+        // reproduces the exact same final signature and would simply fail
+        // `consume_signature` instead of returning the receipt it already
+        // earned. Reserve on the challenge id BEFORE doing any settlement
+        // work so an identical retry — including one whose original HTTP
+        // response never reached the client — returns the same result
+        // instead of erroring. See the PayKit Slice 1 plan's "pay-api
+        // safety and idempotency" section.
+        let challenge_id = credential.challenge.id.clone();
+        let digest = normalized_request_digest(&challenge_id, request, &payload)?;
+        let charge_store = self.charge_replay_store();
+        match charge_store
+            .reserve(&challenge_id, &digest, CHARGE_RESERVATION_LEASE)
+            .await
+            .map_err(|e| VerificationError::new(format!("Store error: {e}")))?
+        {
+            ChargeReservation::AlreadyConfirmed { final_signature } => {
+                return Ok(Receipt::success(
+                    METHOD_NAME,
+                    &final_signature,
+                    challenge_id,
+                ));
+            }
+            ChargeReservation::AlreadyFailed { reason } => {
+                return Err(VerificationError::new(reason));
+            }
+            ChargeReservation::InProgress => {
+                return Err(VerificationError::settlement_in_progress(
+                    "This challenge is already being settled by another request; retry shortly",
+                ));
+            }
+            ChargeReservation::Conflict => {
+                return Err(VerificationError::challenge_conflict(
+                    "This challenge was already presented with a different request or credential",
+                ));
+            }
+            ChargeReservation::Reserved => {}
+        }
+
         // Settle, with the consume_signature reservation sitting between
         // broadcast and confirmation polling. If the server crashes or the
         // poll loop times out after the transaction has already landed,
         // the signature is still reserved so a retry of the same credential
         // cannot trigger a second broadcast. See PR #85 Greptile P1 and
         // audit gap G05.
-        let signature_str = match payload {
-            CredentialPayload::Transaction { ref transaction } => {
+        match self
+            .settle_payload(&payload, request, &method_details)
+            .await
+        {
+            Ok(signature_str) => {
+                if let Err(e) = charge_store
+                    .mark_confirmed(&challenge_id, &signature_str)
+                    .await
+                {
+                    tracing::warn!(
+                        error = %e,
+                        challenge_id = %challenge_id,
+                        "failed to persist confirmed charge record"
+                    );
+                }
+                Ok(Receipt::success(METHOD_NAME, &signature_str, challenge_id))
+            }
+            Err(err) => {
+                if let Err(e) = charge_store.mark_failed(&challenge_id, &err.message).await {
+                    tracing::warn!(
+                        error = %e,
+                        challenge_id = %challenge_id,
+                        "failed to persist failed charge record"
+                    );
+                }
+                Err(err)
+            }
+        }
+    }
+
+    /// Settle a decoded credential payload against `request`/`method_details`
+    /// and return the final on-chain signature.
+    ///
+    /// Extracted from `verify` so the idempotent-replay wrapper there can
+    /// catch a settlement error and persist it via
+    /// `ChargeReplayStore::mark_failed` before propagating it.
+    async fn settle_payload(
+        &self,
+        payload: &CredentialPayload,
+        request: &ChargeRequest,
+        method_details: &MethodDetails,
+    ) -> Result<String, VerificationError> {
+        match payload {
+            CredentialPayload::Transaction { transaction } => {
                 let signature = self
-                    .broadcast_pull(transaction, request, &method_details)
+                    .broadcast_pull(transaction, request, method_details)
                     .await?;
                 self.consume_signature(&signature).await?;
                 self.await_pull_confirmation(&signature)?;
-                signature
+                Ok(signature)
             }
-            CredentialPayload::Signature { ref signature } => {
+            CredentialPayload::Signature { signature } => {
                 // Audit #5: push-mode acceptance is opt-in. Spec §13.5 names
                 // "first accepted presentation wins" as the model — any
                 // matching-shape on-chain tx can claim any matching-shape
@@ -957,39 +1045,37 @@ impl Mpp {
                         "Push-mode credentials are not allowed when the route uses a server-side fee payer",
                     ));
                 }
-                let signature_str = self.verify_push(signature, request, &method_details)?;
+                let signature_str = self.verify_push(signature, request, method_details)?;
                 self.consume_signature(&signature_str).await?;
-                signature_str
+                Ok(signature_str)
             }
             #[cfg(feature = "confidential")]
-            CredentialPayload::Bundle { ref transactions } => {
-                let final_sig = self
-                    .settle_confidential_bundle(transactions, request, &method_details)
-                    .await?;
+            CredentialPayload::Bundle { transactions } => {
                 // The Receipt type has no pending/delivery field (its only
                 // ReceiptStatus is Success), so we emit success like the other
                 // arms once the confidential transfer has confirmed on-chain
                 // and the recipient-recovered amount matches the charge.
                 // TODO: pending-delivery semantics — a future Receipt revision
                 // could mark delivery as "pending" for asynchronous flows.
-                final_sig
+                self.settle_confidential_bundle(transactions, request, method_details)
+                    .await
             }
             #[cfg(not(feature = "confidential"))]
             CredentialPayload::Bundle { .. } => {
                 // Confidential-transfer bundle settlement requires the
                 // `confidential` feature (ZK proof + Token-2022 deps). Fail
                 // closed when it is not compiled in.
-                return Err(VerificationError::credential_mismatch(
+                Err(VerificationError::credential_mismatch(
                     "Confidential-transfer bundle credentials are not supported by this server (built without the `confidential` feature)",
-                ));
+                ))
             }
-        };
+        }
+    }
 
-        Ok(Receipt::success(
-            METHOD_NAME,
-            &signature_str,
-            credential.challenge.id.clone(),
-        ))
+    /// Construct the idempotent charge-settlement ledger over this `Mpp`'s
+    /// configured [`Store`]. Cheap: `ChargeReplayStore` only holds an `Arc`.
+    fn charge_replay_store(&self) -> ChargeReplayStore {
+        ChargeReplayStore::new(self.store.clone())
     }
 
     // ── Settlement ──
@@ -1719,6 +1805,39 @@ fn expected_ata_creation_policy(
         allowed_owners,
         required_owners,
     })
+}
+
+/// PayKit Slice 1: compute a stable digest over everything that must match
+/// for a retried credential to be treated as "the same" settlement attempt —
+/// the challenge id (so an unrelated challenge with coincidentally matching
+/// request fields can't collide), the caller-supplied expected request, and
+/// the credential payload actually presented.
+///
+/// `serde_json::to_vec`'s field order is fixed by each type's struct
+/// definition, so this is deterministic for equal inputs across processes —
+/// sufficient for an idempotency key. It is not used for any cryptographic
+/// purpose: the HMAC challenge id already authenticates the challenge
+/// itself; this digest only distinguishes "identical retry" from
+/// "different request/credential reusing the same challenge id".
+fn normalized_request_digest(
+    challenge_id: &str,
+    request: &ChargeRequest,
+    payload: &CredentialPayload,
+) -> Result<String, VerificationError> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(challenge_id.as_bytes());
+    hasher.update(serde_json::to_vec(request).map_err(|e| {
+        VerificationError::new(format!("Failed to hash request for idempotency check: {e}"))
+    })?);
+    hasher.update(serde_json::to_vec(payload).map_err(|e| {
+        VerificationError::new(format!(
+            "Failed to hash credential payload for idempotency check: {e}"
+        ))
+    })?);
+    let digest = hasher.finalize();
+    Ok(digest.iter().map(|b| format!("{b:02x}")).collect())
 }
 
 /// Audit #1: exhaustively compare the credential's decoded request against
@@ -3165,6 +3284,32 @@ impl VerificationError {
             "Too Many Splits",
             "tag:paymentauth.org,2024:verification-failed",
         )
+    }
+
+    /// PayKit Slice 1: a different request or credential tried to reuse a
+    /// challenge id that already has an in-flight or settled record with a
+    /// different [normalized digest](normalized_request_digest).
+    pub fn challenge_conflict(msg: impl Into<String>) -> Self {
+        Self::with_code(
+            msg,
+            "challenge-conflict",
+            "Challenge Already Presented With A Different Request",
+            "tag:paymentauth.org,2024:challenge-conflict",
+        )
+    }
+
+    /// PayKit Slice 1: an identical credential is already being settled by
+    /// another in-flight request (or its owner crashed before its
+    /// reservation lease expired). Retryable — the caller should back off
+    /// and retry; a settled result will then be returned idempotently.
+    pub fn settlement_in_progress(msg: impl Into<String>) -> Self {
+        Self::with_code(
+            msg,
+            "settlement-in-progress",
+            "Settlement Already In Progress",
+            "tag:paymentauth.org,2024:settlement-in-progress",
+        )
+        .retryable()
     }
 
     /// Return an RFC 9457 Problem Details JSON object.
@@ -6568,6 +6713,133 @@ mod tests {
         // The reservation is durable: a later attempt still loses.
         let after = mpp.consume_signature(signature).await;
         assert_eq!(after.unwrap_err().code, Some("signature-consumed"));
+    }
+
+    // ── PayKit Slice 1: idempotent replay wired into verify() ──
+    //
+    // These pre-seed the challenge-scoped `ChargeReplayStore` directly
+    // (rather than driving a real broadcast, which needs live RPC) to prove
+    // `verify` consults it BEFORE attempting settlement. Both tests use a
+    // deliberately unparseable push-mode signature ("not-a-real-signature");
+    // if the short-circuit did not fire, settlement would attempt
+    // `Signature::from_str` on it and fail with a *different*, clearly
+    // distinguishable error, so the test is self-validating.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_identical_retry_after_confirmation_short_circuits_without_resettling() {
+        let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+        let mpp = Mpp::new(Config {
+            recipient: TEST_RECIPIENT.to_string(),
+            challenge_binding_secret: Some(TEST_SECRET.to_string()),
+            store: Some(store.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let challenge = mpp.charge("0.10").unwrap();
+        let cred = PaymentCredential {
+            challenge: challenge.to_echo(),
+            source: None,
+            payload: serde_json::json!({"type": "signature", "signature": "not-a-real-signature"}),
+        };
+        let expected: ChargeRequest = challenge.request.decode().unwrap();
+
+        // Pre-seed the idempotency record as if an earlier presentation of
+        // this exact credential had already confirmed on-chain — the
+        // response-loss scenario: the first HTTP response never reached the
+        // client, but the settlement itself already happened.
+        let payload: CredentialPayload = serde_json::from_value(cred.payload.clone()).unwrap();
+        let digest = normalized_request_digest(&cred.challenge.id, &expected, &payload).unwrap();
+        let replay_store = ChargeReplayStore::new(store.clone());
+        replay_store
+            .reserve(&cred.challenge.id, &digest, CHARGE_RESERVATION_LEASE)
+            .await
+            .unwrap();
+        replay_store
+            .mark_confirmed(&cred.challenge.id, "already-settled-signature")
+            .await
+            .unwrap();
+
+        // The retry must return the pre-confirmed signature without
+        // attempting real settlement.
+        let receipt = mpp
+            .verify_credential_with_expected(&cred, &expected)
+            .await
+            .unwrap();
+        assert!(receipt.is_success());
+        assert_eq!(receipt.reference, "already-settled-signature");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_conflicting_retry_under_same_challenge_id_is_rejected() {
+        let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+        let mpp = Mpp::new(Config {
+            recipient: TEST_RECIPIENT.to_string(),
+            challenge_binding_secret: Some(TEST_SECRET.to_string()),
+            store: Some(store.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let challenge = mpp.charge("0.10").unwrap();
+        let cred = PaymentCredential {
+            challenge: challenge.to_echo(),
+            source: None,
+            payload: serde_json::json!({"type": "signature", "signature": "not-a-real-signature"}),
+        };
+        let expected: ChargeRequest = challenge.request.decode().unwrap();
+
+        // Pre-seed a CONFIRMED record for a DIFFERENT digest under the same
+        // challenge id — simulating an earlier, different credential having
+        // already settled this exact challenge.
+        let replay_store = ChargeReplayStore::new(store.clone());
+        replay_store
+            .reserve(
+                &cred.challenge.id,
+                "some-other-digest",
+                CHARGE_RESERVATION_LEASE,
+            )
+            .await
+            .unwrap();
+        replay_store
+            .mark_confirmed(&cred.challenge.id, "other-signature")
+            .await
+            .unwrap();
+
+        let err = mpp
+            .verify_credential_with_expected(&cred, &expected)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, Some("challenge-conflict"));
+    }
+
+    #[test]
+    fn normalized_request_digest_is_deterministic_and_input_sensitive() {
+        let request = ChargeRequest {
+            amount: "1000".to_string(),
+            currency: "USDC".to_string(),
+            recipient: Some(TEST_RECIPIENT.to_string()),
+            ..Default::default()
+        };
+        let payload = CredentialPayload::Signature {
+            signature: "sig-a".to_string(),
+        };
+
+        let d1 = normalized_request_digest("chal-1", &request, &payload).unwrap();
+        let d2 = normalized_request_digest("chal-1", &request, &payload).unwrap();
+        assert_eq!(d1, d2, "same inputs must hash identically");
+
+        let d3 = normalized_request_digest("chal-2", &request, &payload).unwrap();
+        assert_ne!(d1, d3, "a different challenge id must change the digest");
+
+        let other_payload = CredentialPayload::Signature {
+            signature: "sig-b".to_string(),
+        };
+        let d4 = normalized_request_digest("chal-1", &request, &other_payload).unwrap();
+        assert_ne!(
+            d1, d4,
+            "a different credential payload must change the digest"
+        );
     }
 
     // ── Receipt tests ──

--- a/rust/crates/kit/src/mpp/server/html.rs
+++ b/rust/crates/kit/src/mpp/server/html.rs
@@ -90,7 +90,9 @@ pub fn challenge_to_html(challenge: &PaymentChallenge, _rpc_url: &str, _network:
         format!("{:.2}", amount_f)
     };
     let amount_display = match currency {
-        "USDC" | "USDT" | "USDG" | "PYUSD" | "CASH" => format!("${display_amount}"),
+        "USDC" | "USDT" | "USDTEST" | "USDG" | "PYUSD" | "CASH" => {
+            format!("${display_amount}")
+        }
         mints::USDC_MAINNET
         | mints::USDC_DEVNET
         | mints::USDT_MAINNET
@@ -98,7 +100,8 @@ pub fn challenge_to_html(challenge: &PaymentChallenge, _rpc_url: &str, _network:
         | mints::USDG_DEVNET
         | mints::PYUSD_MAINNET
         | mints::PYUSD_DEVNET
-        | mints::CASH_MAINNET => format!("${display_amount}"),
+        | mints::CASH_MAINNET
+        | mints::USDTEST_DEVNET => format!("${display_amount}"),
         c if c.to_lowercase() == "sol" => format!("{display_amount} SOL"),
         _ => format!("{display_amount} {}", &currency[..6.min(currency.len())]),
     };

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -27,11 +27,12 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use crate::core::session::VoucherAcceptance;
 use crate::mpp::error::{Error, Result};
 use crate::mpp::program::payment_channels;
+use crate::mpp::protocol::core::{Receipt, ReceiptKind};
 use crate::mpp::protocol::intents::session::{
     resolve_idle_timeout_seconds, validate_idle_timeout_options, ClosePayload, CommitPayload,
     CommitReceipt, CommitStatus, MeteringDirective, OpenPayload, SessionMethodDetails,
-    SessionRequest, SessionSplit, SignedVoucher, TopUpPayload, UsePayload, VoucherData,
-    VoucherPayload, VoucherSignatureType,
+    SessionReceiptExtensions, SessionReceiptIntent, SessionRequest, SessionSplit, SignedVoucher,
+    TopUpPayload, UsePayload, VoucherData, VoucherPayload, VoucherSignatureType,
 };
 use crate::mpp::protocol::solana::{default_token_program_for_currency, resolve_stablecoin_mint};
 use crate::mpp::store::{
@@ -128,10 +129,11 @@ pub struct SessionConfig {
     /// Minimum accepted initial channel deposit.
     pub minimum_deposit: Option<u64>,
 
-    /// Currency identifier (e.g., "USDC", mint address).
+    /// Currency identifier accepted in configuration (e.g., "USDC" or a mint).
+    /// Challenges always normalize this to a concrete SPL mint address.
     pub currency: String,
 
-    /// Token decimals (default 6 for USDC).
+    /// Token decimals (0 through 9; default 6 for USDC).
     pub decimals: u8,
 
     /// Solana network: "mainnet", "devnet", "localnet".
@@ -354,6 +356,12 @@ impl<S: ChannelStore> SessionServer<S> {
     /// MUST use the challenged blockhash — so a silent omission would surface
     /// as a non-retryable payment failure at open time.
     pub fn build_challenge_request(&self) -> Result<SessionRequest> {
+        if self.config.decimals > 9 {
+            return Err(Error::InvalidConfig(
+                "session token decimals must be between 0 and 9".to_string(),
+            ));
+        }
+        let currency = expected_payment_channel_mint(&self.config)?.to_string();
         let hint = self.challenge_open_transaction_context()?;
         let channel_program = self
             .config
@@ -361,7 +369,7 @@ impl<S: ChannelStore> SessionServer<S> {
             .unwrap_or_else(payment_channels::default_program_id);
         Ok(SessionRequest {
             amount: self.config.amount.to_string(),
-            currency: self.config.currency.clone(),
+            currency,
             recipient: self.config.recipient.clone(),
             description: None,
             external_id: None,
@@ -447,6 +455,12 @@ impl<S: ChannelStore> SessionServer<S> {
         let payee = parse_pubkey_field(&payload.payee, "payee")?;
         let mint = parse_pubkey_field(&payload.mint, "mint")?;
         let authorized_signer = parse_pubkey_field(&payload.authorized_signer, "authorizedSigner")?;
+        if !authorized_signer.is_on_curve() {
+            return Err(Error::Other(
+                "payment-channel authorizedSigner must be an on-curve Ed25519 public key"
+                    .to_string(),
+            ));
+        }
         let salt = payload.salt;
         let grace_period = payload.grace_period_seconds;
         let open_slot = payload.open_slot;
@@ -678,11 +692,18 @@ impl<S: ChannelStore> SessionServer<S> {
             ));
         }
 
+        let fresh_open = self
+            .store
+            .get_channel(session_id)
+            .await
+            .map_err(store_err)?
+            .is_none();
         verify_submit_and_fetch_open(
             payload,
             &params,
             context.recent_blockhash,
             self.config.rpc_url.as_deref(),
+            fresh_open,
         )
         .await?;
 
@@ -784,6 +805,52 @@ impl<S: ChannelStore> SessionServer<S> {
 
         let replay = replay.load(std::sync::atomic::Ordering::Relaxed);
         Ok(OpenAcceptance { state, replay })
+    }
+
+    /// Build the required receipt for a successful session action.
+    pub fn receipt(
+        &self,
+        state: &ChannelState,
+        challenge_id: impl Into<String>,
+    ) -> Result<ReceiptKind> {
+        self.receipt_with_close_fields(state, challenge_id, None, None)
+    }
+
+    /// Build a successful close receipt with optional settlement details.
+    pub fn close_receipt(
+        &self,
+        state: &ChannelState,
+        challenge_id: impl Into<String>,
+        tx_hash: Option<String>,
+        refunded: Option<u64>,
+    ) -> Result<ReceiptKind> {
+        self.receipt_with_close_fields(state, challenge_id, tx_hash, refunded)
+    }
+
+    fn receipt_with_close_fields(
+        &self,
+        state: &ChannelState,
+        challenge_id: impl Into<String>,
+        tx_hash: Option<String>,
+        refunded: Option<u64>,
+    ) -> Result<ReceiptKind> {
+        let idle_timeout_seconds = state.idle_timeout_seconds.ok_or_else(|| {
+            Error::Other(format!(
+                "channel {} is missing its negotiated idle timeout",
+                state.channel_id
+            ))
+        })?;
+        Ok(ReceiptKind::Session {
+            base: Receipt::success("solana", state.channel_id.clone(), challenge_id),
+            extensions: SessionReceiptExtensions {
+                intent: SessionReceiptIntent::Session,
+                accepted_cumulative: state.cumulative,
+                spent: state.spent_amount,
+                idle_timeout_seconds,
+                tx_hash,
+                refunded,
+            },
+        })
     }
 
     /// Verify a voucher, advance the watermark, and return the acceptance
@@ -1663,6 +1730,7 @@ async fn verify_submit_and_fetch_open(
     params: &payment_channels::OpenChannelParams,
     challenged_blockhash: &str,
     rpc_url: Option<&str>,
+    validate_current_slot: bool,
 ) -> Result<()> {
     use solana_rpc_client::rpc_client::RpcClient;
 
@@ -1739,6 +1807,26 @@ async fn verify_submit_and_fetch_open(
     }
 
     let rpc = RpcClient::new(rpc_url.to_string());
+    if validate_current_slot {
+        let current_slot = rpc.get_slot().map_err(|error| {
+            Error::Rpc(format!(
+                "failed to fetch current cluster slot for session open: {error}"
+            ))
+        })?;
+        if params.open_slot > current_slot {
+            return Err(Error::Other(format!(
+                "open openSlot {} is ahead of the current cluster slot {current_slot}",
+                params.open_slot
+            )));
+        }
+        if current_slot - params.open_slot > payment_channels::OPEN_SLOT_WINDOW {
+            return Err(Error::Other(format!(
+                "open openSlot {} is outside the {}-slot freshness window of the current cluster slot {current_slot}",
+                params.open_slot,
+                payment_channels::OPEN_SLOT_WINDOW
+            )));
+        }
+    }
     // A broadcast rejection is not authoritative: a retry of an open whose
     // first submission landed (response lost, or the store write after it
     // failed) dies at preflight with "already processed". The confirmed
@@ -1933,6 +2021,7 @@ async fn verify_submit_and_fetch_open(
     _params: &payment_channels::OpenChannelParams,
     _challenged_blockhash: &str,
     _rpc_url: Option<&str>,
+    _validate_current_slot: bool,
 ) -> Result<()> {
     Err(Error::Other(
         "session open verification requires the `server` feature".to_string(),
@@ -2135,7 +2224,7 @@ mod tests {
         let payee = Pubkey::from_str(&server.config.recipient).unwrap();
         let mint = Pubkey::from_str(mints::USDC_MAINNET).unwrap();
         let authorized_signer = match server.config.voucher_signer {
-            VoucherSigner::Client => Pubkey::new_unique(),
+            VoucherSigner::Client => signer_address(1).parse().unwrap(),
             VoucherSigner::Operator => Pubkey::from_str(&server.config.operator).unwrap(),
         };
         let params = payment_channels::OpenChannelParams {
@@ -2171,6 +2260,7 @@ mod tests {
     #[cfg(feature = "server")]
     async fn rpc_for_channel(
         channel: payment_channels::generated::generated::accounts::Channel,
+        current_slot: u64,
     ) -> (String, tokio::task::JoinHandle<()>) {
         use base64::Engine;
         use serde_json::{json, Value};
@@ -2227,6 +2317,7 @@ mod tests {
                         serde_json::from_slice(&bytes[body_start..body_start + content_length])
                             .unwrap();
                     let result = match request["method"].as_str().unwrap_or_default() {
+                        "getSlot" => Ok(json!(current_slot)),
                         "sendTransaction" => {
                             let signature = payment_channels::decode_transaction(
                                 request["params"][0].as_str().unwrap(),
@@ -2391,6 +2482,8 @@ mod tests {
         let server = SessionServer::new(cfg, MemoryChannelStore::new()).with_blockhash_cache(cache);
         let request = server.build_challenge_request().unwrap();
         assert_eq!(request.amount, "25");
+        assert_eq!(request.currency, mints::USDC_MAINNET);
+        assert_eq!(request.method_details.decimals, Some(6));
         assert_eq!(request.minimum_deposit.as_deref(), Some("100"));
         assert_eq!(request.method_details.channel_id, None);
         // Both open-transaction context fields come from the one cached
@@ -2438,6 +2531,10 @@ mod tests {
         invalid = open.clone();
         invalid.channel_id = Pubkey::new_unique().to_string();
         assert!(server.payment_channel_open_params(&invalid).is_err());
+        invalid = open.clone();
+        invalid.authorized_signer = open.channel_id.clone();
+        let err = server.payment_channel_open_params(&invalid).unwrap_err();
+        assert!(err.to_string().contains("on-curve"));
         invalid = open;
         invalid.distribution_splits.clear();
         assert!(server.payment_channel_open_params(&invalid).is_err());
@@ -2452,6 +2549,58 @@ mod tests {
         let server = SessionServer::new(config(VoucherSigner::Client), MemoryChannelStore::new());
         let err = server.build_challenge_request().unwrap_err();
         assert!(err.to_string().contains("recentBlockhash"));
+    }
+
+    #[test]
+    fn challenge_rejects_native_sol_and_out_of_range_decimals() {
+        let cache = crate::core::blockhash::BlockhashCache::new();
+        cache.set(test_blockhash().to_string(), 314, CHALLENGED_SLOT);
+
+        let mut native = config(VoucherSigner::Client);
+        native.currency = "SOL".to_string();
+        let server = SessionServer::new(native, MemoryChannelStore::new())
+            .with_blockhash_cache(cache.clone());
+        assert!(server
+            .build_challenge_request()
+            .unwrap_err()
+            .to_string()
+            .contains("SPL token"));
+
+        let mut invalid_decimals = config(VoucherSigner::Client);
+        invalid_decimals.decimals = 10;
+        let server = SessionServer::new(invalid_decimals, MemoryChannelStore::new())
+            .with_blockhash_cache(cache);
+        assert!(server
+            .build_challenge_request()
+            .unwrap_err()
+            .to_string()
+            .contains("between 0 and 9"));
+    }
+
+    #[test]
+    fn session_receipt_uses_channel_accounting_and_idle_timeout() {
+        let server = SessionServer::new(config(VoucherSigner::Client), MemoryChannelStore::new());
+        let mut channel = state("channel-1".to_string(), signer_address(1));
+        channel.cumulative = 125;
+        channel.spent_amount = 100;
+        channel.idle_timeout_seconds = Some(300);
+
+        let receipt = server
+            .close_receipt(
+                &channel,
+                "challenge-1",
+                Some("settlement-signature".to_string()),
+                Some(25),
+            )
+            .unwrap();
+        assert_eq!(receipt.base().reference, "channel-1");
+        let extensions = receipt.session_extensions().unwrap();
+        assert_eq!(extensions.intent, SessionReceiptIntent::Session);
+        assert_eq!(extensions.accepted_cumulative, 125);
+        assert_eq!(extensions.spent, 100);
+        assert_eq!(extensions.idle_timeout_seconds, 300);
+        assert_eq!(extensions.tx_hash.as_deref(), Some("settlement-signature"));
+        assert_eq!(extensions.refunded, Some(25));
     }
 
     #[tokio::test]
@@ -2570,9 +2719,49 @@ mod tests {
             rent_payer: payment_channels::to_address(&params.rent_payer),
             open_slot: params.open_slot,
         };
-        let (url, rpc) = rpc_for_channel(channel).await;
-        server.config.rpc_url = Some(url);
+        let (future_url, future_rpc) = rpc_for_channel(channel.clone(), params.open_slot - 1).await;
+        let mut future_server =
+            SessionServer::new(server.config.clone(), MemoryChannelStore::new());
+        future_server.config.rpc_url = Some(future_url);
         let challenged_blockhash = test_blockhash().to_string();
+        let future = future_server
+            .process_open(
+                &open,
+                SessionOpenContext {
+                    challenge_id: "opening",
+                    expires: None,
+                    recent_blockhash: &challenged_blockhash,
+                    recent_slot: CHALLENGED_SLOT,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(future
+            .to_string()
+            .contains("ahead of the current cluster slot"));
+        future_rpc.abort();
+
+        let stale_slot = params.open_slot + payment_channels::OPEN_SLOT_WINDOW + 1;
+        let (stale_url, stale_rpc) = rpc_for_channel(channel.clone(), stale_slot).await;
+        let mut stale_server = SessionServer::new(server.config.clone(), MemoryChannelStore::new());
+        stale_server.config.rpc_url = Some(stale_url);
+        let stale = stale_server
+            .process_open(
+                &open,
+                SessionOpenContext {
+                    challenge_id: "opening",
+                    expires: None,
+                    recent_blockhash: &challenged_blockhash,
+                    recent_slot: CHALLENGED_SLOT,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(stale.to_string().contains("current cluster slot"));
+        stale_rpc.abort();
+
+        let (url, rpc) = rpc_for_channel(channel, 43).await;
+        server.config.rpc_url = Some(url);
         // A transaction built against some other blockhash was not built for
         // this challenge — rejected before broadcast.
         let wrong_blockhash = solana_hash::Hash::new_unique().to_string();
@@ -2650,7 +2839,7 @@ mod tests {
             rent_payer: payment_channels::to_address(&params.rent_payer),
             open_slot: params.open_slot,
         };
-        let (url, rpc) = rpc_for_channel(channel).await;
+        let (url, rpc) = rpc_for_channel(channel, 43).await;
         server.config.rpc_url = Some(url);
         let challenged_blockhash = test_blockhash().to_string();
         let context = SessionOpenContext {
@@ -2749,7 +2938,7 @@ mod tests {
             rent_payer: payment_channels::to_address(&payer.pubkey()),
             open_slot: 42,
         };
-        let (url, rpc) = rpc_for_channel(account).await;
+        let (url, rpc) = rpc_for_channel(account, 43).await;
         server.config.rpc_url = Some(url);
         let payload = TopUpPayload {
             channel_id: channel_id.clone(),

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -485,8 +485,7 @@ impl<S: ChannelStore> SessionServer<S> {
         }
         #[cfg(feature = "server")]
         if let Some(ref rpc_url) = self.config.rpc_url {
-            use solana_rpc_client::rpc_client::RpcClient;
-            let rpc = RpcClient::new(rpc_url.clone());
+            let rpc = confirmed_rpc_client(rpc_url);
             return crate::core::blockhash::fetch_blockhash_with_slot(&rpc, rpc.commitment())
                 .map_err(|e| {
                     Error::Rpc(format!(
@@ -648,9 +647,9 @@ impl<S: ChannelStore> SessionServer<S> {
     /// Accepts payment-channel opens and operated-voucher delegated-token opens.
     /// Returns the stored `ChannelState`.
     ///
-    /// When `config.rpc_url` is set, confirms the open transaction is finalized
-    /// on-chain before persisting — rejects the open if the tx is unknown or
-    /// failed. Leave `rpc_url` as `None` in unit tests.
+    /// When `config.rpc_url` is set, confirms the open transaction on-chain at
+    /// confirmed commitment before persisting — rejects the open if the tx is
+    /// unknown or failed. Leave `rpc_url` as `None` in unit tests.
     ///
     /// Replayed opens are idempotent: when a channel already exists for the
     /// session id with the same authorized signer, the existing state is
@@ -1829,6 +1828,14 @@ fn unix_now_i64() -> i64 {
 }
 
 #[cfg(feature = "server")]
+fn confirmed_rpc_client(rpc_url: &str) -> solana_rpc_client::rpc_client::RpcClient {
+    solana_rpc_client::rpc_client::RpcClient::new_with_commitment(
+        rpc_url.to_string(),
+        solana_commitment_config::CommitmentConfig::confirmed(),
+    )
+}
+
+#[cfg(feature = "server")]
 async fn verify_submit_and_fetch_open(
     payload: &OpenPayload,
     params: &payment_channels::OpenChannelParams,
@@ -1837,8 +1844,6 @@ async fn verify_submit_and_fetch_open(
     fresh_open: bool,
     fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
 ) -> Result<String> {
-    use solana_rpc_client::rpc_client::RpcClient;
-
     let rpc_url = rpc_url.ok_or_else(|| {
         Error::Other(
             "session open requires an RPC client; funding verification cannot be skipped"
@@ -1926,7 +1931,7 @@ async fn verify_submit_and_fetch_open(
         .ok_or_else(|| Error::Other("open transaction is missing its fee-payer signature".into()))?
         .to_string();
 
-    let rpc = RpcClient::new(rpc_url.to_string());
+    let rpc = confirmed_rpc_client(rpc_url);
     if fresh_open {
         let current_slot = rpc.get_slot().map_err(|error| {
             Error::Rpc(format!(
@@ -2012,8 +2017,6 @@ async fn verify_submit_and_fetch_topup(
     config: &SessionConfig,
     rpc_url: Option<&str>,
 ) -> Result<String> {
-    use solana_rpc_client::rpc_client::RpcClient;
-
     let rpc_url = rpc_url.ok_or_else(|| {
         Error::Other(
             "session top-up requires an RPC client; funding verification cannot be skipped"
@@ -2134,7 +2137,7 @@ async fn verify_submit_and_fetch_topup(
     if state.processed_topup_signatures.contains(&signature) {
         return Ok(signature);
     }
-    let rpc = RpcClient::new(rpc_url.to_string());
+    let rpc = confirmed_rpc_client(rpc_url);
     if let Err(error) = rpc.send_and_confirm_transaction(&tx) {
         // A duplicate of an already-landed top-up dies at preflight with
         // "already processed". The signature identifies this exact verified
@@ -2346,6 +2349,15 @@ mod tests {
 
     fn signer_address(seed: u8) -> String {
         bs58::encode(key(seed).verifying_key().as_bytes()).into_string()
+    }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn session_rpc_uses_confirmed_commitment() {
+        assert_eq!(
+            confirmed_rpc_client("http://127.0.0.1:1").commitment(),
+            solana_commitment_config::CommitmentConfig::confirmed()
+        );
     }
 
     /// The `recentSlot` every test challenge advertises; matches the

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -22,6 +22,7 @@
 //! never reset the voucher watermark or any other channel state.
 
 use solana_pubkey::Pubkey;
+use solana_signature::Signature;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::core::session::VoucherAcceptance;
@@ -99,6 +100,19 @@ pub struct OpenAcceptance {
     pub state: ChannelState,
     /// Whether the channel already existed and the open was an idempotent replay.
     pub replay: bool,
+    /// Confirmed transaction signature after any server fee-payer co-signing.
+    pub transaction_signature: String,
+}
+
+/// Result of accepting a channel top-up action.
+#[derive(Debug, Clone)]
+pub struct TopUpAcceptance {
+    /// Persisted channel state after processing the top-up.
+    pub state: ChannelState,
+    /// Whether this exact confirmed transaction had already been credited.
+    pub replay: bool,
+    /// Confirmed transaction signature after any server fee-payer co-signing.
+    pub transaction_signature: String,
 }
 
 /// Result of accepting an operator-signed use action.
@@ -109,7 +123,7 @@ pub struct UseAcceptance {
     /// Whether the idempotency key had already been processed.
     pub replay: bool,
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SessionConfig {
     /// Operator public key (base58). Shown to clients in the challenge.
     pub operator: String,
@@ -154,6 +168,12 @@ pub struct SessionConfig {
     /// Ed25519 key used to issue vouchers in operator mode.
     pub operator_signing_key: Option<ed25519_dalek::SigningKey>,
 
+    /// Optional operator signer that sponsors session transaction fees and
+    /// channel-account rent. When set, challenges advertise `feePayer: true`
+    /// and clients leave this signer's fee-payer slot empty for the server to
+    /// co-sign after validating the transaction.
+    pub fee_payer_signer: Option<std::sync::Arc<dyn solana_keychain::SolanaSigner>>,
+
     /// Inactivity thresholds offered for a new channel.
     pub idle_timeout_options_seconds: Option<Vec<u32>>,
 
@@ -173,6 +193,39 @@ pub struct SessionConfig {
     pub rpc_url: Option<String>,
 }
 
+impl std::fmt::Debug for SessionConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SessionConfig")
+            .field("operator", &self.operator)
+            .field("recipient", &self.recipient)
+            .field("splits", &self.splits)
+            .field("amount", &self.amount)
+            .field("suggested_deposit", &self.suggested_deposit)
+            .field("minimum_deposit", &self.minimum_deposit)
+            .field("currency", &self.currency)
+            .field("decimals", &self.decimals)
+            .field("network", &self.network)
+            .field("channel_program", &self.channel_program)
+            .field("token_program", &self.token_program)
+            .field("min_voucher_delta", &self.min_voucher_delta)
+            .field("voucher_signer", &self.voucher_signer)
+            .field("operator_signing_key", &self.operator_signing_key.is_some())
+            .field(
+                "fee_payer_signer",
+                &self.fee_payer_signer.as_ref().map(|signer| signer.pubkey()),
+            )
+            .field(
+                "idle_timeout_options_seconds",
+                &self.idle_timeout_options_seconds,
+            )
+            .field("idle_timeout_seconds", &self.idle_timeout_seconds)
+            .field("grace_period_seconds", &self.grace_period_seconds)
+            .field("rpc_url", &self.rpc_url.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
 impl Default for SessionConfig {
     fn default() -> Self {
         Self {
@@ -190,6 +243,7 @@ impl Default for SessionConfig {
             min_voucher_delta: 0,
             voucher_signer: VoucherSigner::Client,
             operator_signing_key: None,
+            fee_payer_signer: None,
             idle_timeout_options_seconds: None,
             idle_timeout_seconds: 300,
             grace_period_seconds: payment_channels::DEFAULT_GRACE_PERIOD_SECONDS,
@@ -367,6 +421,11 @@ impl<S: ChannelStore> SessionServer<S> {
             .config
             .channel_program
             .unwrap_or_else(payment_channels::default_program_id);
+        let fee_payer_key = self
+            .config
+            .fee_payer_signer
+            .as_ref()
+            .map(|signer| signer.pubkey().to_string());
         Ok(SessionRequest {
             amount: self.config.amount.to_string(),
             currency,
@@ -387,8 +446,8 @@ impl<S: ChannelStore> SessionServer<S> {
                     .config
                     .token_program
                     .map(|key| payment_channels::pubkey_string(&key)),
-                fee_payer: None,
-                fee_payer_key: None,
+                fee_payer: fee_payer_key.as_ref().map(|_| true),
+                fee_payer_key,
                 voucher_signer: Some(self.config.voucher_signer),
                 operator: (self.config.voucher_signer == VoucherSigner::Operator)
                     .then(|| self.config.operator.clone()),
@@ -541,9 +600,15 @@ impl<S: ChannelStore> SessionServer<S> {
                 bps: split.bps,
             })
             .collect();
+        let rent_payer = self
+            .config
+            .fee_payer_signer
+            .as_ref()
+            .map(|signer| signer.pubkey())
+            .unwrap_or(payer);
         let params = payment_channels::OpenChannelParams {
             payer,
-            rent_payer: payer,
+            rent_payer,
             payee,
             mint,
             authorized_signer,
@@ -698,12 +763,13 @@ impl<S: ChannelStore> SessionServer<S> {
             .await
             .map_err(store_err)?
             .is_none();
-        verify_submit_and_fetch_open(
+        let transaction_signature = verify_submit_and_fetch_open(
             payload,
             &params,
             context.recent_blockhash,
             self.config.rpc_url.as_deref(),
             fresh_open,
+            self.config.fee_payer_signer.as_deref(),
         )
         .await?;
 
@@ -728,7 +794,7 @@ impl<S: ChannelStore> SessionServer<S> {
             // gate evaluated later.
             open_slot: Some(payload.open_slot),
             payer: payload.payer.clone(),
-            rent_payer: payload.payer.clone(),
+            rent_payer: params.rent_payer.to_string(),
             opening_challenge_id: context.challenge_id.to_string(),
             authentication,
             voucher_signer: match self.config.voucher_signer {
@@ -760,6 +826,7 @@ impl<S: ChannelStore> SessionServer<S> {
         let session_id_owned = session_id.to_string();
         let authorized_signer = payload.authorized_signer.clone();
         let payer = payload.payer.clone();
+        let rent_payer = params.rent_payer.to_string();
         let opening_challenge_id = context.challenge_id.to_string();
         let authentication = payload.authentication.clone();
         let replay = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -781,6 +848,7 @@ impl<S: ChannelStore> SessionServer<S> {
                             )));
                         }
                         if existing.payer != payer
+                            || existing.rent_payer != rent_payer
                             || existing.opening_challenge_id != opening_challenge_id
                             || existing.authentication
                                 != authentication
@@ -804,7 +872,11 @@ impl<S: ChannelStore> SessionServer<S> {
             .map_err(store_err)?;
 
         let replay = replay.load(std::sync::atomic::Ordering::Relaxed);
-        Ok(OpenAcceptance { state, replay })
+        Ok(OpenAcceptance {
+            state,
+            replay,
+            transaction_signature,
+        })
     }
 
     /// Build the required receipt for a successful session action.
@@ -1113,6 +1185,14 @@ impl<S: ChannelStore> SessionServer<S> {
     /// against the resulting channel account before the deposit is raised.
     /// Missing RPC configuration is a hard error.
     pub async fn process_topup(&self, payload: &TopUpPayload) -> Result<ChannelState> {
+        Ok(self.process_topup_with_outcome(payload).await?.state)
+    }
+
+    /// Process a `topup` action and return its post-co-sign transaction ID.
+    pub async fn process_topup_with_outcome(
+        &self,
+        payload: &TopUpPayload,
+    ) -> Result<TopUpAcceptance> {
         let additional_amount: u64 = payload
             .additional_amount
             .parse()
@@ -1122,32 +1202,24 @@ impl<S: ChannelStore> SessionServer<S> {
                 "additionalAmount must be positive".to_string(),
             ));
         }
-        let topup_signature = payment_channels::decode_transaction(&payload.transaction)?
-            .signatures
-            .first()
-            .ok_or_else(|| Error::Other("top-up transaction is missing a signature".to_string()))?
-            .to_string();
         let existing = self
             .store
             .get_channel(&payload.channel_id)
             .await
             .map_err(store_err)?
             .ok_or_else(|| Error::Other(format!("Channel {} not found", payload.channel_id)))?;
-        // Idempotent replay: this exact transaction was already credited, so
-        // report the stored state without re-broadcasting (a re-broadcast of
-        // a landed transaction fails at preflight).
-        if existing
-            .processed_topup_signatures
-            .contains(&topup_signature)
-        {
-            return Ok(existing);
-        }
         if existing.sealed || existing.close_requested_at.is_some() {
             return Err(Error::Other(
                 "Channel is closed or close is pending".to_string(),
             ));
         }
-        verify_submit_and_fetch_topup(
+        // The transaction id is the fee-payer signature. In sponsored mode
+        // that slot is intentionally empty in the submitted payload, so only
+        // the server can derive the stable dedupe key after validation and
+        // co-signing. A replay may therefore reach RPC again; the confirmed
+        // signature status makes that path idempotent before this mutator
+        // credits the deposit.
+        let topup_signature = verify_submit_and_fetch_topup(
             payload,
             &existing,
             &self.config,
@@ -1157,7 +1229,11 @@ impl<S: ChannelStore> SessionServer<S> {
 
         let cid = payload.channel_id.clone();
         let lifecycle_owner = self.config.operator.clone();
-        self.store
+        let replay = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let replay_out = std::sync::Arc::clone(&replay);
+        let transaction_signature = topup_signature.clone();
+        let state = self
+            .store
             .update_channel(
                 &payload.channel_id,
                 Box::new(move |state_opt| {
@@ -1168,6 +1244,7 @@ impl<S: ChannelStore> SessionServer<S> {
                     // both confirm the same landed transaction, so only the
                     // first check-and-record may credit the deposit.
                     if state.processed_topup_signatures.contains(&topup_signature) {
+                        replay_out.store(true, std::sync::atomic::Ordering::Relaxed);
                         return Ok(state);
                     }
                     if state.sealed {
@@ -1201,7 +1278,12 @@ impl<S: ChannelStore> SessionServer<S> {
                 }),
             )
             .await
-            .map_err(store_err)
+            .map_err(store_err)?;
+        Ok(TopUpAcceptance {
+            state,
+            replay: replay.load(std::sync::atomic::Ordering::Relaxed),
+            transaction_signature,
+        })
     }
 
     /// Reserve capacity for a delivered message/response and return the
@@ -1731,7 +1813,8 @@ async fn verify_submit_and_fetch_open(
     challenged_blockhash: &str,
     rpc_url: Option<&str>,
     validate_current_slot: bool,
-) -> Result<()> {
+    fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
+) -> Result<String> {
     use solana_rpc_client::rpc_client::RpcClient;
 
     let rpc_url = rpc_url.ok_or_else(|| {
@@ -1740,7 +1823,7 @@ async fn verify_submit_and_fetch_open(
                 .to_string(),
         )
     })?;
-    let tx = payment_channels::decode_transaction(&payload.transaction)?;
+    let mut tx = payment_channels::decode_transaction(&payload.transaction)?;
     if tx
         .message
         .address_table_lookups()
@@ -1759,9 +1842,9 @@ async fn verify_submit_and_fetch_open(
         ));
     }
     let keys = tx.message.static_account_keys();
-    if keys.first() != Some(&params.payer) {
+    if keys.first() != Some(&params.rent_payer) {
         return Err(Error::Other(
-            "open transaction fee payer must equal the channel payer".to_string(),
+            "open transaction fee payer does not match the challenge policy".to_string(),
         ));
     }
     let expected = payment_channels::build_open_instruction(params);
@@ -1772,6 +1855,11 @@ async fn verify_submit_and_fetch_open(
             Error::Other("open instruction program index out of range".to_string())
         })?;
         if *program == compute_budget {
+            crate::mpp::server::charge::validate_compute_budget_instruction(
+                ix,
+                fee_payer_signer.is_some(),
+            )
+            .map_err(|error| Error::Other(error.to_string()))?;
             continue;
         }
         if found_open || *program != expected.program_id || ix.data != expected.data {
@@ -1805,6 +1893,16 @@ async fn verify_submit_and_fetch_open(
             "open transaction does not contain the expected open instruction".to_string(),
         ));
     }
+
+    verify_client_transaction_signatures(&tx, fee_payer_signer.map(|signer| signer.pubkey()))?;
+    if let Some(signer) = fee_payer_signer {
+        payment_channels::cosign_fee_payer(signer, &params.rent_payer, &mut tx).await?;
+    }
+    let transaction_signature = tx
+        .signatures
+        .first()
+        .ok_or_else(|| Error::Other("open transaction is missing its fee-payer signature".into()))?
+        .to_string();
 
     let rpc = RpcClient::new(rpc_url.to_string());
     if validate_current_slot {
@@ -1842,7 +1940,8 @@ async fn verify_submit_and_fetch_open(
         (None, confirmed) => confirmed,
         (Some(_), Ok(())) => Ok(()),
         (Some(broadcast_error), Err(_)) => Err(broadcast_error),
-    }
+    }?;
+    Ok(transaction_signature)
 }
 
 #[cfg(feature = "server")]
@@ -1882,7 +1981,7 @@ async fn verify_submit_and_fetch_topup(
     state: &ChannelState,
     config: &SessionConfig,
     rpc_url: Option<&str>,
-) -> Result<()> {
+) -> Result<String> {
     use solana_rpc_client::rpc_client::RpcClient;
 
     let rpc_url = rpc_url.ok_or_else(|| {
@@ -1916,7 +2015,7 @@ async fn verify_submit_and_fetch_topup(
         &token_program,
         &program_id,
     );
-    let tx = payment_channels::decode_transaction(&payload.transaction)?;
+    let mut tx = payment_channels::decode_transaction(&payload.transaction)?;
     if tx
         .message
         .address_table_lookups()
@@ -1927,9 +2026,28 @@ async fn verify_submit_and_fetch_topup(
         ));
     }
     let keys = tx.message.static_account_keys();
-    if keys.first() != Some(&payer) {
+    let stored_rent_payer = parse_pubkey_field(&state.rent_payer, "stored rentPayer")?;
+    let fee_payer_signer = match config.fee_payer_signer.as_deref() {
+        Some(signer) if signer.pubkey() == stored_rent_payer => Some(signer),
+        Some(_) if stored_rent_payer == payer => None,
+        Some(_) => {
+            return Err(Error::Other(
+                "configured session fee payer does not match the channel rentPayer".into(),
+            ));
+        }
+        None if stored_rent_payer == payer => None,
+        None => {
+            return Err(Error::Other(
+                "sponsored session top-up requires the channel fee-payer signer".into(),
+            ));
+        }
+    };
+    let expected_fee_payer = fee_payer_signer
+        .map(|signer| signer.pubkey())
+        .unwrap_or(payer);
+    if keys.first() != Some(&expected_fee_payer) {
         return Err(Error::Other(
-            "top-up transaction fee payer must equal the channel payer".to_string(),
+            "top-up transaction fee payer does not match the challenge policy".to_string(),
         ));
     }
     let compute_budget = parse_pubkey("ComputeBudget111111111111111111111111111111")?;
@@ -1939,6 +2057,11 @@ async fn verify_submit_and_fetch_topup(
             .get(ix.program_id_index as usize)
             .ok_or_else(|| Error::Other("top-up program index out of range".to_string()))?;
         if *program == compute_budget {
+            crate::mpp::server::charge::validate_compute_budget_instruction(
+                ix,
+                fee_payer_signer.is_some(),
+            )
+            .map_err(|error| Error::Other(error.to_string()))?;
             continue;
         }
         let accounts = ix
@@ -1968,6 +2091,18 @@ async fn verify_submit_and_fetch_topup(
     }
     if !found {
         return Err(Error::Other("top-up instruction not found".to_string()));
+    }
+    verify_client_transaction_signatures(&tx, fee_payer_signer.map(|signer| signer.pubkey()))?;
+    if let Some(signer) = fee_payer_signer {
+        payment_channels::cosign_fee_payer(signer, &expected_fee_payer, &mut tx).await?;
+    }
+    let signature = tx
+        .signatures
+        .first()
+        .ok_or_else(|| Error::Other("top-up transaction is missing a signature".to_string()))?
+        .to_string();
+    if state.processed_topup_signatures.contains(&signature) {
+        return Ok(signature);
     }
     let rpc = RpcClient::new(rpc_url.to_string());
     if let Err(error) = rpc.send_and_confirm_transaction(&tx) {
@@ -2000,7 +2135,7 @@ async fn verify_submit_and_fetch_topup(
             "confirmed channel state does not reflect the submitted top-up".to_string(),
         ));
     }
-    Ok(())
+    Ok(signature)
 }
 
 #[cfg(not(feature = "server"))]
@@ -2009,7 +2144,7 @@ async fn verify_submit_and_fetch_topup(
     _state: &ChannelState,
     _config: &SessionConfig,
     _rpc_url: Option<&str>,
-) -> Result<()> {
+) -> Result<String> {
     Err(Error::Other(
         "session top-up verification requires the `server` feature".to_string(),
     ))
@@ -2022,10 +2157,42 @@ async fn verify_submit_and_fetch_open(
     _challenged_blockhash: &str,
     _rpc_url: Option<&str>,
     _validate_current_slot: bool,
-) -> Result<()> {
+    _fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
+) -> Result<String> {
     Err(Error::Other(
         "session open verification requires the `server` feature".to_string(),
     ))
+}
+
+fn verify_client_transaction_signatures(
+    tx: &solana_transaction::versioned::VersionedTransaction,
+    server_fee_payer: Option<Pubkey>,
+) -> Result<()> {
+    let required = usize::from(tx.message.header().num_required_signatures);
+    let keys = tx.message.static_account_keys();
+    if tx.signatures.len() != required || keys.len() < required {
+        return Err(Error::Other(
+            "session transaction signature slots do not match its required signers".into(),
+        ));
+    }
+    let message = tx.message.serialize();
+    for (index, (signature, key)) in tx.signatures.iter().zip(keys).take(required).enumerate() {
+        if server_fee_payer == Some(*key) {
+            if index != 0 || *signature != Signature::default() {
+                return Err(Error::Other(
+                    "session fee-payer signature slot must be empty before server co-signing"
+                        .into(),
+                ));
+            }
+            continue;
+        }
+        if !signature.verify(key.as_ref(), &message) {
+            return Err(Error::Other(format!(
+                "invalid client transaction signature for required signer {key}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn parse_pubkey(s: &str) -> Result<Pubkey> {
@@ -2140,6 +2307,10 @@ mod tests {
         Box::new(MemorySigner::from_bytes(&bytes).unwrap())
     }
 
+    fn shared_signer(seed: u8) -> std::sync::Arc<dyn solana_keychain::SolanaSigner> {
+        std::sync::Arc::from(signer(seed))
+    }
+
     fn signer_address(seed: u8) -> String {
         bs58::encode(key(seed).verifying_key().as_bytes()).into_string()
     }
@@ -2227,9 +2398,15 @@ mod tests {
             VoucherSigner::Client => signer_address(1).parse().unwrap(),
             VoucherSigner::Operator => Pubkey::from_str(&server.config.operator).unwrap(),
         };
+        let rent_payer = server
+            .config
+            .fee_payer_signer
+            .as_ref()
+            .map(|signer| signer.pubkey())
+            .unwrap_or(payer);
         let params = payment_channels::OpenChannelParams {
             payer,
-            rent_payer: payer,
+            rent_payer,
             payee,
             mint,
             authorized_signer,
@@ -2420,9 +2597,15 @@ mod tests {
         };
         let token_program = Pubkey::from_str(programs::TOKEN_PROGRAM).unwrap();
         let program_id = payment_channels::default_program_id();
+        let fee_payer = server
+            .config
+            .fee_payer_signer
+            .as_ref()
+            .map(|signer| signer.pubkey())
+            .unwrap_or_else(|| payer.pubkey());
         let params = payment_channels::OpenChannelParams {
             payer: payer.pubkey(),
-            rent_payer: payer.pubkey(),
+            rent_payer: fee_payer,
             payee,
             mint,
             authorized_signer,
@@ -2446,7 +2629,7 @@ mod tests {
             vec![],
             &token_program,
             &program_id,
-            &payer.pubkey(),
+            &fee_payer,
             test_blockhash(),
         )
         .await
@@ -2538,6 +2721,99 @@ mod tests {
         invalid = open;
         invalid.distribution_splits.clear();
         assert!(server.payment_channel_open_params(&invalid).is_err());
+    }
+
+    #[cfg(feature = "server")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sponsored_open_advertises_cosigns_and_persists_rent_payer() {
+        use base64::Engine;
+        use payment_channels::generated::generated::types::SettlementWatermarks;
+
+        let sponsor = shared_signer(8);
+        let mut cfg = config(VoucherSigner::Client);
+        cfg.fee_payer_signer = Some(std::sync::Arc::clone(&sponsor));
+        let cache = crate::core::blockhash::BlockhashCache::new();
+        cache.set(test_blockhash().to_string(), 314, CHALLENGED_SLOT);
+        let mut server =
+            SessionServer::new(cfg, MemoryChannelStore::new()).with_blockhash_cache(cache);
+        let request = server.build_challenge_request().unwrap();
+        let sponsor_key = sponsor.pubkey().to_string();
+        assert_eq!(request.method_details.fee_payer, Some(true));
+        assert_eq!(
+            request.method_details.fee_payer_key.as_deref(),
+            Some(sponsor_key.as_str())
+        );
+
+        let (open, params) = signed_open(&server, 6).await;
+        assert_eq!(params.rent_payer, sponsor.pubkey());
+        let submitted = payment_channels::decode_transaction(&open.transaction).unwrap();
+        assert_eq!(submitted.signatures[0], Signature::default());
+        verify_client_transaction_signatures(&submitted, Some(sponsor.pubkey())).unwrap();
+
+        let channel = payment_channels::generated::generated::accounts::Channel {
+            discriminator: 1,
+            version: 1,
+            bump: 1,
+            status: 0,
+            salt: params.salt,
+            deposit: params.deposit,
+            settlement: SettlementWatermarks {
+                settled: 0,
+                payout_watermark: 0,
+            },
+            closure_started_at: 0,
+            payer_withdrawn_at: 0,
+            grace_period: params.grace_period,
+            distribution_hash: payment_channels::distribution_hash(&params.recipients),
+            payer: payment_channels::to_address(&params.payer),
+            payee: payment_channels::to_address(&params.payee),
+            authorized_signer: payment_channels::to_address(&params.authorized_signer),
+            mint: payment_channels::to_address(&params.mint),
+            rent_payer: payment_channels::to_address(&params.rent_payer),
+            open_slot: params.open_slot,
+        };
+        let (url, rpc) = rpc_for_channel(channel, 43).await;
+        server.config.rpc_url = Some(url);
+        let challenged_blockhash = test_blockhash().to_string();
+        let acceptance = server
+            .process_open_with_outcome(
+                &open,
+                SessionOpenContext {
+                    challenge_id: "opening",
+                    expires: None,
+                    recent_blockhash: &challenged_blockhash,
+                    recent_slot: CHALLENGED_SLOT,
+                },
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            acceptance.transaction_signature,
+            Signature::default().to_string()
+        );
+        assert_eq!(acceptance.state.rent_payer, sponsor.pubkey().to_string());
+
+        let mut tampered = submitted;
+        tampered.signatures[1] = Signature::default();
+        let mut invalid_open = open;
+        invalid_open.transaction = base64::engine::general_purpose::STANDARD
+            .encode(bincode::serialize(&tampered).unwrap());
+        let error = server
+            .process_open(
+                &invalid_open,
+                SessionOpenContext {
+                    challenge_id: "opening",
+                    expires: None,
+                    recent_blockhash: &challenged_blockhash,
+                    recent_slot: CHALLENGED_SLOT,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("invalid client transaction signature"));
+        rpc.abort();
     }
 
     #[test]
@@ -2870,7 +3146,7 @@ mod tests {
 
     #[cfg(feature = "server")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn confirmed_topup_adds_only_the_declared_amount() {
+    async fn confirmed_sponsored_topup_adds_only_the_declared_amount() {
         use base64::Engine;
         use payment_channels::generated::generated::types::SettlementWatermarks;
         use solana_message::Message;
@@ -2878,15 +3154,19 @@ mod tests {
 
         let (mut server, _session, channel_id) = client_server().await;
         let payer = signer(5);
+        let sponsor = shared_signer(8);
+        server.config.fee_payer_signer = Some(std::sync::Arc::clone(&sponsor));
         server
             .store
             .update_channel(
                 &channel_id,
                 Box::new({
                     let payer = payer.pubkey().to_string();
+                    let rent_payer = sponsor.pubkey().to_string();
                     move |state| {
                         let mut state = state.unwrap();
                         state.payer = payer;
+                        state.rent_payer = rent_payer;
                         Ok(state)
                     }
                 }),
@@ -2907,11 +3187,12 @@ mod tests {
         );
         let message = Message::new_with_blockhash(
             &[ix],
-            Some(&payer.pubkey()),
+            Some(&sponsor.pubkey()),
             &solana_hash::Hash::new_unique(),
         );
         let mut tx = Transaction::new_unsigned(message);
         payer.sign_transaction(&mut tx).await.unwrap();
+        assert_eq!(tx.signatures[0], Signature::default());
         let transaction =
             base64::engine::general_purpose::STANDARD.encode(bincode::serialize(&tx).unwrap());
         let account = payment_channels::generated::generated::accounts::Channel {
@@ -2935,7 +3216,7 @@ mod tests {
             ),
             authorized_signer: payment_channels::to_address(&signer(1).pubkey()),
             mint: payment_channels::to_address(&mint),
-            rent_payer: payment_channels::to_address(&payer.pubkey()),
+            rent_payer: payment_channels::to_address(&sponsor.pubkey()),
             open_slot: 42,
         };
         let (url, rpc) = rpc_for_channel(account, 43).await;
@@ -2945,14 +3226,20 @@ mod tests {
             additional_amount: "100".into(),
             transaction,
         };
-        let updated = server.process_topup(&payload).await.unwrap();
-        assert_eq!(updated.deposit, 1_100);
-        assert!(updated.lifecycle.is_some());
+        let updated = server.process_topup_with_outcome(&payload).await.unwrap();
+        assert_eq!(updated.state.deposit, 1_100);
+        assert!(updated.state.lifecycle.is_some());
+        assert!(!updated.replay);
+        assert_ne!(
+            updated.transaction_signature,
+            Signature::default().to_string()
+        );
 
         // A plain retry replays from the recorded signature without
         // re-broadcasting — no second credit.
-        let replayed = server.process_topup(&payload).await.unwrap();
-        assert_eq!(replayed.deposit, 1_100);
+        let replayed = server.process_topup_with_outcome(&payload).await.unwrap();
+        assert_eq!(replayed.state.deposit, 1_100);
+        assert!(replayed.replay);
 
         // Broadcast landed but the credit was lost (crash between confirm
         // and store write): the retry's re-broadcast dies at preflight, the

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -992,10 +992,18 @@ impl<S: ChannelStore> SessionServer<S> {
         .map_err(Error::from)?;
         let now_ms = now_unix_secs().saturating_mul(1_000) as u64;
         let owner = self.config.operator.clone();
-        // `charged` is 0 for an idempotent replay of the highest voucher, so
-        // adding it unconditionally never double-debits a replay — it only
-        // advances `spent_amount` for a genuinely fresh acceptance.
-        let charged = acceptance.charged;
+        // Debit the fixed per-action price, not the voucher's own cumulative
+        // jump: the client may pre-fund a voucher for more than one action's
+        // worth of `cumulativeAmount`, and `spentAmount` tracks delivered
+        // service (draft-solana-session-00 `spentAmount += cost`), not the
+        // authorized credit line. This matches `process_use`'s debit and the
+        // TypeScript/Python session servers. 0 on an idempotent replay, since
+        // no additional service is delivered.
+        let debit = if acceptance.replay {
+            0
+        } else {
+            self.config.amount
+        };
         self.store
             .update_channel(
                 &voucher.data.channel_id,
@@ -1006,7 +1014,7 @@ impl<S: ChannelStore> SessionServer<S> {
                         )
                     })?;
                     state.spent_amount =
-                        state.spent_amount.checked_add(charged).ok_or_else(|| {
+                        state.spent_amount.checked_add(debit).ok_or_else(|| {
                             StoreError::Internal("session spent amount overflow".to_string())
                         })?;
                     state.last_activity_at = now_ms;
@@ -3315,9 +3323,10 @@ mod tests {
             .unwrap();
         assert!(stored.lifecycle.is_some());
         assert!(stored.last_activity_at > 1);
-        // The replay must not double-debit: spent_amount reflects only the
-        // one fresh acceptance, not the replay that followed it.
-        assert_eq!(stored.spent_amount, 100);
+        // spent_amount debits the fixed per-action price (config.amount == 25
+        // here), not the voucher's own 100-unit cumulative jump — and the
+        // replay must not double-debit it.
+        assert_eq!(stored.spent_amount, 25);
 
         // The top-level routing key must match the signed voucher's inner
         // channelId — a divergent pair is rejected before any state lookup.

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -992,6 +992,10 @@ impl<S: ChannelStore> SessionServer<S> {
         .map_err(Error::from)?;
         let now_ms = now_unix_secs().saturating_mul(1_000) as u64;
         let owner = self.config.operator.clone();
+        // `charged` is 0 for an idempotent replay of the highest voucher, so
+        // adding it unconditionally never double-debits a replay — it only
+        // advances `spent_amount` for a genuinely fresh acceptance.
+        let charged = acceptance.charged;
         self.store
             .update_channel(
                 &voucher.data.channel_id,
@@ -1001,6 +1005,10 @@ impl<S: ChannelStore> SessionServer<S> {
                             "Channel disappeared after voucher acceptance".to_string(),
                         )
                     })?;
+                    state.spent_amount =
+                        state.spent_amount.checked_add(charged).ok_or_else(|| {
+                            StoreError::Internal("session spent amount overflow".to_string())
+                        })?;
                     state.last_activity_at = now_ms;
                     state.lifecycle = state.idle_timeout_seconds.map(|seconds| ChannelLifecycle {
                         owner,
@@ -1533,6 +1541,12 @@ impl<S: ChannelStore> SessionServer<S> {
 
                         state.pending_deliveries.remove(pending_index);
                         state.cumulative = new_cumulative;
+                        state.spent_amount =
+                            state.spent_amount.checked_add(actual_amount).ok_or_else(|| {
+                                StoreError::Internal(
+                                    "session spent amount overflow".to_string(),
+                                )
+                            })?;
                         state.highest_voucher_signature = Some(signature.clone());
                         state.highest_voucher_expires_at = Some(expires_at);
                         // A committed delivery is channel activity: refresh the
@@ -3301,6 +3315,9 @@ mod tests {
             .unwrap();
         assert!(stored.lifecycle.is_some());
         assert!(stored.last_activity_at > 1);
+        // The replay must not double-debit: spent_amount reflects only the
+        // one fresh acceptance, not the replay that followed it.
+        assert_eq!(stored.spent_amount, 100);
 
         // The top-level routing key must match the signed voucher's inner
         // channelId — a divergent pair is rejected before any state lookup.
@@ -3423,13 +3440,17 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(stored.last_activity_at > 1);
+        // A committed delivery debits spent_amount by the delivered amount,
+        // matching the operator `use` and client `voucher` paths.
+        assert_eq!(stored.spent_amount, 50);
         let lifecycle = stored
             .lifecycle
             .expect("commit must re-arm the idle-close deadline");
         assert!(lifecycle.close_after > 1);
 
         // The idempotent replay is not fresh activity: it must not advance the
-        // watermark past what the committed path recorded.
+        // watermark past what the committed path recorded, and must not
+        // double-debit spent_amount.
         let before_replay = stored.last_activity_at;
         assert_eq!(
             server.process_commit(&payload).await.unwrap().status,
@@ -3442,6 +3463,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(after_replay.last_activity_at, before_replay);
+        assert_eq!(after_replay.spent_amount, 50);
     }
 
     #[tokio::test]

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -35,7 +35,7 @@ use crate::mpp::protocol::intents::session::{
     SessionReceiptExtensions, SessionReceiptIntent, SessionRequest, SessionSplit, SignedVoucher,
     TopUpPayload, UsePayload, VoucherData, VoucherPayload, VoucherSignatureType,
 };
-use crate::mpp::protocol::solana::{default_token_program_for_currency, resolve_stablecoin_mint};
+use crate::mpp::protocol::solana::default_token_program_for_currency;
 use crate::mpp::store::{
     ChannelLifecycle, ChannelState, ChannelStore, CommittedDelivery, PendingDelivery, StoreError,
     CHANNEL_STATE_SCHEMA_VERSION,
@@ -2250,8 +2250,11 @@ fn parse_required_operator(operator: &str) -> Result<Pubkey> {
 }
 
 fn expected_payment_channel_mint(config: &SessionConfig) -> Result<Pubkey> {
-    let mint = resolve_stablecoin_mint(&config.currency, Some(config.network.as_str()))
-        .ok_or_else(|| Error::Other("payment-channel sessions require an SPL token".to_string()))?;
+    let mint = crate::mpp::protocol::solana::try_resolve_stablecoin_mint(
+        &config.currency,
+        Some(config.network.as_str()),
+    )?
+    .ok_or_else(|| Error::Other("payment-channel sessions require an SPL token".to_string()))?;
     parse_pubkey_field(mint, "currency")
 }
 
@@ -2371,6 +2374,16 @@ mod tests {
             idle_timeout_seconds: 300,
             ..SessionConfig::default()
         }
+    }
+
+    #[test]
+    fn usdtest_mainnet_challenge_is_rejected_before_rpc() {
+        let mut config = config(VoucherSigner::Client);
+        config.currency = "USDtest".to_string();
+        let server = SessionServer::new(config, MemoryChannelStore::new());
+
+        let error = server.build_challenge_request().unwrap_err();
+        assert!(error.to_string().contains("USDtest is devnet-only"));
     }
 
     fn state(channel_id: String, authorized_signer: String) -> ChannelState {

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -1834,7 +1834,7 @@ async fn verify_submit_and_fetch_open(
     params: &payment_channels::OpenChannelParams,
     challenged_blockhash: &str,
     rpc_url: Option<&str>,
-    validate_current_slot: bool,
+    fresh_open: bool,
     fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
 ) -> Result<String> {
     use solana_rpc_client::rpc_client::RpcClient;
@@ -1927,7 +1927,7 @@ async fn verify_submit_and_fetch_open(
         .to_string();
 
     let rpc = RpcClient::new(rpc_url.to_string());
-    if validate_current_slot {
+    if fresh_open {
         let current_slot = rpc.get_slot().map_err(|error| {
             Error::Rpc(format!(
                 "failed to fetch current cluster slot for session open: {error}"
@@ -1946,6 +1946,14 @@ async fn verify_submit_and_fetch_open(
                 payment_channels::OPEN_SLOT_WINDOW
             )));
         }
+    } else if fetch_and_match_open_channel(&rpc, params).is_ok() {
+        // This open already exists in the store (a resubmit — e.g. the
+        // client never saw the first response), and the channel account
+        // confirmed on-chain already matches this exact open. Return the
+        // already-landed signature instead of resubmitting: co-signing and
+        // rebroadcasting an open that has nothing left to do would burn a
+        // sponsor fee on every duplicate open request, not just the first.
+        return Ok(transaction_signature);
     }
     // A broadcast rejection is not authoritative: a retry of an open whose
     // first submission landed (response lost, or the store write after it
@@ -2178,7 +2186,7 @@ async fn verify_submit_and_fetch_open(
     _params: &payment_channels::OpenChannelParams,
     _challenged_blockhash: &str,
     _rpc_url: Option<&str>,
-    _validate_current_slot: bool,
+    _fresh_open: bool,
     _fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
 ) -> Result<String> {
     Err(Error::Other(
@@ -2460,7 +2468,11 @@ mod tests {
     async fn rpc_for_channel(
         channel: payment_channels::generated::generated::accounts::Channel,
         current_slot: u64,
-    ) -> (String, tokio::task::JoinHandle<()>) {
+    ) -> (
+        String,
+        tokio::task::JoinHandle<()>,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) {
         use base64::Engine;
         use serde_json::{json, Value};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -2474,11 +2486,14 @@ mod tests {
         // signatures that actually landed.
         let landed: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>> =
             std::sync::Arc::default();
+        let send_tx_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let send_tx_count_srv = std::sync::Arc::clone(&send_tx_count);
         let handle = tokio::spawn(async move {
             loop {
                 let (mut stream, _) = listener.accept().await.unwrap();
                 let account_data = account_data.clone();
                 let landed = std::sync::Arc::clone(&landed);
+                let send_tx_count = std::sync::Arc::clone(&send_tx_count_srv);
                 tokio::spawn(async move {
                     let mut bytes = Vec::new();
                     let body_start = loop {
@@ -2518,6 +2533,7 @@ mod tests {
                     let result = match request["method"].as_str().unwrap_or_default() {
                         "getSlot" => Ok(json!(current_slot)),
                         "sendTransaction" => {
+                            send_tx_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                             let signature = payment_channels::decode_transaction(
                                 request["params"][0].as_str().unwrap(),
                             )
@@ -2602,7 +2618,7 @@ mod tests {
                 });
             }
         });
-        (url, handle)
+        (url, handle, send_tx_count)
     }
 
     #[cfg(feature = "server")]
@@ -2794,7 +2810,7 @@ mod tests {
             rent_payer: payment_channels::to_address(&params.rent_payer),
             open_slot: params.open_slot,
         };
-        let (url, rpc) = rpc_for_channel(channel, 43).await;
+        let (url, rpc, _send_tx_count) = rpc_for_channel(channel, 43).await;
         server.config.rpc_url = Some(url);
         let challenged_blockhash = test_blockhash().to_string();
         let acceptance = server
@@ -3017,7 +3033,8 @@ mod tests {
             rent_payer: payment_channels::to_address(&params.rent_payer),
             open_slot: params.open_slot,
         };
-        let (future_url, future_rpc) = rpc_for_channel(channel.clone(), params.open_slot - 1).await;
+        let (future_url, future_rpc, _send_tx_count) =
+            rpc_for_channel(channel.clone(), params.open_slot - 1).await;
         let mut future_server =
             SessionServer::new(server.config.clone(), MemoryChannelStore::new());
         future_server.config.rpc_url = Some(future_url);
@@ -3040,7 +3057,8 @@ mod tests {
         future_rpc.abort();
 
         let stale_slot = params.open_slot + payment_channels::OPEN_SLOT_WINDOW + 1;
-        let (stale_url, stale_rpc) = rpc_for_channel(channel.clone(), stale_slot).await;
+        let (stale_url, stale_rpc, _send_tx_count) =
+            rpc_for_channel(channel.clone(), stale_slot).await;
         let mut stale_server = SessionServer::new(server.config.clone(), MemoryChannelStore::new());
         stale_server.config.rpc_url = Some(stale_url);
         let stale = stale_server
@@ -3058,7 +3076,7 @@ mod tests {
         assert!(stale.to_string().contains("current cluster slot"));
         stale_rpc.abort();
 
-        let (url, rpc) = rpc_for_channel(channel, 43).await;
+        let (url, rpc, send_tx_count) = rpc_for_channel(channel, 43).await;
         server.config.rpc_url = Some(url);
         // A transaction built against some other blockhash was not built for
         // this challenge — rejected before broadcast.
@@ -3089,11 +3107,22 @@ mod tests {
         assert!(!accepted.replay);
         assert_eq!(accepted.state.opening_challenge_id, "opening");
         assert_eq!(accepted.state.idle_timeout_seconds, Some(300));
+        assert_eq!(
+            send_tx_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the fresh open must broadcast exactly once"
+        );
         let replay = server
             .process_open_with_outcome(&open, context)
             .await
             .unwrap();
         assert!(replay.replay);
+        assert_eq!(
+            send_tx_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a replayed open against an already-confirmed channel must not rebroadcast \
+             (and so must not burn a sponsor fee on the duplicate open)"
+        );
 
         server.store.mark_sealed(&open.channel_id).await.unwrap();
         assert!(server.process_open(&open, context).await.is_err());
@@ -3137,7 +3166,7 @@ mod tests {
             rent_payer: payment_channels::to_address(&params.rent_payer),
             open_slot: params.open_slot,
         };
-        let (url, rpc) = rpc_for_channel(channel, 43).await;
+        let (url, rpc, _send_tx_count) = rpc_for_channel(channel, 43).await;
         server.config.rpc_url = Some(url);
         let challenged_blockhash = test_blockhash().to_string();
         let context = SessionOpenContext {
@@ -3241,7 +3270,7 @@ mod tests {
             rent_payer: payment_channels::to_address(&sponsor.pubkey()),
             open_slot: 42,
         };
-        let (url, rpc) = rpc_for_channel(account, 43).await;
+        let (url, rpc, _send_tx_count) = rpc_for_channel(account, 43).await;
         server.config.rpc_url = Some(url);
         let payload = TopUpPayload {
             channel_id: channel_id.clone(),

--- a/rust/crates/kit/src/x402/client/exact/payment.rs
+++ b/rust/crates/kit/src/x402/client/exact/payment.rs
@@ -14,9 +14,9 @@ use crate::x402::{
     error::Error,
     protocol::schemes::exact::{
         caip2_network_for_cluster, cluster_for_caip2_network, default_token_program_for_currency,
-        programs, resolve_stablecoin_mint, PaymentExtensions, PaymentPayload, PaymentProof,
-        PaymentRequiredEnvelope, PaymentRequirements, PaymentSignatureEnvelope, EXACT_SCHEME,
-        MAX_MEMO_BYTES, SOLANA_MAINNET,
+        programs, resolve_stablecoin_mint, try_resolve_stablecoin_mint, PaymentExtensions,
+        PaymentPayload, PaymentProof, PaymentRequiredEnvelope, PaymentRequirements,
+        PaymentSignatureEnvelope, EXACT_SCHEME, MAX_MEMO_BYTES, SOLANA_MAINNET,
     },
     PAYMENT_REQUIRED_HEADER, SOLANA_NETWORK, X402_V1_PAYMENT_REQUIRED_HEADER, X402_VERSION_V1,
     X402_VERSION_V2,
@@ -56,8 +56,11 @@ pub async fn build_payment(
     instructions.push(compute_unit_limit_ix(20_000));
     instructions.push(compute_unit_price_ix(1));
 
-    let cluster = requirements.cluster.as_deref();
-    let mint = resolve_mint(&requirements.currency, cluster);
+    let cluster = requirements
+        .cluster
+        .as_deref()
+        .or_else(|| cluster_for_caip2_network(&requirements.network));
+    let mint = try_resolve_mint(&requirements.currency, cluster)?;
 
     if let Some(mint_str) = mint {
         build_spl_instructions(
@@ -520,8 +523,16 @@ fn transfer_checked_ix(
 /// Resolve a currency to an optional mint address.
 ///
 /// Returns `None` for native SOL, or `Some(mint_address)` for SPL tokens.
+#[cfg(test)]
 fn resolve_mint<'a>(currency: &'a str, cluster: Option<&str>) -> Option<&'a str> {
     resolve_stablecoin_mint(currency, cluster)
+}
+
+fn try_resolve_mint<'a>(
+    currency: &'a str,
+    cluster: Option<&str>,
+) -> Result<Option<&'a str>, Error> {
+    try_resolve_stablecoin_mint(currency, cluster)
 }
 
 #[cfg(test)]

--- a/rust/crates/kit/src/x402/protocol/schemes/exact/types.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/exact/types.rs
@@ -84,6 +84,8 @@ pub fn is_native_sol(currency: &str) -> bool {
 /// Resolve a stablecoin symbol to a mint address for a cluster.
 ///
 /// Returns `None` for native SOL and passes through unknown symbols/mints.
+/// Call [`try_resolve_stablecoin_mint`] when the currency may be `USDtest` so
+/// unsupported clusters produce an actionable error.
 pub fn resolve_stablecoin_mint<'a>(currency: &'a str, cluster: Option<&str>) -> Option<&'a str> {
     if is_native_sol(currency) {
         return None;
@@ -94,6 +96,14 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, cluster: Option<&str>) -> 
             Some(SOLANA_TESTNET) | Some("testnet") => mints::USDC_TESTNET,
             _ => mints::USDC_MAINNET,
         }),
+        "USDTEST"
+            if matches!(
+                cluster,
+                Some(SOLANA_DEVNET) | Some("devnet") | Some("solana-devnet")
+            ) =>
+        {
+            Some(mints::USDTEST_DEVNET)
+        }
         "USDT" => Some(mints::USDT_MAINNET),
         "USDG" => Some(match cluster {
             Some(SOLANA_DEVNET) | Some("devnet") | Some("localnet") => mints::USDG_DEVNET,
@@ -110,6 +120,28 @@ pub fn resolve_stablecoin_mint<'a>(currency: &'a str, cluster: Option<&str>) -> 
     }
 }
 
+/// Resolve a stablecoin symbol while enforcing cluster-specific availability.
+///
+/// `USDtest` is intentionally available only on devnet. Omitted, mainnet,
+/// testnet, and localnet clusters are rejected.
+pub fn try_resolve_stablecoin_mint<'a>(
+    currency: &'a str,
+    cluster: Option<&str>,
+) -> Result<Option<&'a str>, crate::x402::Error> {
+    let is_devnet = matches!(
+        cluster,
+        Some(SOLANA_DEVNET) | Some("devnet") | Some("solana-devnet")
+    );
+    let is_usdtest = currency.eq_ignore_ascii_case("USDtest") || currency == mints::USDTEST_DEVNET;
+    if is_usdtest && !is_devnet {
+        let actual = cluster.unwrap_or("mainnet-beta");
+        return Err(crate::x402::Error::Other(format!(
+            "USDtest is devnet-only; set cluster to `devnet` (got `{actual}`)"
+        )));
+    }
+    Ok(resolve_stablecoin_mint(currency, cluster))
+}
+
 /// Reverse lookup: given a known mint address or stablecoin symbol, return
 /// the canonical symbol. Returns `None` for native SOL or unknown values.
 ///
@@ -123,12 +155,14 @@ pub fn stablecoin_symbol(currency_or_mint: &str) -> Option<&'static str> {
     let upper = currency_or_mint.to_uppercase();
     match upper.as_str() {
         "USDC" => Some("USDC"),
+        "USDTEST" => Some("USDTEST"),
         "USDT" => Some("USDT"),
         "USDG" => Some("USDG"),
         "PYUSD" => Some("PYUSD"),
         "CASH" => Some("CASH"),
         _ => match currency_or_mint {
             mints::USDC_MAINNET | mints::USDC_DEVNET => Some("USDC"),
+            mints::USDTEST_DEVNET => Some("USDTEST"),
             mints::USDT_MAINNET => Some("USDT"),
             mints::USDG_MAINNET | mints::USDG_DEVNET => Some("USDG"),
             mints::PYUSD_MAINNET | mints::PYUSD_DEVNET => Some("PYUSD"),
@@ -144,7 +178,7 @@ pub fn stablecoin_symbol(currency_or_mint: &str) -> Option<&'static str> {
 pub fn stablecoin_uses_token_2022(currency_or_mint: &str) -> bool {
     matches!(
         stablecoin_symbol(currency_or_mint),
-        Some("USDG") | Some("PYUSD") | Some("CASH")
+        Some("USDTEST") | Some("USDG") | Some("PYUSD") | Some("CASH")
     )
 }
 
@@ -727,6 +761,7 @@ mod tests {
 
         assert!(Pubkey::from_str(mints::USDC_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDC_DEVNET).is_ok());
+        assert!(Pubkey::from_str(mints::USDTEST_DEVNET).is_ok());
         assert!(Pubkey::from_str(mints::USDT_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_MAINNET).is_ok());
         assert!(Pubkey::from_str(mints::USDG_DEVNET).is_ok());
@@ -745,6 +780,21 @@ mod tests {
             resolve_stablecoin_mint("PYUSD", Some("devnet")),
             Some(mints::PYUSD_DEVNET)
         );
+        assert_eq!(
+            try_resolve_stablecoin_mint("USDtest", Some("devnet")).unwrap(),
+            Some(mints::USDTEST_DEVNET)
+        );
+        for cluster in [
+            None,
+            Some("mainnet-beta"),
+            Some("testnet"),
+            Some("localnet"),
+        ] {
+            let error = try_resolve_stablecoin_mint("usdtest", cluster).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+            let error = try_resolve_stablecoin_mint(mints::USDTEST_DEVNET, cluster).unwrap_err();
+            assert!(error.to_string().contains("USDtest is devnet-only"));
+        }
         assert_eq!(
             resolve_stablecoin_mint("USDT", None),
             Some(mints::USDT_MAINNET)
@@ -766,6 +816,10 @@ mod tests {
 
     #[test]
     fn token_2022_stablecoins_default_to_token_2022() {
+        assert_eq!(
+            default_token_program_for_currency("USDtest", Some("devnet")),
+            programs::TOKEN_2022_PROGRAM
+        );
         assert_eq!(
             default_token_program_for_currency("USDC", None),
             programs::TOKEN_PROGRAM
@@ -811,7 +865,7 @@ mod tests {
 
     #[test]
     fn stablecoin_symbol_round_trips_symbols() {
-        for sym in ["USDC", "USDT", "USDG", "PYUSD", "CASH"] {
+        for sym in ["USDC", "USDT", "USDTEST", "USDG", "PYUSD", "CASH"] {
             assert_eq!(stablecoin_symbol(sym), Some(sym));
             assert_eq!(stablecoin_symbol(&sym.to_lowercase()), Some(sym));
         }
@@ -821,6 +875,7 @@ mod tests {
     fn stablecoin_symbol_resolves_known_mints() {
         assert_eq!(stablecoin_symbol(mints::USDC_MAINNET), Some("USDC"));
         assert_eq!(stablecoin_symbol(mints::USDC_DEVNET), Some("USDC"));
+        assert_eq!(stablecoin_symbol(mints::USDTEST_DEVNET), Some("USDTEST"));
         assert_eq!(stablecoin_symbol(mints::USDT_MAINNET), Some("USDT"));
         assert_eq!(stablecoin_symbol(mints::USDG_MAINNET), Some("USDG"));
         assert_eq!(stablecoin_symbol(mints::USDG_DEVNET), Some("USDG"));
@@ -843,6 +898,8 @@ mod tests {
         assert!(stablecoin_uses_token_2022("USDG"));
         assert!(stablecoin_uses_token_2022("PYUSD"));
         assert!(stablecoin_uses_token_2022("CASH"));
+        assert!(stablecoin_uses_token_2022("USDtest"));
+        assert!(stablecoin_uses_token_2022(mints::USDTEST_DEVNET));
         assert!(stablecoin_uses_token_2022(mints::USDG_MAINNET));
         assert!(stablecoin_uses_token_2022(mints::PYUSD_DEVNET));
         // Legacy stablecoins use the original SPL Token program.

--- a/rust/crates/kit/src/x402/server/batch_settlement.rs
+++ b/rust/crates/kit/src/x402/server/batch_settlement.rs
@@ -41,8 +41,7 @@ use crate::x402::protocol::schemes::batch_settlement::{
     PROFILE_PAYMENT_CHANNEL,
 };
 use crate::x402::protocol::schemes::exact::{
-    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency,
-    resolve_stablecoin_mint, ResourceInfo,
+    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency, ResourceInfo,
 };
 use crate::x402::server::upto::{
     cosign_operator_fee_payer, decode_transaction, validate_open_instruction,
@@ -152,6 +151,7 @@ impl X402BatchSettlement {
         }
         Pubkey::from_str(&config.recipient)
             .map_err(|e| Error::Other(format!("Invalid recipient pubkey: {e}")))?;
+        crate::x402::exact::try_resolve_stablecoin_mint(&config.currency, Some(&config.cluster))?;
         let operator = config.operator_signer.pubkey();
         let rpc_url = config
             .rpc_url
@@ -180,8 +180,11 @@ impl X402BatchSettlement {
     }
 
     fn mint(&self) -> Result<Pubkey, Error> {
-        let mint = resolve_stablecoin_mint(&self.config.currency, Some(&self.config.cluster))
-            .ok_or_else(|| Error::Other("batch-settlement requires an SPL token".into()))?;
+        let mint = crate::x402::exact::try_resolve_stablecoin_mint(
+            &self.config.currency,
+            Some(&self.config.cluster),
+        )?
+        .ok_or_else(|| Error::Other("batch-settlement requires an SPL token".into()))?;
         Pubkey::from_str(mint).map_err(|e| Error::Other(format!("invalid mint: {e}")))
     }
 

--- a/rust/crates/kit/src/x402/server/exact.rs
+++ b/rust/crates/kit/src/x402/server/exact.rs
@@ -141,6 +141,12 @@ impl X402 {
         }
         Pubkey::from_str(&config.recipient)
             .map_err(|e| Error::Other(format!("Invalid recipient pubkey: {e}")))?;
+        for currency in &config.currencies {
+            crate::x402::exact::try_resolve_stablecoin_mint(
+                &currency.currency,
+                Some(&config.network),
+            )?;
+        }
 
         let rpc_url = config
             .rpc_url
@@ -971,6 +977,18 @@ mod tests {
                 .collect(),
             ..config()
         }
+    }
+
+    #[test]
+    fn usdtest_mainnet_config_is_rejected() {
+        let mut config = multi_currency_config(&["USDtest"]);
+        config.network = "mainnet-beta".to_string();
+
+        let error = match X402::new(config) {
+            Ok(_) => panic!("USDtest must not be accepted on mainnet"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("USDtest is devnet-only"));
     }
 
     fn memory_signer(seed: u8) -> Box<dyn SolanaSigner> {

--- a/rust/crates/kit/src/x402/server/upto.rs
+++ b/rust/crates/kit/src/x402/server/upto.rs
@@ -37,8 +37,7 @@ use crate::core::payment_channels::generated::accounts::Channel;
 
 use crate::x402::error::Error;
 use crate::x402::protocol::schemes::exact::{
-    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency,
-    resolve_stablecoin_mint, ResourceInfo,
+    caip2_network_for_cluster, default_rpc_url, default_token_program_for_currency, ResourceInfo,
 };
 use crate::x402::protocol::schemes::upto::{
     assert_settlement_within_ceiling, verify_upto_payload, UptoExtra, UptoRequiredEnvelope,
@@ -188,6 +187,12 @@ impl X402Upto {
         if config.currencies.is_empty() {
             return Err(Error::Other("at least one currency is required".into()));
         }
+        for currency in &config.currencies {
+            crate::x402::exact::try_resolve_stablecoin_mint(
+                &currency.currency,
+                Some(&config.cluster),
+            )?;
+        }
         if let UptoPayout::Beneficiary { address } = &config.payout {
             Pubkey::from_str(address)
                 .map_err(|e| Error::Other(format!("Invalid recipient pubkey: {e}")))?;
@@ -268,8 +273,11 @@ impl X402Upto {
     /// Resolve the mint for a specific currency descriptor on the configured
     /// cluster.
     fn mint_for(&self, cc: &CurrencyConfig) -> Result<Pubkey, Error> {
-        let mint = resolve_stablecoin_mint(&cc.currency, Some(&self.config.cluster))
-            .ok_or_else(|| Error::Other("upto requires an SPL token (not native SOL)".into()))?;
+        let mint = crate::x402::exact::try_resolve_stablecoin_mint(
+            &cc.currency,
+            Some(&self.config.cluster),
+        )?
+        .ok_or_else(|| Error::Other("upto requires an SPL token (not native SOL)".into()))?;
         Pubkey::from_str(mint).map_err(|e| Error::Other(format!("invalid mint: {e}")))
     }
 

--- a/typescript/packages/mpp/package.json
+++ b/typescript/packages/mpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/mpp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Solana payment method for the MPP protocol",
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@solana/addresses": "^6.10.0",
     "@solana-program/compute-budget": "^0.15.0",
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.11.0",

--- a/typescript/packages/mpp/src/Methods.ts
+++ b/typescript/packages/mpp/src/Methods.ts
@@ -216,6 +216,8 @@ export const session = Method.from({
                     /** Opaque server-scoped authorization policy echoed on the wire. */
                     authorizationPolicy: z.optional(z.record(z.string(), z.unknown())),
                     authorizedSigner: z.string(),
+                    /** Clients MUST NOT send the derived PDA bump. */
+                    bump: z.optional(z.never()),
                     /** Opaque capability map echoed on the wire. */
                     capabilities: z.optional(z.record(z.string(), z.unknown())),
                     channelId: z.string(),

--- a/typescript/packages/mpp/src/__tests__/session-final-contract.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-final-contract.test.ts
@@ -72,6 +72,23 @@ describe('final session wire contract', () => {
                 signature: 'legacy',
             }),
         ).toThrow();
+
+        expect(() =>
+            Methods.session.schema.credential.payload.parse({
+                action: 'open',
+                authorizedSigner: signer.address,
+                bump: 255,
+                channelId: channel.address,
+                depositAmount: '1000',
+                gracePeriodSeconds: 900,
+                mint: signer.address,
+                openSlot: '1',
+                payee: signer.address,
+                payer: signer.address,
+                salt: '1',
+                transaction: 'wire',
+            }),
+        ).toThrow();
     });
 
     test('binds reusable authentication to the opening challenge, payer, and channel', async () => {

--- a/typescript/packages/mpp/src/__tests__/session-open-context.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-open-context.test.ts
@@ -20,6 +20,7 @@ import {
     getBase64Codec,
     getCompiledTransactionMessageDecoder,
     getTransactionDecoder,
+    getProgramDerivedAddress,
 } from '@solana/kit';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -34,7 +35,7 @@ const USDC_DEVNET_MINT = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
 const CHALLENGED_BLOCKHASH = 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N';
 const CHALLENGED_SLOT = 314n;
 
-function blockhashRpc(options: { fail?: boolean; slot?: bigint } = {}) {
+function blockhashRpc(options: { currentSlot?: bigint; fail?: boolean; slot?: bigint } = {}) {
     const send = vi.fn(async () => {
         if (options.fail) throw new Error('rpc down');
         return {
@@ -43,7 +44,8 @@ function blockhashRpc(options: { fail?: boolean; slot?: bigint } = {}) {
         };
     });
     const getLatestBlockhash = vi.fn(() => ({ send }));
-    return { getLatestBlockhash, send };
+    const getSlot = vi.fn(() => ({ send: async () => options.currentSlot ?? options.slot ?? CHALLENGED_SLOT }));
+    return { getLatestBlockhash, getSlot, send };
 }
 
 function serverParams(recipient: string, overrides: Record<string, unknown> = {}) {
@@ -228,6 +230,50 @@ describe('server open verification binds to the challenged recentSlot', () => {
         const credential = openCredential(bare, await openPayloadFor(signer, '42'));
         await expect(method.verify({ credential, request: credential.challenge.request } as never)).rejects.toThrow(
             /open requires a challenge carrying recentBlockhash\/recentSlot/,
+        );
+    });
+
+    test('rejects an openSlot that aged out before verification', async () => {
+        const currentSlot = CHALLENGED_SLOT + OPEN_SLOT_WINDOW + 1n;
+        const { method, signer: merchant } = await methodFor({ rpc: blockhashRpc({ currentSlot }) });
+        const payer = await generateKeyPairSigner();
+        const sessionSigner = await generateKeyPairSigner();
+        const request = challengeRequest(merchant.address) as unknown as SessionRequest;
+        const open = await buildOpenPaymentChannelTransaction({
+            authorizedSigner: sessionSigner.address,
+            request,
+            salt: 7n,
+            signer: payer,
+        });
+        const credential = openCredential(request as unknown as Record<string, unknown>, {
+            authorizedSigner: sessionSigner.address,
+            channelId: open.channelId,
+            depositAmount: open.deposit,
+            gracePeriodSeconds: open.gracePeriod,
+            mint: open.mint,
+            openSlot: open.openSlot,
+            payee: open.payee,
+            payer: open.payer,
+            salt: open.salt,
+            transaction: open.transaction,
+        });
+        await expect(method.verify({ credential, request: credential.challenge.request } as never)).rejects.toThrow(
+            /outside the 1500-slot freshness window of the current cluster slot/,
+        );
+    });
+
+    test('rejects an off-curve authorizedSigner', async () => {
+        const { method, signer } = await methodFor({ rpc: blockhashRpc() });
+        const [offCurveSigner] = await getProgramDerivedAddress({
+            programAddress: PAYMENT_CHANNELS_PROGRAM_ID,
+            seeds: [new TextEncoder().encode('off-curve-signer')],
+        });
+        const credential = openCredential(challengeRequest(signer.address), {
+            ...(await openPayloadFor(signer, CHALLENGED_SLOT.toString())),
+            authorizedSigner: offCurveSigner,
+        });
+        await expect(method.verify({ credential, request: credential.challenge.request } as never)).rejects.toThrow(
+            /on-curve Ed25519 public key/,
         );
     });
 });

--- a/typescript/packages/mpp/src/__tests__/session-settlement.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-settlement.test.ts
@@ -240,7 +240,14 @@ describe('session() verify() topUp', () => {
         );
 
         expect(receipt.status).toBe('success');
-        expect(receipt.reference).toBe('MockSig1');
+        expect(receipt.reference).toBe(f.channel.address);
+        expect(receipt).toMatchObject({
+            acceptedCumulative: '0',
+            idleTimeoutSeconds: 300,
+            intent: 'session',
+            spent: '0',
+            txHash: 'MockSig1',
+        });
         expect(sent).toHaveLength(1);
         expect(statusCalls).toContain('MockSig1');
         const state = await f.store.getChannel(f.channel.address);
@@ -461,13 +468,25 @@ async function watermarkedFixture(rpcOptions: { sendErrors?: number } = {}) {
 
 describe('session() verify() close monotonicity', () => {
     test('an accepted voucher advances the watermark', async () => {
-        const { f, receipt, voucher } = await watermarkedFixture();
+        const { f, method, receipt, voucher } = await watermarkedFixture();
         expect(receipt.status).toBe('success');
-        expect(receipt.reference).toBe(`${f.channel.address}:250`);
+        expect(receipt.reference).toBe(f.channel.address);
+        expect(receipt).toMatchObject({
+            acceptedCumulative: '250',
+            idleTimeoutSeconds: 300,
+            intent: 'session',
+            spent: '100',
+        });
 
         const state = await f.store.getChannel(f.channel.address);
         expect(state?.cumulative).toBe(250n);
         expect(state?.highestVoucherSignature).toBe(voucher.signature);
+
+        const replay = await verify(method, makeCred(f, { action: 'voucher', channelId: f.channel.address, voucher }));
+        expect(replay).toMatchObject({ acceptedCumulative: '250', spent: '200' });
+        await expect(
+            verify(method, makeCred(f, { action: 'voucher', channelId: f.channel.address, voucher })),
+        ).rejects.toThrow(/insufficient authorized voucher availability/);
     });
 
     test('a voucher action whose top-level channelId diverges from the signed voucher is rejected', async () => {
@@ -523,7 +542,8 @@ describe('session() verify() close monotonicity', () => {
 
         const receipt = await verify(method, makeCred(f, { action: 'close', channelId: f.channel.address, voucher }));
         expect(receipt.status).toBe('success');
-        expect(receipt.reference).toBe('MockSig1');
+        expect(receipt.reference).toBe(f.channel.address);
+        expect(receipt).toMatchObject({ refunded: '750', txHash: 'MockSig1' });
         expect(sent).toHaveLength(1);
 
         const state = await f.store.getChannel(f.channel.address);
@@ -647,7 +667,8 @@ describe('session() verify() close authorization', () => {
             makeCred(f, { action: 'close', authentication, channelId: f.channel.address }),
         );
         expect(receipt.status).toBe('success');
-        expect(receipt.reference).toBe('MockSig1');
+        expect(receipt.reference).toBe(f.channel.address);
+        expect(receipt).toMatchObject({ refunded: '1000', txHash: 'MockSig1' });
         expect(sent).toHaveLength(1);
 
         const state = await f.store.getChannel(f.channel.address);

--- a/typescript/packages/mpp/src/__tests__/session-settlement.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-settlement.test.ts
@@ -241,13 +241,15 @@ describe('session() verify() topUp', () => {
 
         expect(receipt.status).toBe('success');
         expect(receipt.reference).toBe(f.channel.address);
+        // txHash is reserved for the close receipt's settlement signature
+        // (draft-solana-session-00 receipt table); a top-up carries none.
         expect(receipt).toMatchObject({
             acceptedCumulative: '0',
             idleTimeoutSeconds: 300,
             intent: 'session',
             spent: '0',
-            txHash: 'MockSig1',
         });
+        expect(receipt).not.toHaveProperty('txHash');
         expect(sent).toHaveLength(1);
         expect(statusCalls).toContain('MockSig1');
         const state = await f.store.getChannel(f.channel.address);
@@ -482,11 +484,16 @@ describe('session() verify() close monotonicity', () => {
         expect(state?.cumulative).toBe(250n);
         expect(state?.highestVoucherSignature).toBe(voucher.signature);
 
+        // An idempotent replay of the already-accepted highest voucher must
+        // not deliver additional service or debit `spent` again — repeated
+        // replays keep returning the same cached amount.
         const replay = await verify(method, makeCred(f, { action: 'voucher', channelId: f.channel.address, voucher }));
-        expect(replay).toMatchObject({ acceptedCumulative: '250', spent: '200' });
-        await expect(
-            verify(method, makeCred(f, { action: 'voucher', channelId: f.channel.address, voucher })),
-        ).rejects.toThrow(/insufficient authorized voucher availability/);
+        expect(replay).toMatchObject({ acceptedCumulative: '250', spent: '100' });
+        const replayAgain = await verify(
+            method,
+            makeCred(f, { action: 'voucher', channelId: f.channel.address, voucher }),
+        );
+        expect(replayAgain).toMatchObject({ acceptedCumulative: '250', spent: '100' });
     });
 
     test('a voucher action whose top-level channelId diverges from the signed voucher is rejected', async () => {

--- a/typescript/packages/mpp/src/client/Session.ts
+++ b/typescript/packages/mpp/src/client/Session.ts
@@ -7,7 +7,7 @@ import {
     type MessagePartialSigner,
     verifySignature,
 } from '@solana/kit';
-import type { Challenge as MppxChallenge } from 'mppx';
+import type { Challenge as MppxChallenge, Receipt as MppxReceipt } from 'mppx';
 import { Credential, Method, z } from 'mppx';
 
 import * as Methods from '../Methods.js';
@@ -29,6 +29,17 @@ export type AmountLike = bigint | number | string;
 
 /** Party that signs cumulative vouchers. */
 export type SessionVoucherSigner = 'client' | 'operator';
+
+/** Receipt extension required by the Solana session intent. */
+export interface SessionReceipt extends MppxReceipt.Receipt {
+    readonly acceptedCumulative: string;
+    readonly challengeId?: string | undefined;
+    readonly idleTimeoutSeconds: number;
+    readonly intent: 'session';
+    readonly refunded?: string | undefined;
+    readonly spent: string;
+    readonly txHash?: string | undefined;
+}
 
 /** Reusable payer proof for an operator-signed channel. */
 export interface SessionAuthentication {

--- a/typescript/packages/mpp/src/client/index.ts
+++ b/typescript/packages/mpp/src/client/index.ts
@@ -62,6 +62,7 @@ export type {
     SessionAuthentication,
     SessionVoucherSigner,
     SessionRequest,
+    SessionReceipt,
     SessionSigner,
     SessionSplit,
     SignedVoucher,

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -456,7 +456,11 @@ type LatestBlockhashRpc = {
  */
 session.routes = function routes(parameters: session.Parameters): session.RoutesHandlers {
     const store = resolveSessionStore(parameters);
-    const currency = parameters.currency;
+    // Deliveries must advertise the same resolved mint challenges do
+    // (`currency: resolvedMint` in `session()`'s request/verify handlers),
+    // not the raw symbol a caller may have configured.
+    const currency = resolveStablecoinMint(parameters.currency, parameters.network ?? 'mainnet');
+    if (!currency) throw new Error('session currency must be an SPL token mint; use wrapped SOL instead of SOL');
 
     return {
         async commit(request) {
@@ -617,7 +621,6 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
         }
     }
 
-    let signature: string | undefined;
     const newState: ChannelState = {
         authentication: payload.authentication,
         authorizedSigner: payload.authorizedSigner,
@@ -666,21 +669,22 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
             // Idempotent replay: never reset the voucher watermark.
             return { ...current, lastActivityAt: Date.now() };
         }
-        const submitted = await submitOpenTx({
+        await submitOpenTx({
             expected,
             openPayload: payload,
             payerSigner: args.feePayer ? args.feePayerSigner : undefined,
             rpc: args.rpc as SubmitOpenRpc,
         });
-        signature = submitted.signature as unknown as string;
         return newState;
     });
     args.lifecycle?.touch(verified.channelId, persisted.idleTimeoutSeconds);
 
+    // txHash is reserved for the close receipt's settlement signature
+    // (draft-solana-session-00 receipt table); open does not settle on-chain
+    // funds, so it carries no txHash.
     return sessionReceipt(persisted, {
         challengeId: args.challengeId,
         externalId: args.externalId,
-        txHash: signature,
     });
 }
 
@@ -827,19 +831,20 @@ async function handleVoucher(args: HandleVoucherArgs): Promise<Receipt.Receipt> 
             // Caller will translate; reuse the Rust convention of throwing.
             throw new Error(`${result.reason}: ${result.detail}`);
         }
-        const acceptedCumulative = result.newCumulative;
-        if (acceptedCumulative - current.spentAmount < args.price) {
+        if (result.status === 'replayed') {
+            // An idempotent replay of the already-accepted highest voucher
+            // must not deliver additional service or debit spentAmount
+            // again — the client already paid for it.
+            return { ...current, lastActivityAt: Date.now() };
+        }
+        if (result.newCumulative - current.spentAmount < args.price) {
             throw new Error('insufficient authorized voucher availability');
         }
         return {
             ...current,
-            ...(result.status === 'accepted'
-                ? {
-                      cumulative: result.newCumulative,
-                      highestVoucherExpiresAt: result.newExpiresAt,
-                      highestVoucherSignature: result.newSignature,
-                  }
-                : {}),
+            cumulative: result.newCumulative,
+            highestVoucherExpiresAt: result.newExpiresAt,
+            highestVoucherSignature: result.newSignature,
             lastActivityAt: Date.now(),
             spentAmount: current.spentAmount + args.price,
         };
@@ -879,10 +884,12 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
     // transaction fails at preflight).
     const topUpSignature = transactionSignatureFromWire(args.payload.transaction) as unknown as string;
     if (existing.processedTopUpSignatures?.includes(topUpSignature)) {
+        // txHash is reserved for the close receipt's settlement signature
+        // (draft-solana-session-00 receipt table); a top-up does not settle
+        // on-chain funds itself, so it carries no txHash.
         return sessionReceipt(existing, {
             challengeId: args.challengeId,
             externalId: args.externalId,
-            txHash: topUpSignature,
         });
     }
     if (existing.sealed) throw new Error('Channel is already sealed');
@@ -890,7 +897,7 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
         throw new Error('Channel close is pending — no further top-ups accepted');
     }
 
-    const signature = await submitTopUpTx({
+    await submitTopUpTx({
         additionalAmount,
         channelId: args.payload.channelId,
         channelProgram: args.channelProgram,
@@ -923,7 +930,6 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
     return sessionReceipt(result, {
         challengeId: args.challengeId,
         externalId: args.externalId,
-        txHash: signature as unknown as string,
     });
 }
 

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -1,5 +1,7 @@
+import { isOffCurveAddress } from '@solana/addresses';
 import {
     type Address,
+    address,
     createSignableMessage,
     createSolanaRpc,
     getBase58Decoder,
@@ -17,7 +19,7 @@ import {
     validateIdleTimeoutOptions,
     verifySessionAuthentication,
 } from '../client/Session.js';
-import { defaultTokenProgramForCurrency, resolveStablecoinMint } from '../constants.js';
+import { defaultTokenProgramForCurrency, resolveStablecoinMint, stablecoinSymbolForCurrency } from '../constants.js';
 import * as Methods from '../Methods.js';
 import type {
     CommitReceipt,
@@ -25,6 +27,7 @@ import type {
     OpenPayload,
     SessionAction,
     SessionAuthentication,
+    SessionReceipt,
     SessionRequest,
     SessionSplit,
     SessionVoucherSigner,
@@ -146,7 +149,13 @@ export function session(parameters: session.Parameters) {
     const operator = operatorVoucherSigner?.address;
     const store = resolveSessionStore(parameters);
     const resolvedProgramId = (channelProgram ?? PAYMENT_CHANNELS_PROGRAM_ID) as Address;
-    const resolvedMint = resolveStablecoinMint(currency, network) ?? currency;
+    const resolvedMint = resolveStablecoinMint(currency, network);
+    if (!resolvedMint) throw new Error('session currency must be an SPL token mint; use wrapped SOL instead of SOL');
+    const resolvedDecimals = decimals ?? (stablecoinSymbolForCurrency(resolvedMint) ? 6 : undefined);
+    if (resolvedDecimals === undefined) throw new Error('decimals is required for a session SPL token mint');
+    if (!Number.isInteger(resolvedDecimals) || resolvedDecimals < 0 || resolvedDecimals > 9) {
+        throw new Error('decimals must be an integer from 0 to 9');
+    }
     const tokenProgram = parameters.tokenProgram ?? defaultTokenProgramForCurrency(currency, network);
     const lifecycleRef: { value: Lifecycle | undefined } = { value: undefined };
 
@@ -187,7 +196,7 @@ export function session(parameters: session.Parameters) {
     const method = Method.toServer(Methods.session, {
         defaults: {
             amount: amount.toString(),
-            currency,
+            currency: resolvedMint,
             methodDetails: {
                 channelProgram: resolvedProgramId.toString(),
                 network,
@@ -213,7 +222,7 @@ export function session(parameters: session.Parameters) {
 
             const challengeRequest: SessionRequest = {
                 amount: request.amount ?? amount.toString(),
-                currency,
+                currency: resolvedMint,
                 ...(request.description ? { description: request.description } : {}),
                 ...(request.externalId ? { externalId: request.externalId } : {}),
                 ...(minimumDeposit !== undefined ? { minimumDeposit: minimumDeposit.toString() } : {}),
@@ -223,7 +232,7 @@ export function session(parameters: session.Parameters) {
                 methodDetails: {
                     ...(resumeChannelId ? { channelId: resumeChannelId } : {}),
                     channelProgram: resolvedProgramId.toString(),
-                    ...(decimals !== undefined ? { decimals } : {}),
+                    decimals: resolvedDecimals,
                     ...(distributionSplits?.length ? { distributionSplits: [...distributionSplits] } : {}),
                     ...(feePayer ? { feePayer: true, feePayerKey: feePayerSigner?.address } : {}),
                     ...(gracePeriodSeconds !== undefined ? { gracePeriodSeconds } : {}),
@@ -254,7 +263,7 @@ export function session(parameters: session.Parameters) {
                     assertChallengeOpenNotExpired(cred.challenge.expires);
                     return await handleOpen({
                         challengeId: cred.challenge.id,
-                        currency,
+                        currency: resolvedMint,
                         distributionSplits,
                         externalId: cred.challenge.request.externalId,
                         feePayer,
@@ -301,6 +310,7 @@ export function session(parameters: session.Parameters) {
                         lifecycle: lifecycleRef.value,
                         minVoucherDelta,
                         payload: cred.payload,
+                        price: parseU64String(cred.challenge.request.amount, 'amount'),
                         settlementWindow: settlementWindowSeconds,
                         store,
                     });
@@ -318,7 +328,7 @@ export function session(parameters: session.Parameters) {
                     return await handleClose({
                         challengeId: cred.challenge.id,
                         currency,
-                        decimals,
+                        decimals: resolvedDecimals,
                         externalId: cred.challenge.request.externalId,
                         lifecycle: lifecycleRef.value,
                         merchantSigner: signer,
@@ -523,6 +533,10 @@ interface HandleOpenArgs {
 
 async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
     const { payload } = args;
+    const authorizedSigner = address(payload.authorizedSigner);
+    if (isOffCurveAddress(authorizedSigner)) {
+        throw new Error('open authorizedSigner must be an on-curve Ed25519 public key');
+    }
     if (args.voucherSigner === 'operator' && (!args.operator || payload.authorizedSigner !== args.operator)) {
         throw new Error('operator voucher signing requires authorizedSigner to match the operator');
     }
@@ -571,6 +585,18 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
         tokenProgram: args.tokenProgram,
     };
     const verified = await verifyOpenTx({ expected, openPayload: payload });
+    const existingChannel = await args.store.getChannel(verified.channelId);
+    if (!existingChannel) {
+        const currentSlot = await currentClusterSlot(args.rpc);
+        if (openSlot > currentSlot) {
+            throw new Error(`open openSlot ${openSlot.toString()} is ahead of the current cluster slot ${currentSlot}`);
+        }
+        if (currentSlot - openSlot > OPEN_SLOT_WINDOW) {
+            throw new Error(
+                `open openSlot ${openSlot.toString()} is outside the ${OPEN_SLOT_WINDOW.toString()}-slot freshness window of the current cluster slot ${currentSlot.toString()}`,
+            );
+        }
+    }
 
     const effectiveIdleTimeoutSeconds = resolveIdleTimeoutSeconds({
         defaultSeconds: args.idleTimeoutSeconds,
@@ -651,13 +677,10 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
     });
     args.lifecycle?.touch(verified.channelId, persisted.idleTimeoutSeconds);
 
-    return Receipt.from({
-        method: 'solana',
-        ...(args.challengeId ? { challengeId: args.challengeId } : {}),
-        ...(args.externalId ? { externalId: args.externalId } : {}),
-        reference: signature ?? verified.channelId,
-        status: 'success',
-        timestamp: new Date().toISOString(),
+    return sessionReceipt(persisted, {
+        challengeId: args.challengeId,
+        externalId: args.externalId,
+        txHash: signature,
     });
 }
 
@@ -667,6 +690,7 @@ interface HandleVoucherArgs {
     readonly lifecycle: Lifecycle | undefined;
     readonly minVoucherDelta: bigint | undefined;
     readonly payload: { readonly action: 'voucher'; readonly channelId: string; readonly voucher: SignedVoucher };
+    readonly price: bigint;
     /** Forced-close grace period a non-zero voucher expiry must outlast. */
     readonly settlementWindow: bigint | undefined;
     readonly store: SessionStore;
@@ -712,7 +736,7 @@ async function handleUse(args: HandleUseArgs): Promise<Receipt.Receipt> {
     let voucherSignature = '';
     let cumulative = 0n;
     let idleTimeoutSeconds: number | undefined;
-    await args.store.updateChannel(args.payload.channelId, async current => {
+    const finalState = await args.store.updateChannel(args.payload.channelId, async current => {
         if (!current) throw new Error(`Channel ${args.payload.channelId} not found`);
         if (current.sealed || current.closeRequestedAt !== undefined) {
             throw new Error('Channel is closed or close is pending');
@@ -758,17 +782,14 @@ async function handleUse(args: HandleUseArgs): Promise<Receipt.Receipt> {
     });
     args.lifecycle?.touch(args.payload.channelId, idleTimeoutSeconds);
 
-    return Receipt.from({
-        method: 'solana',
-        ...(args.challengeId ? { challengeId: args.challengeId } : {}),
-        ...(args.externalId ? { externalId: args.externalId } : {}),
-        reference: `${args.payload.channelId}:${cumulative.toString()}:${voucherSignature}`,
-        status: 'success',
-        timestamp: new Date().toISOString(),
+    return sessionReceipt(finalState, {
+        challengeId: args.challengeId,
+        externalId: args.externalId,
     });
 }
 
 async function handleVoucher(args: HandleVoucherArgs): Promise<Receipt.Receipt> {
+    if (args.price === 0n) throw new Error('session amount must be positive');
     const signed = normalizeSignedVoucher(args.payload.voucher);
     // The top-level channelId is the routing key; it must never diverge from
     // the signed voucher's inner channelId (spec: servers MUST reject the
@@ -793,8 +814,7 @@ async function handleVoucher(args: HandleVoucherArgs): Promise<Receipt.Receipt> 
     rejectIfVoucherRejected(preflight);
 
     // Atomic re-check inside the lock (mirrors the Rust closure pattern).
-    let finalResult: VoucherVerifyResult = preflight;
-    await args.store.updateChannel(channelId, async current => {
+    const finalState = await args.store.updateChannel(channelId, async current => {
         if (!current) throw new Error(`Channel ${channelId} not found`);
         const result = await verifyVoucherForChannel({
             deposit: current.deposit,
@@ -803,34 +823,32 @@ async function handleVoucher(args: HandleVoucherArgs): Promise<Receipt.Receipt> 
             signed,
             state: current,
         });
-        finalResult = result;
         if (result.status === 'rejected') {
             // Caller will translate; reuse the Rust convention of throwing.
             throw new Error(`${result.reason}: ${result.detail}`);
         }
-        if (result.status === 'replayed') return current;
+        const acceptedCumulative = result.newCumulative;
+        if (acceptedCumulative - current.spentAmount < args.price) {
+            throw new Error('insufficient authorized voucher availability');
+        }
         return {
             ...current,
-            cumulative: result.newCumulative,
-            highestVoucherExpiresAt: result.newExpiresAt,
-            highestVoucherSignature: result.newSignature,
+            ...(result.status === 'accepted'
+                ? {
+                      cumulative: result.newCumulative,
+                      highestVoucherExpiresAt: result.newExpiresAt,
+                      highestVoucherSignature: result.newSignature,
+                  }
+                : {}),
             lastActivityAt: Date.now(),
+            spentAmount: current.spentAmount + args.price,
         };
     });
-    if (finalResult.status === 'accepted') {
-        args.lifecycle?.touch(channelId, existing.idleTimeoutSeconds);
-    }
+    args.lifecycle?.touch(channelId, finalState.idleTimeoutSeconds);
 
-    const cumulative =
-        finalResult.status === 'accepted' || finalResult.status === 'replayed' ? finalResult.newCumulative : 0n;
-
-    return Receipt.from({
-        method: 'solana',
-        ...(args.challengeId ? { challengeId: args.challengeId } : {}),
-        ...(args.externalId ? { externalId: args.externalId } : {}),
-        reference: `${channelId}:${cumulative.toString()}`,
-        status: 'success',
-        timestamp: new Date().toISOString(),
+    return sessionReceipt(finalState, {
+        challengeId: args.challengeId,
+        externalId: args.externalId,
     });
 }
 
@@ -861,13 +879,10 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
     // transaction fails at preflight).
     const topUpSignature = transactionSignatureFromWire(args.payload.transaction) as unknown as string;
     if (existing.processedTopUpSignatures?.includes(topUpSignature)) {
-        return Receipt.from({
-            method: 'solana',
-            ...(args.challengeId ? { challengeId: args.challengeId } : {}),
-            ...(args.externalId ? { externalId: args.externalId } : {}),
-            reference: topUpSignature,
-            status: 'success',
-            timestamp: new Date().toISOString(),
+        return sessionReceipt(existing, {
+            challengeId: args.challengeId,
+            externalId: args.externalId,
+            txHash: topUpSignature,
         });
     }
     if (existing.sealed) throw new Error('Channel is already sealed');
@@ -905,13 +920,10 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
     });
     args.lifecycle?.touch(result.channelId, result.idleTimeoutSeconds);
 
-    return Receipt.from({
-        method: 'solana',
-        ...(args.challengeId ? { challengeId: args.challengeId } : {}),
-        ...(args.externalId ? { externalId: args.externalId } : {}),
-        reference: signature as unknown as string,
-        status: 'success',
-        timestamp: new Date().toISOString(),
+    return sessionReceipt(result, {
+        challengeId: args.challengeId,
+        externalId: args.externalId,
+        txHash: signature as unknown as string,
     });
 }
 
@@ -1049,14 +1061,52 @@ async function handleClose(args: HandleCloseArgs): Promise<Receipt.Receipt> {
 
     args.lifecycle?.removeChannel(channelId);
 
-    return Receipt.from({
+    const finalState = await args.store.getChannel(channelId);
+    if (!finalState) throw new Error(`Channel ${channelId} not found after close`);
+    return sessionReceipt(finalState, {
+        challengeId: args.challengeId,
+        externalId: args.externalId,
+        refunded: finalState.deposit - finalState.cumulative,
+        txHash: onChainSignature,
+    });
+}
+
+interface SessionReceiptOptions {
+    readonly challengeId: string | undefined;
+    readonly externalId: string | undefined;
+    readonly refunded?: bigint | undefined;
+    readonly txHash?: string | undefined;
+}
+
+/** Build the receipt extension required by draft-solana-session-00. */
+function sessionReceipt(state: ChannelState, options: SessionReceiptOptions): SessionReceipt {
+    if (state.idleTimeoutSeconds === undefined) {
+        throw new Error(`Channel ${state.channelId} is missing its negotiated idle timeout`);
+    }
+    return {
+        acceptedCumulative: state.cumulative.toString(),
+        ...(options.challengeId ? { challengeId: options.challengeId } : {}),
+        ...(options.externalId ? { externalId: options.externalId } : {}),
+        idleTimeoutSeconds: state.idleTimeoutSeconds,
+        intent: 'session',
         method: 'solana',
-        ...(args.challengeId ? { challengeId: args.challengeId } : {}),
-        ...(args.externalId ? { externalId: args.externalId } : {}),
-        reference: onChainSignature ?? channelId,
+        reference: state.channelId,
+        ...(options.refunded !== undefined ? { refunded: options.refunded.toString() } : {}),
+        spent: state.spentAmount.toString(),
         status: 'success',
         timestamp: new Date().toISOString(),
-    });
+        ...(options.txHash ? { txHash: options.txHash } : {}),
+    };
+}
+
+async function currentClusterSlot(rpc: RpcLike): Promise<bigint> {
+    const getSlot = (rpc as { getSlot?: (config?: { commitment?: string }) => { send(): Promise<bigint> } }).getSlot;
+    if (!getSlot) throw new Error('open freshness validation requires an RPC getSlot method');
+    try {
+        return await getSlot.call(rpc, { commitment: 'confirmed' }).send();
+    } catch (error) {
+        throw new Error(`failed to fetch current cluster slot for session open: ${String(error)}`);
+    }
 }
 
 function sessionAuthenticationMatches(left: SessionAuthentication, right: SessionAuthentication): boolean {
@@ -1215,6 +1265,7 @@ async function commitDelivery(store: SessionStore, args: CommitDeliveryArgs): Pr
             highestVoucherSignature: signed.signature,
             lastActivityAt: Date.now(),
             pendingDeliveries: nextPending,
+            spentAmount: current.spentAmount + actualAmount,
         };
     });
 

--- a/typescript/packages/mpp/src/shared/session-types.ts
+++ b/typescript/packages/mpp/src/shared/session-types.ts
@@ -18,6 +18,7 @@ export type {
     SessionAuthentication,
     SessionVoucherSigner,
     SessionRequest,
+    SessionReceipt,
     SessionSigner,
     SessionSplit,
     SignedVoucher,

--- a/typescript/packages/pay-kit/package.json
+++ b/typescript/packages/pay-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay-kit",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Building blocks for Agentic payments (x402, MPP, AP2)",
     "repository": {
         "type": "git",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -8,9 +8,9 @@ overrides:
   ws: ^8.21.0
   '@x402/core': file:.x402-vendor/x402-core-2.16.0.tgz
   '@hono/node-server': '>=2.0.10'
-  fast-uri: '>=4.1.1'
-  hono: '>=4.12.25'
-  ip-address: '>=10.1.1'
+  fast-uri: '>=4.1.2'
+  hono: '>=4.12.34'
+  ip-address: '>=10.3.1'
   js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'
   qs: '>=6.15.2'
@@ -87,7 +87,7 @@ importers:
         version: 25.5.0
       mppx:
         specifier: ^0.8.15
-        version: 0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
+        version: 0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
       surfpool-sdk:
         specifier: ^1.2.0
         version: 1.2.0
@@ -114,7 +114,7 @@ importers:
         version: 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       mppx:
         specifier: '>=0.5.5'
-        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
+        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
     devDependencies:
       '@solana/mpp':
         specifier: workspace:^
@@ -529,7 +529,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.25'
+      hono: '>=4.12.34'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2557,8 +2557,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
@@ -2712,8 +2712,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2768,8 +2768,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3220,7 +3220,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.25'
+      hono: '>=4.12.34'
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -3239,7 +3239,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.25'
+      hono: '>=4.12.34'
       viem: '>=2.54.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -4405,9 +4405,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@2.0.11(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.13.1)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.13.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -4639,7 +4639,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.13.1)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4649,7 +4649,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.13.1
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6012,7 +6012,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6522,7 +6522,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.5.0
 
   express@5.2.1:
     dependencies:
@@ -6571,7 +6571,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     optional: true
@@ -6733,7 +6733,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.27: {}
+  hono@4.13.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -6797,7 +6797,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -7369,7 +7369,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
-  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
+  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
@@ -7380,14 +7380,14 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1
-      hono: 4.12.27
+      hono: 4.13.1
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - openapi-types
       - supports-color
       - typescript
 
-  mppx@0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
+  mppx@0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0
@@ -7398,7 +7398,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1
-      hono: 4.12.27
+      hono: 4.13.1
     transitivePeerDependencies:
       - typescript
 

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@solana-program/token':
         specifier: ^0.11.0
         version: 0.11.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/addresses':
+        specifier: ^6.10.0
+        version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/program-client-core':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -17,9 +17,11 @@ overrides:
   ws: '^8.21.0'
   '@x402/core': 'file:.x402-vendor/x402-core-2.16.0.tgz'
   '@hono/node-server': '>=2.0.10'
-  fast-uri: '>=4.1.1'
-  hono: '>=4.12.25'
-  ip-address: '>=10.1.1'
+  # fast-uri/hono/ip-address floors below track advisories reached via
+  # @modelcontextprotocol/sdk (see `pnpm why <pkg>`); bump as new CVEs land.
+  fast-uri: '>=4.1.2'
+  hono: '>=4.12.34'
+  ip-address: '>=10.3.1'
   js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'
   qs: '>=6.15.2'


### PR DESCRIPTION
## Summary
- use confirmed commitment for session challenge blockhashes
- confirm channel opens and top-ups without waiting for finalization
- cover the configured commitment with a unit test

## Test Plan
- `cargo test -p solana-pay-kit --no-default-features --features mpp,x402,client,server,confidential,otel,testkit` (890 unit tests + Kotlin vector)