### PR TITLE
docs(skill): modernize Pay Kit protocol references

### DIFF
--- a/skills/pay-sdk-implementation/SKILL.md
+++ b/skills/pay-sdk-implementation/SKILL.md
@@ -1,22 +1,26 @@
 ---
 name: payment-sdk-implementation
-description: Derive a new-language SDK port of the Solana payment SDKs (MPP today, x402 next). Use when the user asks to "port the SDK to <language>", "add <language> client/server for MPP", "scaffold a <language> mpp-sdk", or "add x402 support in <language>". Routes to progressive-disclosure references; do not read every leaf — only the ones for the compatibility-matrix cells the user has in scope.
+description: Port or extend a Pay Kit SDK for x402 and MPP on Solana. Use when the user asks to "port Pay Kit to <language>", "add <language> payment client/server support", "implement an MPP intent", or "add an x402 scheme". Inspect the target language's current matrix before choosing scope, then load only the relevant intent references.
 ---
 
 # Payment SDK implementation
 
-This skill scaffolds a language port of the Solana payment SDKs that stays
-wire-compatible with the Rust reference at `mpp-sdk/rust` (in the
-`solana-foundation/pay-kit` repo). It supports both **MPP** (today) and
-**x402** (scaffolded; spec references only until x402-kit lands).
+This skill scaffolds or extends a language port of Pay Kit while keeping it
+wire-compatible with the public reference implementations in this repository.
+Rust under `rust/crates/kit/src/` is the broadest in-repo reference; TypeScript
+under `typescript/packages/` is also authoritative for the surfaces it ships.
+Both **MPP** and **x402** are implemented today, but coverage varies by language
+and changes quickly.
 
 ## Specs (authoritative)
 
 - MPP / HTTP Payment Authentication scheme — <https://paymentauth.org>
   - Spec PRs — <https://github.com/tempoxyz/mpp-specs>
 - x402 — <https://docs.x402.org/introduction>
-- Reference Rust crate — `mpp-sdk/rust` (every wire-format claim in
-  this skill is grep-able to a path under that tree)
+- Pay Kit interface — `docs/paykit-interface.md`
+- Rust reference — `rust/crates/kit/src/{mpp,x402}`
+- TypeScript reference — `typescript/packages/{mpp,pay-kit}` and
+  `typescript/external/x402`
 
 ## Compatibility matrix — pick the cells in scope
 
@@ -26,17 +30,18 @@ maps to exactly one reference file under `references/intents/`:
 
 | Cell | Reference file | Status |
 |---|---|---|
-| `x402/exact` | `intents/x402-exact.md` | scaffold (future) |
-| `x402/upto` | `intents/x402-upto.md` | scaffold (future) |
-| `x402/batch-settlement` | `intents/x402-batch-settlement.md` | scaffold (future) |
-| `mpp/charge/pull` | `intents/mpp-charge-pull.md` | implemented in Rust |
-| `mpp/charge/push` | `intents/mpp-charge-push.md` | implemented in Rust |
-| `mpp/session` | `intents/mpp-session.md` | implemented in Rust |
-| `mpp/subscription` | `intents/mpp-subscription.md` | not yet specified |
+| `x402/exact` | `intents/x402-exact.md` | public Rust and TypeScript references |
+| `x402/upto` | `intents/x402-upto.md` | public Rust and TypeScript references |
+| `x402/batch-settlement` | `intents/x402-batch-settlement.md` | public Rust and TypeScript references |
+| `mpp/charge/pull` | `intents/mpp-charge-pull.md` | public Rust and TypeScript references |
+| `mpp/charge/push` | `intents/mpp-charge-push.md` | public Rust and TypeScript references |
+| `mpp/session` | `intents/mpp-session.md` | public Rust and TypeScript references |
+| `mpp/subscription` | `intents/mpp-subscription.md` | public Rust and TypeScript references |
 
-> **Default scope today:** MPP only. `mpp/charge/{pull,push}` are required
-> for any new SDK; `mpp/session` is optional; `mpp/subscription` and all
-> x402 cells stay listed in the README as `—` until the spec ships.
+Do not infer a default protocol matrix. Read the target language's README,
+source tree, and its entries in `harness/src/implementations.ts`, then implement
+only the cells requested. A cell implemented in Rust is not automatically
+available or harness-enabled in every other language.
 
 ## Workflow
 
@@ -64,8 +69,8 @@ the directory skeleton and CI from earlier ones.
    read the matching file under `references/intents/`. Each leaf is
    self-contained: wire format, server obligations, client obligations,
    subtle bugs to avoid, test cases to mirror, spec links. Reference the
-   Rust file paths cited in the leaf to disambiguate anything that's
-   under-specified.
+   current Rust and TypeScript paths cited in the leaf to disambiguate
+   anything that's under-specified.
 6. **Consume Solana program clients via Codama.** Read
    `references/codegen.md`. Pay-kit vendors Codama IDLs at
    `idl/<program>.json` and renders per-language clients with
@@ -74,14 +79,13 @@ the directory skeleton and CI from earlier ones.
    program; do **not** hand-write a Solana program client in a new
    language — add a `subscriptions-generate-<lang>` recipe alongside
    the existing `subscriptions-generate-rs` and consume the generated
