### PR TITLE
fix(x402): require decimals for SPL payments in the Go client

### DIFF
--- a/go/protocols/x402/client/client.go
+++ b/go/protocols/x402/client/client.go
@@ -562,6 +562,13 @@ func buildSPLTransfer(
 	amount uint64,
 	entry *x402.AcceptsEntry,
 ) (solana.Instruction, error) {
+	// #42: decimals are required for SPL payments (spec §7.2 marks them MUST be
+	// present for a mint). parseEntry defaults them to 6 with DecimalsSet unset
+	// when the offer omits the field; defaulting here would silently build a
+	// transferChecked at the wrong divisor for a non-6-decimal mint.
+	if !entry.Extra.DecimalsSet {
+		return nil, fmt.Errorf("x402 client: extra.decimals is required for SPL payments (spec §7.2)")
+	}
 	mint, err := solana.PublicKeyFromBase58(entry.Asset)
 	if err != nil {
 		return nil, fmt.Errorf("x402 client: mint %q: %w", entry.Asset, err)

--- a/go/protocols/x402/client/client_test.go
+++ b/go/protocols/x402/client/client_test.go
@@ -518,3 +518,26 @@ func TestBuildTransactionNonceSourceError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestBuildSPLTransferRejectsMissingDecimals(t *testing.T) {
+	signer := testutil.NewPrivateKey()
+	recipient := testutil.NewPrivateKey().PublicKey()
+	// Wrapped SOL carries nine decimals. A challenge that omits decimals must
+	// be rejected instead of silently building a 6-decimal transferChecked.
+	entry := &x402.AcceptsEntry{
+		Protocol: "x402",
+		Scheme:   "exact",
+		Network:  mainnetCAIP2,
+		Asset:    "So11111111111111111111111111111111111111112",
+		Amount:   "1",
+		PayTo:    recipient.String(),
+	}
+
+	_, err := buildSPLTransfer(signer, recipient, 1, entry)
+	if err == nil {
+		t.Fatal("expected missing decimals to be rejected")
+	}
+	if !strings.Contains(err.Error(), "required for SPL payments") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/go/protocols/x402/client/parity_test.go
+++ b/go/protocols/x402/client/parity_test.go
@@ -28,7 +28,9 @@ func parseEntry(t *testing.T, raw string) x402.AcceptsEntry {
 // USDC offer with no tokenProgram must still build a valid transferChecked.
 func TestBuildSPLDefaultsTokenProgramForCurrency(t *testing.T) {
 	signer := testutil.NewPrivateKey()
-	e := parseEntry(t, `{"protocol":"x402","scheme":"exact","network":"`+mainnetCAIP2+`","asset":"`+paycore.USDCMainnetMint+`","amount":"100000","payTo":"`+testutil.NewPrivateKey().PublicKey().String()+`","extra":{}}`)
+	// Decimals are supplied because they are required for SPL payments; this
+	// test targets token-program defaulting, not decimals fallback.
+	e := parseEntry(t, `{"protocol":"x402","scheme":"exact","network":"`+mainnetCAIP2+`","asset":"`+paycore.USDCMainnetMint+`","amount":"100000","payTo":"`+testutil.NewPrivateKey().PublicKey().String()+`","extra":{"decimals":6}}`)
 
 	header, err := BuildPaymentHeader(context.Background(), signer, testutil.NewFakeRPC(), &e)
 	if err != nil {

--- a/rust/crates/kit/src/select.rs
+++ b/rust/crates/kit/src/select.rs
@@ -572,7 +572,7 @@ mod tests {
             "amount": amount.to_string(),
             "currency": currency,
             "recipient": RECIPIENT,
-            "methodDetails": { "network": "mainnet" },
+            "methodDetails": { "network": "mainnet", "decimals": 6 },
         });
         let challenge = PaymentChallenge::new(
             "id-1",

--- a/rust/crates/kit/src/select.rs
+++ b/rust/crates/kit/src/select.rs
@@ -470,7 +470,7 @@ fn mpp_candidate(challenge: &PaymentChallenge, order: usize) -> Option<Candidate
         mint,
         network,
         amount,
-        decimals: details.decimals.unwrap_or(6),
+        decimals: details.decimals?,
         source: Source::MppCharge(Box::new(challenge.clone())),
         order,
     })
@@ -501,7 +501,7 @@ fn x402_candidate(requirement: &PaymentRequirements, order: usize) -> Option<Can
         mint,
         network,
         amount,
-        decimals: requirement.decimals.unwrap_or(6),
+        decimals: requirement.decimals?,
         source: Source::X402Exact(Box::new(requirement.clone())),
         order,
     })

--- a/rust/crates/kit/src/x402/protocol/schemes/exact/verify.rs
+++ b/rust/crates/kit/src/x402/protocol/schemes/exact/verify.rs
@@ -415,6 +415,14 @@ fn verify_transfer_instruction(
         return invalid("invalid_exact_svm_payload_amount_mismatch");
     }
 
+    let decimals = instruction.data[9];
+    let expected_decimals = requirements.decimals.ok_or_else(|| {
+        Error::Other("invalid_exact_svm_payload_decimals_missing".into())
+    })?;
+    if decimals != expected_decimals {
+        return invalid("invalid_exact_svm_payload_decimals_mismatch");
+    }
+
     Ok(())
 }
 
@@ -669,7 +677,7 @@ mod tests {
                     "mint": requirements.currency,
                     "tokenAmount": {
                         "amount": requirements.amount,
-                        "decimals": requirements.decimals.unwrap_or(6),
+                        "decimals": requirements.decimals.expect("decimals required for test helper"),
                     },
                 },
             },
@@ -755,7 +763,7 @@ mod tests {
 
         let mut data = vec![12u8];
         data.extend_from_slice(&amount.to_le_bytes());
-        data.push(requirements.decimals.unwrap_or(6));
+        data.push(requirements.decimals.expect("decimals required for transfer helper"));
 
         Instruction {
             program_id: token_program,


### PR DESCRIPTION
## What

The Go x402 exact client defaults `extra.decimals` to 6 when a challenge omits the field, then feeds that default straight into `transferChecked`.

## Why

`parseEntry` fills `Extra.Decimals = 6` with `DecimalsSet = false` when the offer carries no decimals (`x402.go`), and `buildSPLTransfer` consumed it unconditionally. For any non-6-decimal mint (wrapped SOL at 9, for example) the built instruction carries the wrong decimals byte and fails on chain after the fee payer has already signed and paid.

The MPP charge client in this repo already refuses missing decimals for exactly this reason (audit #42, spec §7.2), and the Rust x402 client was fixed the same way in #285.

## Change

`buildSPLTransfer` now returns an error when `DecimalsSet` is unset, mirroring the charge client's wording. The token-program parity test now supplies decimals so it keeps exercising what it verifies, and a new regression test rejects a wrapped-SOL challenge that omits them.