### PR TITLE
feat(client): expose x402 before-payment-creation hook

### DIFF
--- a/typescript/packages/pay-kit/src/__tests__/client.test.ts
+++ b/typescript/packages/pay-kit/src/__tests__/client.test.ts
@@ -14,9 +14,32 @@ import { createPayKitClient } from '../client/index.js';
 import { ConfigurationError } from '../errors.js';
 
 const RPC_URL = 'http://127.0.0.1:8899';
+const SOLANA_DEVNET = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+const USDC_DEVNET = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
 
 function response(status: number, headers: Record<string, string> = {}): Response {
     return new Response(null, { headers, status });
+}
+
+function x402PaymentRequiredHeader(payTo: string): string {
+    return Buffer.from(
+        JSON.stringify({
+            x402Version: 2,
+            resource: { url: 'http://api.test/joke' },
+            accepts: [
+                {
+                    scheme: 'exact',
+                    network: SOLANA_DEVNET,
+                    amount: '1000',
+                    asset: USDC_DEVNET,
+                    payTo,
+                    maxTimeoutSeconds: 300,
+                    extra: {},
+                },
+            ],
+        }),
+        'utf8',
+    ).toString('base64');
 }
 
 describe('createPayKitClient', () => {
@@ -39,6 +62,34 @@ describe('createPayKitClient', () => {
         const result = await client.fetch('http://api.test/joke');
 
         expect(result).toBe(ok);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes the x402 before-payment-creation hook before signing or retrying', async () => {
+        // KeyPairSigner.signTransactions is non-configurable, so vi.spyOn cannot
+        // wrap the generated signer. Count through a proxy instead.
+        const signTransactions = vi.fn(signer.signTransactions.bind(signer));
+        const countingSigner = new Proxy(signer, {
+            get(target, property, receiver) {
+                if (property === 'signTransactions') return signTransactions;
+                return Reflect.get(target, property, receiver);
+            },
+        });
+        const onBeforeX402PaymentCreation = vi.fn(async () => ({ abort: true as const, reason: 'policy denied' }));
+        mockFetch.mockResolvedValue(
+            response(402, { 'payment-required': x402PaymentRequiredHeader(countingSigner.address) }),
+        );
+
+        const client = await createPayKitClient({
+            accept: ['x402'],
+            onBeforeX402PaymentCreation,
+            rpcUrl: RPC_URL,
+            signer: countingSigner,
+        });
+
+        await expect(client.fetch('http://api.test/joke')).rejects.toThrow('Payment creation aborted: policy denied');
+        expect(onBeforeX402PaymentCreation).toHaveBeenCalledTimes(1);
+        expect(signTransactions).not.toHaveBeenCalled();
         expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 

--- a/typescript/packages/pay-kit/src/client/index.ts
+++ b/typescript/packages/pay-kit/src/client/index.ts
@@ -14,7 +14,7 @@
  */
 import type { KeyPairSigner } from '@solana/kit';
 import { Mppx, solana } from '@solana/mpp/client';
-import { x402Client, x402HTTPClient } from '@x402/core/client';
+import { type BeforePaymentCreationHook, x402Client, x402HTTPClient } from '@x402/core/client';
 import type { Network } from '@x402/core/types';
 import { ExactSvmScheme } from '@x402/svm/exact/client';
 import { UptoSvmScheme } from '@x402/svm/upto/client';
@@ -29,6 +29,8 @@ const nativeFetch: typeof fetch = globalThis.fetch.bind(globalThis);
 export type PayKitClientOptions = {
     /** Protocols the client will pay with. Defaults to `['x402', 'mpp']`. */
     readonly accept?: readonly Protocol[];
+    /** Called before x402 creates or signs a payment. Return `{ abort: true, reason }` to refuse. */
+    readonly onBeforeX402PaymentCreation?: BeforePaymentCreationHook;
     /** Progress callback, forwarded to the MPP charge/subscription methods. */
     readonly onProgress?: (event: unknown) => void;
     /** RPC endpoint used to build payments (sign transfers, open channels). */
@@ -84,6 +86,9 @@ export function createPayKitClient(options: PayKitClientOptions): Promise<PayKit
         const client = new x402Client();
         client.register('solana:*' as Network, new ExactSvmScheme(options.signer, svm));
         client.register('solana:*' as Network, new UptoSvmScheme(options.signer, svm));
+        if (options.onBeforeX402PaymentCreation) {
+            client.onBeforePaymentCreation(options.onBeforeX402PaymentCreation);
+        }
         http = new x402HTTPClient(client);
     }
 


### PR DESCRIPTION
## Summary

Expose an optional `onBeforeX402PaymentCreation` hook on `createPayKitClient` so callers can refuse payment creation before x402 builds a scheme payload or touches the signer.

- Adds `onBeforeX402PaymentCreation?: BeforePaymentCreationHook` to `PayKitClientOptions`
- Registers it on PayKit’s internal `x402Client` via `onBeforePaymentCreation`
- Abort path throws before signing and before any paid retry

This is a thin pass-through of the official `@x402/core` hook; no new payment logic and no branding or third-party dependencies in the patch.

## Test plan

- [x] New regression: abort → zero `signTransactions` calls + fetch stays at the initial 402 (no paid retry)
- [ ] CI green on this PR
- [ ] Confirm hook is only wired when `accept` includes `x402`