### PR TITLE
fix(x402): re-read confirmed channel accounts through replica visibility lag

### DIFF
--- a/go/protocols/x402/upto.go
+++ b/go/protocols/x402/upto.go
@@ -240,6 +240,11 @@ type UptoConfig struct {
 	// extra.recentSlot (deterministic tests). Nil fetches via the RPC client's
 	// getSlot.
 	RecentSlotProvider func() (uint64, error)
+	// ChannelReadMaxAttempts and ChannelReadBackoffStepMs bound the
+	// post-broadcast channel re-read (see fetchChannelAfterBroadcast).
+	// Zero or negative resolves to the package defaults.
+	ChannelReadMaxAttempts   int
+	ChannelReadBackoffStepMs int
 }
 
 // X402Upto is the server-side x402 upto payment-channel engine.
@@ -541,7 +546,7 @@ func (u *X402Upto) VerifyOpen(ctx context.Context, header, maxAmount string) (*U
 	if err := solanatx.WaitForConfirmation(ctx, u.rpc, sig); err != nil {
 		return nil, fmt.Errorf("open confirmation failed: %w", err)
 	}
-	channel, err := u.fetchChannel(ctx, channelID)
+	channel, err := u.fetchChannelAfterBroadcast(ctx, channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -719,6 +724,64 @@ func (u *X402Upto) fetchChannel(ctx context.Context, channelID solana.PublicKey)
 		return nil, fmt.Errorf("channel decode failed: %w", err)
 	}
 	return channel, nil
+}
+
+// Post-broadcast channel read bounds. The delay before attempt N+1 is
+// backoffStep * N, so the defaults schedule 200/400/600/800/1000ms: five
+// sleeps, 3.0s in total, 1s worst single wait. The backoff is linear rather
+// than exponential because replica lag is a small multiple of Solana's ~400ms
+// slot time, so doubling spends the same budget on single waits far longer
+// than the lag it has to absorb.
+const (
+	defaultChannelReadMaxAttempts = 6
+	defaultChannelReadBackoffStep = 200 * time.Millisecond
+)
+
+// fetchChannelAfterBroadcast reads the channel account once the open
+// transaction is confirmed, re-reading while the account is not yet visible.
+// An RPC provider can serve signature status and account state from different
+// replicas, so the replica answering this read can still be behind the one
+// that reported the confirmation; a single miss would hard-fail a payment
+// whose deposit is already escrowed on chain.
+//
+// Only rpc.ErrNotFound is retried: that is the not-yet-visible answer. Every
+// other outcome is a visible state (a transport failure, an account that
+// decodes wrong) and is returned on the first read, as is the not-found error
+// itself once the attempts run out, so the caller's error surface is
+// unchanged. Callers that probe for absence must keep using fetchChannel.
+//
+// The in-flight reservation for this channel is held across the whole loop, so
+// a concurrent request for the SAME channel sees "channel is already being
+// processed" for up to the full budget longer. That is acceptable:
+// WaitForConfirmation above already blocks under the same reservation with no
+// deadline of its own.
+func (u *X402Upto) fetchChannelAfterBroadcast(ctx context.Context, channelID solana.PublicKey) (*pcgen.Channel, error) {
+	maxAttempts := u.cfg.ChannelReadMaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultChannelReadMaxAttempts
+	}
+	backoffStep := time.Duration(u.cfg.ChannelReadBackoffStepMs) * time.Millisecond
+	if backoffStep <= 0 {
+		backoffStep = defaultChannelReadBackoffStep
+	}
+	for attempt := 1; ; attempt++ {
+		channel, err := u.fetchChannel(ctx, channelID)
+		if err == nil || !errors.Is(err, rpc.ErrNotFound) || attempt >= maxAttempts {
+			return channel, err
+		}
+		// Context first, like solanatx.WaitForConfirmation: a disconnected
+		// client must not hold its channel reservation for the full budget.
+		timer := time.NewTimer(backoffStep * time.Duration(attempt))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			// Both, not either: the message keeps the not-found detail while
+			// errors.Is(err, context.Canceled) lets the caller tell a
+			// disconnected client from a genuinely absent channel.
+			return nil, fmt.Errorf("%w: %w", err, ctx.Err())
+		case <-timer.C:
+		}
+	}
 }
 
 // recentLifetime returns the challenge lifetime pair: a recent blockhash and

--- a/go/protocols/x402/upto_coverage_test.go
+++ b/go/protocols/x402/upto_coverage_test.go
@@ -3,10 +3,10 @@ package x402
 // Focused branch-coverage tests for the upto engine: the accepted-object and
 // settlement-header serializers, the in-flight guard, the distribution split
 // derivation, the challenge lifetime (blockhash + recentSlot) resolution, the
-// SettleActual failure paths, the channel-account fetch failure paths, and the
-// open-instruction validator mismatch branches. The happy-path engine flow is
-// pinned by TestUptoVerifyOpenAndSettle; these tests lock the error surfaces
-// around it.
+// SettleActual failure paths, the channel-account fetch failure paths, the
+// post-broadcast channel read retry, and the open-instruction validator
+// mismatch branches. The happy-path engine flow is pinned by
+// TestUptoVerifyOpenAndSettle; these tests lock the error surfaces around it.
 
 import (
 	"context"
@@ -331,14 +331,17 @@ func TestUptoSettleActualErrorPaths(t *testing.T) {
 
 // ── channel account fetch ──
 
-// accountRPC overrides GetAccountInfoWithOpts with a canned result/error.
+// accountRPC overrides GetAccountInfoWithOpts with a canned result/error and
+// counts the reads, so the retry loop's attempt count is observable.
 type accountRPC struct {
 	*testutil.FakeRPC
-	out *rpc.GetAccountInfoResult
-	err error
+	out   *rpc.GetAccountInfoResult
+	err   error
+	reads int
 }
 
 func (r *accountRPC) GetAccountInfoWithOpts(context.Context, solana.PublicKey, *rpc.GetAccountInfoOpts) (*rpc.GetAccountInfoResult, error) {
+	r.reads++
 	return r.out, r.err
 }
 
@@ -376,6 +379,125 @@ func TestUptoFetchChannelErrorPaths(t *testing.T) {
 	if _, err := engine.fetchChannel(context.Background(), channel); err == nil ||
 		!strings.Contains(err.Error(), "channel decode failed") {
 		t.Fatalf("error = %v, want decode failure", err)
+	}
+}
+
+// ── post-broadcast channel read retry ──
+
+// TestUptoFetchChannelAfterBroadcastRetriesNotFound pins the retry schedule:
+// six reads, linear 10/20/30/40/50ms backoff, no sleep after the last attempt.
+func TestUptoFetchChannelAfterBroadcastRetriesNotFound(t *testing.T) {
+	engine := newCoverageUptoEngine(t, nil)
+	engine.cfg.ChannelReadBackoffStepMs = 10
+	stub := &accountRPC{FakeRPC: testutil.NewFakeRPC(), err: rpc.ErrNotFound}
+	engine.SetRPCForTests(stub)
+
+	start := time.Now()
+	_, err := engine.fetchChannelAfterBroadcast(context.Background(), testutil.NewPrivateKey().PublicKey())
+	elapsed := time.Since(start)
+
+	if err == nil || !errors.Is(err, rpc.ErrNotFound) {
+		t.Fatalf("error = %v, want a wrapped rpc.ErrNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "channel account fetch failed") {
+		t.Fatalf("error = %v, want the unchanged fetch error message", err)
+	}
+	if stub.reads != defaultChannelReadMaxAttempts {
+		t.Fatalf("reads = %d, want %d", stub.reads, defaultChannelReadMaxAttempts)
+	}
+	// Linear: 10+20+30+40+50 = 150ms. Exponential doubling off the same step
+	// would sleep 10+20+40+80+160 = 310ms, and a flat step only 50ms.
+	if elapsed < 150*time.Millisecond || elapsed >= 300*time.Millisecond {
+		t.Fatalf("elapsed = %v, want the linear 150ms schedule", elapsed)
+	}
+}
+
+// TestUptoFetchChannelAfterBroadcastKeepsVisibleErrors proves a visible state
+// is never re-read: a wrong answer must fail on the first attempt.
+func TestUptoFetchChannelAfterBroadcastKeepsVisibleErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		stub    *accountRPC
+		wantErr string
+	}{
+		{"transport failure", &accountRPC{FakeRPC: testutil.NewFakeRPC(), err: errors.New("rpc boom")}, "channel account fetch failed"},
+		{"missing account data", &accountRPC{FakeRPC: testutil.NewFakeRPC(), out: &rpc.GetAccountInfoResult{}}, "missing account data"},
+		{"undecodable account", &accountRPC{FakeRPC: testutil.NewFakeRPC(), out: &rpc.GetAccountInfoResult{
+			Value: &rpc.Account{Data: rpc.DataBytesOrJSONFromBytes([]byte{1, 2, 3})},
+		}}, "channel decode failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newCoverageUptoEngine(t, nil)
+			engine.cfg.ChannelReadBackoffStepMs = 10
+			engine.SetRPCForTests(tc.stub)
+			start := time.Now()
+			_, err := engine.fetchChannelAfterBroadcast(context.Background(), testutil.NewPrivateKey().PublicKey())
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
+			}
+			if tc.stub.reads != 1 {
+				t.Fatalf("reads = %d, want a single read", tc.stub.reads)
+			}
+			if elapsed := time.Since(start); elapsed >= 10*time.Millisecond {
+				t.Fatalf("elapsed = %v, want no backoff", elapsed)
+			}
+		})
+	}
+}
+
+// TestUptoFetchChannelAfterBroadcastHonoursConfig covers the attempt override
+// (which also leaves the default 200ms step unslept) and a canceled context
+// releasing the loop, and pins fetchChannel itself as the single-read probe.
+func TestUptoFetchChannelAfterBroadcastHonoursConfig(t *testing.T) {
+	channel := testutil.NewPrivateKey().PublicKey()
+
+	single := newCoverageUptoEngine(t, nil)
+	single.cfg.ChannelReadMaxAttempts = 1
+	singleStub := &accountRPC{FakeRPC: testutil.NewFakeRPC(), err: rpc.ErrNotFound}
+	single.SetRPCForTests(singleStub)
+	if _, err := single.fetchChannelAfterBroadcast(context.Background(), channel); !errors.Is(err, rpc.ErrNotFound) {
+		t.Fatalf("error = %v, want rpc.ErrNotFound", err)
+	}
+	if singleStub.reads != 1 {
+		t.Fatalf("reads = %d, want the configured single attempt", singleStub.reads)
+	}
+
+	canceled := newCoverageUptoEngine(t, nil)
+	canceled.cfg.ChannelReadBackoffStepMs = 50
+	canceledStub := &accountRPC{FakeRPC: testutil.NewFakeRPC(), err: rpc.ErrNotFound}
+	canceled.SetRPCForTests(canceledStub)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, cancelErr := canceled.fetchChannelAfterBroadcast(ctx, channel)
+	if !errors.Is(cancelErr, rpc.ErrNotFound) {
+		t.Fatalf("error = %v, want the not-found error preserved on cancel", cancelErr)
+	}
+	// The cancellation rides along with it: a disconnected client must not look
+	// like an absent channel to the caller.
+	if !errors.Is(cancelErr, context.Canceled) {
+		t.Fatalf("error = %v, want a joined context.Canceled", cancelErr)
+	}
+	if !strings.Contains(cancelErr.Error(), "channel account fetch failed") {
+		t.Fatalf("error = %v, want the fetch detail kept in the message", cancelErr)
+	}
+	if canceledStub.reads != 1 {
+		t.Fatalf("reads = %d, want the loop to stop on the canceled context", canceledStub.reads)
+	}
+
+	// fetchChannel stays a single read for pre-broadcast existence probes. Its
+	// own engine keeps the default attempt count (with a 1ms step so the check
+	// stays fast), so putting the probe on the retry loop would read six times
+	// here instead of once.
+	probe := newCoverageUptoEngine(t, nil)
+	probe.cfg.ChannelReadBackoffStepMs = 1
+	probeStub := &accountRPC{FakeRPC: testutil.NewFakeRPC(), err: rpc.ErrNotFound}
+	probe.SetRPCForTests(probeStub)
+	if _, err := probe.fetchChannel(context.Background(), channel); !errors.Is(err, rpc.ErrNotFound) {
+		t.Fatalf("error = %v, want rpc.ErrNotFound", err)
+	}
+	if probeStub.reads != 1 {
+		t.Fatalf("reads = %d, want fetchChannel to read once", probeStub.reads)
 	}
 }
 

