### PR TITLE
fix(mpp): re-read confirmed accounts through replica visibility lag

### DIFF
--- a/python/src/solana_pay_kit/protocols/mpp/server/session.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session.py
@@ -215,6 +215,20 @@ class SessionConfig:
     # challenge was issued. It may return the slot directly or awaitably.
     current_slot_provider: Callable[[], Awaitable[int] | int] | None = None
 
+    # After an open or top-up confirms, the channel account is re-read to
+    # compare it against the transaction. An RPC provider can serve transaction
+    # status and account state from different replicas, so that read can miss
+    # an account the confirmed transaction already wrote; the missing account
+    # is retried. A visible account is decided on that first visible read,
+    # stale deposit included. Unset or non-positive takes the defaults
+    # (6 attempts, 200ms step: 200/400/600/800/1000ms, 3.0s worst case).
+    #
+    # Both entrances hold the per-channel asyncio.Lock across the retry sleeps
+    # (process_open and process_top_up). The lock is per-channel, not global,
+    # so a slow read delays only further actions on that same channel.
+    channel_read_max_attempts: int | None = None
+    channel_read_backoff_step_ms: int | None = None
+
 
 @dataclass
 class DeliveryRequest:

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_method.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_method.py
@@ -147,6 +147,10 @@ class SessionOptions:
     # on-chain settle-at-close (and the server-broadcast open) transactions.
     # None (or no RPC) leaves close a pure state-flip with settledSignature unset.
     signer: LocalSigner | None = None
+    # Post-confirmation channel-read retry knobs; see SessionConfig. Unset or
+    # non-positive takes the defaults (6 attempts, 200ms step).
+    channel_read_max_attempts: int | None = None
+    channel_read_backoff_step_ms: int | None = None
 
 
 @dataclass
@@ -733,6 +737,8 @@ def new_session(options: SessionOptions) -> Session:
         idle_timeout_options_seconds=options.idle_timeout_options_seconds,
         idle_timeout_seconds=options.idle_timeout_seconds,
         current_slot_provider=lambda: rpc.get_slot(),