-   tree the same way `mpp/program/payment_channels.rs` and
-   `mpp/program/subscriptions.rs` do in Rust.
+   tree the same way `rust/crates/kit/src/mpp/program/` does in Rust.
 7. **Add the harness adapter.** Read `references/harness.md`,
    create `harness/<lang>-client/` (and a `bin/harness_server` if
    you're shipping a server), and register it in
-   `harness/src/implementations.ts`. Run the focused matrix
-   (`MPP_HARNESS_CLIENTS=<lang> MPP_HARNESS_SERVERS=rust pnpm test` and
-   the inverse) before flipping `enabled: true`.
+   `harness/src/implementations.ts`. Run the focused matrix with the
+   protocol-specific `MPP_HARNESS_*` or `X402_HARNESS_*` selectors documented
+   there before flipping `enabled: true`.
 8. **Apply the operability caveats.** Read
    `references/operability-caveats.md`. These are the gaps the Ruby
    gem's PR #142 follow-up closed (default `localnet` RPC, mainnet
@@ -99,8 +103,9 @@ the directory skeleton and CI from earlier ones.
 ## Hard rules
 
 - **No fabricated invariants.** Every wire-format claim in the SDK you
-  ship must trace back to either a Rust file under
-  `rust/crates/mpp/src/` or the spec at `paymentauth.org`. If a
+  ship must trace back to a public implementation under
+  `rust/crates/kit/src/{mpp,x402}`, the corresponding TypeScript package, or
+  the governing protocol spec. If a
   reference file says "see X.rs", open it.
 - **Canonical JSON → base64url, no padding.** Bodies that flow through
   the `request` field, the `opaque` field, or signing inputs use
@@ -110,7 +115,7 @@ the directory skeleton and CI from earlier ones.
   `references/intents/mpp-charge-pull.md` for the exact boundary.
 - **Cross-route replay protection is non-negotiable.** Every server
   must run the tier-2 pinned-field check before settlement — see the
-  pinned-field backstop in `rust/crates/mpp/src/server/charge.rs:424`. The new
+  pinned-field backstop in `rust/crates/kit/src/mpp/server/charge.rs`. The new
   SDK must expose a `verify_credential_with_expected` (or the
   language-idiomatic equivalent) that pins `amount`, `currency`, and
   `recipient` per route.
@@ -126,13 +131,9 @@ the directory skeleton and CI from earlier ones.
 
 ## When the user asks for something this skill does not cover
 
-- Spec gaps (e.g. `mpp/subscription` semantics): point at
-  `intents/mpp-subscription.md` and ask the user to share the spec
-  draft. Do not invent semantics.
-- x402-specific code beyond the scaffold: ask the user to share
-  `~/Coding/x402-kit` (lives on their local machine; not in this
-  container). Treat the scaffold as a placeholder until the reference
-  lands.
+- A protocol or language cell without a public reference: report the exact
+  missing source or harness vector and ask for scope. Do not invent semantics
+  or depend on a private checkout.
 - Anything cross-cutting in the on-chain payment-channels program: treat
   that as out of scope. The Rust crate
   re-exports the on-chain artifacts; the new SDK only needs to

--- a/skills/pay-sdk-implementation/references/ci-quality-coverage.md
+++ b/skills/pay-sdk-implementation/references/ci-quality-coverage.md
@@ -1,6 +1,6 @@
 # CI, quality, coverage
 
-The reference CI is `mpp-sdk/.github/workflows/ci.yml`. Copy the
+The reference CI is `.github/workflows/ci.yml`. Copy the
 shape of `test-rust` (or `test-python`/`test-go` for the closest
 language fit), add formatter + linter steps, gate coverage at ≥ 90 %.
 
@@ -115,7 +115,7 @@ must fail the job:
 
 Every public type/function carries a **one-line summary** so the
 language's hover/LSP shows it. Reference: every `pub` item in
-`rust/crates/mpp/src/lib.rs` has a `///` line. Examples to mirror:
+`rust/crates/kit/src/lib.rs` has a `///` line. Examples to mirror:
 
 ```rust
 /// Payment method identifier (newtype over String).
@@ -154,7 +154,7 @@ the new language:
   in CI if you see drift between local and CI numbers.
 - **`html-assets` is an artifact, not a checked-in directory.** The
   `build-html` job uploads it; downstream jobs `actions/download-artifact`
-  it. Generated HTML files (e.g. `rust/crates/mpp/src/server/html/*.gen.*`) are
+  it. Generated HTML files (e.g. `rust/crates/kit/src/mpp/server/html/*.gen.*`) are
   committed for offline builds but CI verifies the committed copy is
   up-to-date — see the `Verify committed gen files are up to date`
   step in `ci.yml`. New language servers go in that diff list.

--- a/skills/pay-sdk-implementation/references/codegen.md
+++ b/skills/pay-sdk-implementation/references/codegen.md
@@ -3,7 +3,7 @@
 Pay-kit consumes a handful of Solana programs (payment-channels,
 subscriptions, …) whose on-chain wire format is best produced from a
 single source of truth: each program's Codama IDL. Hand-writing a
-client per language is how `rust/crates/mpp/src/program/subscriptions.rs`
+client per language is how `rust/crates/kit/src/mpp/program/subscriptions.rs`
 became 825 lines that drifted from the upstream IDL the moment a new
 field landed.
 

--- a/skills/pay-sdk-implementation/references/coding-conventions.md
+++ b/skills/pay-sdk-implementation/references/coding-conventions.md
@@ -37,7 +37,7 @@ Use the language's canonical identifier case:
   `SCREAMING_SNAKE` for constants.
 
 Wire-format field names are **camelCase JSON** in every language (see
-`rust/crates/mpp/src/protocol/intents/charge.rs:35` — `externalId`, `methodDetails`
+`rust/crates/kit/src/mpp/protocol/intents/charge.rs` — `externalId`, `methodDetails`
 are serde-renamed to camelCase). The struct/class field name follows
 language convention; only the serialized form is camelCase.
 
@@ -64,9 +64,9 @@ language convention; only the serialized form is camelCase.
 The SDK exposes **one** error type per top-level concern:
 
 - `Error` (or `MppError`) — the protocol/SDK-level enum (see
-  `rust/crates/mpp/src/error.rs`).
+  `rust/crates/kit/src/mpp/error.rs`).
 - `StoreError` — replay-store internal errors (see
-  `rust/crates/mpp/src/store.rs:36`).
+  `rust/crates/kit/src/mpp/store.rs`).
 - `VerificationError` — server-side credential verification result.
 
 In typed languages, use the language's enum/sum-type construct
@@ -92,7 +92,7 @@ diff-able across languages.
 The server-side **charge** intent is fundamentally synchronous (one
 HTTP round-trip; one optional RPC call). Only **session** with metered
 streaming forces a true async runtime — see
-`rust/crates/mpp/src/client/http_stream.rs`.
+`rust/crates/kit/src/mpp/client/http_stream.rs`.
 
 ## Memory & concurrency safety
 
@@ -107,9 +107,9 @@ streaming forces a true async runtime — see
 
 Every public type and function carries a one-line doc comment. The
 Rust crate is the reference (`pub fn`/`pub struct` items in
-`rust/crates/mpp/src/lib.rs` all have a `///` summary). Multi-paragraph doc
+`rust/crates/kit/src/mpp/mod.rs` all have a `///` summary). Multi-paragraph doc
 comments are fine where they explain a non-obvious invariant — see
-`rust/crates/mpp/src/protocol/intents/session.rs:71-78` for an example.
+`rust/crates/kit/src/mpp/protocol/intents/session.rs` for an example.
 
 ## Forbidden in committed artifacts
 
@@ -129,12 +129,12 @@ comments are fine where they explain a non-obvious invariant — see
   to switch between languages by changing the import prefix only.
 - **`Default` everywhere it makes sense.** `Config::default()`,
   `ChargeOptions::default()`, `ChargeRequest::default()` — see
-  `rust/crates/mpp/src/server/charge.rs:94`. Default values keep the language's
+  `rust/crates/kit/src/mpp/server/charge.rs`. Default values keep the language's
   builder ergonomics consistent.
 - **Builder methods are short.** `OpenPayload::push()`,
   `OpenPayload::pull()`, `OpenPayload::with_transaction()`,
   `OpenPayload::with_init_tx()` — see
-  `rust/crates/mpp/src/protocol/intents/session.rs:318-455`. Mirror this
+  `rust/crates/kit/src/mpp/protocol/intents/session.rs`. Mirror this
   fluent style in the target language (or its equivalent — Python
   keyword arguments, Go option functions, TS object literal +
   `as const`).

--- a/skills/pay-sdk-implementation/references/harness.md
+++ b/skills/pay-sdk-implementation/references/harness.md
@@ -159,11 +159,13 @@ MPP_HARNESS_CLIENTS=rust MPP_HARNESS_SERVERS=<lang> pnpm test
 MPP_HARNESS_CLIENTS=<lang> MPP_HARNESS_SERVERS=<lang> pnpm test
 ```
 
-For x402, use the corresponding `X402_HARNESS_CLIENTS` and
-`X402_HARNESS_SERVERS` selectors plus `MPP_HARNESS_INTENTS=x402-<scheme>` and a
-matching `MPP_HARNESS_SCENARIOS` value. Copy a current command from the target
-scheme's entries or README; do not assume the MPP adapter IDs also implement
-x402.
+For x402 `exact` or `upto`, use the corresponding `X402_HARNESS_CLIENTS` and
+`X402_HARNESS_SERVERS` selectors plus `MPP_HARNESS_INTENTS=x402-exact` or
+`MPP_HARNESS_INTENTS=x402-upto` and a matching `MPP_HARNESS_SCENARIOS` value.
+Copy a current command from the target scheme's entries or README; do not assume
+the MPP adapter IDs also implement x402. The current harness rejects the
+`batch-settlement` selector. Add its intent and scenarios first instead of
+substituting that scheme into these commands.
 
 Add corresponding `Run <lang> client harness smoke` /
 `Run <lang> server harness smoke` / `Run <lang> end-to-end harness smoke`

--- a/skills/pay-sdk-implementation/references/harness.md
+++ b/skills/pay-sdk-implementation/references/harness.md
@@ -1,7 +1,7 @@
 # Harness adapter
 
 Cross-language compatibility is enforced by the TypeScript/Vitest harness
-at `mpp-sdk/harness`. Read its README first
+at `harness/`. Read its README first
 (`harness/README.md`) — that is the contract; this file summarizes
 the bits that bite when adding a new language.
 
@@ -9,18 +9,19 @@ the bits that bite when adding a new language.
 
 A new language ships **two** adapters that conform to the same contract:
 
-1. **Client adapter** — accepts a `MPP_HARNESS_TARGET_URL`, pays it,
+1. **Client adapter** — accepts the scenario target URL, pays it,
    emits one `result` JSON message on stdout, then exits.
 2. **Server adapter** — listens on `127.0.0.1:<port>`, exposes the
-   scenario's `resourcePath` protected by an MPP `charge` challenge,
+   scenario's `resourcePath` protected by the selected protocol intent,
    emits one `ready` JSON message on stdout, then serves.
 
 Reference adapters:
 
-- `rust/crates/mpp/src/bin/harness_client.rs` (94 lines — copy it).
-- `rust/crates/mpp/src/bin/harness_server.rs` (317 lines — copy it).
-- `harness/rust-client/` — Cargo manifest wrapper used by the
-  harness command.
+- `rust/crates/harness-bins/src/bin/mpp_harness_client.rs`
+- `rust/crates/harness-bins/src/bin/mpp_harness_server.rs`
+- `rust/crates/harness-bins/src/bin/x402_harness_client.rs`
+- `rust/crates/harness-bins/src/bin/x402_harness_server.rs`
+- `harness/rust-client/` — Cargo manifest wrapper used by MPP harness commands.
 
 ## The contract (verbatim from `harness/README.md`)
 
@@ -144,7 +145,8 @@ path-depends on `../../<lang>`, or a `package.json` with a single
 
 ## Focused matrix command
 
-Before enabling the implementation by default, run:
+Before enabling the implementation by default, select the exact intent and
+scenario. For MPP, run:
 
 ```bash
 # new client against the Rust server
@@ -157,6 +159,12 @@ MPP_HARNESS_CLIENTS=rust MPP_HARNESS_SERVERS=<lang> pnpm test
 MPP_HARNESS_CLIENTS=<lang> MPP_HARNESS_SERVERS=<lang> pnpm test
 ```
 
+For x402, use the corresponding `X402_HARNESS_CLIENTS` and
+`X402_HARNESS_SERVERS` selectors plus `MPP_HARNESS_INTENTS=x402-<scheme>` and a
+matching `MPP_HARNESS_SCENARIOS` value. Copy a current command from the target
+scheme's entries or README; do not assume the MPP adapter IDs also implement
+x402.
+
 Add corresponding `Run <lang> client harness smoke` /
 `Run <lang> server harness smoke` / `Run <lang> end-to-end harness smoke`
 steps to the `harness` job in `.github/workflows/ci.yml`. The Rust steps
@@ -168,7 +176,7 @@ in that file are the pattern.
   `[k, v]` tuples. Headers with multiple values are joined per the
   language's HTTP client behavior; if the client receives multiple
   `WWW-Authenticate` headers, use `parse_www_authenticate_all` (see
-  `rust/crates/mpp/src/bin/harness_client.rs:22-32`) to handle them — do not
+  `rust/crates/harness-bins/src/bin/mpp_harness_client.rs`) to handle them — do not
   rely on a single header.
 - **`settlement` is optional** but the harness expects it whenever
   the server returns the `harnessScenario.settlementHeader` header.
@@ -178,7 +186,7 @@ in that file are the pattern.
   route alongside the protected one, then attacks the protected
   route with a credential issued for the cheap one. Your server must
   reject it — see `verify_credential_with_expected` in
-  `rust/crates/mpp/src/bin/harness_server.rs` for the wiring.
+  `rust/crates/harness-bins/src/bin/mpp_harness_server.rs` for the wiring.
 - **Build first, then run** in the harness command if your language
   compiles. Rust uses `cargo run` (which compiles on demand); Go uses
   `go run`. Avoid double-build paths in CI by reusing the language's
@@ -187,8 +195,8 @@ in that file are the pattern.
   `surfnet_setTokenAccount`) are JSON-RPC methods on the Surfpool
   endpoint. The server adapter uses them to fund the recipient's
   token account before serving — see
-  `rust/crates/mpp/src/bin/harness_server.rs` and
-  `rust/examples/payment_link_server.rs:160-186` for the pattern.
+  `rust/crates/harness-bins/src/bin/mpp_harness_server.rs` and
+  `rust/crates/kit/examples/payment_link_server.rs` for the pattern.
 - **Expectations are centralized.** For successful charge scenarios,
   the harness fetches the settlement signature from Surfpool and
   verifies the resulting transaction includes expected SPL

--- a/skills/pay-sdk-implementation/references/intents/mpp-charge-pull.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-charge-pull.md
@@ -7,7 +7,7 @@ shape is `WWW-Authenticate: Payment ...` (server) → `Authorization: Payment ..
 
 Spec: <https://paymentauth.org>, charge intent.
 Spec PR: <https://github.com/tempoxyz/mpp-specs/pull/188>.
-Rust reference: `rust/crates/mpp/src/server/charge.rs`, `rust/crates/mpp/src/client/charge.rs`.
+Rust reference: `rust/crates/kit/src/mpp/server/charge.rs`, `rust/crates/kit/src/mpp/client/charge.rs`.
 
 ## Wire format
 
@@ -21,10 +21,10 @@ Payment realm="<realm>", id="<hmac>", method="solana", intent="charge",
 
 - Multiple challenges in one response — comma-separated. Parse with
   `parse_www_authenticate_all` (handles quoted commas in values; see
-  `rust/crates/mpp/src/protocol/core/headers.rs`).
+  `rust/crates/kit/src/mpp/protocol/core/headers.rs`).
 - All param values **quoted**; the parser unquotes.
 
-`ChargeRequest` (`rust/crates/mpp/src/protocol/intents/charge.rs`):
+`ChargeRequest` (`rust/crates/kit/src/mpp/protocol/intents/charge.rs`):
 
 ```json
 {
@@ -66,18 +66,18 @@ Payment status="success", method="solana", reference="<signature-base58>", chall
 ## Server obligations
 
 Implement these steps in `server::charge::verify` (mirror
-`rust/crates/mpp/src/server/charge.rs:474-563`):
+`rust/crates/kit/src/mpp/server/charge.rs`):
 
 1. **HMAC tier-1.** Recompute the challenge ID with
    `compute_challenge_id(secret_key, realm, method, intent, request,
-   expires, digest, opaque)` (`rust/crates/mpp/src/protocol/core/challenge.rs:192`)
+   expires, digest, opaque)` (`rust/crates/kit/src/mpp/protocol/core/challenge.rs`)
    and compare. Constant-time compare.
 2. **Expiry check.** Reject if `expires` is in the past. Reject if it
    fails to parse as RFC 3339 (fail-closed).
 3. **Pinned-field tier-2.** Even if the credential's echoed request is
    "trusted as-is", pin `method`, `intent`, `realm`, `currency`,
    `recipient` to the server's configured values (see
-   `verify_pinned_fields` at `rust/crates/mpp/src/server/charge.rs:424`). The
+   `verify_pinned_fields` at `rust/crates/kit/src/mpp/server/charge.rs`). The
    realm pin is critical because HMAC uses the server's realm — a
    tampered echoed realm would otherwise pass HMAC.
 4. **Cross-route tier-2 (recommended).** Expose
@@ -85,7 +85,7 @@ Implement these steps in `server::charge::verify` (mirror
    so route handlers can pin `amount`/`currency`/`recipient` per
    endpoint. The expected request — not the credential's echo — is
    then passed to settlement (see
-   `rust/crates/mpp/src/server/charge.rs:412-418` and `examples/payment_link_server.rs:25`).
+   `rust/crates/kit/src/mpp/server/charge.rs` and `rust/crates/kit/examples/payment_link_server.rs`).
 5. **Network blockhash gate.** Before broadcasting, call
    `check_network_blockhash(network, tx.message.recent_blockhash())`
    to reject mainnet keys pointed at a sandbox server (and vice versa).
@@ -111,8 +111,8 @@ Implement these steps in `server::charge::verify` (mirror
 
 ## Client obligations
 
-Mirror `rust/crates/mpp/src/client/charge.rs::build_charge_transaction` and the
-adapter at `rust/crates/mpp/src/bin/harness_client.rs`:
+Mirror `rust/crates/kit/src/mpp/client/charge.rs::build_charge_transaction` and the
+adapter at `rust/crates/harness-bins/src/bin/mpp_harness_client.rs`:
 
 1. Parse all `WWW-Authenticate` values; pick the `solana`/`charge`
    challenge (filter by `method.as_str() == "solana"`,
@@ -147,20 +147,20 @@ adapter at `rust/crates/mpp/src/bin/harness_client.rs`:
   them is the #1 cross-language bug. `parse_authorization` accepts
   both alphabets for the payload but the canonical write path emits
   no-pad URL-safe for header fields and std-with-pad for the
-  transaction body. See `rust/crates/mpp/src/protocol/core/types.rs:177-198`.
+  transaction body. See `rust/crates/kit/src/mpp/protocol/core/types.rs`.
 - **`MethodName` and `IntentName` are normalized lowercase ASCII.** The
   parser rejects mixed case in `method` (see
-  `rust/crates/mpp/src/protocol/core/headers.rs:42-46`). The `IntentName::new` ctor
+  `rust/crates/kit/src/mpp/protocol/core/headers.rs`). The `IntentName::new` ctor
   forces lowercase. Mirror this in your types.
 - **`ChargeRequest.decimals` is `serde(skip)`.** It is not part of the
   wire format; it lives in `methodDetails.decimals` instead. Mark the
   equivalent field non-serialized in your type — see
-  `rust/crates/mpp/src/protocol/intents/charge.rs:22-24`.
+  `rust/crates/kit/src/mpp/protocol/intents/charge.rs`.
 - **`amount` is a string in base units.** Do not parse to a number on
   the wire — JS can't safely round-trip u64. Use `parse_units(amount,
   decimals)` to convert from a decimal display string at the SDK
-  boundary (`rust/crates/mpp/src/protocol/intents/mod.rs:18`).
-- **Splits cap at 8.** `rust/crates/mpp/src/client/charge.rs:76` enforces this; the
+  boundary (`rust/crates/kit/src/mpp/protocol/intents/mod.rs`).
+- **Splits cap at 8.** `rust/crates/kit/src/mpp/client/charge.rs` enforces this; the
   server's pre-broadcast verifier enforces it too. Reject earlier in
   the new SDK.
 - **`recentBlockhash` in `methodDetails`** is **base58**, not base64.
@@ -168,7 +168,7 @@ adapter at `rust/crates/mpp/src/bin/harness_client.rs`:
 - **Pre-broadcast verification is BEFORE co-signing.** Co-signing a
   hostile transaction (and then catching it post-hoc) leaks the fee
   payer key's signature; the order in `verify_pull`
-  (`rust/crates/mpp/src/server/charge.rs:596-599`) is verify → cosign → simulate
+  (`rust/crates/kit/src/mpp/server/charge.rs`) is verify → cosign → simulate
   → broadcast.
 - **Network gate first.** Calling `check_network_blockhash` before
   decoding instructions is cheaper than letting broadcast fail with a
@@ -176,9 +176,9 @@ adapter at `rust/crates/mpp/src/bin/harness_client.rs`:
 
 ## Test plan
 
-Unit tests to mirror (from `rust/crates/mpp/src/protocol/core/types.rs`,
-`rust/crates/mpp/src/protocol/intents/charge.rs`, and
-`rust/crates/mpp/src/server/charge.rs` `#[cfg(test)] mod tests`):
+Unit tests to mirror (from `rust/crates/kit/src/mpp/protocol/core/types.rs`,
+`rust/crates/kit/src/mpp/protocol/intents/charge.rs`, and
+`rust/crates/kit/src/mpp/server/charge.rs` `#[cfg(test)] mod tests`):
 
 - `MethodName` normalizes to lowercase, rejects empty / non-ASCII.
 - `IntentName::is_charge` is case-insensitive.
@@ -197,7 +197,7 @@ Unit tests to mirror (from `rust/crates/mpp/src/protocol/core/types.rs`,
 Integration test:
 
 - Surfpool-backed `tests/charge_integration.<ext>` mirroring
-  `rust/tests/charge_integration.rs`. Cover SOL transfer, SPL transfer,
+  `rust/crates/integration-tests/tests/charge_integration.rs`. Cover SOL transfer, SPL transfer,
   splits with ATA creation, fee-payer mode.
 
 Harness scenario: `charge-basic` and `charge-split-ata` in

--- a/skills/pay-sdk-implementation/references/intents/mpp-charge-push.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-charge-push.md
@@ -7,8 +7,8 @@ This is the default in browser flows (payment links) where the client
 wallet does the broadcasting.
 
 Spec: <https://paymentauth.org>, charge intent.
-Rust reference: `rust/crates/mpp/src/server/charge.rs::verify_push`,
-`rust/crates/mpp/src/protocol/solana.rs::CredentialPayload`.
+Rust reference: `rust/crates/kit/src/mpp/server/charge.rs::verify_push`,
+`rust/crates/kit/src/mpp/protocol/solana.rs::CredentialPayload`.
 
 ## Wire format
 
@@ -26,14 +26,14 @@ itself.
 ```
 
 The credential payload is a `CredentialPayload::Signature { signature }`
-(see `rust/crates/mpp/src/protocol/solana.rs::CredentialPayload`), tagged via serde
+(see `rust/crates/kit/src/mpp/protocol/solana.rs::CredentialPayload`), tagged via serde
 internally tag/untag rules.
 
 ## Server obligations
 
-Mirror `verify_push` (search `rust/crates/mpp/src/server/charge.rs` for the function;
+Mirror `verify_push` (search `rust/crates/kit/src/mpp/server/charge.rs` for the function;
 the entry is `match payload { CredentialPayload::Signature { ref
-signature } => self.verify_push(...) }` at `rust/crates/mpp/src/server/charge.rs:541`):
+signature } => self.verify_push(...) }` at `rust/crates/kit/src/mpp/server/charge.rs`):
 
 1. **HMAC tier-1** + **expiry** + **pinned-field tier-2** + **cross-route
    tier-2** — same as pull (see `mpp-charge-pull.md`).
@@ -83,8 +83,8 @@ signs and broadcasts:
 For payment-link / browser flows, the wallet adapter does steps 3-4 and
 hands the signature back. The MPP SDK's role is steps 1-2 and 5-7;
 see the service worker pattern in
-`rust/crates/mpp/src/server/html/service_worker.gen.js` and the example at
-`rust/examples/payment_link_server.rs`.
+`rust/crates/kit/src/mpp/server/html/service_worker.gen.js` and the example at
+`rust/crates/kit/examples/payment_link_server.rs`.
 
 ## Things to pay attention to
 
@@ -101,13 +101,13 @@ see the service worker pattern in
   server's `CommitmentConfig`; do not accept `Processed` for
   settlement. The Rust default is `Confirmed`.
 - **Browser CORS for `payment-receipt` header.** The example at
-  `rust/examples/payment_link_server.rs:50-58` exposes `payment-receipt`
+  `rust/crates/kit/examples/payment_link_server.rs` exposes `payment-receipt`
   in the response. The corresponding service worker reads it back.
   Don't strip the header in middleware.
 - **Service worker assets must be served from the same origin** as the
   protected route — see `html::SERVICE_WORKER_PARAM` and the
   `service-worker-allowed: /` header in
-  `rust/examples/payment_link_server.rs:79-84`. The new-language server
+  `rust/crates/kit/examples/payment_link_server.rs`. The new-language server
   must expose the same `?<param>` query that returns the generated
   service-worker JS.
 - **Signature length / encoding.** Solana signatures are 64 bytes; the

--- a/skills/pay-sdk-implementation/references/intents/mpp-subscription.md
+++ b/skills/pay-sdk-implementation/references/intents/mpp-subscription.md
@@ -1,41 +1,38 @@
 # `mpp/subscription`
 
-**Status: not yet implemented in any SDK.** No spec PR has merged; no
-Rust reference exists. Include the row in the README compatibility matrix
-as `—`, but do not implement.
+**Status: implemented in Rust and TypeScript.** Use the public sources instead
+of treating subscription semantics as an unpublished draft.
 
-Spec — to be added at <https://github.com/tempoxyz/mpp-specs> when
-proposed. Watch the PR queue for the title `subscription intent`.
+Spec and protocol context: <https://paymentauth.org>
 
-## Why this file exists
+## References
 
-The compatibility matrix in every SDK's README must list this row so the
-matrix is diff-able across languages. Without this leaf, a new SDK might
-quietly drop the row and break the cross-language `README.md` table.
+- Rust wire types: `rust/crates/kit/src/mpp/protocol/intents/subscription.rs`
+- Rust client: `rust/crates/kit/src/mpp/client/subscription.rs`
+- Rust server: `rust/crates/kit/src/mpp/server/subscription.rs`
+- Generated Solana program client:
+  `rust/crates/kit/src/mpp/program/subscriptions.rs`
+- TypeScript shared implementation and tests:
+  `typescript/packages/mpp/src/shared/subscription.ts` and
+  `typescript/packages/mpp/src/__tests__/subscription*.test.ts`
 
-## If a user asks to implement it
+## Porting order
 
-1. Stop and confirm with the user: *"There is no spec PR for
-   `mpp/subscription` yet. Do you have a draft you can share?"*
-2. If yes, ask for the spec text and the canonical TS implementation
-   (when one exists). The user mentions an `~/Coding/x402-kit` directory
-   for x402 work; a parallel `~/Coding/mpp-subscription` or similar
-   would be the expected location for a subscription draft.
-3. Do **not** invent semantics. Subscriptions are likely to be a
-   composition of session + recurring vouchers + automated top-up,
-   but the exact wire format, cap-renewal policy, and cancellation
-   flow are not yet decided.
-4. Until the spec lands, keep the row at `—` in the SDK's README. Do
-   not stub out types in code.
+1. Read both public implementations and the subscriptions IDL under `idl/`.
+2. Port the protocol types and canonical header/payload encoding.
+3. Generate the target-language program client from the checked-in IDL; do not
+   hand-write account or instruction layouts.
+4. Port client lifecycle operations and server verification.
+5. Add replay-safe persistence, expiry, cancellation, and retry tests.
+6. Register any available harness vectors and keep unsupported README cells at
+   `—` until their proof exists.
 
-## README matrix row
+## Guardrails
 
-The row must appear in both Client and Server matrices, with the cell
-content `—`:
-
-```md
-| `mpp/subscription` | — |
-```
-
-Order matters: subscription is the last MPP row, immediately under
-`mpp/session`. See `references/readme-template.md`.
+- Treat subscription state, caps, renewal windows, and cancellation rules as
+  wire-level behavior. Copy them from current code and tests, not intuition.
+- Pin recipient, currency, network, subscription identity, and authorized cap
+  before accepting a credential.
+- Make create, renew, charge, cancel, and retry paths idempotent where the
+  reference is idempotent.
+- Do not infer support in another language from the Rust or TypeScript matrix.

--- a/skills/pay-sdk-implementation/references/intents/x402-batch-settlement.md
+++ b/skills/pay-sdk-implementation/references/intents/x402-batch-settlement.md
@@ -1,77 +1,43 @@
 # `x402/batch-settlement`
 
-**Status: scaffold only.** Reference implementation is
-`~/Coding/x402-kit` on the user's local machine. Don't implement from
-spec text alone.
+**Status: implemented in the public references.** This scheme serves requests
+against cumulative off-chain vouchers and redeems them on chain in batches.
 
-Spec: <https://docs.x402.org/introduction>
-Reference (local-only): `~/Coding/x402-kit`.
+Spec: <https://x402.org>
 
-## Scheme
+## References
 
-`x402/batch-settlement` is the "accumulate small charges, settle on
-chain less often" scheme. Closest MPP analog is the **session intent**:
-both batch off-chain authorizations and settle on chain at intervals.
+- Wire types and verification:
+  `rust/crates/kit/src/x402/protocol/schemes/batch_settlement/`
+- Paying client: `rust/crates/kit/src/x402/client/batch_settlement/`
+- Server lifecycle and batch redemption:
+  `rust/crates/kit/src/x402/server/batch_settlement.rs`
+- Rust public usage: the batch-settlement section in `rust/README.md`
+- Current harness coverage status: `harness/README.md` and
+  `harness/test/intent-selection.test.ts`
 
-The wire shape is likely:
+The TypeScript x402 submodule also ships the SVM scheme, but Pay Kit's
+TypeScript gate adapter may expose fewer lifecycle operations than the protocol
+package. Inspect both the target language's adapter and its harness registration
+before defining scope.
 
-- Server-signed accumulator state (last-settled cumulative, next-expected sequence).
-- Client-signed authorizations (per-request signed amounts).
-- Periodic settlement (every N authorizations, or on time elapsed, or
-  on session close).
+## Porting order
 
-## Relationship to MPP `session`
+1. Port channel, voucher, and cumulative-amount wire types.
+2. Port signature, sequence, role, ceiling, and monotonicity verification.
+3. Add persistent state with atomic compare-and-set semantics.
+4. Add client voucher generation and server-side off-chain acceptance.
+5. Add idempotent batch redemption and distribution.
+6. Add a scoped batch-settlement harness intent and scenarios before claiming
+   cross-language compatibility; the current harness rejects that selector.
 
-The MPP session intent already does on-chain batching: the
-payment-channels program holds funds; vouchers authorize cumulative
-spend; close settles. The biggest implementation overlap with
-`x402/batch-settlement` is voucher / cumulative semantics — see
-`rust/crates/mpp/src/protocol/intents/session.rs::SignedVoucher`
-(lines 656-705) and the cumulative monotonicity rule.
+## Guardrails
 
-When the x402-kit reference is available, much of the voucher logic
-can be re-used; only the wire-format names and the on-chain settlement
-program differ.
-
-## When to implement
-
-Last in the x402 sequence — after `exact` and `upto` are harness-green.
-Batch settlement is the most complex of the three because it requires:
-
-- Lifecycle state in the server (open / accumulate / settle / close).
-- A persistent store for partially-accumulated authorizations
-  (`store.<ext>` already exists; add new key prefixes).
-- Coordination with the on-chain settlement contract (whatever x402
-  picks for Solana).
-
-## Hooks for future implementation
-
-1. **Wire format** — to be defined from x402-kit. Expect a tagged
-   `action: "open" | "authorize" | "settle" | "close"` similar to MPP
-   `SessionAction`.
-2. **Server obligations** — accumulator state, replay protection per
-   `(channelId, sequence)`, settlement transaction submission.
-3. **Client obligations** — sign each authorization, hand the latest
-   cumulative back on every API call, request settlement when the
-   session ends.
-4. **Things to pay attention to**:
-   - Replay key includes both channel and sequence.
-   - Cumulative monotonicity (same rule as MPP session vouchers).
-   - Settle is **idempotent** — multiple settle requests on the same
-     cumulative return a cached receipt.
-   - Cross-protocol replay: settlement signatures must use a
-     namespaced key so an x402 signature cannot be replayed as MPP
-     charge or vice versa. Suggested prefixes —
-     `x402-batch:consumed:<sig>`, `solana-charge:consumed:<sig>`
-     (already used by MPP charge).
-5. **Test plan** — unit (sequence monotonicity, replay,
-   settle-idempotency), integration (Surfpool full lifecycle), harness.
-
-## README matrix row
-
-```md
-| `x402/batch-settlement` | — |
-```
-
-Position: third row in both client and server matrices (immediately
-above `mpp/charge/pull`).
+- Key state by the complete channel identity and reject stale or decreasing
+  cumulative vouchers.
+- Make concurrent voucher acceptance and redemption race-safe.
+- Treat a repeated settlement of the same cumulative state as an idempotent
+  retry, not a second debit.
+- Keep x402 replay keys namespaced away from MPP charge and session state.
+- Leave the README cell incomplete when the target language lacks a client,
+  server, persistent store, or harness proof required by its advertised scope.

--- a/skills/pay-sdk-implementation/references/intents/x402-exact.md
+++ b/skills/pay-sdk-implementation/references/intents/x402-exact.md
@@ -1,65 +1,40 @@
 # `x402/exact`
 
-**Status: scaffold only.** The Solana MPP SDK does not yet ship x402
-support. The reference implementation lives in `~/Coding/x402-kit` on
-the user's local machine; it is **not** in this remote container. Do
-not implement x402 from spec text alone — ask the user to share the
-kit's source first.
+**Status: implemented.** Use the public in-repository sources; do not ask for a
+private x402 checkout.
 
-Spec: <https://docs.x402.org/introduction>
-Reference (local-only): `~/Coding/x402-kit` (ask the user for access).
+Spec: <https://x402.org>
 
-## Scheme
+## References
 
-`x402/exact` is the "pay the advertised amount, no more, no less"
-scheme. The challenge advertises a single amount; the credential
-carries a settlement payload of exactly that amount. This is the
-closest analog to `mpp/charge` and the easiest x402 scheme to ship
-first.
+- Wire types and structural verification:
+  `rust/crates/kit/src/x402/protocol/schemes/exact/`
+- Paying client: `rust/crates/kit/src/x402/client/exact/`
+- Server and settlement: `rust/crates/kit/src/x402/server/exact.rs`
+- Pay Kit adapter: `typescript/packages/pay-kit/src/adapters/x402.ts`
+- Cross-language vectors: the `x402-exact` entries in
+  `harness/src/implementations.ts` and `harness/test/x402-exact.e2e.test.ts`
 
-## When to implement
+Initialize the `typescript/external/x402` submodule when the TypeScript SVM
+scheme internals are needed. The checked-in Pay Kit adapter and tests show how
+that package is integrated.
 
-Wait for the user to confirm:
+## Porting order
 
-1. They have a stable x402-kit reference to copy from.
-2. The MPP `charge` cells are already passing harness in the new SDK
-   (x402 reuses much of the same Solana primitives — splits, fee
-   payer, replay store — so MPP-first is the correct order).
-3. The x402 scheme strings in `harness/src/implementations.ts`
-   have been agreed (likely `"x402:exact"` or similar; do not invent).
+1. Port the exact wire types and canonical serialization.
+2. Port structural verification before settlement or HTTP middleware.
+3. Add the client payment builder and server processor.
+4. Add replay protection and bind the credential to the route's amount,
+   recipient, currency, network, and token program.
+5. Register client and server adapters for the `x402-exact` harness intent and
+   run them against an existing Rust or TypeScript peer.
 
-If any are missing, leave the row at `—` in the README matrix and
-ask the user before proceeding.
+## Guardrails
 
-## What we know
-
-From the user's notes: the matrix cell name is `x402/exact`. The
-intended wire shape is HTTP-402-aligned (same status code as MPP, same
-header style). Solana settlement reuses the on-chain transfer
-primitives already implemented for `mpp/charge`.
-
-## Hooks for future implementation
-
-When the user supplies the x402-kit reference, this file should be
-expanded into a full intent leaf (matching the depth of
-`mpp-charge-pull.md`):
-
-1. **Wire format** — challenge header, credential payload, receipt.
-2. **Server obligations** — challenge issuance, settlement, replay.
-3. **Client obligations** — challenge selection (`extract_payment_scheme`
-   should be extended to recognize the x402 scheme), credential build.
-4. **Things to pay attention to** — base64 alphabet rules, canonical
-   JSON, replay-key namespacing (`x402-exact:consumed:<sig>` vs
-   `solana-charge:consumed:<sig>` — they must not collide), how
-   `methodDetails` differs from MPP's.
-5. **Test plan** — unit + harness. The harness will need a
-   new `intent: "x402-exact"` scenario.
-
-## README matrix row
-
-```md
-| `x402/exact` | — |
-```
-
-Position: top of both client and server matrices (x402 cells before
-MPP cells, in spec order — `exact`, `upto`, `batch-settlement`).
+- Support only the x402 versions and header names demonstrated by the current
+  reference and harness vectors.
+- Treat the payment payload and transaction as untrusted. Verify every required
+  account, instruction, amount, mint, signer, and destination before broadcast.
+- Consume a payment proof atomically so concurrent replays cannot both settle.
+- Do not mark the target language's README cell complete until its focused
+  cross-language harness pair passes.

--- a/skills/pay-sdk-implementation/references/intents/x402-upto.md
+++ b/skills/pay-sdk-implementation/references/intents/x402-upto.md
@@ -1,60 +1,38 @@
 # `x402/upto`
 
-**Status: scaffold only.** Same caveat as `x402-exact.md`: reference
-implementation is `~/Coding/x402-kit` on the user's local machine.
-Don't implement from spec text alone.
+**Status: implemented.** `upto` authorizes a ceiling and settles the measured
+amount after the protected operation.
 
-Spec: <https://docs.x402.org/introduction>
-Reference (local-only): `~/Coding/x402-kit`.
+Spec: <https://x402.org>
 
-## Scheme
+## References
 
-`x402/upto` is the "pay any amount up to the advertised ceiling"
-scheme — the discretionary/tip variant. The challenge advertises a
-maximum; the credential carries the chosen amount and the server
-settles for the chosen amount, verifying it does not exceed the cap.
+- Wire types and verification:
+  `rust/crates/kit/src/x402/protocol/schemes/upto/`
+- Paying client: `rust/crates/kit/src/x402/client/upto/`
+- Server lifecycle: `rust/crates/kit/src/x402/server/upto.rs`
+- TypeScript Pay Kit integration:
+  `typescript/packages/pay-kit/src/adapters/x402-upto.ts`
+- Cross-language vectors: the `x402-upto` entries in
+  `harness/src/implementations.ts`
 
-## Relationship to MPP
+## Porting order
 
-- The MPP charge intent has a single fixed `amount`. The MPP
-  `ChargeRequest.validate_max_amount` helper exists for ad-hoc max
-  checks (`rust/crates/mpp/src/protocol/intents/charge.rs:61`) — that pattern
-  is the closest in-tree analog, but it is not on the wire format
-  the way x402/upto is.
-- Solana settlement reuses the same instruction whitelist + replay
-  store as charge.
+1. Port the challenge and payload types, including the channel-open context.
+2. Port verification that binds the authorization to the route and proves the
+   actual amount does not exceed the advertised ceiling.
+3. Port channel open, post-handler metering, settlement, and close behavior.
+4. Register protocol-specific client and server harness adapters.
 
-## When to implement
+## Guardrails
 
-After `x402/exact` is shipped and harness-green. The "upto" semantics
-add a single check (amount-from-credential ≤ amount-from-challenge)
-on top of the exact flow. Don't ship `upto` before `exact`.
-
-## Hooks for future implementation
-
-This file should be expanded after the x402-kit reference is available:
-
-1. **Wire format** — exactly what differs from `exact` (likely the
-   challenge's amount field becomes a `maxAmount`, the credential
-   echoes the chosen amount, the server checks `<=`).
-2. **Server obligations** — same as `exact` plus the cap check.
-   Receipt must reference the **actual** amount paid, not the cap.
-3. **Client obligations** — UI / API decides the chosen amount up to
-   the ceiling; the credential payload carries it.
-4. **Things to pay attention to**:
-   - Replay key must include the actual amount (or the signature),
-     not the cap.
-   - Cross-route protection still pins `currency`/`recipient`; the
-     amount is bounded by the route's cap, not pinned exactly.
-   - Same canonical-JSON / base64 / base58 rules as MPP.
-5. **Test plan** — unit (cap enforcement at boundary, below, above),
-   integration (Surfpool), harness.
-
-## README matrix row
-
-```md
-| `x402/upto` | — |
-```
-
-Position: second row in both client and server matrices (between
-`x402/exact` and `x402/batch-settlement`).
+- Preserve integer base-unit arithmetic; do not compare floating-point token
+  amounts.
+- Source current blockhash and slot behavior from the reference implementation.
+  Do not reuse expired hints or invent fallback values.
+- Settle and seal through the reference lifecycle even when the protected
+  handler fails; match the current target-language adapter's error semantics.
+- Pin channel roles, mint, network, recipient, fee payer, and ceiling before
+  serving the resource.
+- Do not claim support from unit tests alone; run the focused `x402-upto`
+  harness matrix.

--- a/skills/pay-sdk-implementation/references/repo-layout.md
+++ b/skills/pay-sdk-implementation/references/repo-layout.md
@@ -4,17 +4,21 @@ The new-language SDK lives as a sibling of the existing language
 directories in `solana-foundation/pay-kit`:
 
 ```
-mpp-sdk/
-├── rust/        ← reference; mirror its module split
+pay-kit/
+├── rust/        ← broadest reference; protocol code is in crates/kit/src/
 ├── typescript/
 ├── go/
 ├── python/
+├── kotlin/
+├── swift/
+├── ruby/
+├── php/
 ├── lua/
 ├── <new-lang>/  ← what you are creating
 ├── harness/
 │   └── <new-lang>-client/   ← harness adapter (see harness.md)
 ├── .github/workflows/ci.yml ← add a job (see ci-quality-coverage.md)
-└── justfile     ← add recipes (see "justfile recipes" below)
+└── Justfile     ← add recipes (see "Justfile recipes" below)
 ```
 
 ## Inside `<new-lang>/`
@@ -61,15 +65,14 @@ in the intent leaves translate directly:
 
 The Rust crate is the canonical reference for everything in `src/`:
 
-- `rust/crates/mpp/src/lib.rs` — public re-exports the new SDK must mirror.
-- `rust/crates/mpp/src/protocol/core/{challenge,headers,types}.rs` — wire format.
-- `rust/crates/mpp/src/protocol/intents/{charge,session}.rs` — intent request types.
-- `rust/crates/mpp/src/protocol/solana.rs` — program/mint constants.
-- `rust/crates/mpp/src/server/{mod,charge,session,html,axum}.rs` — server side.
-- `rust/crates/mpp/src/client/{mod,charge,session,...}.rs` — client side.
-- `rust/crates/mpp/src/store.rs` — replay store trait.
-- `rust/crates/mpp/src/bin/harness_{client,server}.rs` — harness adapter shape.
-- `rust/examples/payment_link_server.rs` — minimal protected example.
+- `rust/crates/kit/src/lib.rs` — public Pay Kit re-exports.
+- `rust/crates/kit/src/mpp/protocol/core/{challenge,headers,types}.rs` — MPP wire format.
+- `rust/crates/kit/src/mpp/protocol/intents/` — MPP intent request types.
+- `rust/crates/kit/src/mpp/protocol/solana.rs` — program/mint constants.
+- `rust/crates/kit/src/mpp/{server,client,store.rs}` — MPP runtime surfaces.
+- `rust/crates/kit/src/x402/{protocol,server,client}` — x402 schemes and runtime surfaces.
+- `rust/crates/harness-bins/src/bin/` — Rust harness adapters.
+- `rust/crates/kit/examples/` — protected server and client examples.
 - `rust/Cargo.toml` — manifest pattern (atomic Solana crate pinning).
 
 ## Public surface — re-exports
@@ -106,8 +109,8 @@ prefix:
 
 ## `justfile` recipes
 
-Add one section per language, matching the existing pattern in
-`mpp-sdk/justfile`. The required recipes are:
+Add one section per language, matching the existing pattern in the root
+`Justfile`. The required recipes are:
 
 ```just
 # ── <Language> ──


### PR DESCRIPTION
## Summary
- replace removed mpp-sdk paths with the current Pay Kit Rust, TypeScript, and harness locations
- route x402 exact, upto, and batch-settlement work to the public in-repo implementations instead of a private checkout
- update MPP subscription from unpublished/future guidance to the shipped Rust and TypeScript sources
- make protocol scope target-language-specific and require current harness evidence before marking a matrix cell complete

## Why
The official payment-sdk-implementation skill described x402 as future, said subscriptions had no implementation, and directed contributors to removed paths and a private local checkout. Following it would block valid ports or cause work against the wrong source tree.

## Verification
- strict YAML frontmatter parse; description is 327 characters
- every newly cited in-repo source, test, IDL, workflow, and harness path resolves
- stale-path/status scan found no mpp-sdk root, rust/crates/mpp path, private checkout, or scaffold-only instruction
- git diff --check

The generic quick_validate.py helper was also attempted, but its local Python environment does not include PyYAML; the equivalent metadata checks above passed.