--- a/go/protocols/x402/upto_test.go
+++ b/go/protocols/x402/upto_test.go
@@ -1435,6 +1435,9 @@ func TestUptoFetchChannelRejectsMissingAccount(t *testing.T) {
 		FeePayerSigner:          signerSigner{operatorKey},
 		RecentBlockhashProvider: func() (string, error) { return "4vJ9JU1bJJbzZ4aJ8AqGxH9bK5VwY8bGf3sD5QG6h7h", nil },
 		RecentSlotProvider:      func() (uint64, error) { return 55_555, nil },
+		// The post-broadcast read retries the not-found account: a 1ms step
+		// keeps the full 6-attempt schedule under 15ms instead of 3s.
+		ChannelReadBackoffStepMs: 1,
 	})
 	engine.SetRPCForTests(fakeRPC)
 	env := UptoSignatureEnvelope{X402Version: X402Version, Scheme: UptoScheme, Network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", Payload: UptoPayload{
@@ -1446,6 +1449,85 @@ func TestUptoFetchChannelRejectsMissingAccount(t *testing.T) {
 	_, err := engine.VerifyOpen(context.Background(), base64.StdEncoding.EncodeToString(raw), "1.00")
 	if err == nil || !strings.Contains(err.Error(), "channel account fetch") {
 		t.Fatalf("expected channel fetch error, got %v", err)
+	}
+}
+
+// laggingChannelRPC hides the channel account for the first misses reads of it,
+// the shape of a provider whose account replica trails the one that answered
+// the confirmation. Reads of any other account (the mint owner lookup) pass
+// straight through.
+type laggingChannelRPC struct {
+	*uptoTestRPC
+	channelID solana.PublicKey
+	misses    int
+	reads     int
+}
+
+func (r *laggingChannelRPC) GetAccountInfoWithOpts(ctx context.Context, account solana.PublicKey, opts *rpc.GetAccountInfoOpts) (*rpc.GetAccountInfoResult, error) {
+	if account.Equals(r.channelID) {
+		r.reads++
+		if r.reads <= r.misses {
+			return nil, rpc.ErrNotFound
+		}
+	}
+	return r.uptoTestRPC.GetAccountInfoWithOpts(ctx, account, opts)
+}
+
+// TestUptoVerifyOpenSurvivesLaggingReplica is the end-to-end guard for the
+// whole branch: VerifyOpen must go through the retrying post-broadcast read,
+// not a single fetchChannel. Swapping the call back to fetchChannel makes the
+// first not-found fail the payment, and this test with it.
+func TestUptoVerifyOpenSurvivesLaggingReplica(t *testing.T) {
+	operatorKey := testutil.NewPrivateKey()
+	payerKey := testutil.NewPrivateKey()
+	payee := operatorKey.PublicKey()
+	mint := solana.MustPublicKeyFromBase58(paycore.USDCMainnetMint)
+	salt := uint64(7)
+	channel, _, _ := paymentchannels.FindChannelPDA(payerKey.PublicKey(), payee, mint, operatorKey.PublicKey(), salt, 55_555)
+	params := paymentchannels.OpenChannelParams{
+		Payer: payerKey.PublicKey(), RentPayer: operatorKey.PublicKey(), Payee: payee, Mint: mint, AuthorizedSigner: operatorKey.PublicKey(),
+		Salt: salt, OpenSlot: 55_555, Deposit: 1_000_000, GracePeriod: 900,
+		TokenProgram: solana.TokenProgramID, ProgramID: paymentchannels.ProgramPubkey(),
+	}
+	openIx, _ := paymentchannels.BuildOpenInstruction(params)
+	tx, _ := solana.NewTransaction([]solana.Instruction{openIx}, solana.MustHashFromBase58("4vJ9JU1bJJbzZ4aJ8AqGxH9bK5VwY8bGf3sD5QG6h7h"), solana.TransactionPayer(operatorKey.PublicKey()))
+	solanatx.SignTransaction(tx, payerSigner{payerKey})
+	txBase64, _ := solanatx.EncodeTransactionBase64(tx)
+	distHashArr := distributionHash(singleSplitTo(payee))
+	fakeRPC := newUptoTestRPC()
+	fakeRPC.addChannel(channel, &pcgen.Channel{
+		Discriminator: uint8(pcgen.AccountDiscriminator_Channel), Status: uint8(pcgen.ChannelStatus_Open),
+		Salt: salt, Deposit: 1_000_000, GracePeriod: 900, DistributionHash: distHashArr,
+		Payer: payerKey.PublicKey(), Payee: payee, AuthorizedSigner: operatorKey.PublicKey(), RentPayer: operatorKey.PublicKey(), Mint: mint,
+	})
+	laggingRPC := &laggingChannelRPC{uptoTestRPC: fakeRPC, channelID: channel, misses: 1}
+	engine, _ := NewX402Upto(UptoConfig{
+		Recipient: payee.String(), Currency: "USDC", Decimals: 6, Network: paykit.SolanaLocalnet,
+		FeePayerSigner:          signerSigner{operatorKey},
+		RecentBlockhashProvider: func() (string, error) { return "4vJ9JU1bJJbzZ4aJ8AqGxH9bK5VwY8bGf3sD5QG6h7h", nil },
+		RecentSlotProvider:      func() (uint64, error) { return 55_555, nil },
+		// 1ms step: the one backoff this test sleeps stays invisible.
+		ChannelReadBackoffStepMs: 1,
+	})
+	engine.SetRPCForTests(laggingRPC)
+	env := UptoSignatureEnvelope{X402Version: X402Version, Scheme: UptoScheme, Network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", Payload: UptoPayload{
+		From: payerKey.PublicKey().String(), MaxAmount: "1000000",
+		ExpiresAt: time.Now().Add(time.Hour).Unix(), ChannelID: channel.String(), Deposit: "1000000",
+		Nonce: "7", OpenSlot: "55555", AuthorizedSigner: operatorKey.PublicKey().String(), OpenTransaction: txBase64,
+	}}
+	raw, _ := json.Marshal(env)
+	verified, err := engine.VerifyOpen(context.Background(), base64.StdEncoding.EncodeToString(raw), "1.00")
+	if err != nil {
+		t.Fatalf("VerifyOpen through a lagging replica: %v", err)
+	}
+	if verified.ChannelID != channel {
+		t.Fatalf("channel = %s, want %s", verified.ChannelID, channel)
+	}
+	if verified.Deposit != 1_000_000 {
+		t.Fatalf("deposit = %d, want the on-chain 1000000", verified.Deposit)
+	}
+	if laggingRPC.reads != 2 {
+		t.Fatalf("channel reads = %d, want the miss plus the retry", laggingRPC.reads)
 	}
 }
 

