### PR TITLE
fix(x402): require decimals for SPL payments in the Swift client

### DIFF
--- a/harness/vectors/x402-v1-build.json
+++ b/harness/vectors/x402-v1-build.json
@@ -13,7 +13,10 @@
         "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
         "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
         "maxTimeoutSeconds": 60,
-        "extra": { "feePayer": "6AfzJJo1KfhNWKe56wa5EWszTNQ7B1W5Kfh5SY2JkRGQ" }
+        "extra": {
+          "feePayer": "6AfzJJo1KfhNWKe56wa5EWszTNQ7B1W5Kfh5SY2JkRGQ",
+          "decimals": 6
+        }
       },
       "x402PinnedTransaction": "AA=="
     },
@@ -41,7 +44,10 @@
         "amount": "10000",
         "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
-        "maxTimeoutSeconds": 300
+        "maxTimeoutSeconds": 300,
+        "extra": {
+          "decimals": 6
+        }
       },
       "x402PinnedTransaction": "AA=="
     },
@@ -69,7 +75,9 @@
         "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
         "payTo": "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
         "maxTimeoutSeconds": 300,
-        "extra": { "decimals": 6 }
+        "extra": {
+          "decimals": 6
+        }
       },
       "x402PinnedTransaction": "AA=="
     },

--- a/swift/Sources/SolanaPayKit/Protocols/X402/Client/Exact/Payment.swift
+++ b/swift/Sources/SolanaPayKit/Protocols/X402/Client/Exact/Payment.swift
@@ -12,9 +12,6 @@ let X402ComputeUnitLimit: UInt32 = 20_000
 /// ComputeBudget SetComputeUnitPrice micro-lamports.
 let X402ComputeUnitPrice: UInt64 = 1
 
-/// Default SPL decimals when the offer omits `extra.decimals`.
-let X402DefaultDecimals: UInt8 = 6
-
 // MARK: - Challenge parsing
 
 /// A selected x402 offer together with the protocol version the server's
@@ -317,12 +314,16 @@ private func _buildPaymentPayload(
             ?? Mints.defaultTokenProgram(currency: assetStr, cluster: clusterLabel)
         let tokenProgram = try Pubkey(base58: tokenProgramStr)
         let mint = try Pubkey(base58: mintStr)
-        let decimals: UInt8
-        if let d = offer.effectiveDecimals, d >= 0, d <= 255 {
-            decimals = UInt8(d)
-        } else {
-            decimals = X402DefaultDecimals
+        // Decimals are required for SPL payments (spec §7.2 marks them MUST be
+        // present for a mint). Defaulting a missing value to 6 silently signs
+        // a wrong transferChecked decimals byte / wrong divisor for any
+        // non-6-decimal mint, the worst failure mode for a signed transaction.
+        guard let d = offer.effectiveDecimals, d >= 0, d <= 255 else {
+            throw PayKitError.invalidTransaction(
+                "extra.decimals is required for SPL payments (spec §7.2)"
+            )
         }
+        let decimals = UInt8(d)
         let sourceAta = try AssociatedTokenAccount.address(
             owner: signerPubkey, mint: mint, tokenProgram: tokenProgram
         )

--- a/swift/Tests/SolanaPayKitTests/X402PaymentTests.swift
+++ b/swift/Tests/SolanaPayKitTests/X402PaymentTests.swift
@@ -542,6 +542,25 @@ struct X402PaymentBuildingTests {
             Issue.record("expected error")
         } catch { }
     }
+
+    @Test
+    func throwsOnMissingDecimalsForSPL() async {
+        let signer = try! Self.makeSigner()
+        let rpc = Self.makeRpc()
+        // Wrapped SOL carries nine decimals; an offer omitting decimals must be
+        // rejected rather than silently signed at the default six.
+        let extra: [String: JSONValue] = ["recentBlockhash": .string(Self.knownBlockhash)]
+        let offer = X402AcceptsEntry(
+            scheme: "exact", network: SolanaNetwork.mainnet,
+            amount: "1000", maxAmountRequired: nil,
+            asset: "So11111111111111111111111111111111111111112",
+            payTo: "recipient", recipient: nil, extra: extra
+        )
+        do {
+            _ = try await buildX402PaymentHeader(signer: signer, rpc: rpc, offer: offer)
+            Issue.record("expected error")
+        } catch { }
+    }
 }
 
 // MARK: - Mints / Network registry tests


### PR DESCRIPTION
## What

The Swift x402 exact client defaults `extra.decimals` to 6 when an offer omits the field, then feeds that default straight into `transferChecked`.

## Why

For any non-6-decimal mint (wrapped SOL at 9, for example) the built instruction carries the wrong decimals byte and fails on chain after the fee payer has already signed and paid. The MPP charge client in this repo already refuses missing decimals for exactly this reason (spec §7.2), and the Rust x402 client was fixed the same way in #285.

## Change

`_buildPaymentPayload` now throws `PayKitError.invalidTransaction` when the offer carries no usable `decimals`, instead of falling back to 6. The unused `X402DefaultDecimals` constant is removed.

The two shared build vectors (`harness/vectors/x402-v1-build.json`) whose USDC offers omitted decimals now carry their correct value (`6`) explicitly; only the Swift suite consumes that file. A regression test rejects a wrapped-SOL challenge without decimals.