### PR TITLE
fix(x402/batch): run deposit broadcast+confirm off the async runtime

### DIFF
--- a/rust/crates/kit/src/core/store.rs
+++ b/rust/crates/kit/src/core/store.rs
@@ -1815,7 +1815,9 @@ impl ChannelStore for RedisChannelStore {
             let current_raw = self.get_raw(&channel_id).await?;
             let mut state = match current_raw.as_deref().map(Self::decode).transpose()? {
                 Some(state) => state,
-                None => seed.ok_or_else(|| StoreError::Internal("Channel not found".to_string()))?,
+                None => {
+                    seed.ok_or_else(|| StoreError::Internal("Channel not found".to_string()))?
+                }
             };
             mutator(&mut state)?;
             let (new_raw, _) = Self::encode_for_write(state)?;

--- a/rust/crates/kit/src/x402/server/batch_settlement.rs
+++ b/rust/crates/kit/src/x402/server/batch_settlement.rs
@@ -749,17 +749,23 @@ impl X402BatchSettlement {
                     )
                     .await
                     .map_err(|e| Error::Other(format!("store error: {e}")))?;
-                let (sealed, close_requested, cumulative, highest_voucher_signature, deposit, payer) =
-                    fields
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .take()
-                        .ok_or_else(|| {
-                            batch_err(
-                                codes::INVALID_CHANNEL_STATE,
-                                format!("no channel {channel_b58}; open one with a deposit payload"),
-                            )
-                        })?;
+                let (
+                    sealed,
+                    close_requested,
+                    cumulative,
+                    highest_voucher_signature,
+                    deposit,
+                    payer,
+                ) = fields
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .take()
+                    .ok_or_else(|| {
+                        batch_err(
+                            codes::INVALID_CHANNEL_STATE,
+                            format!("no channel {channel_b58}; open one with a deposit payload"),
+                        )
+                    })?;
                 self.check_channel_open(sealed, close_requested)?;
                 let max_claimable = check_voucher(voucher, &config, &channel_id)?;
                 let replay = self.check_watermark(

--- a/rust/crates/kit/src/x402/server/batch_settlement.rs
+++ b/rust/crates/kit/src/x402/server/batch_settlement.rs
@@ -103,6 +103,52 @@ fn rpc_lookup_channel(rpc: &RpcClient, channel_id: &Pubkey) -> Result<Option<Cha
         .transpose()
 }
 
+/// Simulate, broadcast, and confirm a co-signed deposit/top-up with the
+/// blocking RPC client. Factored out of
+/// [`X402BatchSettlement::broadcast_client_transaction`] so it can run on a
+/// blocking thread (via `spawn_blocking`): `simulate_transaction` and
+/// `send_and_confirm_transaction` otherwise block a Tokio runtime thread for
+/// the full round trip — for `send_and_confirm_transaction`, the entire
+/// confirm-poll loop — which under concurrent channel opens starves the
+/// runtime, collapsing provisioning throughput and, via client-side timeouts
+/// and retries, amplifying `sendTransaction`/`getSignatureStatuses` volume.
+fn broadcast_and_confirm_deposit(
+    rpc: &RpcClient,
+    tx: &VersionedTransaction,
+) -> Result<String, Error> {
+    let signature = *tx
+        .signatures
+        .first()
+        .ok_or_else(|| Error::Other("transaction has no signature slot".into()))?;
+    if matches!(rpc.get_signature_status(&signature), Ok(Some(Ok(())))) {
+        return Ok(signature.to_string());
+    }
+    // Simulate the exact bytes before they reach the network. The static
+    // policy has already bounded what the sponsor is authorizing; this
+    // catches the rest — an unfunded payer, a frozen or wrong-owner token
+    // account, a settlement path that would not be usable later — while
+    // rejecting is still free.
+    let simulation = rpc
+        .simulate_transaction(tx)
+        .map_err(|e| batch_err(codes::INVALID_SETTLEMENT_SIMULATION, e.to_string()))?;
+    if let Some(err) = simulation.value.err {
+        return Err(batch_err(
+            codes::INVALID_SETTLEMENT_SIMULATION,
+            format!("simulation failed: {err:?}"),
+        ));
+    }
+    match rpc.send_and_confirm_transaction(tx) {
+        Ok(confirmed) => Ok(confirmed.to_string()),
+        Err(error) => {
+            if matches!(rpc.get_signature_status(&signature), Ok(Some(Ok(())))) {
+                Ok(signature.to_string())
+            } else {
+                Err(Error::Rpc(format!("broadcast failed: {error}")))
+            }
+        }
+    }
+}
+
 /// Server configuration for the SVM `batch-settlement` scheme.
 #[derive(Clone)]
 pub struct BatchConfig {
@@ -1782,38 +1828,10 @@ impl X402BatchSettlement {
             &mut tx,
         )
         .await?;
-        let signature = *tx
-            .signatures
-            .first()
-            .ok_or_else(|| Error::Other("transaction has no signature slot".into()))?;
-        if matches!(self.rpc.get_signature_status(&signature), Ok(Some(Ok(())))) {
-            return Ok(signature.to_string());
-        }
-        // Simulate the exact bytes before they reach the network. The static
-        // policy has already bounded what the sponsor is authorizing; this
-        // catches the rest — an unfunded payer, a frozen or wrong-owner token
-        // account, a settlement path that would not be usable later — while
-        // rejecting is still free.
-        let simulation = self
-            .rpc
-            .simulate_transaction(&tx)
-            .map_err(|e| batch_err(codes::INVALID_SETTLEMENT_SIMULATION, e.to_string()))?;
-        if let Some(err) = simulation.value.err {
-            return Err(batch_err(
-                codes::INVALID_SETTLEMENT_SIMULATION,
-                format!("simulation failed: {err:?}"),
-            ));
-        }
-        match self.rpc.send_and_confirm_transaction(&tx) {
-            Ok(confirmed) => Ok(confirmed.to_string()),
-            Err(error) => {
-                if matches!(self.rpc.get_signature_status(&signature), Ok(Some(Ok(())))) {
-                    Ok(signature.to_string())
-                } else {
-                    Err(Error::Rpc(format!("broadcast failed: {error}")))
-                }
-            }
-        }
+        let rpc = Arc::clone(&self.rpc);
+        tokio::task::spawn_blocking(move || broadcast_and_confirm_deposit(&rpc, &tx))
+            .await
+            .map_err(|e| Error::Other(format!("broadcast join error: {e}")))?
     }
 
     /// Re-read the confirmed channel and bind every immutable field to the


### PR DESCRIPTION
## Summary

Found while chasing a "why is provisioning so slow, and why does it hit 429" question during a 100k-channel SUNBURST load test: `X402BatchSettlement::broadcast_client_transaction` — the deposit/top-up broadcast path — is an `async fn` that calls the **blocking** `solana_rpc_client::rpc_client::RpcClient` directly, with no `spawn_blocking`.

`get_signature_status`, `simulate_transaction`, and `send_and_confirm_transaction` all execute synchronously in place. `send_and_confirm_transaction` in particular runs its own unbatched confirm-poll loop (repeated `getSignatureStatuses`, one signature at a time) for the transaction's entire confirmation lifetime — occupying the calling Tokio worker thread the whole time.

## Why this matters under load

At `provision_concurrency: 200` (200 concurrent channel opens), each one occupies a worker thread for its full confirm loop. Once concurrent opens exceed the runtime's worker-thread count, additional opens queue for a free thread instead of running concurrently — so wall-clock throughput collapses well below the configured concurrency regardless of how high you set it. The client-side timeouts this produces then retry, which amplifies `sendTransaction`/`getSignatureStatuses` call volume under exactly the load pattern most likely to trip an RPC provider's rate limit — a bad feedback loop (starvation → timeout → retry → more calls → more starvation).

This is the same pattern already fixed once in this file for the stale-snapshot reconcile path (`rpc_lookup_channel`, merged in #304) — the deposit-broadcast path had the identical issue.

## Fix

Extract the blocking sequence (signature precheck → simulate → send-and-confirm → fallback signature check) into a free function, `broadcast_and_confirm_deposit`, and run it via `tokio::task::spawn_blocking`. Behavior is byte-for-byte identical; only the thread it executes on changes — off the async runtime, onto Tokio's blocking pool, where 200 concurrent confirm loops can actually run concurrently instead of queuing.

## Testing

- `cargo test -p solana-pay-kit` — 414/414 pass.
- No API change; `broadcast_client_transaction`'s signature and behavior are unchanged.

## Note on scope

`submit_groups` (the periodic multi-channel settlement broadcast, a few lines below) has the same blocking-RPC-in-async-fn pattern, but runs sequentially rather than at 200-way concurrency, so it's lower-priority. Flagging it here as a known, easy follow-up rather than folding it into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