+        channel_read_max_attempts=options.channel_read_max_attempts,
+        channel_read_backoff_step_ms=options.channel_read_backoff_step_ms,
     )
     config.verify_open_tx = new_open_tx_verifier(
         config,

--- a/python/src/solana_pay_kit/protocols/mpp/server/session_onchain.py
+++ b/python/src/solana_pay_kit/protocols/mpp/server/session_onchain.py
@@ -27,6 +27,11 @@ from solders.signature import Signature  # type: ignore[import-untyped]
 from solders.transaction import Transaction  # type: ignore[import-untyped]
 
 from solana_pay_kit._paycore.errors import PaymentError
+from solana_pay_kit._paycore.rpc import (
+    CHANNEL_READ_BACKOFF_STEP_SECONDS,
+    read_with_replica_retry,
+    resolve_channel_read_policy,
+)
 from solana_pay_kit._paycore.solana import default_token_program_for_currency, resolve_mint
 from solana_pay_kit.protocols.mpp._paymentchannels import (
     PROGRAM_ID,
@@ -87,8 +92,9 @@ TopUpTxVerifier = Callable[[TopUpPayload], Awaitable[None]]
 
 class OpenVerifierConfig(Protocol):
     """The subset of the session config :func:`new_open_tx_verifier` reads:
-    the challenge currency/network/recipient, minimum deposit, and optional
-    payment-channels program override."""
+    the challenge currency/network/recipient, minimum deposit, optional
+    payment-channels program override, and the post-confirmation channel-read
+    retry knobs."""
 
     currency: str
     network: str
@@ -99,6 +105,8 @@ class OpenVerifierConfig(Protocol):
     grace_period_seconds: int | None
     fee_payer: bool
     fee_payer_key: str | None
+    channel_read_max_attempts: int | None
+    channel_read_backoff_step_ms: int | None
 
 
 @dataclass
@@ -512,10 +520,19 @@ def new_open_tx_verifier(
                 await confirm_transaction_signature(rpc_client, str(sent.value), "open")
             except Exception as exc:  # noqa: BLE001 — resolved against the confirmed account below
                 broadcast_error = exc
+        # The open is confirmed, so the deposit is already escrowed on chain: a
+        # single unretried read that lands on a lagging replica would hard-fail
+        # a payment that actually succeeded.
+        read_attempts, read_backoff_step_seconds = resolve_channel_read_policy(
+            config.channel_read_max_attempts,
+            config.channel_read_backoff_step_ms,
+        )
         try:
             await _verify_channel_account(
                 rpc_client,
                 verified.channel_id,
+                attempts=read_attempts,
+                backoff_step_seconds=read_backoff_step_seconds,
                 program_id=program_id,
                 expected={
                     "authorized_signer": payload.authorized_signer,
@@ -621,9 +638,19 @@ def new_top_up_tx_verifier(
         await confirm_transaction_signature(rpc_client, signature, "top-up")
         if amount > _U64_MAX - state.deposit:
             raise PaymentError("top-up deposit overflows u64", code="invalid-payload")
+        # The top-up is confirmed, so escrow is already funded: a single
+        # unretried read that lands on a lagging replica would hard-fail a
+        # payment that actually succeeded. Only the not-yet-visible account is
+        # retried; a STALE deposit on a VISIBLE account is not.
+        read_attempts, read_backoff_step_seconds = resolve_channel_read_policy(
+            config.channel_read_max_attempts,
+            config.channel_read_backoff_step_ms,
+        )
         await _verify_channel_account(
             rpc_client,
             state.channel_id,
+            attempts=read_attempts,
+            backoff_step_seconds=read_backoff_step_seconds,
             program_id=program_id,
             expected={"deposit": state.deposit + amount},
         )
@@ -640,17 +667,44 @@ async def _verify_channel_account(
     *,
     program_id: Pubkey,
     expected: dict[str, Any],
+    attempts: int = 1,
+    backoff_step_seconds: float = CHANNEL_READ_BACKOFF_STEP_SECONDS,
 ) -> None:
-    """Fetch and compare the authoritative channel account after confirmation."""
+    """Fetch and compare the authoritative channel account after confirmation.
+
+    Single-read by default; a post-broadcast caller opts into the replica-lag
+    retry by passing ``attempts``. Only the not-yet-visible account is retried.
+    """
     from solana_pay_kit.protocols.programs.paymentchannels.accounts.channel import Channel
 
-    response = await rpc_client.get_account_info(Pubkey.from_string(channel_id), commitment="confirmed")
-    info = getattr(response, "value", None)
-    if info is None:
+    async def read_channel() -> Any | None:
+        response = await rpc_client.get_account_info(Pubkey.from_string(channel_id), commitment="confirmed")
+        info = getattr(response, "value", None)
+        if info is None:
+            # The only lag symptom that is retried, on both the open and the
+            # top-up path: the transaction confirmed but the replica answering
+            # this read has not seen the account yet.
+            return None
+        if str(info.owner) != str(program_id):
+            raise PaymentError("channel account is owned by the wrong program", code="invalid-payload")
+        return Channel.decode(bytes(info.data))
+
+    # A STALE deposit on a VISIBLE account is NOT retried. Deposit is
+    # monotonically non-decreasing, so re-reading it can only ever flip reject
+    # into accept: a concurrent top-up on this same channel raises the deposit,
+    # and re-sampling over the backoff window would let another top-up's money
+    # satisfy this one's expectation, where the single read below rejects.
+    # Python holds a per-channel asyncio.Lock across this read, which makes
+    # that race unlikely here, but the four SDKs ship ONE predicate and Rust and
+    # TypeScript hold no such lock. So the loop stops at the first VISIBLE read
+    # and the deposit and status are decided once, below, on that read.
+    channel = await read_with_replica_retry(
+        read_channel,
+        attempts=attempts,
+        backoff_step_seconds=backoff_step_seconds,
+    )
+    if channel is None:
         raise PaymentError("confirmed channel account was not found", code="transaction-not-found")
-    if str(info.owner) != str(program_id):
-        raise PaymentError("channel account is owned by the wrong program", code="invalid-payload")
-    channel = Channel.decode(bytes(info.data))
     actual = {
         "authorized_signer": str(channel.authorizedSigner),
         "deposit": channel.deposit,

--- a/python/tests/test_session_onchain.py
+++ b/python/tests/test_session_onchain.py
@@ -345,10 +345,20 @@ async def test_verify_open_tx_rejects_bad_encoding_and_fee_payer() -> None:
 class _MainnetLikeRpc:
     """Mock RPC that, like mainnet, rejects a duplicate send at preflight."""
 
-    def __init__(self, *, account: object | None, status: dict | None) -> None:
+    def __init__(
+        self,
+        *,
+        account: object | None,
+        status: dict | None,
+        sequence: list[object | None] | None = None,
+    ) -> None:
         self.sent: list[bytes] = []
         self.account = account
         self.status = status
+        # ``sequence`` serves one reply per read (replica-lag scenarios);
+        # ``account`` answers every read once it is drained.
+        self.sequence = sequence or []
+        self.reads = 0
 
     async def send_raw_transaction(self, raw_tx: bytes) -> object:
         if raw_tx in self.sent:
@@ -369,6 +379,9 @@ class _MainnetLikeRpc:
         del commitment
         from types import SimpleNamespace
 
+        self.reads += 1
+        if self.sequence:
+            return SimpleNamespace(value=self.sequence.pop(0))
         return SimpleNamespace(value=self.account)
 
     async def get_latest_blockhash(self, commitment: str = "confirmed") -> object:
@@ -393,6 +406,10 @@ def _open_config(fixture: _Fixture) -> SessionConfig:
         token_program=TOKEN_PROGRAM,
         grace_period_seconds=900,
         minimum_deposit=100,
+        # Default attempt count, 1ms backoff step: the suite exercises the
+        # retry loop without sleeping for real seconds. The default schedule
+        # is pinned in test_rpc_methods.
+        channel_read_backoff_step_ms=1,
     )
 
 
@@ -457,6 +474,21 @@ async def test_open_verifier_still_fails_on_account_mismatch_after_clean_broadca
     verifier = new_open_tx_verifier(_open_config(fixture), rpc)
     with pytest.raises(PaymentError, match="confirmed channel account was not found"):
         await verifier(fixture.payload, _context())
+    # The retry exhausts its attempt budget before raising the unchanged error.
+    assert rpc.reads == 6
+
+
+async def test_open_verifier_retries_missing_channel_account_through_replica_lag() -> None:
+    # The open confirmed, so the deposit is escrowed on chain. An RPC provider
+    # can serve transaction status and account state from different replicas,
+    # so the follow-up read can briefly miss the account; re-reading absorbs
+    # exactly that, and only that.
+    fixture = _fixture()
+    account = _channel_account(fixture)
+    rpc = _MainnetLikeRpc(account=account, status=_LANDED_CLEAN, sequence=[None, None, account])
+    verifier = new_open_tx_verifier(_open_config(fixture), rpc)
+    await verifier(fixture.payload, _context())
+    assert rpc.reads == 3
 
 
 def _top_up_scenario(*, deposit_after: int) -> tuple[TopUpPayload, ChannelState, object]:
@@ -514,10 +546,21 @@ def _top_up_scenario(*, deposit_after: int) -> tuple[TopUpPayload, ChannelState,
     return payload, state, account
 
 
-async def _seeded_top_up_verifier(rpc: _MainnetLikeRpc, state: ChannelState) -> TopUpTxVerifier:
+async def _seeded_top_up_verifier(
+    rpc: _MainnetLikeRpc,
+    state: ChannelState,
+    *,
+    max_attempts: int | None = None,
+) -> TopUpTxVerifier:
     store = MemoryChannelStore()
     await store.update_channel(state.channel_id, lambda _: state)
-    config = SessionConfig(currency="USDC", network="mainnet", channel_program=str(PROGRAM_ID))
+    config = SessionConfig(
+        currency="USDC",
+        network="mainnet",
+        channel_program=str(PROGRAM_ID),
+        channel_read_max_attempts=max_attempts,
+        channel_read_backoff_step_ms=1,
+    )
     return new_top_up_tx_verifier(config, store, rpc)
 
 
@@ -552,3 +595,41 @@ async def test_top_up_verifier_keeps_broadcast_error_when_signature_never_landed
     verifier = await _seeded_top_up_verifier(rpc, state)
     with pytest.raises(RuntimeError, match="already been processed"):
         await verifier(payload)
+
+
+async def test_top_up_verifier_retries_missing_channel_account_through_replica_lag() -> None:
+    # The top-up path retries exactly what the open path does: the account the
+    # answering replica has not seen yet.
+    payload, state, account = _top_up_scenario(deposit_after=1_250)
+    rpc = _MainnetLikeRpc(account=account, status=_LANDED_CLEAN, sequence=[None, account])
+    verifier = await _seeded_top_up_verifier(rpc, state)
+    await verifier(payload)
+    assert rpc.reads == 2
+
+
+async def test_top_up_verifier_rejects_a_visible_mismatched_deposit_on_the_first_read() -> None:
+    # A STALE deposit on a VISIBLE account is NOT retried. Deposit is
+    # monotonically non-decreasing, so re-reading a low deposit can only ever
+    # flip reject into accept - and the money that flips it may belong to a
+    # CONCURRENT top-up on this same channel rather than to this one. Low
+    # (stale) and high (someone else's top-up landed) are both answers, not
+    # lag: each raises on the first observation.
+    payload, state, _account = _top_up_scenario(deposit_after=1_250)
+    for deposit_after in (1_000, 1_500):
+        _p, _s, mismatched = _top_up_scenario(deposit_after=deposit_after)
+        rpc = _MainnetLikeRpc(account=mismatched, status=_LANDED_CLEAN)
+        verifier = await _seeded_top_up_verifier(rpc, state)
+        with pytest.raises(PaymentError, match="deposit does not match confirmed transaction"):
+            await verifier(payload)
+        assert rpc.reads == 1
+
+
+async def test_top_up_verifier_channel_read_budget_comes_from_config() -> None:
+    # Both knobs must reach the retry loop, not just the defaults: a two
+    # attempt budget spends exactly two reads on a never-visible account.
+    payload, state, _account = _top_up_scenario(deposit_after=1_250)
+    rpc = _MainnetLikeRpc(account=None, status=_LANDED_CLEAN)
+    verifier = await _seeded_top_up_verifier(rpc, state, max_attempts=2)
+    with pytest.raises(PaymentError, match="confirmed channel account was not found"):
+        await verifier(payload)
+    assert rpc.reads == 2

--- a/rust/crates/kit/src/core/rpc.rs
+++ b/rust/crates/kit/src/core/rpc.rs
@@ -66,6 +66,14 @@ impl Default for ChannelReadPolicy {
 }
 
 impl ChannelReadPolicy {
+    /// One read, no waiting. Several of these reads double as pre-broadcast
+    /// existence probes, where absence is the correct answer and retrying would
+    /// charge every first-time request the whole budget for nothing.
+    pub(crate) const SINGLE_READ: Self = Self {
+        max_attempts: 1,
+        backoff_step: Duration::ZERO,
+    };
+
     /// Resolve operator configuration. Unset or non-positive means "default",
     /// so a caller that always passes a value can pass zero.
     pub(crate) fn from_config(max_attempts: Option<u32>, backoff_step_ms: Option<u64>) -> Self {
@@ -108,6 +116,28 @@ pub(crate) fn read_back_blocking<T, E>(
         }
         match policy.backoff_after(attempt) {
             Some(wait) => std::thread::sleep(wait),
+            None => break,
+        }
+    }
+    Ok(None)
+}
+
+/// Asynchronous [`read_back_blocking`], for reads that already run on the
+/// transaction pipeline instead of a blocking client. Same contract: only
+/// `Ok(None)` is retried.
+pub(crate) async fn read_back<T, E, Fut>(
+    policy: ChannelReadPolicy,
+    mut read: impl FnMut() -> Fut,
+) -> Result<Option<T>, E>
+where
+    Fut: std::future::Future<Output = Result<Option<T>, E>>,
+{
+    for attempt in 1..=policy.max_attempts {
+        if let Some(value) = read().await? {
+            return Ok(Some(value));
+        }
+        match policy.backoff_after(attempt) {
+            Some(wait) => tokio::time::sleep(wait).await,
             None => break,
         }
     }
@@ -173,6 +203,20 @@ mod tests {
     }
 
     #[test]
+    fn single_read_never_retries_or_sleeps() {
+        let mut reads = 0;
+        let found: Result<Option<u8>, ()> =
+            read_back_blocking(ChannelReadPolicy::SINGLE_READ, || {
+                reads += 1;
+                Ok(None)
+            });
+
+        assert_eq!(found, Ok(None));
+        assert_eq!(reads, 1);
+        assert_eq!(ChannelReadPolicy::SINGLE_READ.backoff_after(1), None);
+    }
+
+    #[test]
     fn read_back_blocking_retries_absence_and_stops_at_the_first_hit() {
         let policy = ChannelReadPolicy {
             max_attempts: 6,
@@ -218,5 +262,34 @@ mod tests {
 
         assert_eq!(found, Err("visible and wrong"));
         assert_eq!(reads, 1);
+    }
+
+    #[tokio::test]
+    async fn read_back_retries_only_absence() {
+        let policy = ChannelReadPolicy {
+            max_attempts: 6,
+            backoff_step: Duration::from_millis(1),
+        };
+        let reads = std::cell::Cell::new(0);
+        let read_counter = &reads;
+        let found: Result<Option<u8>, ()> = read_back(policy, move || async move {
+            read_counter.set(read_counter.get() + 1);
+            Ok((read_counter.get() == 2).then_some(9))
+        })
+        .await;
+
+        assert_eq!(found, Ok(Some(9)));
+        assert_eq!(reads.get(), 2);
+
+        let errors = std::cell::Cell::new(0);
+        let error_counter = &errors;
+        let failed: Result<Option<u8>, &str> = read_back(policy, move || async move {
+            error_counter.set(error_counter.get() + 1);
+            Err("visible and wrong")
+        })
+        .await;
+
+        assert_eq!(failed, Err("visible and wrong"));
+        assert_eq!(errors.get(), 1);
     }
 }

--- a/rust/crates/kit/src/mpp/server/session.rs
+++ b/rust/crates/kit/src/mpp/server/session.rs
@@ -25,6 +25,7 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use crate::core::rpc::{read_back, ChannelReadPolicy};
 use crate::core::session::VoucherAcceptance;
 use crate::mpp::error::{Error, Result};
 use crate::mpp::program::payment_channels;
@@ -191,6 +192,20 @@ pub struct SessionConfig {
     /// Required by open and top-up processing. Missing RPC configuration is a
     /// hard error; funding is never inferred from payload claims.
     pub rpc_url: Option<String>,
+
+    /// Reads of a channel account after its open or top-up confirms, before it
+    /// is called absent. `None` or `0` keeps the default of 6.
+    ///
+    /// An RPC provider can serve transaction status and account state from
+    /// different replicas, so the account a confirmed transaction just wrote
+    /// can be missing from the very next read. One miss would otherwise fail a
+    /// payment whose funds are already escrowed on chain.
+    pub channel_read_max_attempts: Option<u32>,
+
+    /// Linear backoff step between those reads, in milliseconds: the wait
+    /// before attempt `n + 1` is `step * n`. `None` or `0` keeps the default
+    /// of 200ms.
+    pub channel_read_backoff_step_ms: Option<u64>,
 }
 
 impl std::fmt::Debug for SessionConfig {
@@ -222,6 +237,11 @@ impl std::fmt::Debug for SessionConfig {
             .field("idle_timeout_seconds", &self.idle_timeout_seconds)
             .field("grace_period_seconds", &self.grace_period_seconds)
             .field("rpc_url", &self.rpc_url.as_ref().map(|_| "[REDACTED]"))
+            .field("channel_read_max_attempts", &self.channel_read_max_attempts)
+            .field(
+                "channel_read_backoff_step_ms",
+                &self.channel_read_backoff_step_ms,
+            )
             .finish()
     }
 }
@@ -248,6 +268,8 @@ impl Default for SessionConfig {
             idle_timeout_seconds: 300,
             grace_period_seconds: payment_channels::DEFAULT_GRACE_PERIOD_SECONDS,
             rpc_url: None,
+            channel_read_max_attempts: None,
+            channel_read_backoff_step_ms: None,
         }
     }
 }
@@ -808,6 +830,7 @@ impl<S: ChannelStore> SessionServer<S> {
             &pipeline,
             fresh_open,
             self.config.fee_payer_signer.as_deref(),
+            channel_read_policy(&self.config),
         )
         .await?;
         #[cfg(not(feature = "server"))]
@@ -818,6 +841,7 @@ impl<S: ChannelStore> SessionServer<S> {
             &(),
             fresh_open,
             self.config.fee_payer_signer.as_deref(),
+            channel_read_policy(&self.config),
         )
         .await?;
 
@@ -1898,6 +1922,59 @@ fn unix_now_i64() -> i64 {
         .as_secs() as i64
 }
 
+/// The confirmed account must show at least the pre-top-up deposit plus this
+/// top-up's amount, on a still-`Open` channel.
+///
+/// Decided once, on the first read that sees the account, and never re-read.
+/// A non-`Open` status is terminal for the obvious reason: Closing, Closed or
+/// Sealed is not a state waiting to be undone. A short `deposit` is terminal
+/// for the opposite reason. `deposit` is monotonically non-decreasing, so a
+/// stale read of it is always LOW, which makes monotonicity the argument
+/// against re-reading it: re-sampling can only ever flip this rejection into
+/// an acceptance, never the reverse. And the money that flips it need not be
+/// this payer's. A concurrent top-up on the same channel raises the same
+/// `deposit`, and nothing here holds a per-channel lock across the read, so a
+/// retry loop would let someone else's deposit satisfy this request's minimum
+/// where a single read had correctly rejected it. Only the account's absence
+/// is worth another read; see the call site.
+fn assert_topup_reflected(state_deposit: u64, amount: u64, status: u8, deposit: u64) -> Result<()> {
+    let minimum = state_deposit
+        .checked_add(amount)
+        .ok_or_else(|| Error::Other("top-up deposit overflow".to_string()))?;
+    if status != 0 || deposit < minimum {
+        return Err(Error::Other(
+            "confirmed channel state does not reflect the submitted top-up".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve the open-channel read policy for one call site and run the read
+/// under it: `None` is the pre-broadcast probe and gets a single read, `Some`
+/// is the post-broadcast read and gets the retry budget.
+///
+/// The reader is injected so a test can count the reads this site makes
+/// without standing up an RPC.
+async fn read_open_channel_account<T, E, Fut>(
+    read_policy: Option<ChannelReadPolicy>,
+    read: impl FnMut() -> Fut,
+) -> std::result::Result<Option<T>, E>
+where
+    Fut: std::future::Future<Output = std::result::Result<Option<T>, E>>,
+{
+    read_back(read_policy.unwrap_or(ChannelReadPolicy::SINGLE_READ), read).await
+}
+
+/// Retry budget for reading a channel account back right after the transaction
+/// that wrote it confirmed. Applied per call site, never to the reads that
+/// double as pre-broadcast existence probes.
+fn channel_read_policy(config: &SessionConfig) -> ChannelReadPolicy {
+    ChannelReadPolicy::from_config(
+        config.channel_read_max_attempts,
+        config.channel_read_backoff_step_ms,
+    )
+}
+
 #[cfg(feature = "server")]
 fn confirmed_rpc_client(rpc_url: &str) -> solana_rpc_client::rpc_client::RpcClient {
     solana_rpc_client::rpc_client::RpcClient::new_with_commitment(
@@ -1914,6 +1991,7 @@ async fn verify_submit_and_fetch_open(
     pipeline: &crate::core::tx_pipeline::TxPipeline,
     fresh_open: bool,
     fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
+    read_policy: ChannelReadPolicy,
 ) -> Result<String> {
     let mut tx = payment_channels::decode_transaction(&payload.transaction)?;
     if tx
@@ -2014,7 +2092,7 @@ async fn verify_submit_and_fetch_open(
                 payment_channels::OPEN_SLOT_WINDOW
             )));
         }
-    } else if fetch_and_match_open_channel(pipeline, params, None)
+    } else if fetch_and_match_open_channel(pipeline, params, None, None)
         .await
         .is_ok()
     {
@@ -2034,7 +2112,8 @@ async fn verify_submit_and_fetch_open(
     // what the broadcast said.
     let submission = pipeline.submit_verified(&tx).await;
     let min_context_slot = submission.as_ref().ok().map(|confirmed| confirmed.slot);
-    let confirmed = fetch_and_match_open_channel(pipeline, params, min_context_slot).await;
+    let confirmed =
+        fetch_and_match_open_channel(pipeline, params, min_context_slot, Some(read_policy)).await;
     match (submission, confirmed) {
         (Ok(_), confirmed) => confirmed,
         (Err(_), Ok(())) => Ok(()),
@@ -2044,17 +2123,28 @@ async fn verify_submit_and_fetch_open(
 }
 
 #[cfg(feature = "server")]
+/// Read the confirmed channel account and check it against the verified open.
+///
+/// `read_policy` is `None` for the pre-broadcast resubmit-dedupe probe, where a
+/// missing account is the expected answer and re-reading it would charge every
+/// first-time open the whole retry budget for nothing. After a broadcast it
+/// carries the budget: the account can be missing from the replica this read
+/// lands on even though the transaction confirmed. Only that absence is
+/// retried - the field comparison below is a visible-and-wrong state, terminal
+/// on its first observation.
 async fn fetch_and_match_open_channel(
     pipeline: &crate::core::tx_pipeline::TxPipeline,
     params: &payment_channels::OpenChannelParams,
     min_context_slot: Option<u64>,
+    read_policy: Option<ChannelReadPolicy>,
 ) -> Result<()> {
     let channel_address = payment_channels::derive_channel_addresses(params).channel;
-    let account_data = pipeline
-        .read_account_data(channel_address, min_context_slot)
-        .await
-        .map_err(|error| Error::Rpc(format!("fetch confirmed channel failed: {error}")))?
-        .ok_or_else(|| Error::Rpc("confirmed channel account not found".to_string()))?;
+    let account_data = read_open_channel_account(read_policy, move || {
+        pipeline.read_account_data(channel_address, min_context_slot)
+    })
+    .await
+    .map_err(|error| Error::Rpc(format!("fetch confirmed channel failed: {error}")))?
+    .ok_or_else(|| Error::Rpc("confirmed channel account not found".to_string()))?;
     let channel =
         payment_channels::generated::generated::accounts::Channel::from_bytes(&account_data)
             .map_err(|error| Error::Other(format!("decode confirmed channel: {error}")))?;
@@ -2216,23 +2306,30 @@ async fn verify_submit_and_fetch_topup(
         .submit_verified(&tx)
         .await
         .map_err(|error| Error::Rpc(format!("top-up submission failed: {error}")))?;
-    let account_data = pipeline
-        .read_account_data(channel, Some(confirmed.slot))
-        .await
-        .map_err(|error| Error::Rpc(format!("fetch topped-up channel failed: {error}")))?
-        .ok_or_else(|| Error::Rpc("confirmed topped-up channel account not found".to_string()))?;
+    // The top-up is confirmed, but the replica serving this read can lag the
+    // one that served the confirmation, so the account can still be missing.
+    // Only that absence is re-read: the loop stops at the first visible read,
+    // and the state it saw decides the request. A stale deposit on a VISIBLE
+    // account is NOT retried - re-sampling it over the retry window can only
+    // turn this rejection into an acceptance, and a concurrent top-up on the
+    // same channel is enough to do it, because nothing here holds a
+    // per-channel lock across the read. See `assert_topup_reflected`.
+    let confirmed_slot = confirmed.slot;
+    let account_data = read_back(channel_read_policy(config), move || {
+        pipeline.read_account_data(channel, Some(confirmed_slot))
+    })
+    .await
+    .map_err(|error| Error::Rpc(format!("fetch topped-up channel failed: {error}")))?
+    .ok_or_else(|| Error::Rpc("confirmed topped-up channel account not found".to_string()))?;
     let channel_state =
         payment_channels::generated::generated::accounts::Channel::from_bytes(&account_data)
             .map_err(|error| Error::Other(format!("decode topped-up channel: {error}")))?;
-    let minimum = state
-        .deposit
-        .checked_add(amount)
-        .ok_or_else(|| Error::Other("top-up deposit overflow".to_string()))?;
-    if channel_state.status != 0 || channel_state.deposit < minimum {
-        return Err(Error::Other(
-            "confirmed channel state does not reflect the submitted top-up".to_string(),
-        ));
-    }
+    assert_topup_reflected(
+        state.deposit,
+        amount,
+        channel_state.status,
+        channel_state.deposit,
+    )?;
     Ok(signature)
 }
 
@@ -2256,6 +2353,7 @@ async fn verify_submit_and_fetch_open(
     _pipeline: &(),
     _fresh_open: bool,
     _fee_payer_signer: Option<&dyn solana_keychain::SolanaSigner>,
+    _read_policy: ChannelReadPolicy,
 ) -> Result<String> {
     Err(Error::Other(
         "session open verification requires the `server` feature".to_string(),
@@ -4406,5 +4504,108 @@ mod tests {
         assert!(invalid.settle_instructions(&operator).is_err());
         invalid.voucher_signature = Some(bs58::encode([0_u8; 64]).into_string());
         assert!(invalid.settle_instructions(&operator).is_err());
+    }
+    #[test]
+    fn a_visible_channel_decides_the_topup_once_whatever_it_says() {
+        // 1_000 was already on chain and this request adds 500, so the
+        // confirmed account has to show at least 1_500.
+        //
+        // Exactly the minimum is enough, and so is more.
+        assert_topup_reflected(1_000, 500, 0, 1_500).unwrap();
+        assert_topup_reflected(1_000, 500, 0, 9_999).unwrap();
+        // One lamport short: rejected on the spot. Not re-read, because the
+        // only thing a second read could change is our answer, and a
+        // concurrent top-up on the same channel is enough to change it.
+        let short = assert_topup_reflected(1_000, 500, 0, 1_499).unwrap_err();
+        assert!(
+            short
+                .to_string()
+                .contains("confirmed channel state does not reflect the submitted top-up"),
+            "unexpected error: {short}"
+        );
+        // A deposit that ignores `amount` entirely is the double-credit hole:
+        // the pre-top-up balance alone must never satisfy a top-up that landed
+        // nothing.
+        assert!(assert_topup_reflected(1_000, 500, 0, 1_000).is_err());
+        // Not open: a rejection whatever the deposit says, since no amount of
+        // waiting undoes a Closing/Closed/Sealed channel.
+        for status in [1_u8, 2, 3, 255] {
+            assert!(assert_topup_reflected(1_000, 500, status, 1_500).is_err());
+            assert!(assert_topup_reflected(1_000, 500, status, u64::MAX).is_err());
+        }
+        // The minimum itself can overflow. That is an error, never a wrapped
+        // zero that any deposit clears.
+        let overflow = assert_topup_reflected(u64::MAX, 1, 0, u64::MAX).unwrap_err();
+        assert!(
+            overflow.to_string().contains("top-up deposit overflow"),
+            "unexpected error: {overflow}"
+        );
+    }
+
+    #[test]
+    fn channel_read_policy_follows_session_config() {
+        let mut config = SessionConfig::default();
+        let default = channel_read_policy(&config);
+        assert_eq!(default.max_attempts, 6);
+        assert_eq!(default.backoff_step, std::time::Duration::from_millis(200));
+
+        config.channel_read_max_attempts = Some(0);
+        config.channel_read_backoff_step_ms = Some(0);
+        let zeroed = channel_read_policy(&config);
+        assert_eq!(zeroed.max_attempts, default.max_attempts);
+        assert_eq!(zeroed.backoff_step, default.backoff_step);
+
+        config.channel_read_max_attempts = Some(3);
+        config.channel_read_backoff_step_ms = Some(25);
+        let tuned = channel_read_policy(&config);
+        assert_eq!(tuned.max_attempts, 3);
+        assert_eq!(tuned.backoff_step, std::time::Duration::from_millis(25));
+    }
+
+    #[tokio::test]
+    async fn the_open_probe_opts_out_of_the_retry() {
+        // `fetch_and_match_open_channel(.., None)` is the pre-broadcast
+        // resubmit-dedupe probe, where a missing channel is the right answer:
+        // one read, or every first-time open pays the whole retry budget.
+        let reads = std::cell::Cell::new(0);
+        let counter = &reads;
+        let probe: std::result::Result<Option<u8>, ()> =
+            read_open_channel_account(None, move || async move {
+                counter.set(counter.get() + 1);
+                Ok(None)
+            })
+            .await;
+        assert_eq!(probe, Ok(None));
+        assert_eq!(reads.get(), 1);
+
+        // After the broadcast the same read carries the budget and spends all
+        // of it on an account that never becomes visible.
+        let policy = ChannelReadPolicy {
+            max_attempts: 4,
+            backoff_step: std::time::Duration::from_millis(1),
+        };
+        let reads = std::cell::Cell::new(0);
+        let counter = &reads;
+        let missing: std::result::Result<Option<u8>, ()> =
+            read_open_channel_account(Some(policy), move || async move {
+                counter.set(counter.get() + 1);
+                Ok(None)
+            })
+            .await;
+        assert_eq!(missing, Ok(None));
+        assert_eq!(reads.get(), 4);
+
+        // A visible account ends the loop on the first read; the field
+        // comparison against the verified open then runs once, outside it.
+        let reads = std::cell::Cell::new(0);
+        let counter = &reads;
+        let visible: std::result::Result<Option<u8>, ()> =
+            read_open_channel_account(Some(policy), move || async move {
+                counter.set(counter.get() + 1);
+                Ok(Some(7))
+            })
+            .await;
+        assert_eq!(visible, Ok(Some(7)));
+        assert_eq!(reads.get(), 1);
     }
 }

--- a/rust/crates/kit/src/mpp/server/subscription.rs
+++ b/rust/crates/kit/src/mpp/server/subscription.rs
@@ -35,6 +35,7 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_transaction::Transaction;
 
+use crate::core::rpc::{read_back_blocking, ChannelReadPolicy};
 use crate::mpp::error::Error;
 use crate::mpp::expires;
 use crate::mpp::program::subscriptions::{
@@ -129,6 +130,21 @@ pub struct SubscriptionConfig {
     /// they're paying for. Typically the endpoint's `description:` YAML
     /// field.
     pub description: Option<String>,
+
+    /// Reads of the `SubscriptionDelegation` account after an activation
+    /// confirms, before it is called absent. `None` or `0` keeps the default
+    /// of 6.
+    ///
+    /// An RPC provider can serve transaction status and account state from
+    /// different replicas, so the delegation a confirmed activation just
+    /// created can be missing from the very next read. One miss would
+    /// otherwise fail an activation that already charged the subscriber.
+    pub channel_read_max_attempts: Option<u32>,
+
+    /// Linear backoff step between those reads, in milliseconds: the wait
+    /// before attempt `n + 1` is `step * n`. `None` or `0` keeps the default
+    /// of 200ms.
+    pub channel_read_backoff_step_ms: Option<u64>,
 }
 
 impl Default for SubscriptionConfig {
@@ -156,6 +172,8 @@ impl Default for SubscriptionConfig {
             plan_bump: None,
             plan_created_at: None,
             description: None,
+            channel_read_max_attempts: None,
+            channel_read_backoff_step_ms: None,
         }
     }
 }
@@ -469,7 +487,7 @@ impl SubscriptionServer {
                 let (delegation_pda, _) =
                     find_subscription_pda(&plan_pda, &subscriber, &program_id);
                 let delegation_already_exists = self
-                    .fetch_subscription_delegation(&delegation_pda)
+                    .fetch_subscription_delegation(&delegation_pda, None)
                     .await
                     .is_ok();
 
@@ -509,8 +527,11 @@ impl SubscriptionServer {
             .map_err(|e| VerificationError::new(e.to_string()))?;
         let (subscription_pda, _) = find_subscription_pda(&plan_pda, &subscriber, &program_id);
 
+        // The activation is confirmed, so re-read while the delegation is not
+        // yet visible; every terms check below stays terminal on its first
+        // observation.
         let delegation = self
-            .fetch_subscription_delegation(&subscription_pda)
+            .fetch_subscription_delegation(&subscription_pda, Some(self.channel_read_policy()))
             .await?;
 
         // ── Validate snapshotted terms ──────────────────────────────────
@@ -605,18 +626,52 @@ impl SubscriptionServer {
         .map_err(|e| VerificationError::network_error(format!("RPC task join: {e}")))?
     }
 
+    /// Retry budget for reading a delegation back right after the activation
+    /// that created it confirmed.
+    fn channel_read_policy(&self) -> ChannelReadPolicy {
+        ChannelReadPolicy::from_config(
+            self.config.channel_read_max_attempts,
+            self.config.channel_read_backoff_step_ms,
+        )
+    }
+
+    /// Read and decode the `SubscriptionDelegation` PDA.
+    ///
+    /// `read_policy` is `None` for the pre-broadcast existence probe, where a
+    /// missing delegation is the expected answer and re-reading it would charge
+    /// every first-time activation the whole retry budget for nothing. After a
+    /// broadcast it carries the budget, and only the absence is retried: a
+    /// decode failure, an unreachable RPC and every terms check in the caller
+    /// are terminal on their first observation.
     async fn fetch_subscription_delegation(
         &self,
         subscription_pda: &Pubkey,
+        read_policy: Option<ChannelReadPolicy>,
     ) -> Result<SubscriptionDelegationView, VerificationError> {
+        use solana_commitment_config::CommitmentConfig;
         use solana_rpc_client::rpc_client::RpcClient;
         let rpc_url = self.rpc_url.clone();
         let pda = *subscription_pda;
         tokio::task::spawn_blocking(move || {
-            let rpc = RpcClient::new(rpc_url);
-            let account = rpc.get_account(&pda).map_err(|e| {
+            // The read commitment must match the broadcast's. `RpcClient::new`
+            // defaults to `finalized`, roughly 13s behind the `confirmed` the
+            // activation was confirmed at, so it cannot see the account that
+            // activation just wrote.
+            let rpc = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+            // `get_account` collapses a missing account into the same error as
+            // an unreachable RPC; only the former is worth another read.
+            let account = read_delegation_account(read_policy, || {
+                rpc.get_account_with_commitment(&pda, rpc.commitment())
+                    .map(|response| response.value)
+                    .map_err(|e| {
+                        VerificationError::not_found(format!(
+                            "SubscriptionDelegation account {pda} not found: {e}"
+                        ))
+                    })
+            })?
+            .ok_or_else(|| {
                 VerificationError::not_found(format!(
-                    "SubscriptionDelegation account {pda} not found: {e}"
+                    "SubscriptionDelegation account {pda} not found"
                 ))
             })?;
             decode_subscription_delegation(&account.data).map_err(VerificationError::new)
@@ -637,11 +692,15 @@ impl SubscriptionServer {
         &self,
         subscription_pda: &Pubkey,
     ) -> Result<String, VerificationError> {
+        use solana_commitment_config::CommitmentConfig;
         use solana_rpc_client::rpc_client::RpcClient;
         let rpc_url = self.rpc_url.clone();
         let pda = *subscription_pda;
         tokio::task::spawn_blocking(move || {
-            let rpc = RpcClient::new(rpc_url);
+            // Same read-after-confirm flow as the delegation fetch: the read
+            // commitment must match the broadcast's `confirmed`, not
+            // `RpcClient::new`'s `finalized` default.
+            let rpc = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
             let sigs = rpc.get_signatures_for_address(&pda).map_err(|e| {
                 VerificationError::network_error(format!(
                     "getSignaturesForAddress({pda}) failed: {e}"
@@ -695,6 +754,19 @@ impl SubscriptionServer {
 }
 
 // ── Verify helpers ──────────────────────────────────────────────────────────
+
+/// Resolve the delegation read policy for one call site and run the read under
+/// it: `None` is the pre-broadcast existence probe and gets a single read,
+/// `Some` is the post-broadcast read and gets the retry budget.
+///
+/// The reader is injected so a test can count the reads this site makes
+/// without standing up an RPC.
+fn read_delegation_account<T, E>(
+    read_policy: Option<ChannelReadPolicy>,
+    read: impl FnMut() -> Result<Option<T>, E>,
+) -> Result<Option<T>, E> {
+    read_back_blocking(read_policy.unwrap_or(ChannelReadPolicy::SINGLE_READ), read)
+}
 
 /// Pluck the `ActivatePayload` out of a credential's `payload` field,
 /// accepting both the raw `ActivatePayload` shape (the v0 spec) and the
@@ -1377,5 +1449,71 @@ mod tests {
             msg.contains("push-mode") || msg.contains("not yet supported"),
             "{err:?}"
         );
+    }
+    #[test]
+    fn channel_read_policy_follows_subscription_config() {
+        let mut config = make_config();
+        assert_eq!(config.channel_read_max_attempts, None);
+        assert_eq!(config.channel_read_backoff_step_ms, None);
+
+        let default = SubscriptionServer::new(config.clone())
+            .expect("server")
+            .channel_read_policy();
+        assert_eq!(default.max_attempts, 6);
+        assert_eq!(default.backoff_step, std::time::Duration::from_millis(200));
+
+        config.channel_read_max_attempts = Some(0);
+        config.channel_read_backoff_step_ms = Some(0);
+        let zeroed = SubscriptionServer::new(config.clone())
+            .expect("server")
+            .channel_read_policy();
+        assert_eq!(zeroed.max_attempts, default.max_attempts);
+        assert_eq!(zeroed.backoff_step, default.backoff_step);
+
+        config.channel_read_max_attempts = Some(2);
+        config.channel_read_backoff_step_ms = Some(30);
+        let tuned = SubscriptionServer::new(config)
+            .expect("server")
+            .channel_read_policy();
+        assert_eq!(tuned.max_attempts, 2);
+        assert_eq!(tuned.backoff_step, std::time::Duration::from_millis(30));
+    }
+
+    #[test]
+    fn the_delegation_existence_probe_opts_out_of_the_retry() {
+        // `fetch_subscription_delegation(.., None)` runs before the broadcast,
+        // where a missing delegation is the correct answer. Retrying it would
+        // charge every first-time activation the whole budget for nothing.
+        let mut reads = 0;
+        let probe: Result<Option<u8>, ()> = read_delegation_account(None, || {
+            reads += 1;
+            Ok(None)
+        });
+        assert_eq!(probe, Ok(None));
+        assert_eq!(reads, 1);
+
+        // After the broadcast the same read carries the budget and spends all
+        // of it on a delegation that never becomes visible.
+        let policy = ChannelReadPolicy {
+            max_attempts: 4,
+            backoff_step: std::time::Duration::from_millis(1),
+        };
+        let mut reads = 0;
+        let missing: Result<Option<u8>, ()> = read_delegation_account(Some(policy), || {
+            reads += 1;
+            Ok(None)
+        });
+        assert_eq!(missing, Ok(None));
+        assert_eq!(reads, 4);
+
+        // Visible on the first read: the loop stops there, and every terms
+        // check in the caller runs once against that state.
+        let mut reads = 0;
+        let visible: Result<Option<u8>, ()> = read_delegation_account(Some(policy), || {
+            reads += 1;
+            Ok(Some(3))
+        });
+        assert_eq!(visible, Ok(Some(3)));
+        assert_eq!(reads, 1);
     }
 }

--- a/typescript/packages/mpp/src/__tests__/session-replica-lag.test.ts
+++ b/typescript/packages/mpp/src/__tests__/session-replica-lag.test.ts
@@ -1,0 +1,630 @@
+/**
+ * Replica-lag tolerance for the account reads that follow a confirmed
+ * transaction.
+ *
+ * An RPC provider can serve transaction status and account state from
+ * different replicas, so an account a just-confirmed transaction created or
+ * mutated can briefly read back missing or stale. Each site below re-reads
+ * on exactly one not-yet-visible signal and on nothing else:
+ *
+ *   - `readUntilVisible` itself: the linear 200/400/600/800/1000ms schedule,
+ *     no sleep after the final attempt, non-positive config falling back to
+ *     the defaults, and a throwing read never being retried.
+ *   - `submitOpenTx` (both the happy path and the broadcast-failure
+ *     retry-idempotency branch): only an absent channel account is re-read,
+ *     and an exhausted broadcast-failure branch still rethrows the ORIGINAL
+ *     broadcast error.
+ *   - `submitTopUpTx`: only an absent account is re-read. A visible account
+ *     with a stale deposit is rejected on the spot, because deposit only
+ *     grows and a concurrent top-up could otherwise clear the threshold.
+ *   - `fetchSubscriptionDelegation`: only an absent delegation is re-read.
+ *
+ * Integration legs inject a 1ms backoff step so the suite never sleeps for
+ * real seconds; the schedule itself is asserted against a captured
+ * `setTimeout`.
+ */
+import { address, generateKeyPairSigner, getBase64Codec, type KeyPairSigner, type Signature } from '@solana/kit';
+import { describe, expect, test, vi } from 'vitest';
+
+import { buildOpenPaymentChannelTransaction } from '../client/PaymentChannels.js';
+import type { SessionRequest } from '../client/Session.js';
+import { getChannelEncoder } from '../generated/payment-channels/accounts/channel.js';
+import { ChannelStatus } from '../generated/payment-channels/types/channelStatus.js';
+import {
+    buildTopUpInstruction,
+    PAYMENT_CHANNELS_PROGRAM_ID,
+    submitOpenTx,
+    submitTopUpTx,
+    type VerifyOpenTxExpected,
+} from '../server/session/on-chain.js';
+import { buildAndSignWireTransaction } from '../server/session/wire-tx.js';
+import { __testing } from '../server/Subscription.js';
+import type { OpenPayload } from '../shared/session-types.js';
+import { readUntilVisible } from '../utils/account-read.js';
+
+const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+// resolveStablecoinMint('USDC', 'devnet')
+const USDC_DEVNET_MINT = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+const CHALLENGED_BLOCKHASH = 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N';
+const CHALLENGED_SLOT = 314n;
+const OPEN_SIGNATURE = 'OpenSig1111111111111111111111111111111111111111111111111111111' as Signature;
+/** Injected step keeps the whole retry budget under 15ms of real time. */
+const FAST_BACKOFF = { channelReadBackoffStepMs: 1 } as const;
+
+// ── readUntilVisible ────────────────────────────────────────────────────
+
+/**
+ * Run `work` with `setTimeout` replaced by a recorder that fires its
+ * callback immediately, so the backoff schedule is observable without
+ * sleeping.
+ */
+async function captureSleeps(work: () => Promise<unknown>): Promise<number[]> {
+    const delays: number[] = [];
+    const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: () => void, ms?: number) => {
+        delays.push(ms ?? 0);
+        callback();
+        return 0;
+    }) as never);
+    try {
+        await work();
+    } finally {
+        spy.mockRestore();
+    }
+    return delays;
+}
+
+describe('readUntilVisible', () => {
+    test('reads 6 times on a 200/400/600/800/1000ms linear schedule with no trailing sleep', async () => {
+        let reads = 0;
+        const delays = await captureSleeps(() =>
+            readUntilVisible(
+                () => {
+                    reads += 1;
+                    return Promise.resolve('missing');
+                },
+                value => value !== 'missing',
+                {},
+            ),
+        );
+
+        expect(reads).toBe(6);
+        expect(delays).toEqual([200, 400, 600, 800, 1_000]);
+        // 3.0s total, 1s longest single wait.
+        expect(delays.reduce((sum, ms) => sum + ms, 0)).toBe(3_000);
+    });
+
+    test('stops at the first visible read', async () => {
+        let reads = 0;
+        const delays = await captureSleeps(() =>
+            readUntilVisible(
+                () => {
+                    reads += 1;
+                    return Promise.resolve(reads);
+                },
+                value => value >= 2,
+                {},
+            ),
+        );
+
+        expect(reads).toBe(2);
+        expect(delays).toEqual([200]);
+    });
+
+    test('non-positive config resolves to the defaults', async () => {
+        let reads = 0;
+        const delays = await captureSleeps(() =>
+            readUntilVisible(
+                () => {
+                    reads += 1;
+                    return Promise.resolve('missing');
+                },
+                value => value !== 'missing',
+                { channelReadBackoffStepMs: 0, channelReadMaxAttempts: 0 },
+            ),
+        );
+
+        expect(reads).toBe(6);
+        expect(delays).toEqual([200, 400, 600, 800, 1_000]);
+    });
+
+    test('honors explicit positive overrides', async () => {
+        let reads = 0;
+        const delays = await captureSleeps(() =>
+            readUntilVisible(
+                () => {
+                    reads += 1;
+                    return Promise.resolve('missing');
+                },
+                value => value !== 'missing',
+                { channelReadBackoffStepMs: 50, channelReadMaxAttempts: 3 },
+            ),
+        );
+
+        expect(reads).toBe(3);
+        expect(delays).toEqual([50, 100]);
+    });
+
+    test('an RPC transport error is never retried', async () => {
+        let reads = 0;
+        await expect(
+            readUntilVisible(
+                () => {
+                    reads += 1;
+                    return Promise.reject(new Error('socket hang up'));
+                },
+                () => true,
+                {},
+            ),
+        ).rejects.toThrow(/socket hang up/);
+        expect(reads).toBe(1);
+    });
+});
+
+// ── shared on-chain fixtures ────────────────────────────────────────────
+
+interface ChannelAccountFacts {
+    readonly authorizedSigner: string;
+    readonly deposit: bigint;
+    readonly mint: string;
+    readonly payee: string;
+    readonly payer: string;
+    readonly rentPayer: string;
+    readonly status?: number;
+}
+
+function channelAccountData(facts: ChannelAccountFacts): string {
+    const data = getChannelEncoder().encode({
+        authorizedSigner: address(facts.authorizedSigner),
+        bump: 255,
+        closureStartedAt: 0n,
+        deposit: facts.deposit,
+        discriminator: 1,
+        distributionHash: new Array<number>(32).fill(0),
+        gracePeriod: 900,
+        mint: address(facts.mint),
+        openSlot: CHALLENGED_SLOT,
+        payee: address(facts.payee),
+        payer: address(facts.payer),
+        payerWithdrawnAt: 0n,
+        rentPayer: address(facts.rentPayer),
+        salt: 7n,
+        settlement: { payoutWatermark: 0n, settled: 0n },
+        status: facts.status ?? Number(ChannelStatus.Open),
+        version: 1,
+    });
+    return getBase64Codec().decode(data as Uint8Array);
+}
+
+/**
+ * RPC mock whose `getAccountInfo` walks `accountSequence` (a `null` entry is
+ * an absent account) and sticks on the last entry, so a test can spell out
+ * "missing, then present" and count the reads it took.
+ */
+function sequencedRpc(accountSequence: readonly (string | null)[], sendError?: Error) {
+    const accountLookups: string[] = [];
+    const sends: string[] = [];
+    return {
+        accountLookups,
+        getAccountInfo: (accountAddress: string) => ({
+            send: () => {
+                const index = Math.min(accountLookups.length, accountSequence.length - 1);
+                accountLookups.push(accountAddress);
+                const data = accountSequence[index] ?? null;
+                return Promise.resolve({
+                    context: { slot: 1n },
+                    value:
+                        data === null
+                            ? null
+                            : {
+                                  data: [data, 'base64'],
+                                  executable: false,
+                                  lamports: 1_000_000n,
+                                  owner: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+                                  rentEpoch: 0n,
+                                  space: BigInt(getBase64Codec().encode(data).byteLength),
+                              },
+                });
+            },
+        }),
+        getLatestBlockhash: () => ({
+            send: () =>
+                Promise.resolve({
+                    context: { slot: CHALLENGED_SLOT },
+                    value: { blockhash: CHALLENGED_BLOCKHASH, lastValidBlockHeight: 100n },
+                }),
+        }),
+        getSignatureStatuses: () => ({
+            send: () => Promise.resolve({ value: [{ confirmationStatus: 'confirmed', err: null }] }),
+        }),
+        sendTransaction: (wire: string) => ({
+            send: () => {
+                if (sendError) return Promise.reject(sendError);
+                sends.push(wire);
+                return Promise.resolve(OPEN_SIGNATURE);
+            },
+        }),
+        sends,
+    };
+}
+
+async function verifiedOpenFixture() {
+    const payer = await generateKeyPairSigner();
+    const sessionSigner = await generateKeyPairSigner();
+    const payee = await generateKeyPairSigner();
+    const request = {
+        amount: '100',
+        currency: 'USDC',
+        methodDetails: {
+            channelProgram: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+            gracePeriodSeconds: 900,
+            network: 'devnet',
+            recentBlockhash: CHALLENGED_BLOCKHASH,
+            recentSlot: CHALLENGED_SLOT.toString(),
+            tokenProgram: TOKEN_PROGRAM,
+        },
+        recipient: payee.address,
+        suggestedDeposit: '5000',
+    } as unknown as SessionRequest;
+    const open = await buildOpenPaymentChannelTransaction({
+        authorizedSigner: sessionSigner.address,
+        request,
+        salt: 7n,
+        signer: payer,
+    });
+    const openPayload: OpenPayload = {
+        authorizedSigner: sessionSigner.address,
+        channelId: open.channelId,
+        depositAmount: open.deposit,
+        gracePeriodSeconds: open.gracePeriod,
+        mint: open.mint,
+        openSlot: open.openSlot,
+        payee: open.payee,
+        payer: open.payer,
+        salt: open.salt,
+        transaction: open.transaction,
+    };
+    const expected: VerifyOpenTxExpected = {
+        authorizedSigner: sessionSigner.address,
+        channelProgram: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+        currency: 'USDC',
+        feePayer: payer.address,
+        network: 'devnet',
+        openSlot: CHALLENGED_SLOT,
+        recentBlockhash: CHALLENGED_BLOCKHASH,
+        recipient: open.payee,
+        rentPayer: payer.address,
+        splits: [],
+        tokenProgram: TOKEN_PROGRAM,
+    };
+    const confirmed = channelAccountData({
+        authorizedSigner: sessionSigner.address,
+        deposit: 5_000n,
+        mint: USDC_DEVNET_MINT,
+        payee: open.payee,
+        payer: payer.address,
+        rentPayer: payer.address,
+    });
+    return { confirmed, expected, open, openPayload, payer, sessionSigner };
+}
+
+// ── submitOpenTx: the confirmed-channel re-read ─────────────────────────
+
+describe('submitOpenTx post-confirm channel read', () => {
+    test('re-reads a channel that is not visible yet on the first read', async () => {
+        const { confirmed, expected, open, openPayload } = await verifiedOpenFixture();
+        const rpc = sequencedRpc([null, null, confirmed]);
+
+        const result = await submitOpenTx({
+            channelRead: FAST_BACKOFF,
+            confirm: { pollIntervalMs: 1, timeoutMs: 2_000 },
+            expected,
+            openPayload,
+            rpc: rpc as never,
+        });
+
+        expect(result.channelId).toBe(open.channelId);
+        expect(rpc.accountLookups).toHaveLength(3);
+    });
+
+    test('a visible channel with a mismatched field is rejected on the first read', async () => {
+        const { expected, open, openPayload, payer, sessionSigner } = await verifiedOpenFixture();
+        // Deposit 4_000 against a verified 5_000: visible and wrong, which is
+        // never a lag artifact and must not buy a single extra read.
+        const rpc = sequencedRpc([
+            channelAccountData({
+                authorizedSigner: sessionSigner.address,
+                deposit: 4_000n,
+                mint: USDC_DEVNET_MINT,
+                payee: open.payee,
+                payer: payer.address,
+                rentPayer: payer.address,
+            }),
+        ]);
+
+        await expect(
+            submitOpenTx({
+                channelRead: FAST_BACKOFF,
+                confirm: { pollIntervalMs: 1, timeoutMs: 2_000 },
+                expected,
+                openPayload,
+                rpc: rpc as never,
+            }),
+        ).rejects.toThrow(/does not match the verified open transaction/);
+        expect(rpc.accountLookups).toHaveLength(1);
+    });
+
+    test('a preflight-rejected duplicate is rescued once the landed channel becomes visible', async () => {
+        // The money-losing case: the first submission landed and the escrow
+        // is funded, the retry dies at preflight, and one unlucky read used
+        // to turn a funded channel into a hard failure.
+        const { confirmed, expected, open, openPayload } = await verifiedOpenFixture();
+        const rpc = sequencedRpc(
+            [null, confirmed],
+            new Error('Transaction simulation failed: This transaction has already been processed'),
+        );
+
+        const result = await submitOpenTx({
+            channelRead: FAST_BACKOFF,
+            confirm: { pollIntervalMs: 1, timeoutMs: 2_000 },
+            expected,
+            openPayload,
+            rpc: rpc as never,
+        });
+
+        expect(result.channelId).toBe(open.channelId);
+        expect(rpc.accountLookups).toHaveLength(2);
+    });
+
+    test('an exhausted retry on the broadcast-failure branch rethrows the original broadcast error', async () => {
+        const { expected, openPayload } = await verifiedOpenFixture();
+        const rpc = sequencedRpc(
+            [null],
+            new Error('Transaction simulation failed: This transaction has already been processed'),
+        );
+
+        await expect(
+            submitOpenTx({
+                channelRead: FAST_BACKOFF,
+                confirm: { pollIntervalMs: 1, timeoutMs: 2_000 },
+                expected,
+                openPayload,
+                rpc: rpc as never,
+            }),
+        ).rejects.toThrow(/already been processed/);
+        expect(rpc.accountLookups).toHaveLength(6);
+    });
+});
+
+// ── submitTopUpTx: the confirmed-deposit re-read ────────────────────────
+
+interface TopUpFixture {
+    readonly channel: KeyPairSigner;
+    readonly merchant: KeyPairSigner;
+    readonly payer: KeyPairSigner;
+    readonly sessionSigner: KeyPairSigner;
+}
+
+async function topUpFixture(): Promise<TopUpFixture> {
+    return {
+        channel: await generateKeyPairSigner(),
+        merchant: await generateKeyPairSigner(),
+        payer: await generateKeyPairSigner(),
+        sessionSigner: await generateKeyPairSigner(),
+    };
+}
+
+function topUpChannelData(f: TopUpFixture, deposit: bigint, status?: number): string {
+    return channelAccountData({
+        authorizedSigner: f.sessionSigner.address,
+        deposit,
+        mint: USDC_DEVNET_MINT,
+        payee: f.merchant.address,
+        payer: f.payer.address,
+        rentPayer: f.payer.address,
+        ...(status === undefined ? {} : { status }),
+    });
+}
+
+async function topUpWire(f: TopUpFixture, rpc: unknown, amount: bigint): Promise<string> {
+    const instruction = await buildTopUpInstruction({
+        amount,
+        channelId: f.channel.address,
+        mint: USDC_DEVNET_MINT,
+        payer: f.payer,
+        tokenProgram: TOKEN_PROGRAM,
+    });
+    return await buildAndSignWireTransaction(rpc as never, f.payer, [instruction]);
+}
+
+describe('submitTopUpTx post-confirm channel read', () => {
+    test('a visible account whose deposit has not caught up is rejected on the first read', async () => {
+        // The money case. Deposit only grows, so a second read that shows
+        // 5_000 proves nothing about OUR top-up: a concurrent top-up on this
+        // channel raises the same field, and nothing holds a per-channel
+        // lock across this read. The sequence below is exactly the one a
+        // retry loop would "rescue", so it must reject after one read.
+        const f = await topUpFixture();
+        const rpc = sequencedRpc([topUpChannelData(f, 1_000n), topUpChannelData(f, 5_000n)]);
+        const wire = await topUpWire(f, rpc, 4_000n);
+
+        await expect(
+            submitTopUpTx({
+                additionalAmount: 4_000n,
+                channelId: f.channel.address,
+                channelProgram: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+                channelRead: FAST_BACKOFF,
+                currentDeposit: 1_000n,
+                payer: f.payer.address,
+                rpc: rpc as never,
+                transaction: wire,
+            }),
+        ).rejects.toThrow(/does not reflect the submitted top-up/);
+        expect(rpc.accountLookups).toHaveLength(1);
+    });
+
+    test('re-reads a channel that is not visible yet', async () => {
+        const f = await topUpFixture();
+        const rpc = sequencedRpc([null, topUpChannelData(f, 5_000n)]);
+        const wire = await topUpWire(f, rpc, 4_000n);
+
+        await submitTopUpTx({
+            additionalAmount: 4_000n,
+            channelId: f.channel.address,
+            channelProgram: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+            channelRead: FAST_BACKOFF,
+            currentDeposit: 1_000n,
+            payer: f.payer.address,
+            rpc: rpc as never,
+            transaction: wire,
+        });
+
+        expect(rpc.accountLookups).toHaveLength(2);
+    });
+
+    test('a status other than Open is rejected on the first read, never re-read', async () => {
+        // Open is the channel's earliest state, so a stale replica can only
+        // serve Open or older: Closing can never be a lag artifact. The
+        // status check gates the deposit check, and the deposit here is
+        // high enough that only the status can be the rejection reason.
+        const f = await topUpFixture();
+        const rpc = sequencedRpc([topUpChannelData(f, 5_000n, Number(ChannelStatus.Closing))]);
+        const wire = await topUpWire(f, rpc, 4_000n);
+
+        await expect(
+            submitTopUpTx({
+                additionalAmount: 4_000n,
+                channelId: f.channel.address,
+                channelProgram: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+                channelRead: FAST_BACKOFF,
+                currentDeposit: 1_000n,
+                payer: f.payer.address,
+                rpc: rpc as never,
+                transaction: wire,
+            }),
+        ).rejects.toThrow(/does not reflect the submitted top-up/);
+        expect(rpc.accountLookups).toHaveLength(1);
+    });
+
+    test('an account that never becomes visible fails after the attempt budget', async () => {
+        const f = await topUpFixture();
+        const rpc = sequencedRpc([null]);
+        const wire = await topUpWire(f, rpc, 4_000n);
+
+        await expect(
+            submitTopUpTx({
+                additionalAmount: 4_000n,
+                channelId: f.channel.address,
+                channelProgram: PAYMENT_CHANNELS_PROGRAM_ID.toString(),
+                channelRead: FAST_BACKOFF,
+                currentDeposit: 1_000n,
+                payer: f.payer.address,
+                rpc: rpc as never,
+                transaction: wire,
+            }),
+        ).rejects.toThrow(/Account not found/);
+        expect(rpc.accountLookups).toHaveLength(6);
+    });
+});
+
+// ── fetchSubscriptionDelegation ─────────────────────────────────────────
+
+const SUBSCRIPTION_PDA = '9xAXssX9j7vuK99c7cFwqbixzL3bFrzPy9PUhCtDPAYJ';
+/** Zero-filled SubscriptionDelegation: presence is all this site retries on. */
+const DELEGATION_DATA = getBase64Codec().decode(new Uint8Array(201));
+
+/**
+ * Stub `fetch` with a JSON-RPC `getAccountInfo` responder walking
+ * `accountSequence`, and count the calls.
+ */
+function stubGetAccountInfoFetch(accountSequence: readonly (string | null)[]): { calls: () => number } {
+    let calls = 0;
+    vi.stubGlobal('fetch', () => {
+        const index = Math.min(calls, accountSequence.length - 1);
+        calls += 1;
+        const data = accountSequence[index] ?? null;
+        return Promise.resolve(
+            new Response(
+                JSON.stringify({
+                    id: 1,
+                    jsonrpc: '2.0',
+                    result: {
+                        context: { slot: 1 },
+                        value:
+                            data === null
+                                ? null
+                                : {
+                                      data: [data, 'base64'],
+                                      executable: false,
+                                      lamports: 1000000,
+                                      owner: SUBSCRIPTION_PDA,
+                                      rentEpoch: 0,
+                                      space: 201,
+                                  },
+                    },
+                }),
+                { headers: { 'Content-Type': 'application/json' }, status: 200 },
+            ),
+        );
+    });
+    return { calls: () => calls };
+}
+
+describe('fetchSubscriptionDelegation post-activation read', () => {
+    test('re-reads a delegation that is not visible yet', async () => {
+        const fetchStub = stubGetAccountInfoFetch([null, null, DELEGATION_DATA]);
+        try {
+            const delegation = await __testing.fetchSubscriptionDelegation(
+                'http://localhost:8899',
+                SUBSCRIPTION_PDA,
+                FAST_BACKOFF,
+            );
+            expect(delegation).not.toBeNull();
+            expect(fetchStub.calls()).toBe(3);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    test('an existing delegation is returned on the first read', async () => {
+        // Every field check lives in verify(), outside this function, so any
+        // account that exists must short-circuit the loop immediately.
+        const fetchStub = stubGetAccountInfoFetch([DELEGATION_DATA]);
+        try {
+            const delegation = await __testing.fetchSubscriptionDelegation(
+                'http://localhost:8899',
+                SUBSCRIPTION_PDA,
+                FAST_BACKOFF,
+            );
+            expect(delegation).not.toBeNull();
+            expect(fetchStub.calls()).toBe(1);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    test('an absent delegation still resolves to null after the attempt budget', async () => {
+        const fetchStub = stubGetAccountInfoFetch([null]);
+        try {
+            const delegation = await __testing.fetchSubscriptionDelegation(
+                'http://localhost:8899',
+                SUBSCRIPTION_PDA,
+                FAST_BACKOFF,
+            );
+            expect(delegation).toBeNull();
+            expect(fetchStub.calls()).toBe(6);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    test('without the retry option the read stays a single RPC call', async () => {
+        const fetchStub = stubGetAccountInfoFetch([null]);
+        try {
+            const delegation = await __testing.fetchSubscriptionDelegation('http://localhost:8899', SUBSCRIPTION_PDA);
+            expect(delegation).toBeNull();
+            expect(fetchStub.calls()).toBe(1);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+});

--- a/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
@@ -872,6 +872,11 @@ describe('subscription().verify() (push mode)', () => {
             }
         };
         const method = subscription({
+            // An absent delegation is the retried state, so the default
+            // 6-attempt schedule would sleep ~3s of real time here. The
+            // replica-lag schedule itself is covered in
+            // session-replica-lag.test.ts.
+            channelReadMaxAttempts: 1,
             decimals: 6,
             mint: MINT,
             network: 'devnet',

--- a/typescript/packages/mpp/src/server/Session.ts
+++ b/typescript/packages/mpp/src/server/Session.ts
@@ -34,6 +34,7 @@ import type {
     SignedVoucher,
 } from '../shared/session-types.js';
 import { encodeVoucherMessageLoose, normalizeSignedVoucher, verifyVoucherSignature } from '../shared/voucher.js';
+import type { ChannelReadRetryOptions } from '../utils/account-read.js';
 import { createLifecycle, type Lifecycle } from './session/lifecycle.js';
 import {
     OPEN_SLOT_WINDOW,
@@ -157,6 +158,13 @@ export function session(parameters: session.Parameters) {
         throw new Error('decimals must be an integer from 0 to 9');
     }
     const tokenProgram = parameters.tokenProgram ?? defaultTokenProgramForCurrency(currency, network);
+    // Replica-lag tolerance for the post-confirm channel re-reads in
+    // submitOpenTx / submitTopUpTx. Both knobs fall back to their defaults
+    // when unset or non-positive.
+    const channelRead: ChannelReadRetryOptions = {
+        channelReadBackoffStepMs: parameters.channelReadBackoffStepMs,
+        channelReadMaxAttempts: parameters.channelReadMaxAttempts,
+    };
     const lifecycleRef: { value: Lifecycle | undefined } = { value: undefined };
 
     // Note: lifecycle's closeOnIdle would normally drive an on-chain settle.
@@ -263,6 +271,7 @@ export function session(parameters: session.Parameters) {
                     assertChallengeOpenNotExpired(cred.challenge.expires);
                     return await handleOpen({
                         challengeId: cred.challenge.id,
+                        channelRead,
                         currency: resolvedMint,
                         distributionSplits,
                         externalId: cred.challenge.request.externalId,
@@ -318,6 +327,7 @@ export function session(parameters: session.Parameters) {
                     return await handleTopUp({
                         challengeId: cred.challenge.id,
                         channelProgram: resolvedProgramId.toString(),
+                        channelRead,
                         externalId: cred.challenge.request.externalId,
                         lifecycle: lifecycleRef.value,
                         payload: cred.payload,
@@ -511,6 +521,8 @@ session.routes = function routes(parameters: session.Parameters): session.Routes
 
 interface HandleOpenArgs {
     readonly challengeId: string | undefined;
+    /** Replica-lag tolerance for the post-confirm channel re-read. */
+    readonly channelRead: ChannelReadRetryOptions | undefined;
     readonly currency: string;
     /** Server-configured splits the challenge advertised; the open must encode exactly these. */
     readonly distributionSplits: readonly SessionSplit[] | undefined;
@@ -670,6 +682,7 @@ async function handleOpen(args: HandleOpenArgs): Promise<Receipt.Receipt> {
             return { ...current, lastActivityAt: Date.now() };
         }
         await submitOpenTx({
+            channelRead: args.channelRead,
             expected,
             openPayload: payload,
             payerSigner: args.feePayer ? args.feePayerSigner : undefined,
@@ -860,6 +873,8 @@ async function handleVoucher(args: HandleVoucherArgs): Promise<Receipt.Receipt> 
 interface HandleTopUpArgs {
     readonly challengeId: string | undefined;
     readonly channelProgram: string;
+    /** Replica-lag tolerance for the post-confirm channel re-read. */
+    readonly channelRead: ChannelReadRetryOptions | undefined;
     readonly externalId: string | undefined;
     readonly lifecycle: Lifecycle | undefined;
     readonly payload: {
@@ -901,6 +916,7 @@ async function handleTopUp(args: HandleTopUpArgs): Promise<Receipt.Receipt> {
         additionalAmount,
         channelId: args.payload.channelId,
         channelProgram: args.channelProgram,
+        channelRead: args.channelRead,
         currentDeposit: existing.deposit,
         payer: existing.payer,
         rpc: args.rpc as SubmitOpenRpc,
@@ -1511,6 +1527,42 @@ export declare namespace session {
         readonly blockhashCache?: BlockhashCache;
         /** Payment-channels program ID. */
         readonly channelProgram?: Address | string;
+        /**
+         * Linear backoff step in ms for the post-confirm channel re-read.
+         * Defaults to 200, giving a 200/400/600/800/1000ms schedule.
+         * Unset or non-positive resolves to the default.
+         *
+         * Linear on purpose: replica lag is a small multiple of Solana's
+         * ~400ms slot time, so an exponential schedule would spend the same
+         * budget on single waits far longer than the lag it absorbs.
+         */
+        readonly channelReadBackoffStepMs?: number;
+        /**
+         * Total post-confirm channel reads, including the first, before an
+         * open or top-up gives up. Defaults to 6, which at the default step is
+         * 3.0s of added worst-case latency. Unset or non-positive
+         * resolves to the default.
+         *
+         * A read is only repeated while the account is absent
+         * (`getAccountInfo` returned null). Once the account is visible the
+         * loop stops and its fields decide the outcome on the spot. A
+         * top-up's stale deposit is NOT a retry signal: deposit only grows,
+         * so re-sampling it could clear the threshold with a concurrent
+         * top-up's money.
+         *
+         * LOCK: `handleOpen` calls `submitOpenTx` from INSIDE
+         * `store.updateChannel(...)`, and `createMemorySessionStore`
+         * serializes `updateChannel` per channel id, so up to
+         * `(maxAttempts - 1) * maxAttempts / 2 * backoffStep` of sleeping
+         * runs while that channel's lock is held. That is deliberate: the
+         * confirmed read is what authorizes the persist, and moving it
+         * outside the mutator would reopen the concurrent open-replay race
+         * the existence check inside the mutator closes. `SessionStore` is
+         * a public interface, so a third-party store may hold a real
+         * distributed lock here. Size these knobs against that lock's lease,
+         * not just against RPC latency.
+         */
+        readonly channelReadMaxAttempts?: number;
         /** Currency identifier (e.g. 'USDC' or an SPL mint address). */
         readonly currency: string;
         /** Token decimals (default 6). */

--- a/typescript/packages/mpp/src/server/Subscription.ts
+++ b/typescript/packages/mpp/src/server/Subscription.ts
@@ -19,6 +19,7 @@ import {
 } from '../constants.js';
 import * as Methods from '../Methods.js';
 import { deriveSubscriptionPda, mapSubscriptionPeriodToHours } from '../shared/subscription.js';
+import { type ChannelReadRetryOptions, readUntilVisible } from '../utils/account-read.js';
 import { coSignBase64Transaction } from '../utils/transactions.js';
 
 /**
@@ -71,6 +72,13 @@ export function subscription(parameters: subscription.Parameters) {
         splits,
         subscriptionExpires,
     } = parameters;
+
+    // Replica-lag tolerance for the post-activation delegation read. Both
+    // knobs fall back to their defaults when unset or non-positive.
+    const channelRead: ChannelReadRetryOptions = {
+        channelReadBackoffStepMs: parameters.channelReadBackoffStepMs,
+        channelReadMaxAttempts: parameters.channelReadMaxAttempts,
+    };
 
     if (tokenProgram !== TOKEN_PROGRAM && tokenProgram !== TOKEN_2022_PROGRAM) {
         throw new Error(`tokenProgram must be ${TOKEN_PROGRAM} or ${TOKEN_2022_PROGRAM}`);
@@ -172,7 +180,7 @@ export function subscription(parameters: subscription.Parameters) {
                 Number(challenge.periodCount),
             );
 
-            const delegation = await fetchSubscriptionDelegation(rpcUrl, subscriptionPda);
+            const delegation = await fetchSubscriptionDelegation(rpcUrl, subscriptionPda, channelRead);
             if (!delegation) {
                 throw new Error('SubscriptionDelegation account not found after activation');
             }
@@ -410,12 +418,29 @@ type SubscriptionDelegation = {
     subscriber: string;
 };
 
+/**
+ * Read the on-chain `SubscriptionDelegation`, or `null` when the account is
+ * absent.
+ *
+ * `channelRead` opts this read into replica-lag tolerance: RPC providers can
+ * serve transaction status and account state from different replicas, so the
+ * delegation an activation just created can read back missing for a few
+ * hundred ms. Only the absent account is retried: every field check lives
+ * in `verify()`, outside this function, so a delegation that exists but does
+ * not match the challenge is still rejected on the first read. Omitting
+ * `channelRead` keeps single-read semantics.
+ */
 async function fetchSubscriptionDelegation(
     rpcUrl: string,
     subscriptionPda: { toString(): string },
+    channelRead?: ChannelReadRetryOptions,
 ): Promise<SubscriptionDelegation | null> {
     const rpc = createSolanaRpc(rpcUrl);
-    const account = await rpc.getAccountInfo(address(subscriptionPda.toString()), { encoding: 'base64' }).send();
+    const account = await readUntilVisible(
+        () => rpc.getAccountInfo(address(subscriptionPda.toString()), { encoding: 'base64' }).send(),
+        result => result.value !== null,
+        channelRead,
+    );
     if (!account.value) return null;
     const [b64] = account.value.data;
     const data = new Uint8Array(getBase64Codec().encode(b64));
@@ -681,11 +706,34 @@ export const __testing = {
     decodeSubscriptionDelegation,
     encodeBase58,
     extractSubscriberFromTransaction,
+    fetchSubscriptionDelegation,
     validateActivationInstructions,
 };
 
 export declare namespace subscription {
     type Parameters = {
+        /**
+         * Linear backoff step in ms for the post-activation delegation
+         * re-read. Defaults to 200, giving a 200/400/600/800/1000ms
+         * schedule. Unset or non-positive resolves to the default.
+         *
+         * Linear on purpose: replica lag is a small multiple of Solana's
+         * ~400ms slot time, so an exponential schedule would spend the same
+         * budget on single waits far longer than the lag it absorbs.
+         */
+        channelReadBackoffStepMs?: number;
+        /**
+         * Total post-activation delegation reads, including the first,
+         * before activation fails. Defaults to 6, which at the default step is
+         * 3.0s of added worst-case latency. Unset or non-positive
+         * resolves to the default. Named to match the session method's
+         * knobs; the account read here is the `SubscriptionDelegation`.
+         *
+         * A read is only repeated while the account is absent. A delegation
+         * that exists but does not match the challenge is rejected on the
+         * first read, never retried.
+         */
+        channelReadMaxAttempts?: number;
         /** Token decimals for the mint. */
         decimals: number;
         /** Base58 of the SPL token mint. MUST match the on-chain plan.mint. */

--- a/typescript/packages/mpp/src/server/session/on-chain.ts
+++ b/typescript/packages/mpp/src/server/session/on-chain.ts
@@ -17,6 +17,7 @@ import {
     type AccountMeta,
     type Address,
     address,
+    assertAccountExists,
     getAddressEncoder,
     getBase58Encoder,
     getBase64Codec,
@@ -38,7 +39,7 @@ import {
 import { findAssociatedTokenPda } from '@solana-program/token';
 
 import { ASSOCIATED_TOKEN_PROGRAM, defaultTokenProgramForCurrency, resolveStablecoinMint } from '../../constants.js';
-import { fetchChannel } from '../../generated/payment-channels/accounts/channel.js';
+import { fetchMaybeChannel } from '../../generated/payment-channels/accounts/channel.js';
 import { getDistributeInstruction } from '../../generated/payment-channels/instructions/distribute.js';
 import { getOpenInstructionDataDecoder } from '../../generated/payment-channels/instructions/open.js';
 import { getReclaimInstruction } from '../../generated/payment-channels/instructions/reclaim.js';
@@ -50,6 +51,7 @@ import { PAYMENT_CHANNELS_PROGRAM_ADDRESS } from '../../generated/payment-channe
 import { ChannelStatus } from '../../generated/payment-channels/types/channelStatus.js';
 import type { OpenPayload, SignedVoucher } from '../../shared/session-types.js';
 import { VOUCHER_MAGIC } from '../../shared/voucher.js';
+import { type ChannelReadRetryOptions, readUntilVisible } from '../../utils/account-read.js';
 import { coSignBase64Transaction } from '../../utils/transactions.js';
 
 /**
@@ -748,6 +750,11 @@ export async function submitTopUpTx(args: {
     readonly additionalAmount: bigint;
     readonly channelId: string;
     readonly channelProgram: string;
+    /**
+     * Opt-in replica-lag tolerance for the post-confirm channel re-read.
+     * Omit it and the re-read stays a single RPC call.
+     */
+    readonly channelRead?: ChannelReadRetryOptions | undefined;
     /** Deposit recorded before this top-up, for the post-confirm re-check. */
     readonly currentDeposit: bigint;
     readonly payer: string;
@@ -804,7 +811,28 @@ export async function submitTopUpTx(args: {
     // Post-confirm re-check, mirroring Rust: the confirmed channel account
     // must be open and reflect at least the recorded deposit plus this
     // top-up before the deposit cap is raised.
-    const account = await fetchChannel(args.rpc as never, address(args.channelId), { commitment: 'confirmed' });
+    //
+    // Status and account state can come from different replicas, so the
+    // account can still read as missing right after the transaction
+    // confirms. An absent account is the ONLY not-yet-visible signal; the
+    // loop stops at the first read that sees the account at all.
+    //
+    // A stale deposit on a VISIBLE account is deliberately NOT retried.
+    // Deposit only ever grows, so re-sampling it can only flip reject into
+    // accept, and a concurrent top-up on this same channel is what would
+    // raise it. Nothing holds a per-channel lock across this read, so a
+    // retry loop could clear our threshold with someone else's money where
+    // a single read correctly rejected. Status and deposit are therefore
+    // decided once, below, on the first visible read, exactly as they were
+    // before this re-read grew a retry loop.
+    const account = await readUntilVisible(
+        () => fetchMaybeChannel(args.rpc as never, address(args.channelId), { commitment: 'confirmed' }),
+        maybeAccount => maybeAccount.exists,
+        args.channelRead,
+    );
+    // Preserves the SolanaError a missing account raised before the re-read
+    // grew a retry loop.
+    assertAccountExists(account);
     if (
         account.data.status !== Number(ChannelStatus.Open) ||
         account.data.deposit < args.currentDeposit + args.additionalAmount
@@ -875,6 +903,11 @@ export async function waitForSignatureConfirmation(args: {
  * for a transaction that never landed.
  */
 export interface SubmitOpenTxArgs extends VerifyOpenTxArgs {
+    /**
+     * Opt-in replica-lag tolerance for the post-confirm channel re-read.
+     * Omit it and the re-read stays a single RPC call.
+     */
+    readonly channelRead?: ChannelReadRetryOptions | undefined;
     /** Confirmation polling overrides (timeout, poll interval, abort). */
     readonly confirm?: ConfirmSignatureOptions | undefined;
     /**
@@ -914,9 +947,20 @@ export async function submitOpenTx(args: SubmitOpenTxArgs): Promise<SubmitOpenTx
         }
     }
     const assertConfirmedChannelMatchesOpen = async (): Promise<void> => {
-        const account = await fetchChannel(args.rpc as never, address(verified.channelId), {
-            commitment: 'confirmed',
-        });
+        // Signature status and account state can be served by different
+        // replicas, so a channel whose open just confirmed can read back
+        // missing for a few hundred ms. `exists === false` (getAccountInfo
+        // returned `value: null`) is the ONLY retryable signal: a decode
+        // failure or any field mismatch below is a visible-and-wrong state
+        // and stays authoritative on the first read.
+        const account = await readUntilVisible(
+            () => fetchMaybeChannel(args.rpc as never, address(verified.channelId), { commitment: 'confirmed' }),
+            maybeAccount => maybeAccount.exists,
+            args.channelRead,
+        );
+        // Preserves the SolanaError a missing account raised before the
+        // re-read grew a retry loop.
+        assertAccountExists(account);
         const channel = account.data;
         const expectedMint =
             args.expected.mint ??

--- a/typescript/packages/mpp/src/utils/account-read.ts
+++ b/typescript/packages/mpp/src/utils/account-read.ts
@@ -1,0 +1,73 @@
+// Replica-lag tolerance for the account read that follows a confirmed
+// transaction.
+//
+// RPC providers can serve transaction status and account state from
+// different replicas, so an account a just-confirmed transaction created or
+// mutated can briefly read back missing or stale. A single unretried read
+// turns that into a hard payment failure even though the funds are already
+// escrowed on chain.
+//
+// Ported from x402-foundation/x402#3367 and widened to pay-kit's MPP sites.
+
+/** Default number of reads, including the first. */
+export const DEFAULT_CHANNEL_READ_MAX_ATTEMPTS = 6;
+
+/** Default linear backoff step in ms. */
+export const DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS = 200;
+
+/**
+ * Tuning knobs for {@link readUntilVisible}. Both are optional and both
+ * resolve to their default when unset or non-positive.
+ */
+export interface ChannelReadRetryOptions {
+    /** Linear backoff step in ms. Defaults to 200. */
+    readonly channelReadBackoffStepMs?: number | undefined;
+    /** Total reads, including the first. Defaults to 6. */
+    readonly channelReadMaxAttempts?: number | undefined;
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+    return value !== undefined && value > 0 ? value : fallback;
+}
+
+/**
+ * Re-read `read()` with LINEAR backoff until `isVisible` accepts the result
+ * or the attempt budget runs out, then return the last result either way.
+ *
+ * The delay before attempt N+1 is `backoffStep * N`, so the defaults
+ * (6 attempts, 200ms step) schedule 200/400/600/800/1000ms: 3.0s total
+ * with a 1s longest single wait. Linear, not exponential: replica lag is a
+ * small multiple of Solana's ~400ms slot time, so doubling spends the
+ * budget on single waits far longer than the lag it absorbs. There is no
+ * sleep after the final attempt.
+ *
+ * `isVisible` must be false ONLY for the not-yet-visible state of that call
+ * site. A visible-but-wrong state has to be reported as visible so the
+ * caller rejects it on the spot, because retrying a wrong state on a money
+ * path is worse than the lag it hides. A throwing `read()` (RPC transport
+ * error) propagates immediately and is never retried.
+ *
+ * `options` is REQUIRED and its presence is the opt-in: pass `undefined`
+ * and the read stays a single RPC call. Several of these reads double as
+ * pre-broadcast existence probes where an absent account is the correct
+ * answer, and those must not pay the retry budget on every first-time
+ * request. An options object opts in; the two fields inside it fall back to
+ * their defaults when unset or non-positive.
+ */
+export async function readUntilVisible<T>(
+    read: () => Promise<T>,
+    isVisible: (value: T) => boolean,
+    options: ChannelReadRetryOptions | undefined,
+): Promise<T> {
+    if (options === undefined) return await read();
+    const maxAttempts = positiveOr(options.channelReadMaxAttempts, DEFAULT_CHANNEL_READ_MAX_ATTEMPTS);
+    const backoffStepMs = positiveOr(options.channelReadBackoffStepMs, DEFAULT_CHANNEL_READ_BACKOFF_STEP_MS);
+
+    let result = await read();
+    for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+        if (isVisible(result)) return result;
+        await new Promise(resolve => setTimeout(resolve, backoffStepMs * attempt));
+        result = await read();
+    }
+    return result;
+}


### PR DESCRIPTION
Stacked on #310, which adds the shared `ChannelReadPolicy`. Review that first; the base moves to `main` once it merges.

## Why

Same bug as #310, different protocol. MPP has its own readers and shares no code path with x402, but it runs the same broadcast, confirm, read flow against the same on-chain payment-channels program, so it carries the same replica visibility lag independently.

The worst site in either PR is here, in the TypeScript open path:

```
submitOpenTx catch branch
  broadcast error is not authoritative
  the open actually landed, preflight says "already processed"
  the confirmed channel account is the only remaining evidence
  one read against a lagging replica -> funded escrow, nothing persisted
```

Elsewhere the cost of a miss is a failed request. Here it is a funded channel with no record of it.

## What

| SDK | Sites |
|---|---|
| Rust | session open and top-up, subscription activate |
| Python | session open and top-up |
| TypeScript | session open, open catch branch, top-up, subscription activate |

Also fixes a commitment mismatch: the Rust subscription read used the default `finalized` right after a broadcast that only waited for `confirmed`, roughly 13s apart, which no retry budget can close.

## How

The schedule and the config fields come from #310. What is specific here:

**Only a confirmed absence is re-read.** The top-up sites are why that rule is strict:

```
deposit is monotonically non-decreasing
  -> a stale read is always LOW
  -> re-sampling "deposit < expected" can only flip reject into accept, never the reverse
```

A concurrent top-up on the same channel supplies that lift, and neither Rust nor TypeScript holds a per-channel lock across the read, so re-sampling could satisfy one payer's minimum with another's money. A short deposit is decided once, on the first read that sees the account.

Reads that double as pre-broadcast existence probes keep single-read semantics, so a first-time open or activation pays no added latency.

One trade-off worth naming: a genuine broadcast failure now costs up to 3.0s before the original error is rethrown, in TypeScript under the per-channel store lock. That is deliberate, since that branch is where the funded escrow gets lost.
