### PR TITLE
fix(x402): require decimals for SPL payments in the Kotlin client

### DIFF
--- a/kotlin/src/main/kotlin/com/solana/paykit/protocols/x402/client/exact/Payment.kt
+++ b/kotlin/src/main/kotlin/com/solana/paykit/protocols/x402/client/exact/Payment.kt
@@ -63,8 +63,6 @@ private const val COMPUTE_UNIT_LIMIT = 20_000
 /** ComputeBudget SetComputeUnitPrice microlamports. */
 private const val COMPUTE_UNIT_PRICE = 1L
 
-/** Default SPL decimals when the offer omits ``extra.decimals``. */
-private const val DEFAULT_DECIMALS = 6
 
 /**
  * x402 memo byte cap. INVARIANT: 256 (rust ``MAX_MEMO_BYTES``). This is
@@ -284,7 +282,12 @@ fun buildPayment(
         val mintStr = resolveStablecoinMint(asset, label) ?: asset
         val tokenProgramStr = requirement.effectiveTokenProgram
             ?: defaultTokenProgramForCurrency(asset, label)
-        val decimals = requirement.effectiveDecimals ?: DEFAULT_DECIMALS
+        // Decimals are required for SPL payments (spec section 7.2 marks them
+        // MUST be present for a mint). Defaulting a missing value to 6
+        // silently signs a wrong transferChecked decimals byte for any
+        // non-6-decimal mint, the worst failure mode for a signed transaction.
+        val decimals = requirement.effectiveDecimals
+            ?: throw IllegalArgumentException("extra.decimals is required for SPL payments (spec §7.2)")
         val tokenProgramKey = PublicKey.fromBase58(tokenProgramStr)
         val mintKey = PublicKey.fromBase58(mintStr)
         val sourceAta = Pda.associatedTokenAddress(signerKey, mintKey, tokenProgramKey)

--- a/kotlin/src/test/kotlin/com/solana/paykit/protocols/x402/client/exact/BuildPaymentTest.kt
+++ b/kotlin/src/test/kotlin/com/solana/paykit/protocols/x402/client/exact/BuildPaymentTest.kt
@@ -312,6 +312,28 @@ class BuildPaymentTest {
     }
 
     @Test
+    fun rejectsSplPaymentWhenDecimalsMissing() {
+        // Wrapped SOL carries nine decimals; an offer omitting decimals must be
+        // rejected rather than silently signed at the default six.
+        val offer = X402AcceptsEntry(
+            scheme = "exact",
+            network = Network.SOLANA_MAINNET,
+            asset = "So11111111111111111111111111111111111111112",
+            amount = "1000",
+            payTo = devnetRecipient,
+            extra = X402Extra(
+                tokenProgram = Programs.TOKEN_PROGRAM,
+                decimals = null,
+                recentBlockhash = "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM",
+            ),
+        )
+        val error = assertFailsWith<IllegalArgumentException> {
+            buildPayment(signer, offer, fixedBlockhash)
+        }
+        assertTrue(error.message!!.contains("required for SPL payments"))
+    }
+
+    @Test
     fun splOfferMissingTokenProgramDefaultsFromCurrency() {
         // A known stablecoin offer that omits the token program defaults it
         // from the currency (rust `default_token_program_for_currency`) rather


### PR DESCRIPTION
## What

The Kotlin x402 exact client defaults `extra.decimals` to 6 when an offer omits the field, then feeds that default straight into `transferChecked`.

## Why

For any non-6-decimal mint (wrapped SOL at 9, for example) the built instruction carries the wrong decimals byte and fails on chain after the fee payer has already signed and paid. The MPP charge client in this repo already refuses missing decimals for exactly this reason (spec §7.2), and the Rust x402 client was fixed the same way in #285.

## Change

`buildPayment` now throws `IllegalArgumentException` when the offer carries no usable `decimals`, instead of falling back to 6. The now-unused `DEFAULT_DECIMALS` constant is removed.

A regression test rejects a wrapped-SOL challenge without decimals.