### PR TITLE
pay-kit: require decimals for SPL candidates and verify decimals

### DIFF
--- a/rust/crates/kit/src/select.rs
+++ b/rust/crates/kit/src/select.rs
@@ -572,7 +572,7 @@ mod tests {
             "amount": amount.to_string(),
             "currency": currency,
             "recipient": RECIPIENT,
-            "methodDetails": { "network": "mainnet" },
+            "methodDetails": { "network": "mainnet", "decimals": 6 },
         });
         let challenge = PaymentChallenge::new(
             "id-1",

--- a/rust/crates/kit/src/select.rs
+++ b/rust/crates/kit/src/select.rs
@@ -470,7 +470,7 @@ fn mpp_candidate(challenge: &PaymentChallenge, order: usize) -> Option<Candidate
         mint,
         network,
         amount,
-        decimals: details.decimals.unwrap_or(6),
+        decimals: details.decimals?,
         source: Source::MppCharge(Box::new(challenge.clone())),
         order,
     })
@@ -501,7 +501,7 @@ fn x402_candidate(requirement: &PaymentRequirements, order: usize) -> Option<Can
         mint,
         network,
         amount,
-        decimals: requirement.decimals.unwrap_or(6),
+        decimals: requirement.decimals?,
         source: Source::X402Exact(Box::new(requirement.clone())),
         order,
     })

--- a/rust/crates/kit/src/x402/protocol/schemes/exact/verify.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/exact/verify.rs
@@ -415,6 +415,14 @@ fn verify_transfer_instruction(
         return invalid("invalid_exact_svm_payload_amount_mismatch");
     }
 
+    let decimals = instruction.data[9];
+    let expected_decimals = requirements.decimals.ok_or_else(|| {
+        Error::Other("invalid_exact_svm_payload_decimals_missing".into())
+    })?;
+    if decimals != expected_decimals {
+        return invalid("invalid_exact_svm_payload_decimals_mismatch");
+    }
+
     Ok(())
 }
 
@@ -669,7 +677,7 @@ mod tests {
                     "mint": requirements.currency,
                     "tokenAmount": {
                         "amount": requirements.amount,
-                        "decimals": requirements.decimals.unwrap_or(6),
+                        "decimals": requirements.decimals.expect("decimals required for test helper"),
                     },
                 },
             },
@@ -755,7 +763,7 @@ mod tests {
 
         let mut data = vec![12u8];
         data.extend_from_slice(&amount.to_le_bytes());
-        data.push(requirements.decimals.unwrap_or(6));
+        data.push(requirements.decimals.expect("decimals required for transfer helper"));
 
         Instruction {
             program_id: token_program,


### PR DESCRIPTION
x402 exact and mpp select used unwrap_or(6) to default decimals to 6 when the server omitted it. For non-6-decimal mints this silently produces wrong human_amount ranking (1000x skew for 9-decimal tokens) and wrong TransferChecked decimals.

Require decimals for SPL candidates (return None to skip) and verify that the on-chain TransferChecked decimals byte matches the requirements. Update test helpers to expect decimals instead of defaulting.

Fixes the remaining unwrap_or(6) instances after #285 (Audit #42) which fixed mpp/client/charge.rs.

Verification: POC verified 1000% — wrong decimals 9 vs 6 now fails verify (was Ok), select ranking skew 1000x confirmed, cargo check passes.