--- a/python/src/solana_pay_kit/_paycore/rpc.py
+++ b/python/src/solana_pay_kit/_paycore/rpc.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 import asyncio
 import base64
 import itertools
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
 
 import httpx
 
@@ -30,6 +31,13 @@ from solana_pay_kit._paycore.errors import PaymentError
 
 class _RpcError(PaymentError):
     """JSON-RPC level error from a Solana node."""
+
+
+class MalformedAccountError(_RpcError):
+    """``getAccountInfo`` answered with an account object this client cannot
+    read: no non-empty ``owner`` string, or a ``data`` field of an unexpected
+    shape. The account is VISIBLE, so this is an answer and not replica lag -
+    callers must fail on it rather than re-read."""
 
 
 class _RpcResponse:
@@ -147,23 +155,32 @@ class SolanaRpc:
 
     async def get_account_info(self, address: str, commitment: str = "confirmed") -> tuple[bytes, str] | None:
         """Fetch an account's raw data bytes and owner (base58), or ``None`` when
-        the account is missing. Used to read on-chain payment-channel state
-        during x402 ``upto`` verification; the generated ``Channel.decode`` then
-        parses the returned bytes."""
+        the envelope carried no account object. Used to read on-chain
+        payment-channel state during x402 ``upto`` verification; the generated
+        ``Channel.decode`` then parses the returned bytes.
+
+        ``None`` means one thing only: the account is not there. A genuinely
+        absent account and one a lagging replica has not seen yet answer the
+        same way, so ``None`` is the single read a caller may retry. A VISIBLE
+        account this client cannot read raises :class:`MalformedAccountError`,
+        which the caller must fail on straight away.
+        """
         result = await self._call("getAccountInfo", [address, {"encoding": "base64", "commitment": commitment}])
         value = (result or {}).get("value") if isinstance(result, dict) else None
         if not isinstance(value, dict):
             return None
         owner = value.get("owner")
         if not isinstance(owner, str) or not owner:
-            return None
+            raise MalformedAccountError("getAccountInfo returned an account with no owner", code="payment_invalid")
         data_field = value.get("data")
         if isinstance(data_field, list) and data_field and isinstance(data_field[0], str):
             raw = base64.b64decode(data_field[0])
         elif isinstance(data_field, str):
             raw = base64.b64decode(data_field)
         else:
-            return None
+            raise MalformedAccountError(
+                "getAccountInfo returned an account with an unreadable data field", code="payment_invalid"
+            )
         return raw, owner
 
     async def get_signature_statuses(self, signatures: list[str]) -> list[Any]:
@@ -236,3 +253,70 @@ class SolanaRpc:
             f"timed out awaiting confirmation for {signature}",
             code="transaction-not-found",
         )
+
+
+# -- channel-read replica lag -----------------------------------------------
+
+# An RPC provider can answer getSignatureStatuses and getAccountInfo from
+# different replicas, so an account written by a just-confirmed transaction can
+# still read back MISSING on the replica that serves the follow-up read.
+# Re-reading absorbs that, and only that: an account that is visible but does
+# not say what the caller expected is an answer, not lag.
+#
+# LINEAR backoff, not exponential: replica lag is a small multiple of Solana's
+# ~400ms slot time, so doubling spends the budget on single waits far longer
+# than the lag being absorbed. Six attempts at a 200ms step schedule
+# 200/400/600/800/1000ms - 3.0s total, 1s maximum single wait.
+CHANNEL_READ_ATTEMPTS = 6
+CHANNEL_READ_BACKOFF_STEP_SECONDS = 0.2
+
+_T = TypeVar("_T")
+
+
+def resolve_channel_read_policy(
+    max_attempts: int | None,
+    backoff_step_ms: int | None,
+) -> tuple[int, float]:
+    """Resolve the optional channel-read knobs to ``(attempts, step_seconds)``.
+
+    Unset or non-positive takes the default, so a caller may pass a zero value
+    (an unset field in a language without optionals) without disabling the
+    retry.
+    """
+    attempts = CHANNEL_READ_ATTEMPTS
+    if not isinstance(max_attempts, bool) and isinstance(max_attempts, int) and max_attempts > 0:
+        attempts = max_attempts
+    step_seconds = CHANNEL_READ_BACKOFF_STEP_SECONDS
+    if not isinstance(backoff_step_ms, bool) and isinstance(backoff_step_ms, int) and backoff_step_ms > 0:
+        step_seconds = backoff_step_ms / 1000
+    return attempts, step_seconds
+
+
+async def read_with_replica_retry(
+    read: Callable[[], Awaitable[_T]],
+    attempts: int = CHANNEL_READ_ATTEMPTS,
+    backoff_step_seconds: float = CHANNEL_READ_BACKOFF_STEP_SECONDS,
+) -> _T:
+    """Re-read until the read returns something (``value is not None``).
+
+    The not-yet-visible read is the ONLY lag symptom this absorbs, and there is
+    deliberately no hook to widen it. A visible-but-wrong value is an answer,
+    not lag: it is returned straight away and the caller raises on that first
+    observation. Re-sampling a wrong-but-visible value over the backoff window
+    can only ever flip reject into accept, on state a concurrent writer may
+    have moved in the meantime. Anything ``read`` raises propagates immediately
+    and is never retried.
+
+    The last read is returned as-is once ``attempts`` is exhausted, so the
+    caller keeps its own error for the still-invisible case. Sleeps only
+    *between* attempts: the wait before attempt N+1 is
+    ``backoff_step_seconds * N``, and there is no sleep after the final
+    attempt.
+    """
+    attempt = 1
+    while True:
+        value = await read()
+        if attempt >= attempts or value is not None:
+            return value
+        await asyncio.sleep(backoff_step_seconds * attempt)
+        attempt += 1

--- a/python/src/solana_pay_kit/config.py
+++ b/python/src/solana_pay_kit/config.py
@@ -99,6 +99,19 @@ class X402Config(pydantic.BaseModel):
     facilitator_url: str | None = None
     scheme: Literal["exact"] = "exact"
     signer: LocalSigner | None = None
+    # ``upto`` re-reads the channel account after the open is confirmed, because
+    # an RPC provider can serve transaction status and account state from
+    # different replicas. Unset or non-positive takes the defaults (6 attempts,
+    # 200ms step: 200/400/600/800/1000ms, 3.0s worst case).
+    #
+    # Worst-case latency is not free everywhere: ``django._run`` detects a
+    # running loop and then does ``thread.start(); thread.join()`` on the event
+    # loop thread, so under ASGI ``verify_open`` already stalls the whole loop
+    # and this extends that stall by up to 3.0s. Flask's ``_run`` is
+    # ``asyncio.run``, so it pins one WSGI worker thread. FastAPI is genuinely
+    # async and unaffected. Fixing the Django stall is separate work.
+    channel_read_max_attempts: int | None = None
+    channel_read_backoff_step_ms: int | None = None
 
     def is_delegated(self) -> bool:
         """``True`` when a non-empty facilitator URL routes verify/settle off-host."""

--- a/python/src/solana_pay_kit/protocols/x402/upto/__init__.py
+++ b/python/src/solana_pay_kit/protocols/x402/upto/__init__.py
@@ -51,7 +51,13 @@ from solana_pay_kit._paycore.paymentchannels import (
     treasury_owner,
     voucher_message_bytes,
 )
-from solana_pay_kit._paycore.rpc import SolanaRpc
+from solana_pay_kit._paycore.rpc import (
+    CHANNEL_READ_BACKOFF_STEP_SECONDS,
+    MalformedAccountError,
+    SolanaRpc,
+    read_with_replica_retry,
+    resolve_channel_read_policy,
+)
 from solana_pay_kit._paycore.transaction import is_v0_wire_bytes
 from solana_pay_kit.errors import ConfigurationError, InvalidProofError
 from solana_pay_kit.protocols.programs.paymentchannels.accounts.channel import Channel
@@ -333,7 +339,20 @@ class X402Upto:
             sent = await rpc.send_raw_transaction(cosigned)
             await rpc.await_confirmation(str(sent.value))
 
-            channel = await self._fetch_channel(rpc, channel_id, program_id)
+            # The open is confirmed, so the funds are already escrowed on
+            # chain: a single unretried read that lands on a lagging replica
+            # would hard-fail a payment that actually succeeded.
+            read_attempts, read_backoff_step_seconds = resolve_channel_read_policy(
+                self._config.x402.channel_read_max_attempts,
+                self._config.x402.channel_read_backoff_step_ms,
+            )
+            channel = await self._fetch_channel(
+                rpc,
+                channel_id,
+                program_id,
+                attempts=read_attempts,
+                backoff_step_seconds=read_backoff_step_seconds,
+            )
             self._validate_channel_state(
                 channel,
                 fee_payer_pubkey,
@@ -518,8 +537,41 @@ class X402Upto:
         beneficiary = Pubkey.from_string(requirements["payTo"])
         return [Distribution(recipient=beneficiary, bps=10_000)]
 
-    async def _fetch_channel(self, rpc: SolanaRpc, channel_id: Pubkey, program_id: Pubkey) -> Any:
-        account = await rpc.get_account_info(str(channel_id))
+    async def _fetch_channel(
+        self,
+        rpc: SolanaRpc,
+        channel_id: Pubkey,
+        program_id: Pubkey,
+        *,
+        attempts: int = 1,
+        backoff_step_seconds: float = CHANNEL_READ_BACKOFF_STEP_SECONDS,
+    ) -> Any:
+        # Single-read by default; the post-broadcast caller opts into the
+        # replica-lag retry. ``SolanaRpc.get_account_info`` returns ``None`` for
+        # one condition only: the envelope carried no account object (``value``
+        # is not a dict), which is how the genuinely absent account and the
+        # lagging replica both read. That is the sole retried case. A VISIBLE
+        # account this client cannot read - no non-empty ``owner`` string, or a
+        # ``data`` field of an unexpected shape - raises
+        # ``MalformedAccountError``, translated below to the unchanged error on
+        # the first read; an account whose base64 ``data`` does not decode
+        # raises ``binascii.Error`` straight out of the RPC client. Everything
+        # after the read stays single-shot too - wrong owner, empty data, decode
+        # failure, and every bind check in ``_validate_channel_state`` - since a
+        # visible-and-wrong account is an answer, not lag.
+        async def read_account() -> tuple[bytes, str] | None:
+            try:
+                return await rpc.get_account_info(str(channel_id))
+            except MalformedAccountError as exc:
+                raise InvalidProofError(
+                    "channel account fetch failed: missing account data", code="payment_invalid"
+                ) from exc
+
+        account = await read_with_replica_retry(
+            read_account,
+            attempts=attempts,
+            backoff_step_seconds=backoff_step_seconds,
+        )
         if account is None:
             raise InvalidProofError("channel account fetch failed: missing account data", code="payment_invalid")
         data, owner = account

--- a/python/tests/test_pk_x402_upto_settle.py
+++ b/python/tests/test_pk_x402_upto_settle.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import json
 import time
+from typing import Any
 
 import pytest
 from solders.keypair import Keypair  # type: ignore[import-untyped]
@@ -30,7 +31,8 @@ from solana_pay_kit import (
 )
 from solana_pay_kit._paycore.mints import resolve, token_program_for
 from solana_pay_kit._paycore.paymentchannels import Distribution
-from solana_pay_kit.config import reset
+from solana_pay_kit._paycore.rpc import MalformedAccountError
+from solana_pay_kit.config import X402Config, reset
 from solana_pay_kit.errors import InvalidProofError
 from solana_pay_kit.protocols.programs.paymentchannels.accounts.channel import Channel
 from solana_pay_kit.protocols.x402.client.upto import build_upto_payload, encode_upto_header
@@ -52,9 +54,11 @@ def _clean(monkeypatch: pytest.MonkeyPatch):
 class _FakeRpc:
     """Async RPC stub matching the SolanaRpc surface the engine uses."""
 
-    def __init__(self, holder: dict[str, tuple[bytes, str] | None]) -> None:
+    def __init__(self, holder: dict[str, Any]) -> None:
         self._holder = holder
         self.sent: list[bytes] = []
+        # Channel-account reads, so the replica-lag retry can be pinned.
+        self.reads = 0
 
     async def send_raw_transaction(self, raw: bytes):
         self.sent.append(raw)
@@ -68,7 +72,16 @@ class _FakeRpc:
         return None
 
     async def get_account_info(self, _addr: str, commitment: str = "confirmed"):
-        return self._holder["account"]
+        self.reads += 1
+        # "sequence" serves one reply per read (replica-lag scenarios); the
+        # plain "account" holder answers every read.
+        sequence = self._holder.get("sequence")
+        reply = sequence.pop(0) if sequence else self._holder["account"]
+        # An exception reply is raised, mirroring the RPC client on a visible
+        # account whose object it cannot read.
+        if isinstance(reply, BaseException):
+            raise reply
+        return reply
 
     async def get_latest_blockhash(self, commitment: str = "confirmed"):
         class _V:
@@ -83,7 +96,7 @@ class _FakeRpc:
         return None
 
 
-def _engine(monkeypatch) -> tuple[X402Upto, Config, dict[str, tuple[bytes, str] | None]]:
+def _engine(monkeypatch, x402: X402Config | None = None) -> tuple[X402Upto, Config, dict[str, Any]]:
     op = Operator(signer=LocalSigner.from_keypair(Keypair()), recipient=str(Keypair().pubkey()))
     cfg = configure(
         network="solana_localnet",
@@ -91,10 +104,20 @@ def _engine(monkeypatch) -> tuple[X402Upto, Config, dict[str, tuple[bytes, str] 
         accept=(Protocol.X402,),
         operator=op,
         rpc_url="http://127.0.0.1:8899",
+        # Keep the post-confirmation channel-read retry on its default attempt
+        # count but drop the backoff step to 1ms so the suite never sleeps for
+        # real seconds. The default schedule is pinned in test_rpc_methods.
+        x402=x402 if x402 is not None else X402Config(channel_read_backoff_step_ms=1),
     )
     eng = X402Upto(cfg, recent_state_provider=lambda: (BH, RECENT_SLOT))
-    holder: dict[str, tuple[bytes, str] | None] = {"account": None}
-    monkeypatch.setattr(upto_mod, "SolanaRpc", lambda *_a, **_k: _FakeRpc(holder))
+    holder: dict[str, Any] = {"account": None}
+
+    def _rpc(*_a, **_k) -> _FakeRpc:
+        rpc = _FakeRpc(holder)
+        holder["rpc"] = rpc
+        return rpc
+
+    monkeypatch.setattr(upto_mod, "SolanaRpc", _rpc)
     return eng, cfg, holder
 
 
@@ -510,6 +533,62 @@ async def test_verify_open_channel_missing(monkeypatch) -> None:
     holder["account"] = None
     with pytest.raises(InvalidProofError, match="missing account data"):
         await eng.verify_open(_gate(cfg), _Req(header))
+    # The retry exhausts its attempt budget and then raises the unchanged
+    # error; it never gives up after the first miss.
+    assert holder["rpc"].reads == 6
+
+
+@pytest.mark.asyncio
+async def test_verify_open_reads_a_malformed_channel_account_exactly_once(monkeypatch) -> None:
+    # A VISIBLE account the RPC client cannot read (no owner, or a data field
+    # of an unexpected shape) is an answer, not replica lag: it fails on the
+    # first read with the unchanged error instead of spending the retry budget.
+    eng, cfg, holder = _engine(monkeypatch)
+    header, _pk, _req = _client_header(eng, cfg)
+    holder["account"] = MalformedAccountError(
+        "getAccountInfo returned an account with no owner", code="payment_invalid"
+    )
+    with pytest.raises(InvalidProofError, match="missing account data"):
+        await eng.verify_open(_gate(cfg), _Req(header))
+    assert holder["rpc"].reads == 1
+
+
+@pytest.mark.asyncio
+async def test_verify_open_channel_read_budget_comes_from_config(monkeypatch) -> None:
+    # Both knobs must reach the retry loop, not just the defaults: a two
+    # attempt budget spends exactly two reads on a never-visible account.
+    eng, cfg, holder = _engine(
+        monkeypatch,
+        X402Config(channel_read_max_attempts=2, channel_read_backoff_step_ms=1),
+    )
+    header, _pk, _req = _client_header(eng, cfg)
+    holder["account"] = None
+    with pytest.raises(InvalidProofError, match="missing account data"):
+        await eng.verify_open(_gate(cfg), _Req(header))
+    assert holder["rpc"].reads == 2
+
+
+@pytest.mark.asyncio
+async def test_verify_open_retries_channel_read_through_replica_lag(monkeypatch) -> None:
+    # The open is confirmed, so the deposit is escrowed; an RPC provider can
+    # still serve the account read from a replica that has not caught up. Two
+    # misses must not fail a payment whose funds already moved.
+    eng, cfg, holder = _engine(monkeypatch)
+    header, client_pk, req = _client_header(eng, cfg)
+    operator = _op_pubkey(cfg)
+    account = _fake_channel(
+        payer=client_pk,
+        payee=operator,
+        mint=req["asset"],
+        operator=operator,
+        deposit=100000,
+        distribution_hash=_expected_distribution_hash(cfg.effective_recipient(), operator),
+    )
+    holder["sequence"] = [None, None, account]
+    verified = await eng.verify_open(_gate(cfg), _Req(header))
+    assert verified.deposit == 100000
+    assert holder["rpc"].reads == 3
+    verified.release()
 
 
 @pytest.mark.asyncio
@@ -528,6 +607,9 @@ async def test_verify_open_owner_mismatch(monkeypatch) -> None:
     holder["account"] = (data, str(Keypair().pubkey()))  # wrong owner
     with pytest.raises(InvalidProofError, match="not owned by"):
         await eng.verify_open(_gate(cfg), _Req(header))
+    # A visible-but-wrong account is an answer, not replica lag: rejected on
+    # the first read, never retried.
+    assert holder["rpc"].reads == 1
 
 
 def test_reserve_channel_concurrent(monkeypatch) -> None:

--- a/python/tests/test_rpc_methods.py
+++ b/python/tests/test_rpc_methods.py
@@ -9,10 +9,19 @@ the 90 percent line coverage gate: the error branch in ``_call``, both
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 
 from solana_pay_kit._paycore.errors import PaymentError
-from solana_pay_kit._paycore.rpc import SolanaRpc, _RpcError, _RpcResponse
+from solana_pay_kit._paycore.rpc import (
+    MalformedAccountError,
+    SolanaRpc,
+    _RpcError,
+    _RpcResponse,
+    read_with_replica_retry,
+    resolve_channel_read_policy,
+)
 
 
 class _FakeResponse:
@@ -234,3 +243,129 @@ async def test_get_slot_returns_integer_and_rejects_garbage():
     assert await _rpc({"result": 12345, "id": 1}).get_slot() == 12345
     with pytest.raises(_RpcError):
         await _rpc({"result": "not-a-slot", "id": 1}).get_slot()
+
+
+# -- getAccountInfo shape ---------------------------------------------------
+
+
+async def test_get_account_info_returns_none_only_for_an_absent_account() -> None:
+    rpc = _rpc({"result": {"value": None}, "id": 1})
+    assert await rpc.get_account_info("Chan") is None
+
+
+async def test_get_account_info_decodes_both_data_shapes() -> None:
+    encoded = base64.b64encode(b"channel").decode("ascii")
+    assert await _rpc({"result": {"value": {"owner": "Prog", "data": [encoded, "base64"]}}, "id": 1}).get_account_info(
+        "Chan"
+    ) == (b"channel", "Prog")
+    assert await _rpc({"result": {"value": {"owner": "Prog", "data": encoded}}, "id": 1}).get_account_info("Chan") == (
+        b"channel",
+        "Prog",
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"data": [base64.b64encode(b"channel").decode("ascii"), "base64"]},
+        {"owner": "", "data": [base64.b64encode(b"channel").decode("ascii"), "base64"]},
+        {"owner": "Prog"},
+        {"owner": "Prog", "data": {"parsed": {}}},
+        {"owner": "Prog", "data": []},
+    ],
+)
+async def test_get_account_info_raises_on_a_visible_but_malformed_account(value: dict) -> None:
+    # The account IS there, this client just cannot read it. That is an answer,
+    # not replica lag, so it must not come back as the retryable ``None``.
+    rpc = _rpc({"result": {"value": value}, "id": 1})
+    with pytest.raises(MalformedAccountError):
+        await rpc.get_account_info("Chan")
+    assert rpc._client.calls == 1  # type: ignore[attr-defined]
+
+
+async def test_read_with_replica_retry_reads_a_malformed_account_exactly_once() -> None:
+    # The retry wraps this read on the post-confirmation path: a malformed
+    # account must burn one attempt, not the whole backoff budget.
+    rpc = _rpc({"result": {"value": {"owner": "Prog", "data": {"parsed": {}}}}, "id": 1})
+    with pytest.raises(MalformedAccountError):
+        await read_with_replica_retry(lambda: rpc.get_account_info("Chan"), backoff_step_seconds=0.001)
+    assert rpc._client.calls == 1  # type: ignore[attr-defined]
+
+
+# -- channel-read replica-lag retry -----------------------------------------
+
+
+async def test_read_with_replica_retry_uses_linear_backoff_schedule(monkeypatch) -> None:
+    # The contract: 6 attempts, 200ms step, the wait before attempt N+1 is
+    # step * N, and no sleep after the final attempt. Linear, not exponential:
+    # replica lag is a small multiple of the ~400ms slot time, so doubling
+    # would spend the budget on single waits far longer than the lag absorbed.
+    import asyncio
+
+    real_sleep = asyncio.sleep
+    delays: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        delays.append(seconds)
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+
+    reads = 0
+
+    async def _read() -> object | None:
+        nonlocal reads
+        reads += 1
+        return None
+
+    assert await read_with_replica_retry(_read) is None
+    assert reads == 6
+    assert delays == pytest.approx([0.2, 0.4, 0.6, 0.8, 1.0])
+    assert sum(delays) == pytest.approx(3.0)
+    assert max(delays) == pytest.approx(1.0)
+
+
+async def test_read_with_replica_retry_stops_at_the_first_visible_read() -> None:
+    values = [None, None, "channel"]
+
+    async def _read() -> object | None:
+        return values.pop(0)
+
+    assert await read_with_replica_retry(_read, backoff_step_seconds=0.001) == "channel"
+    assert values == []
+
+
+async def test_read_with_replica_retry_never_retries_a_visible_value() -> None:
+    # A visible value is an answer, not lag: returned on the first read, even
+    # when the caller is about to reject it.
+    reads = 0
+
+    async def _read() -> int:
+        nonlocal reads
+        reads += 1
+        return 1_500
+
+    assert await read_with_replica_retry(_read, backoff_step_seconds=0.001) == 1_500
+    assert reads == 1
+
+
+async def test_read_with_replica_retry_propagates_read_errors_without_retrying() -> None:
+    reads = 0
+
+    async def _read() -> object:
+        nonlocal reads
+        reads += 1
+        raise PaymentError("wrong owner", code="invalid-payload")
+
+    with pytest.raises(PaymentError, match="wrong owner"):
+        await read_with_replica_retry(_read, backoff_step_seconds=0.001)
+    assert reads == 1
+
+
+def test_resolve_channel_read_policy_defaults_on_unset_or_non_positive() -> None:
+    # Unset or non-positive resolves to the default, so a caller may pass a
+    # zero value without disabling the retry.
+    assert resolve_channel_read_policy(None, None) == (6, 0.2)
+    assert resolve_channel_read_policy(0, 0) == (6, 0.2)
+    assert resolve_channel_read_policy(-1, -5) == (6, 0.2)
+    assert resolve_channel_read_policy(3, 50) == (3, 0.05)

--- a/rust/crates/kit/src/core/rpc.rs
+++ b/rust/crates/kit/src/core/rpc.rs
@@ -1,10 +1,16 @@
-//! Shared RPC send policies.
+//! Shared RPC send and read-back policies.
 //!
 //! Most payment transactions should use the node's default preflight. A few
 //! server-side flows already have stronger local/on-chain validation and can
 //! hit false-negative preflight simulations when the RPC bank lags a confirmed
 //! dependency. Those flows broadcast directly and rely on the existing
 //! confirmation/reconciliation path for the durable result.
+//!
+//! [`ChannelReadPolicy`] covers the opposite direction: reading an account back
+//! immediately after its transaction confirmed, where the replica serving the
+//! read can briefly lag the one that served the status.
+
+use std::time::Duration;
 
 use solana_client::rpc_config::RpcSendTransactionConfig;
 
@@ -28,6 +34,86 @@ pub(crate) const SKIP_PREFLIGHT_SEND: RpcSendPolicy = RpcSendPolicy {
     skip_preflight: true,
 };
 
+/// Attempts and backoff for re-reading an account right after the transaction
+/// that wrote it confirmed.
+///
+/// RPC providers can serve transaction status and account state from different
+/// replicas, so an account a confirmed transaction just wrote can still be
+/// missing from the very next read. The backoff is linear (`backoff_step *
+/// attempt`) rather than exponential: replica lag is a small multiple of
+/// Solana's ~400ms slot time, so doubling spends the budget on single waits far
+/// longer than the lag being absorbed. The defaults wait 200/400/600/800/1000ms
+/// between six reads - 3.0s of total budget, 1s of longest single wait.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ChannelReadPolicy {
+    pub(crate) max_attempts: u32,
+    pub(crate) backoff_step: Duration,
+}
+
+/// Reads a post-broadcast account fetch makes before treating it as absent.
+const CHANNEL_READ_MAX_ATTEMPTS: u32 = 6;
+
+/// Linear step: the wait before attempt `n + 1` is `step * n`.
+const CHANNEL_READ_BACKOFF_STEP: Duration = Duration::from_millis(200);
+
+impl Default for ChannelReadPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: CHANNEL_READ_MAX_ATTEMPTS,
+            backoff_step: CHANNEL_READ_BACKOFF_STEP,
+        }
+    }
+}
+
+impl ChannelReadPolicy {
+    /// Resolve operator configuration. Unset or non-positive means "default",
+    /// so a caller that always passes a value can pass zero.
+    pub(crate) fn from_config(max_attempts: Option<u32>, backoff_step_ms: Option<u64>) -> Self {
+        let default = Self::default();
+        Self {
+            max_attempts: max_attempts
+                .filter(|attempts| *attempts > 0)
+                .unwrap_or(default.max_attempts),
+            backoff_step: backoff_step_ms
+                .filter(|step| *step > 0)
+                .map(Duration::from_millis)
+                .unwrap_or(default.backoff_step),
+        }
+    }
+
+    /// Wait owed after the 1-based `attempt`, or `None` when that attempt was
+    /// the last one - the final read is never followed by a sleep.
+    fn backoff_after(self, attempt: u32) -> Option<Duration> {
+        (attempt < self.max_attempts).then(|| self.backoff_step * attempt)
+    }
+}
+
+/// Re-read with the blocking RPC client until the account becomes visible.
+///
+/// `Ok(None)` is the only retryable answer, and whether a confirmed absence is
+/// an error stays with the caller: some call sites use the same read as a
+/// pre-broadcast existence probe, where absence is the expected result. An
+/// `Err` is never retried - it means the read itself failed, or the caller
+/// observed a state that is visible and wrong.
+///
+/// Sleeps the calling thread, so call this from inside an existing
+/// `spawn_blocking` rather than spawning one per attempt.
+pub(crate) fn read_back_blocking<T, E>(
+    policy: ChannelReadPolicy,
+    mut read: impl FnMut() -> Result<Option<T>, E>,
+) -> Result<Option<T>, E> {
+    for attempt in 1..=policy.max_attempts {
+        if let Some(value) = read()? {
+            return Ok(Some(value));
+        }
+        match policy.backoff_after(attempt) {
+            Some(wait) => std::thread::sleep(wait),
+            None => break,
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,5 +130,93 @@ mod tests {
         assert_eq!(config.encoding, None);
         assert_eq!(config.max_retries, None);
         assert_eq!(config.min_context_slot, None);
+    }
+    #[test]
+    fn channel_read_defaults_are_six_reads_of_linear_backoff() {
+        let policy = ChannelReadPolicy::default();
+
+        assert_eq!(policy.max_attempts, 6);
+        assert_eq!(policy.backoff_step, Duration::from_millis(200));
+        // Linear, and no sleep after the final read: 200+400+600+800+1000ms.
+        let schedule: Vec<_> = (1..=policy.max_attempts)
+            .map(|attempt| policy.backoff_after(attempt))
+            .collect();
+        assert_eq!(
+            schedule,
+            vec![
+                Some(Duration::from_millis(200)),
+                Some(Duration::from_millis(400)),
+                Some(Duration::from_millis(600)),
+                Some(Duration::from_millis(800)),
+                Some(Duration::from_millis(1000)),
+                None,
+            ]
+        );
+        let total: Duration = schedule.into_iter().flatten().sum();
+        assert_eq!(total, Duration::from_millis(3000));
+    }
+
+    #[test]
+    fn channel_read_config_treats_unset_and_zero_as_default() {
+        let default = ChannelReadPolicy::default();
+        for policy in [
+            ChannelReadPolicy::from_config(None, None),
+            ChannelReadPolicy::from_config(Some(0), Some(0)),
+        ] {
+            assert_eq!(policy.max_attempts, default.max_attempts);
+            assert_eq!(policy.backoff_step, default.backoff_step);
+        }
+
+        let tuned = ChannelReadPolicy::from_config(Some(3), Some(50));
+        assert_eq!(tuned.max_attempts, 3);
+        assert_eq!(tuned.backoff_step, Duration::from_millis(50));
+    }
+
+    #[test]
+    fn read_back_blocking_retries_absence_and_stops_at_the_first_hit() {
+        let policy = ChannelReadPolicy {
+            max_attempts: 6,
+            backoff_step: Duration::from_millis(1),
+        };
+        let mut reads = 0;
+        let found: Result<Option<u8>, ()> = read_back_blocking(policy, || {
+            reads += 1;
+            Ok((reads == 3).then_some(7))
+        });
+
+        assert_eq!(found, Ok(Some(7)));
+        assert_eq!(reads, 3);
+    }
+
+    #[test]
+    fn read_back_blocking_gives_up_after_max_attempts() {
+        let policy = ChannelReadPolicy {
+            max_attempts: 4,
+            backoff_step: Duration::from_millis(1),
+        };
+        let mut reads = 0;
+        let found: Result<Option<u8>, ()> = read_back_blocking(policy, || {
+            reads += 1;
+            Ok(None)
+        });
+
+        assert_eq!(found, Ok(None));
+        assert_eq!(reads, 4);
+    }
+
+    #[test]
+    fn read_back_blocking_never_retries_an_error() {
+        let policy = ChannelReadPolicy {
+            max_attempts: 6,
+            backoff_step: Duration::from_millis(1),
+        };
+        let mut reads = 0;
+        let found: Result<Option<u8>, &str> = read_back_blocking(policy, || {
+            reads += 1;
+            Err("visible and wrong")
+        });
+
+        assert_eq!(found, Err("visible and wrong"));
+        assert_eq!(reads, 1);
     }
 }

--- a/rust/crates/kit/src/x402/server/batch_settlement.rs
+++ b/rust/crates/kit/src/x402/server/batch_settlement.rs
@@ -44,6 +44,7 @@ use solana_transaction::Transaction;
 
 use crate::core::payment_channels as pc;
 use crate::core::payment_channels::generated::accounts::Channel;
+use crate::core::rpc::{read_back_blocking, ChannelReadPolicy};
 use crate::core::settlement::packing::{pack, ChannelInstructionGroup};
 use crate::core::store::{
     BatchReservation, ChannelState, ChannelStore, MemoryChannelStore, PendingSetup,
@@ -202,6 +203,25 @@ fn spawn_next_submission(
     });
 }
 
+/// Read the escrow channel back after the deposit confirms, re-reading only
+/// while it is not yet visible and mapping an exhausted budget to this site's
+/// "does not exist".
+///
+/// The reader is injected so a test can count the reads this site makes
+/// without standing up an RPC.
+fn read_deposited_channel<T>(
+    policy: ChannelReadPolicy,
+    channel_id: &Pubkey,
+    read: impl FnMut() -> Result<Option<T>, Error>,
+) -> Result<T, Error> {
+    read_back_blocking(policy, read)?.ok_or_else(|| {
+        batch_err(
+            codes::INVALID_CHANNEL_STATE,
+            format!("channel {} does not exist", pc::pubkey_string(channel_id)),
+        )
+    })
+}
+
 /// Fetch and decode a channel account with the blocking RPC client. Factored out
 /// of [`X402BatchSettlement::lookup_channel`] so the reconcile path can run it on
 /// a blocking thread (via `spawn_blocking`) instead of stalling an async worker:
@@ -326,6 +346,18 @@ pub struct BatchConfig {
     /// default because a forced close cannot seal until its grace period —
     /// at least 900 seconds — has run.
     pub channel_snapshot_max_age_seconds: u64,
+    /// Reads of the escrow account after a deposit confirms, before it is
+    /// called absent. `None` or `0` keeps the default of 6.
+    ///
+    /// An RPC provider can serve transaction status and account state from
+    /// different replicas, so the account a confirmed deposit just funded can
+    /// be missing from the very next read. One miss would otherwise fail a
+    /// payment whose funds are already escrowed on chain.
+    pub channel_read_max_attempts: Option<u32>,
+    /// Linear backoff step between those reads, in milliseconds: the wait
+    /// before attempt `n + 1` is `step * n`. `None` or `0` keeps the default
+    /// of 200ms.
+    pub channel_read_backoff_step_ms: Option<u64>,
 }
 
 impl BatchConfig {
@@ -352,6 +384,8 @@ impl BatchConfig {
             fee_payer_signer,
             program_id: None,
             channel_snapshot_max_age_seconds: 30,
+            channel_read_max_attempts: None,
+            channel_read_backoff_step_ms: None,
         }
     }
 }
@@ -1636,7 +1670,22 @@ impl X402BatchSettlement {
                 let signature = self
                     .broadcast_client_transaction(&deposit.transaction)
                     .await?;
-                let channel = self.fetch_channel(&pc::parse_pubkey(&outcome.channel_id)?)?;
+                // The deposit is confirmed, but the replica serving this read
+                // can still lag the one that served the confirmation. Re-read
+                // while the account is not yet visible; the binding checks
+                // below stay terminal on their first observation. The blocking
+                // client would otherwise sleep on a Tokio worker, so the whole
+                // loop runs on one blocking thread.
+                let channel_id = pc::parse_pubkey(&outcome.channel_id)?;
+                let rpc = Arc::clone(&self.rpc);
+                let read_policy = self.channel_read_policy();
+                let channel = tokio::task::spawn_blocking(move || {
+                    read_deposited_channel(read_policy, &channel_id, || {
+                        rpc_lookup_channel(&rpc, &channel_id)
+                    })
+                })
+                .await
+                .map_err(|e| Error::Other(format!("channel read task failed: {e}")))??;
                 self.check_channel_bindings(
                     &channel,
                     outcome.payload.channel_config(),
@@ -2275,6 +2324,16 @@ impl X402BatchSettlement {
     /// clear, because it holds the only copy of this server's charge watermark.
     fn lookup_channel(&self, channel_id: &Pubkey) -> Result<Option<Channel>, Error> {
         rpc_lookup_channel(&self.rpc, channel_id)
+    }
+
+    /// Retry budget for reading an escrow account back right after its deposit
+    /// confirmed. Opt-in per call site: `lookup_channel` itself also answers
+    /// "does this channel exist yet", where absence is the correct answer.
+    fn channel_read_policy(&self) -> ChannelReadPolicy {
+        ChannelReadPolicy::from_config(
+            self.config.channel_read_max_attempts,
+            self.config.channel_read_backoff_step_ms,
+        )
     }
 
     fn fetch_channel(&self, channel_id: &Pubkey) -> Result<Channel, Error> {
@@ -4103,5 +4162,81 @@ mod tests {
             3_000,
         )
         .expect("the client accepts the proof");
+    }
+    #[test]
+    fn channel_read_policy_follows_batch_config() {
+        let signer = TestSigner::new(3);
+        let mut config = BatchConfig::new(PAY_TO, "localnet", Arc::new(signer));
+        // Unset: the escrow read-back after a deposit confirms gets six reads
+        // on a 200ms linear step.
+        assert_eq!(config.channel_read_max_attempts, None);
+        assert_eq!(config.channel_read_backoff_step_ms, None);
+
+        let engine = X402BatchSettlement::new(config.clone()).expect("engine should build");
+        let default = engine.channel_read_policy();
+        assert_eq!(default.max_attempts, 6);
+        assert_eq!(default.backoff_step, std::time::Duration::from_millis(200));
+
+        config.channel_read_max_attempts = Some(0);
+        config.channel_read_backoff_step_ms = Some(0);
+        let zeroed = X402BatchSettlement::new(config.clone())
+            .expect("engine should build")
+            .channel_read_policy();
+        assert_eq!(zeroed.max_attempts, default.max_attempts);
+        assert_eq!(zeroed.backoff_step, default.backoff_step);
+
+        config.channel_read_max_attempts = Some(2);
+        config.channel_read_backoff_step_ms = Some(15);
+        let tuned = X402BatchSettlement::new(config)
+            .expect("engine should build")
+            .channel_read_policy();
+        assert_eq!(tuned.max_attempts, 2);
+        assert_eq!(tuned.backoff_step, std::time::Duration::from_millis(15));
+    }
+
+    #[test]
+    fn only_a_missing_escrow_is_re_read_after_the_deposit_confirms() {
+        let policy = ChannelReadPolicy {
+            max_attempts: 4,
+            backoff_step: std::time::Duration::from_millis(1),
+        };
+        let channel_id = Pubkey::new_unique();
+
+        let mut reads = 0;
+        let found = read_deposited_channel(policy, &channel_id, || {
+            reads += 1;
+            Ok((reads == 2).then_some(1_u8))
+        });
+        assert_eq!(reads, 2);
+        assert!(matches!(found, Ok(1)));
+
+        // Visible on the first read: the binding checks in `finish_commit` run
+        // once, against a channel that is visible and therefore final.
+        let mut reads = 0;
+        let visible = read_deposited_channel(policy, &channel_id, || {
+            reads += 1;
+            Ok(Some(2_u8))
+        });
+        assert_eq!(reads, 1);
+        assert!(matches!(visible, Ok(2)));
+
+        // Never visible: the whole budget, then this site's "does not exist".
+        let mut reads = 0;
+        let missing: Result<u8, Error> = read_deposited_channel(policy, &channel_id, || {
+            reads += 1;
+            Ok(None)
+        });
+        assert_eq!(reads, 4);
+        assert!(missing.is_err());
+
+        // `rpc_lookup_channel` already separates absence from failure, and only
+        // the absence is re-read.
+        let mut reads = 0;
+        let failed: Result<u8, Error> = read_deposited_channel(policy, &channel_id, || {
+            reads += 1;
+            Err(Error::Rpc("channel account fetch failed".to_string()))
+        });
+        assert_eq!(reads, 1);
+        assert!(failed.is_err());
     }
 }

--- a/rust/crates/kit/src/x402/server/upto.rs
+++ b/rust/crates/kit/src/x402/server/upto.rs
@@ -35,6 +35,7 @@ use solana_transaction::Transaction;
 
 use crate::core::payment_channels as pc;
 use crate::core::payment_channels::generated::accounts::Channel;
+use crate::core::rpc::{read_back_blocking, ChannelReadPolicy};
 // The ComputeBudget wire format is identical wherever it appears, so the
 // charge verifier's policy-free decoder is reused here rather than duplicated.
 
@@ -176,6 +177,10 @@ pub struct X402Upto {
     /// handler `Clone` while sharing one worker. Mirrors the mpp session path.
     settlement_worker:
         Arc<tokio::sync::OnceCell<crate::core::settlement::worker::SettlementHandle>>,
+    /// How hard [`verify_open`](Self::verify_open) re-reads the channel account
+    /// after the open confirms, before calling it absent. See
+    /// [`with_channel_read_retry`](Self::with_channel_read_retry).
+    channel_read: ChannelReadPolicy,
 }
 
 fn now_unix() -> i64 {
@@ -229,6 +234,7 @@ impl X402Upto {
             in_flight: Arc::new(Mutex::new(HashSet::new())),
             blockhash_cache: None,
             settlement_worker: Arc::new(tokio::sync::OnceCell::new()),
+            channel_read: ChannelReadPolicy::default(),
         })
     }
 
@@ -237,6 +243,23 @@ impl X402Upto {
     /// fetch. Falls back to a direct fetch when the cache is empty or stale.
     pub fn with_blockhash_cache(mut self, cache: crate::core::blockhash::BlockhashCache) -> Self {
         self.blockhash_cache = Some(cache);
+        self
+    }
+
+    /// Tune the post-broadcast channel read in
+    /// [`verify_open`](Self::verify_open). A confirmed `open` can still be
+    /// invisible to the next account read when the RPC provider serves status
+    /// and account state from different replicas, so that read is retried on a
+    /// linear backoff. `None` or a zero value keeps the default (6 reads,
+    /// 200ms step). Offered as a builder rather than as `UptoConfig` fields
+    /// because `UptoConfig` has no `Default`, so new fields would break every
+    /// existing struct-literal construction site.
+    pub fn with_channel_read_retry(
+        mut self,
+        max_attempts: Option<u32>,
+        backoff_step_ms: Option<u64>,
+    ) -> Self {
+        self.channel_read = ChannelReadPolicy::from_config(max_attempts, backoff_step_ms);
         self
     }
 
@@ -591,8 +614,22 @@ impl X402Upto {
             .send_and_confirm_transaction(&tx)
             .map_err(|e| Error::Rpc(format!("open broadcast failed: {e}")))?;
 
-        // Read the confirmed channel state and bind it.
-        let channel = self.fetch_channel(&channel_id)?;
+        // Read the confirmed channel state and bind it. The open is confirmed,
+        // but the replica serving this read can still lag the one that served
+        // the confirmation, so re-read while the account is not yet visible.
+        // Every bind check below stays terminal on its first observation - the
+        // funds are already escrowed, and a visible-and-wrong channel is never
+        // going to become right. The blocking client would otherwise sleep on a
+        // Tokio worker, so the whole loop runs on a blocking thread.
+        let rpc = Arc::clone(&self.rpc);
+        let read_policy = self.channel_read;
+        let channel = tokio::task::spawn_blocking(move || {
+            read_opened_channel(read_policy, &channel_id, || {
+                rpc_lookup_channel(&rpc, &channel_id)
+            })
+        })
+        .await
+        .map_err(|e| Error::Other(format!("channel read task failed: {e}")))??;
         if channel.status != CHANNEL_STATUS_OPEN {
             return Err(Error::Other(
                 "channel is not open after broadcast".to_string(),
@@ -934,14 +971,46 @@ impl X402Upto {
             .map_err(|e| Error::Other(format!("fee payer signing failed: {e}")))?;
         Ok(())
     }
+}
 
-    fn fetch_channel(&self, channel_id: &Pubkey) -> Result<Channel, Error> {
-        let data = self
-            .rpc
-            .get_account_data(channel_id)
-            .map_err(|e| Error::Rpc(format!("channel account fetch failed: {e}")))?;
-        Channel::from_bytes(&data).map_err(|e| Error::Other(format!("channel decode failed: {e}")))
-    }
+/// Read the channel back after the open confirms, re-reading only while it is
+/// not yet visible and mapping an exhausted budget to this site's "not found".
+///
+/// The reader is injected so a test can count the reads this site makes
+/// without standing up an RPC.
+fn read_opened_channel<T>(
+    policy: ChannelReadPolicy,
+    channel_id: &Pubkey,
+    read: impl FnMut() -> Result<Option<T>, Error>,
+) -> Result<T, Error> {
+    read_back_blocking(policy, read)?.ok_or_else(|| {
+        Error::Rpc(format!(
+            "channel account fetch failed: account {} not found",
+            pc::pubkey_string(channel_id)
+        ))
+    })
+}
+
+/// Read a channel account, separating a confirmed absence from a transient RPC
+/// or decode failure.
+///
+/// `Ok(None)` is the account not being there; anything else - an unreachable
+/// RPC, an undecodable account - is an error and never an absence. Only the
+/// absence is worth re-reading, so `get_account_data`, which collapses the two
+/// into one `ClientError`, is not usable here. Kept separate from the
+/// `batch-settlement` reader of the same shape: the two return different error
+/// types.
+fn rpc_lookup_channel(rpc: &RpcClient, channel_id: &Pubkey) -> Result<Option<Channel>, Error> {
+    let account = rpc
+        .get_account_with_commitment(channel_id, rpc.commitment())
+        .map_err(|e| Error::Rpc(format!("channel account fetch failed: {e}")))?
+        .value;
+    account
+        .map(|account| {
+            Channel::from_bytes(&account.data)
+                .map_err(|e| Error::Other(format!("channel decode failed: {e}")))
+        })
+        .transpose()
 }
 
 /// Co-sign the operator's (fee-payer) slot of a partially-signed transaction.
@@ -2236,5 +2305,79 @@ mod tests {
         assert!(serde_json::to_value(&req).unwrap()["extra"]
             .get("facilitatorAddress")
             .is_none());
+    }
+    #[test]
+    fn channel_read_retry_is_configurable_and_defaults_to_the_linear_schedule() {
+        // The `open` is confirmed before this read, so a missing account is
+        // replica lag rather than an answer. Six reads, 200ms linear step.
+        let engine = multi_currency_engine(&["USDC"]);
+        assert_eq!(engine.channel_read.max_attempts, 6);
+        assert_eq!(
+            engine.channel_read.backoff_step,
+            std::time::Duration::from_millis(200)
+        );
+
+        // Zero means "unset", so an operator that always passes a value can.
+        let zeroed = multi_currency_engine(&["USDC"]).with_channel_read_retry(Some(0), Some(0));
+        assert_eq!(zeroed.channel_read.max_attempts, 6);
+        assert_eq!(
+            zeroed.channel_read.backoff_step,
+            std::time::Duration::from_millis(200)
+        );
+
+        let tuned = multi_currency_engine(&["USDC"]).with_channel_read_retry(Some(2), Some(10));
+        assert_eq!(tuned.channel_read.max_attempts, 2);
+        assert_eq!(
+            tuned.channel_read.backoff_step,
+            std::time::Duration::from_millis(10)
+        );
+    }
+
+    #[test]
+    fn only_a_missing_channel_is_re_read_after_the_open_confirms() {
+        let policy = ChannelReadPolicy {
+            max_attempts: 4,
+            backoff_step: std::time::Duration::from_millis(1),
+        };
+        let channel_id = Pubkey::new_unique();
+
+        // Absent: re-read until it shows up, then stop.
+        let mut reads = 0;
+        let found = read_opened_channel(policy, &channel_id, || {
+            reads += 1;
+            Ok((reads == 3).then_some(1_u8))
+        });
+        assert_eq!(reads, 3);
+        assert!(matches!(found, Ok(1)));
+
+        // Visible on the first read: one read, and every bind check in the
+        // caller then runs against that one state, outside the loop.
+        let mut reads = 0;
+        let visible = read_opened_channel(policy, &channel_id, || {
+            reads += 1;
+            Ok(Some(2_u8))
+        });
+        assert_eq!(reads, 1);
+        assert!(matches!(visible, Ok(2)));
+
+        // Never visible: the whole budget, then this site's not-found.
+        let mut reads = 0;
+        let missing: Result<u8, Error> = read_opened_channel(policy, &channel_id, || {
+            reads += 1;
+            Ok(None)
+        });
+        assert_eq!(reads, 4);
+        assert!(matches!(missing, Err(Error::Rpc(_))));
+
+        // A decode failure or an RPC error is visible-and-wrong, or a read that
+        // did not happen. Neither is re-read: the funds are already escrowed
+        // and a bad bind must fail now, not in three seconds.
+        let mut reads = 0;
+        let failed: Result<u8, Error> = read_opened_channel(policy, &channel_id, || {
+            reads += 1;
+            Err(Error::Other("channel decode failed".to_string()))
+        });
+        assert_eq!(reads, 1);
+        assert!(failed.is_err());
     }
 }


### PR DESCRIPTION
## Why

An RPC provider can serve transaction status and account state from different replicas, so the channel PDA a confirmed open just wrote can be missing from the very next read. The upto and batch settlement servers treated that one read as authoritative and failed the request, with the payer's deposit already escrowed on chain.

```mermaid
sequenceDiagram
  participant C as Client
  participant F as Facilitator
  participant A as RPC replica A
  participant B as RPC replica B
  C->>F: signed channel open
  F->>A: broadcast and confirm
  A-->>F: confirmed
  F->>B: read channel PDA
  B-->>F: account not found
  F-->>C: failure, deposit already escrowed
```

## What

Ports the linear backoff from [x402-foundation/x402#3367](https://github.com/x402-foundation/x402/pull/3367).

| SDK | Site |
|---|---|
| Rust | x402 upto open, batch settlement deposit |
| Go | x402 upto open |
| Python | x402 upto open |

TypeScript is not here: its x402 upto facilitator lives in the vendored `@x402/svm` tarball, built from the `solana-foundation/x402` fork. That fork is 16 commits behind upstream and #3367 is among them, so it needs a fork bump plus `just x402-vendor`, not a source edit.

Two optional config fields, `channelReadMaxAttempts` and `channelReadBackoffStepMs`, unset or non-positive meaning the default.

Rust x402 also swaps `get_account_data` for a lookup returning `Option`, so absence is distinguishable from an unreachable RPC without matching on error text.

## How

One read becomes up to six, waiting `step * attempt`: 200/400/600/800/1000ms, 3.0s of budget. Linear rather than exponential because replica lag is a small multiple of Solana's ~400ms slot time, so doubling spends the budget on single waits far longer than the lag being absorbed.

**Only a confirmed absence is re-read.** RPC errors, decode failures, wrong owners and every binding check are visible answers, and each still fails on the first read with the error it raised before.

MPP carries the same bug independently, against the same on-chain program. It is a separate protocol with its own readers and no shared code path, so it ships separately in #311.
