### PR TITLE
fix(mpp): harden payment verification

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -172,6 +172,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install LuaJIT 2.1, LuaRocks, libsodium, openssl
         run: |
+          # The hosted runner's unrelated Chrome apt index can briefly serve a
+          # stale hash and block installation of Ubuntu-hosted Lua packages.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y luajit libluajit-5.1-dev luarocks libsodium-dev libssl-dev
           luajit -v

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -15,6 +15,9 @@ jobs:
 
       - name: Install LuaJIT 2.1, LuaRocks, libsodium, openssl
         run: |
+          # The hosted runner's unrelated Chrome apt index can briefly serve a
+          # stale hash and block installation of Ubuntu-hosted Lua packages.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y luajit libluajit-5.1-dev luarocks libsodium-dev libssl-dev
           luajit -v
@@ -107,6 +110,9 @@ jobs:
 
       - name: Install LuaJIT 2.1, LuaRocks, libsodium, openssl
         run: |
+          # The hosted runner's unrelated Chrome apt index can briefly serve a
+          # stale hash and block installation of Ubuntu-hosted Lua packages.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y luajit libluajit-5.1-dev luarocks libsodium-dev libssl-dev
           luajit -v

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -57,6 +57,9 @@ jobs:
           bundler-cache: true
           working-directory: ruby
       - uses: ./.github/actions/setup-harness
+        with:
+          cargo-bins: "paykit-harness-bins:x402_harness_client"
+          cargo-cache-key: ruby
       # Dual-protocol proof: one e2e run drives MPP charge scenarios
       # (typescript client) and x402 exact (rust-x402 client) against
       # the same ruby adapter binary. The harness's harnessEnv exposes

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ set shell := ["bash", "-uc"]
 # reproducibility doesn't depend on whatever `main` happens to be when
 # the `*-pull-idl` recipes were last run.
 subscriptions_repo     := "solana-foundation/subscriptions"
-subscriptions_ref      := "30a6f7cbd1c53862cc598d93cb771c2c86a10cbf"
+subscriptions_ref      := "5a347ffaa969036061d274d3c91e0277962e2b51"
 payment_channels_repo  := "Moonsong-Labs/solana-payment-channels"
 payment_channels_ref   := "0c07d5751c8972abf6a219570a3f39a72f46f879"
 

--- a/harness/pnpm-lock.yaml
+++ b/harness/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: file:../typescript/packages/mpp(@solana/kit@6.8.0(typescript@5.9.3))(mppx@0.5.17(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)
       '@solana/pay-kit':
         specifier: file:../typescript/packages/pay-kit
-        version: file:../typescript/packages/pay-kit(@solana/addresses@6.10.0(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(typescript@5.9.3))(@solana/keys@6.10.0(typescript@5.9.3))(@solana/signers@6.10.0(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3))(@solana/transactions@6.10.0(typescript@5.9.3))(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))
+        version: file:../typescript/packages/pay-kit(@solana/addresses@7.1.1(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(typescript@5.9.3))(@solana/keys@7.1.1(typescript@5.9.3))(@solana/signers@7.1.1(typescript@5.9.3))(@solana/transactions@7.1.1(typescript@5.9.3))(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))
       '@solana/surfpool':
         specifier: 1.4.0
         version: 1.4.0
@@ -374,16 +374,38 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.3.0
 
+  '@solana-program/record@0.3.0':
+    resolution: {integrity: sha512-q8z86INfXRQ5357qgVBrw05vC+u3xg8Vb4E1gEwnYUvAkL3cbJSjWVfTlGRiGWYmPNq/FYIWbsFrhsxXyhaJ+w==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana-program/system@0.12.0':
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
       '@solana/kit': ^6.1.0
+
+  '@solana-program/system@0.13.0':
+    resolution: {integrity: sha512-Id6QQxCG7ByImXPD5X/c3Ag2kySD+49aJ9waIkfxyUFyokhMQgxYQAx2rKuaygaBlaBQY6VVfBS46pqxZV+99A==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
 
   '@solana-program/token-2022@0.11.0':
     resolution: {integrity: sha512-4yhSajmlZdMl98vJvt63kW6L0ERtV7UFcfZGJFyUVfTMxTrgghp8BNyhh5S1Ho3p4yHqfgL4N9VgVQ9GCnqqbg==}
     peerDependencies:
       '@solana/kit': ^6.0.0
       '@solana/sysvars': ^5.0
+      '@solana/zk-sdk': ^0.4.2
+    peerDependenciesMeta:
+      '@solana/zk-sdk':
+        optional: true
+
+  '@solana-program/token-2022@0.14.1':
+    resolution: {integrity: sha512-8yDF8xgEYU3HyfT4o7nLKHKMWQr3r2+1zBFojWYMkRyVh6YjuPO6Sxzf+p9trvL9Ddwp0d8SvqmMdYeErBZROA==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+      '@solana/sysvars': ^7.0.0
       '@solana/zk-sdk': ^0.4.2
     peerDependenciesMeta:
       '@solana/zk-sdk':
@@ -399,19 +421,21 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.5.0
 
+  '@solana-program/token@0.15.0':
+    resolution: {integrity: sha512-SeLm08EYIfT453I6lo7wTGgfMbz1s7bJ1jSHFHBFebSJHD3xF46zRgMxq3YKRlr/RM8jN0cG8SjZVu+IDvMxEA==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana-program/zk-elgamal-proof@0.1.0':
     resolution: {integrity: sha512-MKyeapz8P7SqkkC7h53ARFLoanb59ylVzokSMyINDH7hxY3JyiZs92/VfPa/qedhLAEHLd8jcc8sQ3pr3GyXtw==}
     peerDependencies:
       '@solana/kit': ^5.0
 
-  '@solana/accounts@5.5.1':
-    resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
-    engines: {node: '>=20.18.0'}
+  '@solana-program/zk-elgamal-proof@0.3.2':
+    resolution: {integrity: sha512-bCiRVKtqYZpajgC2RVypZL4A0xHjQYVEsVSNMTtPJ1jjE5KOUvsXhnngGMYShK6BHv+fQP4F8QKvEVW/HOSFAg==}
     peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      '@solana/kit': ^7.0.0
 
   '@solana/accounts@6.10.0':
     resolution: {integrity: sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==}
@@ -431,11 +455,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/addresses@5.5.1':
-    resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
+  '@solana/accounts@7.1.1':
+    resolution: {integrity: sha512-7sy9VIFMdmu/7+2kVBRMU6mEvYx/DDjfam8DsBXbh+JszaTNZH3V8FutQYHRxrca3jxiumVfsy5USwKfVg8ElQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -458,11 +482,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@5.5.1':
-    resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
+  '@solana/addresses@7.1.1':
+    resolution: {integrity: sha512-/Tk2aTOT7UEcaJrdEcB3+SK09v5cZ/92NWqHBzEobxusTPNoeOFxa3MwV74Q1MgPecWdLz7TPreEhAKpcvV/vw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -485,11 +509,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@5.5.1':
-    resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
+  '@solana/assertions@7.1.1':
+    resolution: {integrity: sha512-tD07UKuw5i9Tw5xloVH+TUMrLzbHKixaB4DlGXumMEQU+JbYRPtFNqtMlrpVLuVM45nkbPfFp2Da0sXNRIqFHA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -512,11 +536,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@5.5.1':
-    resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
+  '@solana/codecs-core@7.1.1':
+    resolution: {integrity: sha512-C1UOAQ7LH8RuCTfaij6hthTZeBlpp8GuD2g9Nag/xgiNKJGvAfVrcorb+kO/sufdYI8Lu+BiVvPeKOjQDQiKqg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -539,11 +563,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@5.5.1':
-    resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
+  '@solana/codecs-data-structures@7.1.1':
+    resolution: {integrity: sha512-MO+wMAuaatAQ96N3HhTsd7Uno+79rJw88P+OiU2n+pHK/rZuyu1yB2j12veqK4jUNWPR0aOyCuZ4rB2idrDjpg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -566,15 +590,12 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@5.5.1':
-    resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
+  '@solana/codecs-numbers@7.1.1':
+    resolution: {integrity: sha512-TWWrQq6Wp5Yf5bSc6RbxDDYCRUBBmRtRgjvUMHGp0P9K+4uFwxllRjSZFzBPHgXj3UTeZmFJdcoD271QhAgibg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
-      fastestsmallesttextencoderdecoder:
-        optional: true
       typescript:
         optional: true
 
@@ -602,12 +623,15 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@5.5.1':
-    resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
+  '@solana/codecs-strings@7.1.1':
+    resolution: {integrity: sha512-6qWl+atG60D2LmP47GyGapQFhVsG1sVhVrEaM3lV09vwrGOMeOZARZ4ObaQ5m6uQmM04G+f8dY9d17nCMbGHGg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
       typescript:
         optional: true
 
@@ -616,16 +640,6 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/errors@5.5.1':
-    resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -650,6 +664,16 @@ packages:
       typescript:
         optional: true
 
+  '@solana/errors@7.1.1':
+    resolution: {integrity: sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/fast-stable-stringify@6.8.0':
     resolution: {integrity: sha512-lZa3Qnsn+9ew6rHTXkPc+uqSa3i+AWqSBhV6oYxxBc+smvuxovItU4TPIs30cTfA7lAP+j+oYAQtUDu2dLy0hA==}
     engines: {node: '>=20.18.0'}
@@ -661,6 +685,15 @@ packages:
 
   '@solana/fixed-points@6.10.0':
     resolution: {integrity: sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fixed-points@7.1.1':
+    resolution: {integrity: sha512-qPj/V7kcFG/P0kuEa1U529+5L6mbkMwRIwvYBTDgBqPOt6wOdk9/c7Qn2VUQgSV0HgCXWxdHUdwaxBrYqO2ibg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -686,6 +719,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/functional@7.1.1':
+    resolution: {integrity: sha512-AnFohvUHGrqAu3kTxxC0rZyU4JddA08hOUZ1/DT9XogCZWetBpNJktX9uNuXQe+sN4FKTX2MfL//iBFBAsxtDA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/instruction-plans@6.10.0':
     resolution: {integrity: sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==}
     engines: {node: '>=20.18.0'}
@@ -704,6 +746,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/instruction-plans@7.1.1':
+    resolution: {integrity: sha512-KQGpsjeDflMcbKCdcF4KZVHcotYMS94DveRs0ZiBOsxb45dgkYrFmQ6ExJ/2exUOVF/rlp73knAP5ACrPMIAzA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/instructions@6.10.0':
     resolution: {integrity: sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==}
     engines: {node: '>=20.18.0'}
@@ -718,6 +769,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@7.1.1':
+    resolution: {integrity: sha512-VxMpJI++RTwaqSBLIP1GTjOPLtlYOqxOJ93ug6DlSdu9jku8M/or77DiXDUi62VmEh3bbsECR646vTJXUaPArw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -759,6 +819,30 @@ packages:
       typescript:
         optional: true
 
+  '@solana/keys@7.1.1':
+    resolution: {integrity: sha512-Rx+vzWAXUa/Ko7W6wG1HOG9B3nQFZ5dALz113WoAmBZf7iQvaLG7U4ECDM/ydR+Nbdy6wYww7zQKRIye+1d+Nw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit-plugin-instruction-plan@0.13.0':
+    resolution: {integrity: sha512-9RA94e0LLtVLN+bvGclpu8l0lAXGOGS72DxPIQ1VyGZs7vK/WTwPOqKnWhjJs2Cv/SDJ2xsCAhYkXr0UltVrOg==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
+  '@solana/kit-plugin-rpc@0.15.0':
+    resolution: {integrity: sha512-Abymr7WLP9yQ6ixCCv+tKzjoWpAkxJ90JWzL+pfkTAFGTpVk9N0myhMcO2ohl6yztJRMOxsw1CXWjcVecxxUlg==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
+  '@solana/kit-plugin-signer@0.13.0':
+    resolution: {integrity: sha512-Vtlyt2Td8WfeQvC30yOU7a+CFo4+loMCSQKUFwvSQvbpKG39S6UyQc1euhcvtwCbJRZR3m5nAZvHayQ1rxeUkA==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana/kit@6.8.0':
     resolution: {integrity: sha512-+McC1aCgcUBdM7Cd7U6k2ZHJ9OKCy5mzpb0XWrhkrgsFxT0QoRr0AcWJc85o6tIDfG6Jz7vVhbS3l8ugYz2Vzw==}
     engines: {node: '>=20.18.0'}
@@ -774,15 +858,6 @@ packages:
       '@solana/kit': '>=6.10.0'
       mppx: '>=0.5.5'
 
-  '@solana/nominal-types@5.5.1':
-    resolution: {integrity: sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@solana/nominal-types@6.10.0':
     resolution: {integrity: sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==}
     engines: {node: '>=20.18.0'}
@@ -797,6 +872,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/nominal-types@7.1.1':
+    resolution: {integrity: sha512-do4rmmOlSplVYN92zV6nROJxkiRn0c7juoH1lka2Pmq+cAC3QhQXKYAwWffTFYDJJDO9qCOh00uv2hhSZi6RDw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -819,11 +903,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@5.5.1':
-    resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
+  '@solana/offchain-messages@7.1.1':
+    resolution: {integrity: sha512-Py0/8HaIF0y+KSXHAWdQYDdZlGNoaqOZonTFuGKyDsrkgvod3wRc0cpZ5I/D/Rei4tVpvjNUfCXLpyoiJAZ7kg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -867,6 +951,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/plugin-interfaces@7.1.1':
+    resolution: {integrity: sha512-2SHkGiftGmxg5xA5esxbwiY5wf+BOUsJG5rxD64/SHadUMaN3L0SDUSJfAXETJq5dCmVWxWGGPf2yVox4RIfdA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/program-client-core@6.10.0':
     resolution: {integrity: sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==}
     engines: {node: '>=20.18.0'}
@@ -881,6 +974,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/program-client-core@7.1.1':
+    resolution: {integrity: sha512-zoMq8Qg6psj6tFYpA35xKhSrF/LpdiVflV6nKohxZg3ocwtRqRhQfbY8/mjCA9EfH8vqvsn5il5CnxALRqmJJA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -912,6 +1014,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/promises@7.1.1':
+    resolution: {integrity: sha512-d3lhCfiFwiVyTRR6zhy1lcjDIh+l0a5gp1WPe64Vfa2gP0myC8P5C1Tknfjrp4d97DF3uBPqKAb5vV8hahNcNA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-api@6.10.0':
     resolution: {integrity: sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==}
     engines: {node: '>=20.18.0'}
@@ -926,6 +1037,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-api@7.1.1':
+    resolution: {integrity: sha512-ELGIqNbz8apeAxCLdD1PEPAnu6KtgHmWvUbH4VqqNg2jgWquyUOfTI5rblvdflx2Hcb7GK05w8/iiUaknOQKnw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -948,11 +1068,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@5.5.1':
-    resolution: {integrity: sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==}
+  '@solana/rpc-parsed-types@7.1.1':
+    resolution: {integrity: sha512-DiQSj2rNnhOKOTs6YDjQ2y4KuOkv8lh6moLFiQnY0+TvanJrGrQjxLSrHdCUQxymQcUxzrraZL9k6vxNzId4gw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -975,11 +1095,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@5.5.1':
-    resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
+  '@solana/rpc-spec-types@7.1.1':
+    resolution: {integrity: sha512-FDDgXfAPfq28sQNnGhZr/+2kp5QTTcNZ5m/Q9y9Jrlux6brdPsbf9Sh1Q/lgz7i76arzNW/rzRY125RzqGWANg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -998,6 +1118,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@7.1.1':
+    resolution: {integrity: sha512-1FwhgL18qasRYlWffdBNIUoxQyGLzdh3YMQW3y33M61vk/q1ldEGJRypV9B/SrXmxwqDiUbQ+m+zgainCTp1ZA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1038,6 +1167,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-spec@7.1.1':
+    resolution: {integrity: sha512-yrqd+fV2Ae4hkzXX42aKRmTrz3FwvzKqO4h0ahs88dzSvXpy8l6Svu1k+uRgMlZ64g2P83jfQW+3Pj5fBoxmdw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-subscriptions@6.8.0':
     resolution: {integrity: sha512-9CotreNZmKAP2z07FY1I7TPPvylKLFF5p4mujB5ZFMHQPp5JVQFVCmMIhSj5voZHAeYx7jdwJ2Kf0RDeClqJzA==}
     engines: {node: '>=20.18.0'}
@@ -1065,20 +1203,20 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-transformers@7.1.1':
+    resolution: {integrity: sha512-k8a/JZFso/nvPBgurOGJ/ZC6sXCtYE3lCvTj95i29pl45C4SgjdetJrAH/pWEEhQXcxaJs7OLBGmCh2enazlJw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-transport-http@6.8.0':
     resolution: {integrity: sha512-jw/L0q2motGcx7yo6KvkKJd2HGVg9gvViXatFloLl1XmHbkwE7+97YYmG17WRuM5xauzI/UGYOXNW7cEB+Uaxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/rpc-types@5.5.1':
-    resolution: {integrity: sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1097,6 +1235,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-types@7.1.1':
+    resolution: {integrity: sha512-yHlSUWgynaaqevuqipGhhcZnmFVNs+F6KIlbUZ0kQY6NMVtaSzx5AQrtQjbtAQzNRsRTDYkKuQg8nOruiDoseQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1128,6 +1275,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/signers@7.1.1':
+    resolution: {integrity: sha512-UfWYnAglm21q5hS3Op1bU5mYiWfx0VesovZcIur0uYPc3EJlfBVikl8pf745x+bB77xG6lIzNbb+99t48SQbkg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/subscribable@6.10.0':
     resolution: {integrity: sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==}
     engines: {node: '>=20.18.0'}
@@ -1145,6 +1301,20 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/subscribable@7.1.1':
+    resolution: {integrity: sha512-l4Wzc2L+7WQPeC/kaCiia1aaUY/SJJdrNHnLibKchS2pb7YbF7J2OygsweHXliWCVpG0jZwcvIVpusgygbZQLw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscriptions@0.5.0':
+    resolution: {integrity: sha512-N7mA5U3rqak9sSbAfB/iYGlgbuIjwGUHfNDlQRGqgXIACnxPcvA3e6f6cHkD0GITstRNxX+rg9uyE1FGGlw/Jw==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
 
   '@solana/surfpool-darwin-arm64@1.4.0':
     resolution: {integrity: sha512-/sh7zJEzulPtBbB7ykUmhhrox+X1BJ1ff/OH81C7X/W0usXZtIRuonSKA2KgWHFFUVFHYRemMv6GmkmbbPlTjQ==}
@@ -1168,15 +1338,6 @@ packages:
   '@solana/surfpool@1.4.0':
     resolution: {integrity: sha512-YAHZz4Gkq4JKg82pVt4yENs+zxvcUliyS1Nz5JVBYiww3LZp9SG0Fsf/vHakQdgyuEaBwPuLVhS/PritsEhUbA==}
     engines: {node: '>=18'}
-
-  '@solana/sysvars@5.5.1':
-    resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@solana/sysvars@6.8.0':
     resolution: {integrity: sha512-pwfMpMNL6MSmm07eHQYdTdRdzmPOd+EuVCCaNLSYdWGpYcocVJiaLiNWRV3cXA5wPj/ZFkoUGtc1bo0v7H50lw==}
@@ -1214,6 +1375,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/transaction-messages@7.1.1':
+    resolution: {integrity: sha512-UBgd/TU0c8blrYDC9sD9P+wgmOOEK4OdODxD8CxB7oumN4ZAENv20u0AdZuvu1n4OwWwc1ikhtKjwg18e4wTIg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/transactions@6.10.0':
     resolution: {integrity: sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==}
     engines: {node: '>=20.18.0'}
@@ -1228,6 +1398,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@7.1.1':
+    resolution: {integrity: sha512-jop8y4+xiDJlocRLxqN++33Z5PDTe72HwmtgGrcIuGB4zq7U/lUX0uZM1JVcs9d3lJ3wBy2CcLTCyoYb78Swhg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1368,10 +1547,6 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  commander@14.0.2:
-    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
-    engines: {node: '>=20'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -2196,16 +2371,30 @@ snapshots:
     dependencies:
       '@solana/kit': 6.8.0(typescript@5.9.3)
 
+  '@solana-program/record@0.3.0(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+
   '@solana-program/system@0.12.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
       '@solana/kit': 6.8.0(typescript@5.9.3)
 
-  '@solana-program/token-2022@0.11.0(@solana/kit@6.8.0(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3))':
+  '@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+
+  '@solana-program/token-2022@0.11.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
       '@noble/curves': 1.9.7
       '@solana-program/zk-elgamal-proof': 0.1.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana/kit': 6.8.0(typescript@5.9.3)
-      '@solana/sysvars': 5.5.1(typescript@5.9.3)
+
+  '@solana-program/token-2022@0.14.1(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
 
   '@solana-program/token@0.11.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
@@ -2217,23 +2406,20 @@ snapshots:
       '@solana-program/system': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana/kit': 6.8.0(typescript@5.9.3)
 
+  '@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+
   '@solana-program/zk-elgamal-proof@0.1.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
       '@solana-program/system': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana/kit': 6.8.0(typescript@5.9.3)
 
-  '@solana/accounts@5.5.1(typescript@5.9.3)':
+  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
 
   '@solana/accounts@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -2261,13 +2447,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.5.1(typescript@5.9.3)':
+  '@solana/accounts@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2297,11 +2484,17 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@5.5.1(typescript@5.9.3)':
+  '@solana/addresses@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/assertions': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/assertions@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -2315,9 +2508,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@5.5.1(typescript@5.9.3)':
+  '@solana/assertions@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2333,11 +2526,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-data-structures@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-core@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2357,10 +2548,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-data-structures@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2378,11 +2570,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-numbers@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2402,17 +2593,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-strings@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/options': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
 
   '@solana/codecs@6.8.0(typescript@5.9.3)':
     dependencies:
@@ -2425,13 +2612,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@5.5.1(typescript@5.9.3)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.2
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@solana/errors@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -2447,6 +2627,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/errors@7.1.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 15.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/fast-stable-stringify@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
@@ -2458,11 +2645,22 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/fixed-points@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/functional@6.10.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
   '@solana/functional@6.8.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/functional@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2492,6 +2690,19 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/instruction-plans@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/instructions@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.10.0(typescript@5.9.3)
@@ -2506,23 +2717,30 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.10.0(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(typescript@5.9.3))(@solana/keys@6.10.0(typescript@5.9.3))(@solana/signers@6.10.0(typescript@5.9.3))(@solana/transactions@6.10.0(typescript@5.9.3))':
+  '@solana/instructions@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.10.0(typescript@5.9.3)
-      '@solana/keys': 6.10.0(typescript@5.9.3)
-      '@solana/signers': 6.10.0(typescript@5.9.3)
-      '@solana/transactions': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/keychain-memory@1.4.0(@solana/addresses@6.10.0(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(typescript@5.9.3))(@solana/keys@6.10.0(typescript@5.9.3))(@solana/signers@6.10.0(typescript@5.9.3))(@solana/transactions@6.10.0(typescript@5.9.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@7.1.1(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(typescript@5.9.3))(@solana/keys@7.1.1(typescript@5.9.3))(@solana/signers@7.1.1(typescript@5.9.3))(@solana/transactions@7.1.1(typescript@5.9.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.10.0(typescript@5.9.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(typescript@5.9.3))(@solana/keys@6.10.0(typescript@5.9.3))(@solana/signers@6.10.0(typescript@5.9.3))(@solana/transactions@6.10.0(typescript@5.9.3))
-      '@solana/keys': 6.10.0(typescript@5.9.3)
-      '@solana/signers': 6.10.0(typescript@5.9.3)
-      '@solana/transactions': 6.10.0(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+
+  '@solana/keychain-memory@1.4.0(@solana/addresses@7.1.1(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(typescript@5.9.3))(@solana/keys@7.1.1(typescript@5.9.3))(@solana/signers@7.1.1(typescript@5.9.3))(@solana/transactions@7.1.1(typescript@5.9.3))':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@7.1.1(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(typescript@5.9.3))(@solana/keys@7.1.1(typescript@5.9.3))(@solana/signers@7.1.1(typescript@5.9.3))(@solana/transactions@7.1.1(typescript@5.9.3))
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
@@ -2551,6 +2769,32 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/kit-plugin-instruction-plan@0.13.0(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+
+  '@solana/kit-plugin-rpc@0.15.0(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+      '@solana/kit-plugin-instruction-plan': 0.13.0(@solana/kit@6.8.0(typescript@5.9.3))
+
+  '@solana/kit-plugin-signer@0.13.0(@solana/kit@6.8.0(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
 
   '@solana/kit@6.8.0(typescript@5.9.3)':
     dependencies:
@@ -2591,23 +2835,27 @@ snapshots:
       '@solana-program/compute-budget': 0.15.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana-program/system': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana-program/token': 0.11.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/addresses': 6.10.0(typescript@5.9.3)
       '@solana/kit': 6.8.0(typescript@5.9.3)
       '@solana/program-client-core': 6.10.0(typescript@5.9.3)
+      '@solana/subscriptions': 0.5.0(@solana/kit@6.8.0(typescript@5.9.3))(typescript@5.9.3)
       mppx: 0.5.17(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))
       zod: 4.4.3
     transitivePeerDependencies:
+      - '@solana/sysvars'
+      - '@solana/zk-sdk'
       - fastestsmallesttextencoderdecoder
       - typescript
-
-  '@solana/nominal-types@5.5.1(typescript@5.9.3)':
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@solana/nominal-types@6.10.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
   '@solana/nominal-types@6.8.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/nominal-types@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2641,13 +2889,16 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@5.5.1(typescript@5.9.3)':
+  '@solana/offchain-messages@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2665,12 +2916,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/pay-kit@file:../typescript/packages/pay-kit(@solana/addresses@6.10.0(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(typescript@5.9.3))(@solana/keys@6.10.0(typescript@5.9.3))(@solana/signers@6.10.0(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3))(@solana/transactions@6.10.0(typescript@5.9.3))(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))':
+  '@solana/pay-kit@file:../typescript/packages/pay-kit(@solana/addresses@7.1.1(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(typescript@5.9.3))(@solana/keys@7.1.1(typescript@5.9.3))(@solana/signers@7.1.1(typescript@5.9.3))(@solana/transactions@7.1.1(typescript@5.9.3))(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       '@solana-program/compute-budget': 0.15.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana-program/token': 0.13.0(@solana/kit@6.8.0(typescript@5.9.3))
-      '@solana-program/token-2022': 0.11.0(@solana/kit@6.8.0(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3))
-      '@solana/keychain-memory': 1.4.0(@solana/addresses@6.10.0(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(typescript@5.9.3))(@solana/keys@6.10.0(typescript@5.9.3))(@solana/signers@6.10.0(typescript@5.9.3))(@solana/transactions@6.10.0(typescript@5.9.3))
+      '@solana-program/token-2022': 0.11.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/keychain-memory': 1.4.0(@solana/addresses@7.1.1(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(typescript@5.9.3))(@solana/keys@7.1.1(typescript@5.9.3))(@solana/signers@7.1.1(typescript@5.9.3))(@solana/transactions@7.1.1(typescript@5.9.3))
       '@solana/kit': 6.8.0(typescript@5.9.3)
       mppx: 0.5.17(express@4.22.2)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3)(zod@4.3.6))
     transitivePeerDependencies:
@@ -2724,6 +2975,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/plugin-interfaces@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/program-client-core@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/accounts': 6.10.0(typescript@5.9.3)
@@ -2756,6 +3022,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/program-client-core@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/plugin-interfaces': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-api': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/programs@6.8.0(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.8.0(typescript@5.9.3)
@@ -2770,6 +3052,10 @@ snapshots:
       typescript: 5.9.3
 
   '@solana/promises@6.8.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/promises@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2809,6 +3095,24 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-api@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-parsed-types@6.10.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
@@ -2817,7 +3121,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec-types@5.5.1(typescript@5.9.3)':
+  '@solana/rpc-parsed-types@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2829,10 +3133,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec@5.5.1(typescript@5.9.3)':
+  '@solana/rpc-spec-types@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2848,6 +3151,14 @@ snapshots:
     dependencies:
       '@solana/errors': 6.8.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2896,6 +3207,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/rpc-subscriptions-spec@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/rpc-subscriptions@6.8.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@5.9.3)
@@ -2940,6 +3260,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-transformers@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-transport-http@6.8.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@5.9.3)
@@ -2948,19 +3280,6 @@ snapshots:
       undici-types: 8.1.0
     optionalDependencies:
       typescript: 5.9.3
-
-  '@solana/rpc-types@5.5.1(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
 
   '@solana/rpc-types@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -2984,6 +3303,20 @@ snapshots:
       '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
       '@solana/errors': 6.8.0(typescript@5.9.3)
       '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-types@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/fixed-points': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3037,6 +3370,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/signers@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/offchain-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/subscribable@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@5.9.3)
@@ -3049,6 +3398,27 @@ snapshots:
       '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/subscribable@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/subscriptions@0.5.0(@solana/kit@6.8.0(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana-program/token-2022': 0.14.1(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+      '@solana/kit-plugin-rpc': 0.15.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit-plugin-signer': 0.13.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/program-client-core': 7.1.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+      - '@solana/zk-sdk'
+      - fastestsmallesttextencoderdecoder
+      - typescript
 
   '@solana/surfpool-darwin-arm64@1.4.0':
     optional: true
@@ -3064,17 +3434,6 @@ snapshots:
       '@solana/surfpool-darwin-arm64': 1.4.0
       '@solana/surfpool-darwin-x64': 1.4.0
       '@solana/surfpool-linux-x64-gnu': 1.4.0
-
-  '@solana/sysvars@5.5.1(typescript@5.9.3)':
-    dependencies:
-      '@solana/accounts': 5.5.1(typescript@5.9.3)
-      '@solana/codecs': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
 
   '@solana/sysvars@6.8.0(typescript@5.9.3)':
     dependencies:
@@ -3140,6 +3499,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/transaction-messages@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/transactions@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.10.0(typescript@5.9.3)
@@ -3173,6 +3548,25 @@ snapshots:
       '@solana/nominal-types': 6.8.0(typescript@5.9.3)
       '@solana/rpc-types': 6.8.0(typescript@5.9.3)
       '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3336,8 +3730,6 @@ snapshots:
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
-
-  commander@14.0.2: {}
 
   commander@14.0.3: {}
 

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -324,6 +324,24 @@
     "definedTypes": [
       {
         "kind": "definedTypeNode",
+        "name": "cancelSubscriptionNowData",
+        "type": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedCurrentPeriodStartTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        }
+      },
+      {
+        "kind": "definedTypeNode",
         "name": "createFixedDelegationData",
         "type": {
           "fields": [
@@ -666,6 +684,50 @@
                   "kind": "stringTypeNode"
                 }
               }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedCreatedAt",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedEndTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedPullers",
+              "type": {
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 4
+                },
+                "item": {
+                  "kind": "publicKeyTypeNode"
+                },
+                "kind": "arrayTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedMetadataUri",
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 128,
+                "type": {
+                  "encoding": "utf8",
+                  "kind": "stringTypeNode"
+                }
+              }
             }
           ],
           "kind": "structTypeNode"
@@ -697,6 +759,24 @@
               "name": "mint",
               "type": {
                 "kind": "publicKeyTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "resumeData",
+        "type": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedExpiresAtTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
               }
             }
           ],
@@ -1057,6 +1137,12 @@
         "name": "staleSubscriptionAuthority"
       },
       {
+        "code": 137,
+        "kind": "errorNode",
+        "message": "Too many transfer hook accounts provided",
+        "name": "transferHookTooManyAccounts"
+      },
+      {
         "code": 300,
         "kind": "errorNode",
         "message": "Transfer amount exceeds delegation limit",
@@ -1121,6 +1207,12 @@
         "kind": "errorNode",
         "message": "Delegation period has not started yet",
         "name": "delegationNotStarted"
+      },
+      {
+        "code": 408,
+        "kind": "errorNode",
+        "message": "start_ts of 0 (start on landing) requires a non-zero expiry",
+        "name": "recurringDelegationStartOnLandingRequiresExpiry"
       },
       {
         "code": 500,
@@ -1243,6 +1335,24 @@
         "name": "planTermsMismatch"
       },
       {
+        "code": 520,
+        "kind": "errorNode",
+        "message": "A finite plan end timestamp can only be shortened, not removed or extended",
+        "name": "planEndTsCannotExtend"
+      },
+      {
+        "code": 521,
+        "kind": "errorNode",
+        "message": "Subscription approval does not match the current subscription",
+        "name": "staleSubscriptionApproval"
+      },
+      {
+        "code": 522,
+        "kind": "errorNode",
+        "message": "Plan update approval does not match the current plan state",
+        "name": "stalePlanApproval"
+      },
+      {
         "code": 600,
         "kind": "errorNode",
         "message": "Invalid event authority PDA",
@@ -1265,9 +1375,655 @@
         "kind": "errorNode",
         "message": "Unknown event discriminator",
         "name": "invalidEventDiscriminator"
+      },
+      {
+        "code": 604,
+        "kind": "errorNode",
+        "message": "Self program account does not match this program",
+        "name": "invalidSelfProgram"
       }
     ],
-    "events": [],
+    "events": [
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegation",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegator",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegatee",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "mint",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "amount",
+              "type": {
+                "endian": "le",
+                "format": "u64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "remainingAmount",
+              "type": {
+                "endian": "le",
+                "format": "u64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "receiver",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "receiverTokenAccount",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "03",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "fixedTransferEvent"
+      },
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "plan",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "owner",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "status",
+              "type": {
+                "endian": "le",
+                "format": "u8",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "endTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "pullers",
+              "type": {
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 4
+                },
+                "item": {
+                  "kind": "publicKeyTypeNode"
+                },
+                "kind": "arrayTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "06",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "planUpdatedEvent"
+      },
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegation",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegator",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegatee",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "mint",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "amount",
+              "type": {
+                "endian": "le",
+                "format": "u64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "periodStartTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "periodEndTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "amountPulledInPeriod",
+              "type": {
+                "endian": "le",
+                "format": "u64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "receiver",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "receiverTokenAccount",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "04",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "recurringTransferEvent"
+      },
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "plan",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "subscriber",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expiresAtTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "01",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "subscriptionCancelledEvent"
+      },
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "plan",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "subscriber",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "mint",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "createdTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "payer",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "00",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "subscriptionCreatedEvent"
+      },
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "plan",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "subscriber",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "resumedTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "05",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "subscriptionResumedEvent"
+      },
+      {
+        "data": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "subscription",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "plan",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "delegator",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "mint",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "amount",
+              "type": {
+                "endian": "le",
+                "format": "u64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "periodStartTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "periodEndTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "amountPulledInPeriod",
+              "type": {
+                "endian": "le",
+                "format": "u64",
+                "kind": "numberTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "receiver",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "receiverTokenAccount",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "puller",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        },
+        "discriminators": [
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "e445a52e51cb9a1d",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 0
+          },
+          {
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "data": "02",
+                "encoding": "base16",
+                "kind": "bytesValueNode"
+              }
+            },
+            "kind": "constantDiscriminatorNode",
+            "offset": 8
+          }
+        ],
+        "kind": "eventNode",
+        "name": "subscriptionTransferEvent"
+      }
+    ],
     "instructions": [
       {
         "accounts": [
@@ -1353,6 +2109,16 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "tokenProgram"
+          },
+          {
+            "docs": [
+              "Optional sponsor that funds the account rent. Defaults to the owner/signer when omitted."
+            ],
+            "isOptional": true,
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
           }
         ],
         "arguments": [
@@ -1379,7 +2145,8 @@
           }
         ],
         "kind": "instructionNode",
-        "name": "initSubscriptionAuthority"
+        "name": "initSubscriptionAuthority",
+        "optionalAccountStrategy": "omitted"
       },
       {
         "accounts": [
@@ -1431,6 +2198,16 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "systemProgram"
+          },
+          {
+            "docs": [
+              "Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted."
+            ],
+            "isOptional": true,
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
           }
         ],
         "arguments": [
@@ -1465,7 +2242,8 @@
           }
         ],
         "kind": "instructionNode",
-        "name": "createFixedDelegation"
+        "name": "createFixedDelegation",
+        "optionalAccountStrategy": "omitted"
       },
       {
         "accounts": [
@@ -1517,6 +2295,16 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "systemProgram"
+          },
+          {
+            "docs": [
+              "Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted."
+            ],
+            "isOptional": true,
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
           }
         ],
         "arguments": [
@@ -1551,7 +2339,8 @@
           }
         ],
         "kind": "instructionNode",
-        "name": "createRecurringDelegation"
+        "name": "createRecurringDelegation",
+        "optionalAccountStrategy": "omitted"
       },
       {
         "accounts": [
@@ -1667,8 +2456,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "The event authority PDA"
@@ -1793,8 +2586,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "The event authority PDA"
@@ -1871,6 +2668,16 @@
             "isWritable": true,
             "kind": "instructionAccountNode",
             "name": "subscriptionAuthority"
+          },
+          {
+            "docs": [
+              "Optional rent recipient, required when the recorded payer differs from the user. Must match the stored payer."
+            ],
+            "isOptional": true,
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "receiver"
           }
         ],
         "arguments": [
@@ -1897,7 +2704,8 @@
           }
         ],
         "kind": "instructionNode",
-        "name": "closeSubscriptionAuthority"
+        "name": "closeSubscriptionAuthority",
+        "optionalAccountStrategy": "omitted"
       },
       {
         "accounts": [
@@ -1953,6 +2761,16 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "tokenProgram"
+          },
+          {
+            "docs": [
+              "Optional sponsor that funds the plan rent. Defaults to the merchant/signer when omitted; delete_plan refunds the owner, not the payer."
+            ],
+            "isOptional": true,
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
           }
         ],
         "arguments": [
@@ -1987,7 +2805,8 @@
           }
         ],
         "kind": "instructionNode",
-        "name": "createPlan"
+        "name": "createPlan",
+        "optionalAccountStrategy": "omitted"
       },
       {
         "accounts": [
@@ -2008,6 +2827,36 @@
             "isWritable": true,
             "kind": "instructionAccountNode",
             "name": "planPda"
+          },
+          {
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
+            },
+            "docs": [
+              "The event authority PDA"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "eventAuthority"
+          },
+          {
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
+            },
+            "docs": [
+              "This program (for self-CPI)"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "selfProgram"
           }
         ],
         "arguments": [
@@ -2167,8 +3016,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "The event authority PDA"
@@ -2313,8 +3166,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "The event authority PDA"
@@ -2336,6 +3193,16 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "selfProgram"
+          },
+          {
+            "docs": [
+              "Optional sponsor that funds the account rent. Defaults to the subscriber/signer when omitted."
+            ],
+            "isOptional": true,
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
           }
         ],
         "arguments": [
@@ -2370,7 +3237,8 @@
           }
         ],
         "kind": "instructionNode",
-        "name": "subscribe"
+        "name": "subscribe",
+        "optionalAccountStrategy": "omitted"
       },
       {
         "accounts": [
@@ -2428,8 +3296,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "The event authority PDA"
@@ -2534,9 +3406,22 @@
             "name": "subscriptionPda"
           },
           {
+            "docs": [
+              "The subscriber's SubscriptionAuthority PDA for the plan's mint"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionAuthority"
+          },
+          {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "The event authority PDA"
@@ -2574,6 +3459,14 @@
               "format": "u8",
               "kind": "numberTypeNode"
             }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "resumeData",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "resumeData"
+            }
           }
         ],
         "discriminators": [
@@ -2585,6 +3478,365 @@
         ],
         "kind": "instructionNode",
         "name": "resumeSubscription"
+      },
+      {
+        "accounts": [
+          {
+            "docs": [
+              "The ATA owner: revokes the program's delegate and, when still open, closes the SubscriptionAuthority PDA (receives rent when self-funded)"
+            ],
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "user"
+          },
+          {
+            "docs": [
+              "The user's ATA whose delegate is being revoked"
+            ],
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "userAta"
+          },
+          {
+            "docs": [
+              "The token mint of the user's ATA"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "tokenMint"
+          },
+          {
+            "docs": [
+              "Token program"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "tokenProgram"
+          },
+          {
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "subscriptionAuthority"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "user",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "user"
+                  }
+                },
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "tokenMint",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "tokenMint"
+                  }
+                }
+              ]
+            },
+            "docs": [
+              "The SubscriptionAuthority PDA. Closed when still open; ignored when already closed."
+            ],
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionAuthority"
+          },
+          {
+            "docs": [
+              "Optional rent recipient, required when the SubscriptionAuthority is still open and its recorded payer differs from the user. Must match the stored payer."
+            ],
+            "isOptional": true,
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "receiver"
+          }
+        ],
+        "arguments": [
+          {
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 14
+            },
+            "defaultValueStrategy": "omitted",
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "endian": "le",
+              "format": "u8",
+              "kind": "numberTypeNode"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "kind": "instructionNode",
+        "name": "revokeSubscriptionAuthority",
+        "optionalAccountStrategy": "omitted"
+      },
+      {
+        "accounts": [
+          {
+            "docs": [
+              "The recorded payer reclaiming rent"
+            ],
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
+          },
+          {
+            "docs": [
+              "The fixed or recurring delegation PDA to close"
+            ],
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "delegationAccount"
+          },
+          {
+            "docs": [
+              "The delegation's recorded SubscriptionAuthority PDA (may be closed)"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionAuthority"
+          }
+        ],
+        "arguments": [
+          {
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 15
+            },
+            "defaultValueStrategy": "omitted",
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "endian": "le",
+              "format": "u8",
+              "kind": "numberTypeNode"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "kind": "instructionNode",
+        "name": "revokeAbandonedDelegation"
+      },
+      {
+        "accounts": [
+          {
+            "docs": [
+              "The recorded payer reclaiming rent"
+            ],
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
+          },
+          {
+            "docs": [
+              "The abandoned subscription PDA to close"
+            ],
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionAccount"
+          },
+          {
+            "docs": [
+              "The subscriber's recorded SubscriptionAuthority PDA for the plan's mint (may be closed)"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionAuthority"
+          },
+          {
+            "docs": [
+              "The plan the subscription belongs to; provides the mint"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "planPda"
+          }
+        ],
+        "arguments": [
+          {
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 16
+            },
+            "defaultValueStrategy": "omitted",
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "endian": "le",
+              "format": "u8",
+              "kind": "numberTypeNode"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "kind": "instructionNode",
+        "name": "revokeAbandonedSubscription"
+      },
+      {
+        "accounts": [
+          {
+            "docs": [
+              "The subscriber cancelling the subscription"
+            ],
+            "isSigner": true,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "subscriber"
+          },
+          {
+            "docs": [
+              "The owner of the subscription plan approving immediate cancellation"
+            ],
+            "isSigner": true,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "merchant"
+          },
+          {
+            "docs": [
+              "The plan PDA for the subscription"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "planPda"
+          },
+          {
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "subscriptionDelegation"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "planPda",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "planPda"
+                  }
+                },
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "subscriber",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "subscriber"
+                  }
+                }
+              ]
+            },
+            "docs": [
+              "The subscription PDA being cancelled immediately"
+            ],
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionPda"
+          },
+          {
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
+            },
+            "docs": [
+              "The event authority PDA"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "eventAuthority"
+          },
+          {
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
+            },
+            "docs": [
+              "This program (for self-CPI)"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "selfProgram"
+          }
+        ],
+        "arguments": [
+          {
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 17
+            },
+            "defaultValueStrategy": "omitted",
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "endian": "le",
+              "format": "u8",
+              "kind": "numberTypeNode"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "cancelSubscriptionNowData",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cancelSubscriptionNowData"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "kind": "instructionNode",
+        "name": "cancelSubscriptionNow"
       }
     ],
     "kind": "programNode",
@@ -2798,7 +4050,7 @@
       }
     ],
     "publicKey": "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44",
-    "version": "0.1.0"
+    "version": "0.5.0"
   },
   "standard": "codama",
   "version": "1.0.0"

--- a/lua/pay_kit/protocols/x402/init.lua
+++ b/lua/pay_kit/protocols/x402/init.lua
@@ -31,6 +31,7 @@ local tx_cosign  = require('pay_kit.solana.tx_cosign')
 local x402_verify = require('pay_kit.protocols.x402.exact.verify')
 local tx_mod     = require('pay_kit.solana.transaction')
 local network_check = require('pay_kit.solana.network_check')
+local json        = require('pay_kit.util.json')
 
 local M = {}
 local Adapter = {}
@@ -63,6 +64,8 @@ local LEGACY_PAYMENT_RESPONSE_HEADER = 'x-payment-response'
 local DEFAULT_FIXTURE_SETTLEMENT_HEADER = 'x-payment-settlement-signature'
 local DEFAULT_MAX_TIMEOUT_SECONDS = 60
 local DEFAULT_DECIMALS = 6
+local DEFAULT_CONFIRMATION_ATTEMPTS = 40
+local DEFAULT_CONFIRMATION_DELAY_SECONDS = 0.25
 local TOKEN_PROGRAM_BASE58 = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 
 local CAIP2_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
@@ -370,6 +373,39 @@ local function consume_signature(store, signature)
   return true
 end
 
+local function sleep_seconds(seconds)
+  local ngx_global = rawget(_G, 'ngx')
+  if ngx_global and type(ngx_global.sleep) == 'function' then
+    return ngx_global.sleep(seconds)
+  end
+  local ok, socket = pcall(require, 'socket')
+  if ok and socket and type(socket.sleep) == 'function' then
+    return socket.sleep(seconds)
+  end
+  local deadline = os.clock() + seconds
+  while os.clock() < deadline do end
+end
+
+local function await_confirmation(rpc, signature)
+  for attempt = 1, DEFAULT_CONFIRMATION_ATTEMPTS do
+    local statuses = rpc:signature_statuses({signature})
+    local status = statuses and statuses[1]
+    if type(status) == 'table' then
+      if status.err ~= nil and status.err ~= json.null then
+        return nil, 'transaction failed on-chain: ' .. tostring(status.err)
+      end
+      if status.confirmationStatus == 'confirmed' or
+         status.confirmationStatus == 'finalized' then
+        return true
+      end
+    end
+    if attempt < DEFAULT_CONFIRMATION_ATTEMPTS then
+      sleep_seconds(DEFAULT_CONFIRMATION_DELAY_SECONDS)
+    end
+  end
+  return nil, 'timed out waiting for transaction confirmation'
+end
+
 -- --- public API -----------------------------------------------------
 
 function M.new(opts)
@@ -581,6 +617,14 @@ function Adapter:verify_and_settle(gate, req)
     return nil, errors.SIGNATURE_CONSUMED
   end
 
+  local call_ok, confirmed, confirm_err = pcall(await_confirmation, rpc, signature)
+  if not call_ok then
+    return nil, errors.INVALID_PROOF .. ': confirmation failed: ' .. tostring(confirmed)
+  end
+  if not confirmed then
+    return nil, errors.INVALID_PROOF .. ': confirmation failed: ' .. tostring(confirm_err)
+  end
+
   -- Settlement response. v1 emits X-PAYMENT-RESPONSE carrying the plain SVM
   -- network slug and the payer pubkey (rust v1 settlement shape
   -- { success, transaction, network, payer }); v2 emits PAYMENT-RESPONSE
@@ -630,6 +674,7 @@ M._private = {
   PAYMENT_IDENTIFIER_KEY       = PAYMENT_IDENTIFIER_KEY,
   caip2_network_for_cluster    = caip2_network_for_cluster,
   legacy_network_slug          = legacy_network_slug,
+  await_confirmation           = await_confirmation,
   LEGACY_PAYMENT_HEADER          = LEGACY_PAYMENT_HEADER,
   LEGACY_PAYMENT_RESPONSE_HEADER = LEGACY_PAYMENT_RESPONSE_HEADER,
 }

--- a/lua/pay_kit/protocols/x402/init.lua
+++ b/lua/pay_kit/protocols/x402/init.lua
@@ -364,13 +364,27 @@ local function build_rpc(config)
   return rpc_mod.new({url = config.rpc_url, transport = rpc_transport.new()})
 end
 
-local function consume_signature(store, signature)
-  if not store then return true end
-  local key = 'x402-svm-exact:consumed:' .. signature
-  if store.put_if_absent then
-    return store:put_if_absent(key)
+local function claim_signature(store, signature)
+  if not store or not store.put_if_absent then return 'claimed' end
+  local prefix = 'x402-svm-exact:' .. signature
+  if store:get(prefix .. ':confirmed') then return 'confirmed' end
+
+  -- A short lease prevents concurrent requests from both returning success,
+  -- while allowing a later request to recover after a crashed or timed-out
+  -- confirmation attempt. The durable consumed marker still records that the
+  -- transaction has been broadcast.
+  if store:put_if_absent(prefix .. ':pending', 15) then
+    store:put_if_absent(prefix .. ':consumed')
+    return 'claimed'
   end
-  return true
+  return 'pending'
+end
+
+local function confirm_signature(store, signature)
+  if not store or not store.put_if_absent then return end
+  local prefix = 'x402-svm-exact:' .. signature
+  store:put_if_absent(prefix .. ':confirmed')
+  store:delete(prefix .. ':pending')
 end
 
 local function sleep_seconds(seconds)
@@ -613,16 +627,20 @@ function Adapter:verify_and_settle(gate, req)
     return nil, errors.INVALID_PROOF .. ': empty broadcast result'
   end
 
-  if not consume_signature(self._store, signature) then
-    return nil, errors.SIGNATURE_CONSUMED
+  local replay_state = claim_signature(self._store, signature)
+  if replay_state == 'pending' then
+    return nil, errors.SIGNATURE_CONSUMED .. ': settlement confirmation is pending'
   end
 
-  local call_ok, confirmed, confirm_err = pcall(await_confirmation, rpc, signature)
-  if not call_ok then
-    return nil, errors.INVALID_PROOF .. ': confirmation failed: ' .. tostring(confirmed)
-  end
-  if not confirmed then
-    return nil, errors.INVALID_PROOF .. ': confirmation failed: ' .. tostring(confirm_err)
+  if replay_state ~= 'confirmed' then
+    local call_ok, confirmed, confirm_err = pcall(await_confirmation, rpc, signature)
+    if not call_ok then
+      return nil, errors.INVALID_PROOF .. ': confirmation failed: ' .. tostring(confirmed)
+    end
+    if not confirmed then
+      return nil, errors.INVALID_PROOF .. ': confirmation failed: ' .. tostring(confirm_err)
+    end
+    confirm_signature(self._store, signature)
   end
 
   -- Settlement response. v1 emits X-PAYMENT-RESPONSE carrying the plain SVM

--- a/lua/tests/pay_kit/x402_broadcast_spec.lua
+++ b/lua/tests/pay_kit/x402_broadcast_spec.lua
@@ -42,7 +42,9 @@ package.loaded['pay_kit.solana.rpc'] = {
       end,
       latest_blockhash    = function() return string.rep('0', 32) end,
       simulate_transaction = function() return {err = nil} end,
-      signature_statuses   = function() return {} end,
+      signature_statuses   = function()
+        return {{confirmationStatus = 'confirmed'}}
+      end,
     }
   end,
   Rpc                = {},
@@ -206,8 +208,22 @@ helper.test('x402 verify_and_settle: SIGNATURE_CONSUMED on duplicate submit', fu
         send_raw_transaction = function() return 'fakeSignatureBase58' end,
         latest_blockhash    = function() return string.rep('0', 32) end,
         simulate_transaction = function() return {err = nil} end,
+        signature_statuses = function()
+          return {{confirmationStatus = 'confirmed', err = cjson.null}}
+        end,
       }
     end,
   }
   helper.assert_true(true)  -- exercise the require path
+end)
+
+helper.test('x402 verify_and_settle: rejects a failed on-chain transaction', function()
+  local confirmed, err = require('pay_kit.protocols.x402')._private.await_confirmation({
+    signature_statuses = function()
+      return {{confirmationStatus = 'confirmed', err = {InstructionError = {0, 'Custom'}}}}
+    end,
+  }, 'failedSignatureBase58')
+
+  helper.assert_true(confirmed == nil)
+  helper.assert_true(tostring(err):match('transaction failed on%-chain') ~= nil)
 end)

--- a/lua/tests/pay_kit/x402_broadcast_spec.lua
+++ b/lua/tests/pay_kit/x402_broadcast_spec.lua
@@ -195,11 +195,22 @@ helper.test('x402 verify_and_settle: cosigns + broadcasts + reserves signature',
   helper.assert_equal(payment.scheme,   'exact')
   helper.assert_equal(payment.transaction, 'fakeSignatureBase58')
   helper.assert_equal(#broadcast_calls, 1)
+
+  local recovered, retry_err = pay_kit.try_payment('paid-resource', {
+    method = 'GET',
+    path   = '/paid-resource',
+    headers = {['payment-signature'] = cred_b64},
+    query  = {},
+  })
+  helper.assert_true(recovered ~= nil,
+    'expected an identical retry to recover settlement; err=' .. tostring(retry_err))
+  helper.assert_equal(recovered.transaction, 'fakeSignatureBase58')
+  helper.assert_equal(#broadcast_calls, 2)
 end)
 
-helper.test('x402 verify_and_settle: SIGNATURE_CONSUMED on duplicate submit', function()
-  -- Re-using the same credential should trip the replay store via
-  -- consume_signature returning false.
+helper.test('x402 verify_and_settle: duplicate proof uses recovery path', function()
+  -- Duplicate proofs are confirmed again and reconstruct the same receipt;
+  -- this test keeps the isolated module-reset path covered.
   pay_kit._reset_for_tests()
   -- Re-install the same stub since reset clears the dispatcher.
   package.loaded['pay_kit.solana.rpc'] = {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solana-pay-kit"
-version = "0.7.0"
+version = "0.8.0"
 description = "Building blocks for Agentic payments (x402, MPP, AP2)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/src/solana_pay_kit/protocols/x402/__init__.py
+++ b/python/src/solana_pay_kit/protocols/x402/__init__.py
@@ -16,7 +16,9 @@ facilitator URL is configured. Self-hosted is the only x402 path that ships.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -61,6 +63,7 @@ _RESPONSE_HEADER = "payment-response"
 # X402_V1_PAYMENT_RESPONSE_HEADER, constants.rs:22).
 _RESPONSE_HEADER_LEGACY = "x-payment-response"
 _REPLAY_PREFIX = "x402-svm-exact:consumed:"
+_PENDING_LEASE_SECONDS = 60
 
 
 class X402Adapter:
@@ -230,13 +233,47 @@ class X402Adapter:
             if not signature:
                 raise InvalidProofError("solana_pay_kit: empty broadcast result", code="payment_invalid")
 
-            # Replay reservation. Namespace is distinct from the MPP charge key
-            # so an x402 signature can never satisfy an MPP route and vice
-            # versa. Reserve BEFORE confirmation so a concurrent resubmit of the
-            # same signature loses the race and is rejected as consumed.
+            # Replay reservation. Bind the signature to the exact cosigned wire
+            # and distinguish pending from confirmed settlement. A deterministic
+            # recovery key lets exactly one retry take over an expired lease,
+            # even when the store only exposes atomic put-if-absent.
             replay_key = _REPLAY_PREFIX + signature
-            if not await self._store.put_if_absent(replay_key, True):
-                raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+            binding = hashlib.sha256(cosigned_wire).hexdigest()
+            now = time.time()
+            replay_record = {
+                "binding": binding,
+                "leaseUntil": now + _PENDING_LEASE_SECONDS,
+                "state": "pending",
+            }
+            inserted = await self._store.put_if_absent(replay_key, replay_record)
+            skip_confirmation = False
+            if not inserted:
+                current = await self._store.get(replay_key)
+                if not isinstance(current, dict):
+                    raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+                current_record = cast("dict[str, object]", current)
+                if current_record.get("binding") != binding:
+                    raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+                if current_record.get("state") == "confirmed":
+                    skip_confirmation = True
+                elif current_record.get("state") == "pending" and isinstance(
+                    current_record.get("leaseUntil"), int | float
+                ):
+                    lease_until = float(cast("int | float", current_record["leaseUntil"]))
+                    if lease_until > now:
+                        raise InvalidProofError(
+                            "solana_pay_kit: signature_consumed: settlement confirmation is pending",
+                            code="signature_consumed",
+                        )
+                    recovery_key = f"{replay_key}:recovery:{lease_until}"
+                    if not await self._store.put_if_absent(recovery_key, True):
+                        raise InvalidProofError(
+                            "solana_pay_kit: signature_consumed: settlement recovery is in progress",
+                            code="signature_consumed",
+                        )
+                    await self._store.put(replay_key, replay_record)
+                else:
+                    raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
 
             # Await on-chain confirmation BEFORE returning success. Without this
             # the adapter returned a settlement header for a transaction that
@@ -245,18 +282,21 @@ class X402Adapter:
             # ``transaction-failed`` (included but reverted) or
             # ``transaction-not-found`` (never confirmed inside the window).
             #
-            # Keep the reservation after broadcast even when confirmation
-            # fails. A timeout or transport error is ambiguous: the transaction
-            # may still land after this request returns. Releasing the key here
-            # would let the same signed payment race a later request and produce
-            # multiple fulfillments. This mirrors the durable post-broadcast
-            # reservation in the MPP charge flow.
-            try:
-                await rpc.await_confirmation(signature)
-            except Exception as exc:  # noqa: BLE001
-                raise InvalidProofError(
-                    f"solana_pay_kit: invalid proof: confirmation failed: {exc}", code="payment_invalid"
-                ) from exc
+            if not skip_confirmation:
+                try:
+                    await rpc.await_confirmation(signature)
+                    await self._store.put(
+                        replay_key,
+                        {"binding": binding, "leaseUntil": replay_record["leaseUntil"], "state": "confirmed"},
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    # Keep the pending lease after an ambiguous failure. A retry
+                    # can atomically take over after expiry and determine whether
+                    # the transaction landed, without permitting two concurrent
+                    # requests to return successful fulfillment.
+                    raise InvalidProofError(
+                        f"solana_pay_kit: invalid proof: confirmation failed: {exc}", code="payment_invalid"
+                    ) from exc
         finally:
             await rpc.aclose()
 

--- a/python/src/solana_pay_kit/protocols/x402/__init__.py
+++ b/python/src/solana_pay_kit/protocols/x402/__init__.py
@@ -245,14 +245,15 @@ class X402Adapter:
             # ``transaction-failed`` (included but reverted) or
             # ``transaction-not-found`` (never confirmed inside the window).
             #
-            # On failure roll the reservation back: the transaction did not
-            # land, so the same signature must remain replayable for an honest
-            # retry. Mirrors the confirmation gate the MPP charge flow runs
-            # (protocols/mpp/server/charge.py).
+            # Keep the reservation after broadcast even when confirmation
+            # fails. A timeout or transport error is ambiguous: the transaction
+            # may still land after this request returns. Releasing the key here
+            # would let the same signed payment race a later request and produce
+            # multiple fulfillments. This mirrors the durable post-broadcast
+            # reservation in the MPP charge flow.
             try:
                 await rpc.await_confirmation(signature)
             except Exception as exc:  # noqa: BLE001
-                await self._store.delete(replay_key)
                 raise InvalidProofError(
                     f"solana_pay_kit: invalid proof: confirmation failed: {exc}", code="payment_invalid"
                 ) from exc

--- a/python/src/solana_pay_kit/protocols/x402/__init__.py
+++ b/python/src/solana_pay_kit/protocols/x402/__init__.py
@@ -63,7 +63,11 @@ _RESPONSE_HEADER = "payment-response"
 # X402_V1_PAYMENT_RESPONSE_HEADER, constants.rs:22).
 _RESPONSE_HEADER_LEGACY = "x-payment-response"
 _REPLAY_PREFIX = "x402-svm-exact:consumed:"
-_PENDING_LEASE_SECONDS = 60
+# `SolanaRpc.await_confirmation` performs at most 40 requests, each with the
+# client's 30-second timeout, plus polling delays. Keep the recovery lease past
+# that complete worst-case window so a takeover cannot overlap the original
+# confirmation coroutine.
+_PENDING_LEASE_SECONDS = 21 * 60
 
 
 class X402Adapter:
@@ -271,7 +275,24 @@ class X402Adapter:
                             "solana_pay_kit: signature_consumed: settlement recovery is in progress",
                             code="signature_consumed",
                         )
-                    await self._store.put(replay_key, replay_record)
+                    # The original request may have confirmed between the first
+                    # read and our recovery claim. Re-read before replacing a
+                    # pending record so confirmed state can never regress.
+                    latest = await self._store.get(replay_key)
+                    if not isinstance(latest, dict):
+                        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+                    latest_record = cast("dict[str, object]", latest)
+                    if latest_record.get("binding") != binding:
+                        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+                    if latest_record.get("state") == "confirmed":
+                        skip_confirmation = True
+                    elif latest_record.get("state") == "pending" and latest_record.get("leaseUntil") == lease_until:
+                        await self._store.put(replay_key, replay_record)
+                    else:
+                        raise InvalidProofError(
+                            "solana_pay_kit: signature_consumed: settlement recovery state changed",
+                            code="signature_consumed",
+                        )
                 else:
                     raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
 

--- a/python/src/solana_pay_kit/protocols/x402/__init__.py
+++ b/python/src/solana_pay_kit/protocols/x402/__init__.py
@@ -224,77 +224,44 @@ class X402Adapter:
 
         # Cosign as the facilitator fee payer (slot-splice, version aware).
         cosigned_wire = _co_sign(tx_base64, signer)
+        signature = _transaction_signature(cosigned_wire)
+        replay_key = _REPLAY_PREFIX + signature
+        binding = hashlib.sha256(cosigned_wire).hexdigest()
+        now = time.time()
+        replay_record: dict[str, object] = {
+            "binding": binding,
+            "leaseUntil": now + _PENDING_LEASE_SECONDS,
+            "state": "pending",
+        }
 
-        rpc = SolanaRpc(rpc_url)
+        current = await self._store.get(replay_key)
+        should_broadcast = current is None
+        skip_confirmation = False
+        if current is not None:
+            skip_confirmation = await _recover_replay_record(
+                self._store, replay_key, binding, replay_record, current, now
+            )
+
+        rpc: SolanaRpc | None = None
         try:
-            try:
-                response = await rpc.send_raw_transaction(cosigned_wire)
-                signature = str(response.value if hasattr(response, "value") else response)
-            except Exception as exc:  # noqa: BLE001
-                raise InvalidProofError(
-                    f"solana_pay_kit: invalid proof: broadcast failed: {exc}", code="payment_invalid"
-                ) from exc
-            if not signature:
-                raise InvalidProofError("solana_pay_kit: empty broadcast result", code="payment_invalid")
+            if should_broadcast:
+                rpc = SolanaRpc(rpc_url)
+                try:
+                    response = await rpc.send_raw_transaction(cosigned_wire)
+                    broadcast_signature = str(response.value if hasattr(response, "value") else response)
+                except Exception as exc:  # noqa: BLE001
+                    raise InvalidProofError(
+                        f"solana_pay_kit: invalid proof: broadcast failed: {exc}", code="payment_invalid"
+                    ) from exc
+                if not broadcast_signature:
+                    raise InvalidProofError("solana_pay_kit: empty broadcast result", code="payment_invalid")
 
-            # Replay reservation. Bind the signature to the exact cosigned wire
-            # and distinguish pending from confirmed settlement. A deterministic
-            # recovery key lets exactly one retry take over an expired lease,
-            # even when the store only exposes atomic put-if-absent.
-            replay_key = _REPLAY_PREFIX + signature
-            binding = hashlib.sha256(cosigned_wire).hexdigest()
-            now = time.time()
-            replay_record = {
-                "binding": binding,
-                "leaseUntil": now + _PENDING_LEASE_SECONDS,
-                "state": "pending",
-            }
-            inserted = await self._store.put_if_absent(replay_key, replay_record)
-            skip_confirmation = False
-            if not inserted:
-                current = await self._store.get(replay_key)
-                if not isinstance(current, dict):
-                    raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
-                current_record = cast("dict[str, object]", current)
-                if current_record.get("binding") != binding:
-                    raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
-                if current_record.get("state") == "confirmed":
-                    skip_confirmation = True
-                elif current_record.get("state") == "pending" and isinstance(
-                    current_record.get("leaseUntil"), int | float
-                ):
-                    lease_until = float(cast("int | float", current_record["leaseUntil"]))
-                    if lease_until > now:
-                        raise InvalidProofError(
-                            "solana_pay_kit: signature_consumed: settlement confirmation is pending",
-                            code="signature_consumed",
-                        )
-                    recovery_key = f"{replay_key}:recovery:{lease_until}"
-                    if not await self._store.put_if_absent(recovery_key, True):
-                        raise InvalidProofError(
-                            "solana_pay_kit: signature_consumed: settlement recovery is in progress",
-                            code="signature_consumed",
-                        )
-                    # The original request may have confirmed between the first
-                    # read and our recovery claim. Re-read before replacing a
-                    # pending record so confirmed state can never regress.
-                    latest = await self._store.get(replay_key)
-                    if not isinstance(latest, dict):
-                        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
-                    latest_record = cast("dict[str, object]", latest)
-                    if latest_record.get("binding") != binding:
-                        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
-                    if latest_record.get("state") == "confirmed":
-                        skip_confirmation = True
-                    elif latest_record.get("state") == "pending" and latest_record.get("leaseUntil") == lease_until:
-                        await self._store.put(replay_key, replay_record)
-                    else:
-                        raise InvalidProofError(
-                            "solana_pay_kit: signature_consumed: settlement recovery state changed",
-                            code="signature_consumed",
-                        )
-                else:
-                    raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+                inserted = await self._store.put_if_absent(replay_key, replay_record)
+                if not inserted:
+                    current = await self._store.get(replay_key)
+                    skip_confirmation = await _recover_replay_record(
+                        self._store, replay_key, binding, replay_record, current, now
+                    )
 
             # Await on-chain confirmation BEFORE returning success. Without this
             # the adapter returned a settlement header for a transaction that
@@ -304,6 +271,8 @@ class X402Adapter:
             # ``transaction-not-found`` (never confirmed inside the window).
             #
             if not skip_confirmation:
+                if rpc is None:
+                    rpc = SolanaRpc(rpc_url)
                 try:
                     await rpc.await_confirmation(signature)
                     await self._store.put(
@@ -319,7 +288,8 @@ class X402Adapter:
                         f"solana_pay_kit: invalid proof: confirmation failed: {exc}", code="payment_invalid"
                     ) from exc
         finally:
-            await rpc.aclose()
+            if rpc is not None:
+                await rpc.aclose()
 
         accepted_network = accepted.get("network")
         response_body: X402ResponseEnvelope = {
@@ -520,6 +490,79 @@ def _co_sign(transaction_b64: str, signer: Any) -> bytes:
     sig_start = 1 + idx * 64
     serialized[sig_start : sig_start + 64] = sig_bytes
     return bytes(serialized)
+
+
+def _transaction_signature(transaction_wire: bytes) -> str:
+    """Return the deterministic first signature from a signed wire transaction."""
+    from solders.transaction import Transaction, VersionedTransaction
+
+    from solana_pay_kit._paycore.transaction import is_v0_wire_bytes
+
+    try:
+        if is_v0_wire_bytes(transaction_wire):
+            signatures = VersionedTransaction.from_bytes(transaction_wire).signatures
+        else:
+            try:
+                signatures = Transaction.from_bytes(transaction_wire).signatures
+            except Exception:  # noqa: BLE001 - accept other solders versioned variants
+                signatures = VersionedTransaction.from_bytes(transaction_wire).signatures
+    except Exception as exc:  # noqa: BLE001
+        raise InvalidProofError(
+            "invalid_exact_svm_payload_transaction_parse",
+            code="invalid_exact_svm_payload_transaction_parse",
+        ) from exc
+    if not signatures:
+        raise InvalidProofError("solana_pay_kit: transaction has no signature", code="payment_invalid")
+    return str(signatures[0])
+
+
+async def _recover_replay_record(
+    store: Store,
+    replay_key: str,
+    binding: str,
+    replay_record: dict[str, object],
+    current: object,
+    now: float,
+) -> bool:
+    """Claim an expired settlement for confirmation, or return a confirmed replay."""
+    if not isinstance(current, dict):
+        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+    current_record = cast("dict[str, object]", current)
+    if current_record.get("binding") != binding:
+        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+    if current_record.get("state") == "confirmed":
+        return True
+    if current_record.get("state") != "pending" or not isinstance(current_record.get("leaseUntil"), int | float):
+        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+
+    lease_until = float(cast("int | float", current_record["leaseUntil"]))
+    if lease_until > now:
+        raise InvalidProofError(
+            "solana_pay_kit: signature_consumed: settlement confirmation is pending",
+            code="signature_consumed",
+        )
+    recovery_key = f"{replay_key}:recovery:{lease_until}"
+    if not await store.put_if_absent(recovery_key, True):
+        raise InvalidProofError(
+            "solana_pay_kit: signature_consumed: settlement recovery is in progress",
+            code="signature_consumed",
+        )
+
+    latest = await store.get(replay_key)
+    if not isinstance(latest, dict):
+        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+    latest_record = cast("dict[str, object]", latest)
+    if latest_record.get("binding") != binding:
+        raise InvalidProofError("solana_pay_kit: signature_consumed", code="signature_consumed")
+    if latest_record.get("state") == "confirmed":
+        return True
+    if latest_record.get("state") == "pending" and latest_record.get("leaseUntil") == lease_until:
+        await store.put(replay_key, replay_record)
+        return False
+    raise InvalidProofError(
+        "solana_pay_kit: signature_consumed: settlement recovery state changed",
+        code="signature_consumed",
+    )
 
 
 def _recent_blockhash_of(transaction_b64: str) -> str | None:

--- a/python/tests/test_pk_x402_client.py
+++ b/python/tests/test_pk_x402_client.py
@@ -764,7 +764,7 @@ async def test_transport_402_then_pay_then_200(monkeypatch):
 
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
-    assert resp.headers["x-fixture-settlement"] == "SIG-client-harness"
+    assert resp.headers["x-fixture-settlement"] == resp.json()["transaction"]
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_pk_x402_legacy.py
+++ b/python/tests/test_pk_x402_legacy.py
@@ -323,12 +323,13 @@ async def test_server_accepts_legacy_x_payment_header(monkeypatch):
     header = _legacy_envelope(adapter, gate, op_kp)
     payment = await adapter.verify_and_settle(gate, _LegacyReq(header))
     assert payment.protocol is Protocol.X402
-    assert payment.transaction == "SIG-legacy-ok"
+    assert payment.transaction
     # A v1 credential gets the legacy X-PAYMENT-RESPONSE receipt header, NOT the
     # v2 payment-response (rust X402_V1_PAYMENT_RESPONSE_HEADER, constants.rs:22).
     assert "payment-response" not in payment.settlement_headers
     resp = json.loads(base64.b64decode(payment.settlement_headers["x-payment-response"]))
     assert resp["network"] == SOLANA_DEVNET_CAIP2
+    assert resp["transaction"] == payment.transaction
 
 
 @pytest.mark.asyncio
@@ -338,7 +339,7 @@ async def test_server_accepts_legacy_header_from_dict_request(monkeypatch):
     header = _legacy_envelope(adapter, gate, op_kp)
     req = {"path": "/report", "headers": {"X-Payment": header}}
     payment = await adapter.verify_and_settle(gate, req)
-    assert payment.transaction == "SIG-dict"
+    assert payment.transaction
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_pk_x402_settle.py
+++ b/python/tests/test_pk_x402_settle.py
@@ -220,7 +220,7 @@ async def test_success_path_awaits_confirmation_before_returning(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_confirmation_timeout_raises_and_does_not_return_success(monkeypatch):
+async def test_confirmation_timeout_raises_and_keeps_replay_reservation(monkeypatch):
     from solana_pay_kit._paycore.errors import PaymentError
 
     store = MemoryStore()
@@ -235,12 +235,18 @@ async def test_confirmation_timeout_raises_and_does_not_return_success(monkeypat
         await adapter.verify_and_settle(gate, _Req(header))
     assert exc.value.code == "payment_invalid"
     assert "confirmation failed" in str(exc.value)
-    # Reservation must be rolled back so an honest retry can replay.
-    assert await store.get("x402-svm-exact:consumed:SIG-timeout") is None
+    # Broadcast was accepted, so a timeout is ambiguous: the transaction may
+    # still land. Keep the reservation to prevent a later duplicate fulfillment.
+    assert await store.get("x402-svm-exact:consumed:SIG-timeout") is True
+
+    retry = _build_envelope(adapter, gate, op_kp)
+    with pytest.raises(InvalidProofError) as retry_exc:
+        await adapter.verify_and_settle(gate, _Req(retry))
+    assert retry_exc.value.code == "signature_consumed"
 
 
 @pytest.mark.asyncio
-async def test_confirmation_onchain_failure_rolls_back_reservation(monkeypatch):
+async def test_confirmation_onchain_failure_keeps_replay_reservation(monkeypatch):
     from solana_pay_kit._paycore.errors import PaymentError
 
     store = MemoryStore()
@@ -253,7 +259,7 @@ async def test_confirmation_onchain_failure_rolls_back_reservation(monkeypatch):
     header = _build_envelope(adapter, gate, op_kp)
     with pytest.raises(InvalidProofError):
         await adapter.verify_and_settle(gate, _Req(header))
-    assert await store.get("x402-svm-exact:consumed:SIG-revert") is None
+    assert await store.get("x402-svm-exact:consumed:SIG-revert") is True
 
 
 # -- sub-microunit price truncation (149-2) ----------------------------------

--- a/python/tests/test_pk_x402_settle.py
+++ b/python/tests/test_pk_x402_settle.py
@@ -184,12 +184,23 @@ async def test_verify_and_settle_happy_path(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_replay_same_signature_rejected(monkeypatch):
+async def test_replay_same_transaction_recovers_confirmed_settlement(monkeypatch):
+    store = MemoryStore()
+    rpcs: list = []
+    adapter, gate, op_kp = _adapter(store=store, signature="SIG-dupe", monkeypatch=monkeypatch, rpcs=rpcs)
+    header = _build_envelope(adapter, gate, op_kp)
+    first = await adapter.verify_and_settle(gate, _Req(header))
+    recovered = await adapter.verify_and_settle(gate, _Req(header))
+    assert recovered.transaction == first.transaction
+    assert rpcs[0].confirm_calls == 1
+    assert rpcs[1].confirm_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_replay_same_signature_with_different_transaction_rejected(monkeypatch):
     store = MemoryStore()
     adapter, gate, op_kp = _adapter(store=store, signature="SIG-dupe", monkeypatch=monkeypatch)
-    header = _build_envelope(adapter, gate, op_kp)
-    await adapter.verify_and_settle(gate, _Req(header))
-    # Second submit of a credential that broadcasts the same signature: consumed.
+    await adapter.verify_and_settle(gate, _Req(_build_envelope(adapter, gate, op_kp)))
     header2 = _build_envelope(adapter, gate, op_kp)
     with pytest.raises(InvalidProofError) as exc:
         await adapter.verify_and_settle(gate, _Req(header2))
@@ -224,6 +235,8 @@ async def test_confirmation_timeout_raises_and_keeps_replay_reservation(monkeypa
     from solana_pay_kit._paycore.errors import PaymentError
 
     store = MemoryStore()
+    now = [1_000.0]
+    monkeypatch.setattr(xmod.time, "time", lambda: now[0])
     adapter, gate, op_kp = _adapter(
         store=store,
         signature="SIG-timeout",
@@ -237,12 +250,30 @@ async def test_confirmation_timeout_raises_and_keeps_replay_reservation(monkeypa
     assert "confirmation failed" in str(exc.value)
     # Broadcast was accepted, so a timeout is ambiguous: the transaction may
     # still land. Keep the reservation to prevent a later duplicate fulfillment.
-    assert await store.get("x402-svm-exact:consumed:SIG-timeout") is True
+    record = await store.get("x402-svm-exact:consumed:SIG-timeout")
+    assert isinstance(record, dict)
+    assert record["state"] == "pending"
 
     retry = _build_envelope(adapter, gate, op_kp)
     with pytest.raises(InvalidProofError) as retry_exc:
         await adapter.verify_and_settle(gate, _Req(retry))
     assert retry_exc.value.code == "signature_consumed"
+
+    now[0] += 61
+    recovered_rpcs: list = []
+
+    def _recovery_factory(*_a, **_k):
+        rpc = _FakeRpc(signature="SIG-timeout")
+        recovered_rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr(xmod, "SolanaRpc", _recovery_factory)
+    payment = await adapter.verify_and_settle(gate, _Req(header))
+    assert payment.transaction == "SIG-timeout"
+    assert recovered_rpcs[0].confirm_calls == 1
+    confirmed_record = await store.get("x402-svm-exact:consumed:SIG-timeout")
+    assert isinstance(confirmed_record, dict)
+    assert confirmed_record["state"] == "confirmed"
 
 
 @pytest.mark.asyncio
@@ -259,7 +290,9 @@ async def test_confirmation_onchain_failure_keeps_replay_reservation(monkeypatch
     header = _build_envelope(adapter, gate, op_kp)
     with pytest.raises(InvalidProofError):
         await adapter.verify_and_settle(gate, _Req(header))
-    assert await store.get("x402-svm-exact:consumed:SIG-revert") is True
+    record = await store.get("x402-svm-exact:consumed:SIG-revert")
+    assert isinstance(record, dict)
+    assert record["state"] == "pending"
 
 
 # -- sub-microunit price truncation (149-2) ----------------------------------

--- a/python/tests/test_pk_x402_settle.py
+++ b/python/tests/test_pk_x402_settle.py
@@ -92,6 +92,21 @@ class _FakeRpc:
         return None
 
 
+class _ConfirmDuringRecoveryStore(MemoryStore):
+    """Simulate the original request confirming as a retry claims recovery."""
+
+    confirm_during_recovery = False
+
+    async def put_if_absent(self, key, value):
+        inserted = await super().put_if_absent(key, value)
+        if inserted and self.confirm_during_recovery and ":recovery:" in key:
+            replay_key = key.split(":recovery:", 1)[0]
+            current = await self.get(replay_key)
+            assert isinstance(current, dict)
+            await self.put(replay_key, {**current, "state": "confirmed"})
+        return inserted
+
+
 @pytest.fixture(autouse=True)
 def _clean(monkeypatch):
     reset()
@@ -259,7 +274,7 @@ async def test_confirmation_timeout_raises_and_keeps_replay_reservation(monkeypa
         await adapter.verify_and_settle(gate, _Req(retry))
     assert retry_exc.value.code == "signature_consumed"
 
-    now[0] += 61
+    now[0] += 21 * 60 + 1
     recovered_rpcs: list = []
 
     def _recovery_factory(*_a, **_k):
@@ -274,6 +289,41 @@ async def test_confirmation_timeout_raises_and_keeps_replay_reservation(monkeypa
     confirmed_record = await store.get("x402-svm-exact:consumed:SIG-timeout")
     assert isinstance(confirmed_record, dict)
     assert confirmed_record["state"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_replace_concurrently_confirmed_state(monkeypatch):
+    from solana_pay_kit._paycore.errors import PaymentError
+
+    now = [1_000.0]
+    monkeypatch.setattr(xmod.time, "time", lambda: now[0])
+    store = _ConfirmDuringRecoveryStore()
+    adapter, gate, op_kp = _adapter(
+        store=store,
+        signature="SIG-confirm-race",
+        confirm_error=PaymentError("timed out", code="transaction-not-found"),
+        monkeypatch=monkeypatch,
+    )
+    header = _build_envelope(adapter, gate, op_kp)
+    with pytest.raises(InvalidProofError):
+        await adapter.verify_and_settle(gate, _Req(header))
+
+    now[0] += 21 * 60 + 1
+    store.confirm_during_recovery = True
+    recovery_rpcs: list = []
+
+    def _recovery_factory(*_a, **_k):
+        rpc = _FakeRpc(signature="SIG-confirm-race")
+        recovery_rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr(xmod, "SolanaRpc", _recovery_factory)
+    payment = await adapter.verify_and_settle(gate, _Req(header))
+    assert payment.transaction == "SIG-confirm-race"
+    assert recovery_rpcs[0].confirm_calls == 0
+    record = await store.get("x402-svm-exact:consumed:SIG-confirm-race")
+    assert isinstance(record, dict)
+    assert record["state"] == "confirmed"
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_pk_x402_settle.py
+++ b/python/tests/test_pk_x402_settle.py
@@ -41,6 +41,7 @@ from solana_pay_kit.protocols.x402 import (
     _co_sign,
     _is_loopback_rpc,
     _request_path,
+    _transaction_signature,
 )
 from solana_pay_kit.protocols.x402.exact.verify import (
     COMPUTE_BUDGET_PROGRAM,
@@ -60,25 +61,25 @@ class _FakeRpc:
     def __init__(
         self,
         *_a,
-        signature: str = "SIG-broadcast",
         fail: bool = False,
         confirm_error: Exception | None = None,
         **_k,
     ):
-        self._signature = signature
         self._fail = fail
         self._confirm_error = confirm_error
         self.confirm_calls = 0
+        self.send_calls = 0
         self.aclose_calls = 0
 
     async def send_raw_transaction(self, _raw):
+        self.send_calls += 1
         if self._fail:
             raise RuntimeError("broadcast boom")
 
         class _Resp:
-            value = self._signature  # type: ignore[assignment]
+            value = ""
 
-        _Resp.value = self._signature
+        _Resp.value = _transaction_signature(bytes(_raw))
         return _Resp()
 
     async def await_confirmation(self, _signature, *_a, **_k):
@@ -115,7 +116,7 @@ def _clean(monkeypatch):
     reset()
 
 
-def _adapter(store=None, signature="SIG-broadcast", fail=False, confirm_error=None, monkeypatch=None, rpcs=None):
+def _adapter(store=None, fail=False, confirm_error=None, monkeypatch=None, rpcs=None):
     op_kp = Keypair()
     op = Operator(signer=LocalSigner.from_keypair(op_kp), recipient=str(Keypair().pubkey()))
     cfg = configure(
@@ -134,7 +135,7 @@ def _adapter(store=None, signature="SIG-broadcast", fail=False, confirm_error=No
     adapter = X402Adapter(cfg, replay_store=store or MemoryStore())
 
     def _factory(*_a, **_k):
-        rpc = _FakeRpc(signature=signature, fail=fail, confirm_error=confirm_error)
+        rpc = _FakeRpc(fail=fail, confirm_error=confirm_error)
         if rpcs is not None:
             rpcs.append(rpc)
         return rpc
@@ -178,6 +179,12 @@ def _build_envelope(adapter, gate, op_kp, *, amount_override=None, memo_override
     return base64.b64encode(json.dumps(envelope).encode()).decode()
 
 
+def _settlement_signature(header: str, op_kp: Keypair) -> str:
+    envelope = json.loads(base64.b64decode(header))
+    wire = _co_sign(envelope["payload"]["transaction"], LocalSigner.from_keypair(op_kp))
+    return _transaction_signature(wire)
+
+
 class _Req:
     def __init__(self, header, path="/report"):
         self.headers = {"payment-signature": header}
@@ -189,12 +196,13 @@ class _Req:
 
 @pytest.mark.asyncio
 async def test_verify_and_settle_happy_path(monkeypatch):
-    adapter, gate, op_kp = _adapter(signature="SIG-1", monkeypatch=monkeypatch)
+    adapter, gate, op_kp = _adapter(monkeypatch=monkeypatch)
     header = _build_envelope(adapter, gate, op_kp)
+    signature = _settlement_signature(header, op_kp)
     payment = await adapter.verify_and_settle(gate, _Req(header))
     assert payment.protocol is Protocol.X402
-    assert payment.transaction == "SIG-1"
-    assert payment.settlement_headers["x-payment-settlement-signature"] == "SIG-1"
+    assert payment.transaction == signature
+    assert payment.settlement_headers["x-payment-settlement-signature"] == signature
     assert "payment-response" in payment.settlement_headers
 
 
@@ -202,23 +210,28 @@ async def test_verify_and_settle_happy_path(monkeypatch):
 async def test_replay_same_transaction_recovers_confirmed_settlement(monkeypatch):
     store = MemoryStore()
     rpcs: list = []
-    adapter, gate, op_kp = _adapter(store=store, signature="SIG-dupe", monkeypatch=monkeypatch, rpcs=rpcs)
+    adapter, gate, op_kp = _adapter(store=store, monkeypatch=monkeypatch, rpcs=rpcs)
     header = _build_envelope(adapter, gate, op_kp)
     first = await adapter.verify_and_settle(gate, _Req(header))
     recovered = await adapter.verify_and_settle(gate, _Req(header))
     assert recovered.transaction == first.transaction
     assert rpcs[0].confirm_calls == 1
-    assert rpcs[1].confirm_calls == 0
+    assert rpcs[0].send_calls == 1
+    assert len(rpcs) == 1
 
 
 @pytest.mark.asyncio
 async def test_replay_same_signature_with_different_transaction_rejected(monkeypatch):
     store = MemoryStore()
-    adapter, gate, op_kp = _adapter(store=store, signature="SIG-dupe", monkeypatch=monkeypatch)
-    await adapter.verify_and_settle(gate, _Req(_build_envelope(adapter, gate, op_kp)))
-    header2 = _build_envelope(adapter, gate, op_kp)
+    adapter, gate, op_kp = _adapter(store=store, monkeypatch=monkeypatch)
+    header = _build_envelope(adapter, gate, op_kp)
+    signature = _settlement_signature(header, op_kp)
+    await store.put(
+        f"x402-svm-exact:consumed:{signature}",
+        {"binding": "different-wire", "leaseUntil": 0, "state": "confirmed"},
+    )
     with pytest.raises(InvalidProofError) as exc:
-        await adapter.verify_and_settle(gate, _Req(header2))
+        await adapter.verify_and_settle(gate, _Req(header))
     assert exc.value.code == "signature_consumed"
 
 
@@ -236,10 +249,11 @@ async def test_broadcast_failure_is_invalid_proof(monkeypatch):
 @pytest.mark.asyncio
 async def test_success_path_awaits_confirmation_before_returning(monkeypatch):
     rpcs: list = []
-    adapter, gate, op_kp = _adapter(signature="SIG-ok", monkeypatch=monkeypatch, rpcs=rpcs)
+    adapter, gate, op_kp = _adapter(monkeypatch=monkeypatch, rpcs=rpcs)
     header = _build_envelope(adapter, gate, op_kp)
+    signature = _settlement_signature(header, op_kp)
     payment = await adapter.verify_and_settle(gate, _Req(header))
-    assert payment.transaction == "SIG-ok"
+    assert payment.transaction == signature
     # The adapter must poll confirmation, then close the RPC after the poll.
     assert rpcs[0].confirm_calls == 1
     assert rpcs[0].aclose_calls == 1
@@ -254,39 +268,39 @@ async def test_confirmation_timeout_raises_and_keeps_replay_reservation(monkeypa
     monkeypatch.setattr(xmod.time, "time", lambda: now[0])
     adapter, gate, op_kp = _adapter(
         store=store,
-        signature="SIG-timeout",
         confirm_error=PaymentError("timed out", code="transaction-not-found"),
         monkeypatch=monkeypatch,
     )
     header = _build_envelope(adapter, gate, op_kp)
+    signature = _settlement_signature(header, op_kp)
     with pytest.raises(InvalidProofError) as exc:
         await adapter.verify_and_settle(gate, _Req(header))
     assert exc.value.code == "payment_invalid"
     assert "confirmation failed" in str(exc.value)
     # Broadcast was accepted, so a timeout is ambiguous: the transaction may
     # still land. Keep the reservation to prevent a later duplicate fulfillment.
-    record = await store.get("x402-svm-exact:consumed:SIG-timeout")
+    record = await store.get(f"x402-svm-exact:consumed:{signature}")
     assert isinstance(record, dict)
     assert record["state"] == "pending"
 
-    retry = _build_envelope(adapter, gate, op_kp)
     with pytest.raises(InvalidProofError) as retry_exc:
-        await adapter.verify_and_settle(gate, _Req(retry))
+        await adapter.verify_and_settle(gate, _Req(header))
     assert retry_exc.value.code == "signature_consumed"
 
     now[0] += 21 * 60 + 1
     recovered_rpcs: list = []
 
     def _recovery_factory(*_a, **_k):
-        rpc = _FakeRpc(signature="SIG-timeout")
+        rpc = _FakeRpc()
         recovered_rpcs.append(rpc)
         return rpc
 
     monkeypatch.setattr(xmod, "SolanaRpc", _recovery_factory)
     payment = await adapter.verify_and_settle(gate, _Req(header))
-    assert payment.transaction == "SIG-timeout"
+    assert payment.transaction == signature
     assert recovered_rpcs[0].confirm_calls == 1
-    confirmed_record = await store.get("x402-svm-exact:consumed:SIG-timeout")
+    assert recovered_rpcs[0].send_calls == 0
+    confirmed_record = await store.get(f"x402-svm-exact:consumed:{signature}")
     assert isinstance(confirmed_record, dict)
     assert confirmed_record["state"] == "confirmed"
 
@@ -300,11 +314,11 @@ async def test_recovery_does_not_replace_concurrently_confirmed_state(monkeypatc
     store = _ConfirmDuringRecoveryStore()
     adapter, gate, op_kp = _adapter(
         store=store,
-        signature="SIG-confirm-race",
         confirm_error=PaymentError("timed out", code="transaction-not-found"),
         monkeypatch=monkeypatch,
     )
     header = _build_envelope(adapter, gate, op_kp)
+    signature = _settlement_signature(header, op_kp)
     with pytest.raises(InvalidProofError):
         await adapter.verify_and_settle(gate, _Req(header))
 
@@ -313,15 +327,15 @@ async def test_recovery_does_not_replace_concurrently_confirmed_state(monkeypatc
     recovery_rpcs: list = []
 
     def _recovery_factory(*_a, **_k):
-        rpc = _FakeRpc(signature="SIG-confirm-race")
+        rpc = _FakeRpc()
         recovery_rpcs.append(rpc)
         return rpc
 
     monkeypatch.setattr(xmod, "SolanaRpc", _recovery_factory)
     payment = await adapter.verify_and_settle(gate, _Req(header))
-    assert payment.transaction == "SIG-confirm-race"
-    assert recovery_rpcs[0].confirm_calls == 0
-    record = await store.get("x402-svm-exact:consumed:SIG-confirm-race")
+    assert payment.transaction == signature
+    assert recovery_rpcs == []
+    record = await store.get(f"x402-svm-exact:consumed:{signature}")
     assert isinstance(record, dict)
     assert record["state"] == "confirmed"
 
@@ -333,14 +347,14 @@ async def test_confirmation_onchain_failure_keeps_replay_reservation(monkeypatch
     store = MemoryStore()
     adapter, gate, op_kp = _adapter(
         store=store,
-        signature="SIG-revert",
         confirm_error=PaymentError("reverted", code="transaction-failed"),
         monkeypatch=monkeypatch,
     )
     header = _build_envelope(adapter, gate, op_kp)
+    signature = _settlement_signature(header, op_kp)
     with pytest.raises(InvalidProofError):
         await adapter.verify_and_settle(gate, _Req(header))
-    record = await store.get("x402-svm-exact:consumed:SIG-revert")
+    record = await store.get(f"x402-svm-exact:consumed:{signature}")
     assert isinstance(record, dict)
     assert record["state"] == "pending"
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "solana-pay-kit"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "anchorpy" },

--- a/rust/crates/kit/Cargo.toml
+++ b/rust/crates/kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-pay-kit"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Building blocks for Agentic payments (x402, MPP, AP2)"
 license = "MIT"

--- a/rust/crates/kit/src/generated/subscriptions/generated/accounts/fixed_delegation.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/accounts/fixed_delegation.rs
@@ -44,7 +44,7 @@ impl FixedDelegation {
                 subscription_authority.as_ref(),
                 delegator.as_ref(),
                 delegatee.as_ref(),
-                nonce.to_string().as_ref(),
+                &nonce.to_le_bytes(),
                 &[bump],
             ],
             &crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -63,7 +63,7 @@ impl FixedDelegation {
                 subscription_authority.as_ref(),
                 delegator.as_ref(),
                 delegatee.as_ref(),
-                nonce.to_string().as_ref(),
+                &nonce.to_le_bytes(),
             ],
             &crate::generated::subscriptions::SUBSCRIPTIONS_ID,
         )

--- a/rust/crates/kit/src/generated/subscriptions/generated/accounts/plan.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/accounts/plan.rs
@@ -38,7 +38,7 @@ impl Plan {
             &[
                 "plan".as_bytes(),
                 owner.as_ref(),
-                plan_id.to_string().as_ref(),
+                &plan_id.to_le_bytes(),
                 &[bump],
             ],
             &crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -47,11 +47,7 @@ impl Plan {
 
     pub fn find_pda(owner: &Address, plan_id: u64) -> (solana_address::Address, u8) {
         solana_address::Address::find_program_address(
-            &[
-                "plan".as_bytes(),
-                owner.as_ref(),
-                plan_id.to_string().as_ref(),
-            ],
+            &["plan".as_bytes(), owner.as_ref(), &plan_id.to_le_bytes()],
             &crate::generated::subscriptions::SUBSCRIPTIONS_ID,
         )
     }

--- a/rust/crates/kit/src/generated/subscriptions/generated/accounts/recurring_delegation.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/accounts/recurring_delegation.rs
@@ -47,7 +47,7 @@ impl RecurringDelegation {
                 subscription_authority.as_ref(),
                 delegator.as_ref(),
                 delegatee.as_ref(),
-                nonce.to_string().as_ref(),
+                &nonce.to_le_bytes(),
                 &[bump],
             ],
             &crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -66,7 +66,7 @@ impl RecurringDelegation {
                 subscription_authority.as_ref(),
                 delegator.as_ref(),
                 delegatee.as_ref(),
-                nonce.to_string().as_ref(),
+                &nonce.to_le_bytes(),
             ],
             &crate::generated::subscriptions::SUBSCRIPTIONS_ID,
         )

--- a/rust/crates/kit/src/generated/subscriptions/generated/errors/subscriptions.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/errors/subscriptions.rs
@@ -121,6 +121,9 @@ pub enum SubscriptionsError {
     /// 136 - Delegation init_id does not match current SubscriptionAuthority
     #[error("Delegation init_id does not match current SubscriptionAuthority")]
     StaleSubscriptionAuthority = 0x88,
+    /// 137 - Too many transfer hook accounts provided
+    #[error("Too many transfer hook accounts provided")]
+    TransferHookTooManyAccounts = 0x89,
     /// 300 - Transfer amount exceeds delegation limit
     #[error("Transfer amount exceeds delegation limit")]
     AmountExceedsLimit = 0x12C,
@@ -154,6 +157,9 @@ pub enum SubscriptionsError {
     /// 407 - Delegation period has not started yet
     #[error("Delegation period has not started yet")]
     DelegationNotStarted = 0x197,
+    /// 408 - start_ts of 0 (start on landing) requires a non-zero expiry
+    #[error("start_ts of 0 (start on landing) requires a non-zero expiry")]
+    RecurringDelegationStartOnLandingRequiresExpiry = 0x198,
     /// 500 - Plan is in sunset status
     #[error("Plan is in sunset status")]
     PlanSunset = 0x1F4,
@@ -214,6 +220,15 @@ pub enum SubscriptionsError {
     /// 519 - Subscription plan terms do not match the current plan
     #[error("Subscription plan terms do not match the current plan")]
     PlanTermsMismatch = 0x207,
+    /// 520 - A finite plan end timestamp can only be shortened, not removed or extended
+    #[error("A finite plan end timestamp can only be shortened, not removed or extended")]
+    PlanEndTsCannotExtend = 0x208,
+    /// 521 - Subscription approval does not match the current subscription
+    #[error("Subscription approval does not match the current subscription")]
+    StaleSubscriptionApproval = 0x209,
+    /// 522 - Plan update approval does not match the current plan state
+    #[error("Plan update approval does not match the current plan state")]
+    StalePlanApproval = 0x20A,
     /// 600 - Invalid event authority PDA
     #[error("Invalid event authority PDA")]
     InvalidEventAuthority = 0x258,
@@ -226,6 +241,9 @@ pub enum SubscriptionsError {
     /// 603 - Unknown event discriminator
     #[error("Unknown event discriminator")]
     InvalidEventDiscriminator = 0x25B,
+    /// 604 - Self program account does not match this program
+    #[error("Self program account does not match this program")]
+    InvalidSelfProgram = 0x25C,
 }
 
 impl From<SubscriptionsError> for solana_program_error::ProgramError {

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/cancel_subscription_now.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/cancel_subscription_now.rs
@@ -5,19 +5,22 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use crate::generated::subscriptions::generated::types::CancelSubscriptionNowData;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
-pub const CANCEL_SUBSCRIPTION_DISCRIMINATOR: u8 = 12;
+pub const CANCEL_SUBSCRIPTION_NOW_DISCRIMINATOR: u8 = 17;
 
 /// Accounts.
 #[derive(Debug)]
-pub struct CancelSubscription {
+pub struct CancelSubscriptionNow {
     /// The subscriber cancelling the subscription
     pub subscriber: solana_address::Address,
+    /// The owner of the subscription plan approving immediate cancellation
+    pub merchant: solana_address::Address,
     /// The plan PDA for the subscription
     pub plan_pda: solana_address::Address,
-    /// The subscription PDA being cancelled
+    /// The subscription PDA being cancelled immediately
     pub subscription_pda: solana_address::Address,
     /// The event authority PDA
     pub event_authority: solana_address::Address,
@@ -25,19 +28,27 @@ pub struct CancelSubscription {
     pub self_program: solana_address::Address,
 }
 
-impl CancelSubscription {
-    pub fn instruction(&self) -> solana_instruction::Instruction {
-        self.instruction_with_remaining_accounts(&[])
+impl CancelSubscriptionNow {
+    pub fn instruction(
+        &self,
+        args: CancelSubscriptionNowInstructionArgs,
+    ) -> solana_instruction::Instruction {
+        self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
+        args: CancelSubscriptionNowInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.subscriber,
+            true,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            self.merchant,
             true,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -57,9 +68,11 @@ impl CancelSubscription {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = CancelSubscriptionInstructionData::new()
+        let mut data = CancelSubscriptionNowInstructionData::new()
             .try_to_vec()
             .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -70,13 +83,13 @@ impl CancelSubscription {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct CancelSubscriptionInstructionData {
+pub struct CancelSubscriptionNowInstructionData {
     discriminator: u8,
 }
 
-impl CancelSubscriptionInstructionData {
+impl CancelSubscriptionNowInstructionData {
     pub fn new() -> Self {
-        Self { discriminator: 12 }
+        Self { discriminator: 17 }
     }
 
     pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
@@ -84,32 +97,46 @@ impl CancelSubscriptionInstructionData {
     }
 }
 
-impl Default for CancelSubscriptionInstructionData {
+impl Default for CancelSubscriptionNowInstructionData {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Instruction builder for `CancelSubscription`.
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+pub struct CancelSubscriptionNowInstructionArgs {
+    pub cancel_subscription_now_data: CancelSubscriptionNowData,
+}
+
+impl CancelSubscriptionNowInstructionArgs {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
+}
+
+/// Instruction builder for `CancelSubscriptionNow`.
 ///
 /// ### Accounts:
 ///
 ///   0. `[signer]` subscriber
-///   1. `[]` plan_pda
-///   2. `[writable]` subscription_pda
-///   3. `[]` event_authority
-///   4. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
+///   1. `[signer]` merchant
+///   2. `[]` plan_pda
+///   3. `[writable]` subscription_pda
+///   4. `[]` event_authority
+///   5. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
 #[derive(Clone, Debug, Default)]
-pub struct CancelSubscriptionBuilder {
+pub struct CancelSubscriptionNowBuilder {
     subscriber: Option<solana_address::Address>,
+    merchant: Option<solana_address::Address>,
     plan_pda: Option<solana_address::Address>,
     subscription_pda: Option<solana_address::Address>,
     event_authority: Option<solana_address::Address>,
     self_program: Option<solana_address::Address>,
+    cancel_subscription_now_data: Option<CancelSubscriptionNowData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
-impl CancelSubscriptionBuilder {
+impl CancelSubscriptionNowBuilder {
     pub fn new() -> Self {
         Self::default()
     }
@@ -119,13 +146,19 @@ impl CancelSubscriptionBuilder {
         self.subscriber = Some(subscriber);
         self
     }
+    /// The owner of the subscription plan approving immediate cancellation
+    #[inline(always)]
+    pub fn merchant(&mut self, merchant: solana_address::Address) -> &mut Self {
+        self.merchant = Some(merchant);
+        self
+    }
     /// The plan PDA for the subscription
     #[inline(always)]
     pub fn plan_pda(&mut self, plan_pda: solana_address::Address) -> &mut Self {
         self.plan_pda = Some(plan_pda);
         self
     }
-    /// The subscription PDA being cancelled
+    /// The subscription PDA being cancelled immediately
     #[inline(always)]
     pub fn subscription_pda(&mut self, subscription_pda: solana_address::Address) -> &mut Self {
         self.subscription_pda = Some(subscription_pda);
@@ -142,6 +175,14 @@ impl CancelSubscriptionBuilder {
     #[inline(always)]
     pub fn self_program(&mut self, self_program: solana_address::Address) -> &mut Self {
         self.self_program = Some(self_program);
+        self
+    }
+    #[inline(always)]
+    pub fn cancel_subscription_now_data(
+        &mut self,
+        cancel_subscription_now_data: CancelSubscriptionNowData,
+    ) -> &mut Self {
+        self.cancel_subscription_now_data = Some(cancel_subscription_now_data);
         self
     }
     /// Add an additional account to the instruction.
@@ -161,8 +202,9 @@ impl CancelSubscriptionBuilder {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_instruction::Instruction {
-        let accounts = CancelSubscription {
+        let accounts = CancelSubscriptionNow {
             subscriber: self.subscriber.expect("subscriber is not set"),
+            merchant: self.merchant.expect("merchant is not set"),
             plan_pda: self.plan_pda.expect("plan_pda is not set"),
             subscription_pda: self.subscription_pda.expect("subscription_pda is not set"),
             event_authority: self.event_authority.expect("event_authority is not set"),
@@ -170,18 +212,26 @@ impl CancelSubscriptionBuilder {
                 "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
             )),
         };
+        let args = CancelSubscriptionNowInstructionArgs {
+            cancel_subscription_now_data: self
+                .cancel_subscription_now_data
+                .clone()
+                .expect("cancel_subscription_now_data is not set"),
+        };
 
-        accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
+        accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
     }
 }
 
-/// `cancel_subscription` CPI accounts.
-pub struct CancelSubscriptionCpiAccounts<'a, 'b> {
+/// `cancel_subscription_now` CPI accounts.
+pub struct CancelSubscriptionNowCpiAccounts<'a, 'b> {
     /// The subscriber cancelling the subscription
     pub subscriber: &'b solana_account_info::AccountInfo<'a>,
+    /// The owner of the subscription plan approving immediate cancellation
+    pub merchant: &'b solana_account_info::AccountInfo<'a>,
     /// The plan PDA for the subscription
     pub plan_pda: &'b solana_account_info::AccountInfo<'a>,
-    /// The subscription PDA being cancelled
+    /// The subscription PDA being cancelled immediately
     pub subscription_pda: &'b solana_account_info::AccountInfo<'a>,
     /// The event authority PDA
     pub event_authority: &'b solana_account_info::AccountInfo<'a>,
@@ -189,34 +239,41 @@ pub struct CancelSubscriptionCpiAccounts<'a, 'b> {
     pub self_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
-/// `cancel_subscription` CPI instruction.
-pub struct CancelSubscriptionCpi<'a, 'b> {
+/// `cancel_subscription_now` CPI instruction.
+pub struct CancelSubscriptionNowCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_account_info::AccountInfo<'a>,
     /// The subscriber cancelling the subscription
     pub subscriber: &'b solana_account_info::AccountInfo<'a>,
+    /// The owner of the subscription plan approving immediate cancellation
+    pub merchant: &'b solana_account_info::AccountInfo<'a>,
     /// The plan PDA for the subscription
     pub plan_pda: &'b solana_account_info::AccountInfo<'a>,
-    /// The subscription PDA being cancelled
+    /// The subscription PDA being cancelled immediately
     pub subscription_pda: &'b solana_account_info::AccountInfo<'a>,
     /// The event authority PDA
     pub event_authority: &'b solana_account_info::AccountInfo<'a>,
     /// This program (for self-CPI)
     pub self_program: &'b solana_account_info::AccountInfo<'a>,
+    /// The arguments for the instruction.
+    pub __args: CancelSubscriptionNowInstructionArgs,
 }
 
-impl<'a, 'b> CancelSubscriptionCpi<'a, 'b> {
+impl<'a, 'b> CancelSubscriptionNowCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_account_info::AccountInfo<'a>,
-        accounts: CancelSubscriptionCpiAccounts<'a, 'b>,
+        accounts: CancelSubscriptionNowCpiAccounts<'a, 'b>,
+        args: CancelSubscriptionNowInstructionArgs,
     ) -> Self {
         Self {
             __program: program,
             subscriber: accounts.subscriber,
+            merchant: accounts.merchant,
             plan_pda: accounts.plan_pda,
             subscription_pda: accounts.subscription_pda,
             event_authority: accounts.event_authority,
             self_program: accounts.self_program,
+            __args: args,
         }
     }
     #[inline(always)]
@@ -242,9 +299,13 @@ impl<'a, 'b> CancelSubscriptionCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.subscriber.key,
+            true,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            *self.merchant.key,
             true,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -270,18 +331,21 @@ impl<'a, 'b> CancelSubscriptionCpi<'a, 'b> {
                 is_signer: remaining_account.2,
             })
         });
-        let data = CancelSubscriptionInstructionData::new()
+        let mut data = CancelSubscriptionNowInstructionData::new()
             .try_to_vec()
             .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.subscriber.clone());
+        account_infos.push(self.merchant.clone());
         account_infos.push(self.plan_pda.clone());
         account_infos.push(self.subscription_pda.clone());
         account_infos.push(self.event_authority.clone());
@@ -298,29 +362,32 @@ impl<'a, 'b> CancelSubscriptionCpi<'a, 'b> {
     }
 }
 
-/// Instruction builder for `CancelSubscription` via CPI.
+/// Instruction builder for `CancelSubscriptionNow` via CPI.
 ///
 /// ### Accounts:
 ///
 ///   0. `[signer]` subscriber
-///   1. `[]` plan_pda
-///   2. `[writable]` subscription_pda
-///   3. `[]` event_authority
-///   4. `[]` self_program
+///   1. `[signer]` merchant
+///   2. `[]` plan_pda
+///   3. `[writable]` subscription_pda
+///   4. `[]` event_authority
+///   5. `[]` self_program
 #[derive(Clone, Debug)]
-pub struct CancelSubscriptionCpiBuilder<'a, 'b> {
-    instruction: Box<CancelSubscriptionCpiBuilderInstruction<'a, 'b>>,
+pub struct CancelSubscriptionNowCpiBuilder<'a, 'b> {
+    instruction: Box<CancelSubscriptionNowCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a, 'b> CancelSubscriptionCpiBuilder<'a, 'b> {
+impl<'a, 'b> CancelSubscriptionNowCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
-        let instruction = Box::new(CancelSubscriptionCpiBuilderInstruction {
+        let instruction = Box::new(CancelSubscriptionNowCpiBuilderInstruction {
             __program: program,
             subscriber: None,
+            merchant: None,
             plan_pda: None,
             subscription_pda: None,
             event_authority: None,
             self_program: None,
+            cancel_subscription_now_data: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -334,13 +401,19 @@ impl<'a, 'b> CancelSubscriptionCpiBuilder<'a, 'b> {
         self.instruction.subscriber = Some(subscriber);
         self
     }
+    /// The owner of the subscription plan approving immediate cancellation
+    #[inline(always)]
+    pub fn merchant(&mut self, merchant: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.merchant = Some(merchant);
+        self
+    }
     /// The plan PDA for the subscription
     #[inline(always)]
     pub fn plan_pda(&mut self, plan_pda: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.plan_pda = Some(plan_pda);
         self
     }
-    /// The subscription PDA being cancelled
+    /// The subscription PDA being cancelled immediately
     #[inline(always)]
     pub fn subscription_pda(
         &mut self,
@@ -365,6 +438,14 @@ impl<'a, 'b> CancelSubscriptionCpiBuilder<'a, 'b> {
         self_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.self_program = Some(self_program);
+        self
+    }
+    #[inline(always)]
+    pub fn cancel_subscription_now_data(
+        &mut self,
+        cancel_subscription_now_data: CancelSubscriptionNowData,
+    ) -> &mut Self {
+        self.instruction.cancel_subscription_now_data = Some(cancel_subscription_now_data);
         self
     }
     /// Add an additional account to the instruction.
@@ -401,10 +482,19 @@ impl<'a, 'b> CancelSubscriptionCpiBuilder<'a, 'b> {
     #[allow(clippy::clone_on_copy)]
     #[allow(clippy::vec_init_then_push)]
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program_error::ProgramResult {
-        let instruction = CancelSubscriptionCpi {
+        let args = CancelSubscriptionNowInstructionArgs {
+            cancel_subscription_now_data: self
+                .instruction
+                .cancel_subscription_now_data
+                .clone()
+                .expect("cancel_subscription_now_data is not set"),
+        };
+        let instruction = CancelSubscriptionNowCpi {
             __program: self.instruction.__program,
 
             subscriber: self.instruction.subscriber.expect("subscriber is not set"),
+
+            merchant: self.instruction.merchant.expect("merchant is not set"),
 
             plan_pda: self.instruction.plan_pda.expect("plan_pda is not set"),
 
@@ -422,6 +512,7 @@ impl<'a, 'b> CancelSubscriptionCpiBuilder<'a, 'b> {
                 .instruction
                 .self_program
                 .expect("self_program is not set"),
+            __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,
@@ -431,13 +522,15 @@ impl<'a, 'b> CancelSubscriptionCpiBuilder<'a, 'b> {
 }
 
 #[derive(Clone, Debug)]
-struct CancelSubscriptionCpiBuilderInstruction<'a, 'b> {
+struct CancelSubscriptionNowCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     subscriber: Option<&'b solana_account_info::AccountInfo<'a>>,
+    merchant: Option<&'b solana_account_info::AccountInfo<'a>>,
     plan_pda: Option<&'b solana_account_info::AccountInfo<'a>>,
     subscription_pda: Option<&'b solana_account_info::AccountInfo<'a>>,
     event_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     self_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    cancel_subscription_now_data: Option<CancelSubscriptionNowData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/create_fixed_delegation.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/create_fixed_delegation.rs
@@ -24,6 +24,8 @@ pub struct CreateFixedDelegation {
     pub delegatee: solana_address::Address,
     /// The system program
     pub system_program: solana_address::Address,
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    pub payer: Option<solana_address::Address>,
 }
 
 impl CreateFixedDelegation {
@@ -40,7 +42,7 @@ impl CreateFixedDelegation {
         args: CreateFixedDelegationInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.delegator, true));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.subscription_authority,
@@ -58,6 +60,9 @@ impl CreateFixedDelegation {
             self.system_program,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(payer, true));
+        }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = CreateFixedDelegationInstructionData::new()
             .try_to_vec()
@@ -114,6 +119,7 @@ impl CreateFixedDelegationInstructionArgs {
 ///   2. `[writable]` delegation_account
 ///   3. `[]` delegatee
 ///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   5. `[writable, signer, optional]` payer
 #[derive(Clone, Debug, Default)]
 pub struct CreateFixedDelegationBuilder {
     delegator: Option<solana_address::Address>,
@@ -121,6 +127,7 @@ pub struct CreateFixedDelegationBuilder {
     delegation_account: Option<solana_address::Address>,
     delegatee: Option<solana_address::Address>,
     system_program: Option<solana_address::Address>,
+    payer: Option<solana_address::Address>,
     fixed_delegation: Option<CreateFixedDelegationData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -163,6 +170,13 @@ impl CreateFixedDelegationBuilder {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<solana_address::Address>) -> &mut Self {
+        self.payer = payer;
+        self
+    }
     #[inline(always)]
     pub fn fixed_delegation(&mut self, fixed_delegation: CreateFixedDelegationData) -> &mut Self {
         self.fixed_delegation = Some(fixed_delegation);
@@ -197,6 +211,7 @@ impl CreateFixedDelegationBuilder {
             system_program: self
                 .system_program
                 .unwrap_or(solana_address::address!("11111111111111111111111111111111")),
+            payer: self.payer,
         };
         let args = CreateFixedDelegationInstructionArgs {
             fixed_delegation: self
@@ -221,6 +236,8 @@ pub struct CreateFixedDelegationCpiAccounts<'a, 'b> {
     pub delegatee: &'b solana_account_info::AccountInfo<'a>,
     /// The system program
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
 /// `create_fixed_delegation` CPI instruction.
@@ -237,6 +254,8 @@ pub struct CreateFixedDelegationCpi<'a, 'b> {
     pub delegatee: &'b solana_account_info::AccountInfo<'a>,
     /// The system program
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateFixedDelegationInstructionArgs,
 }
@@ -254,6 +273,7 @@ impl<'a, 'b> CreateFixedDelegationCpi<'a, 'b> {
             delegation_account: accounts.delegation_account,
             delegatee: accounts.delegatee,
             system_program: accounts.system_program,
+            payer: accounts.payer,
             __args: args,
         }
     }
@@ -280,7 +300,7 @@ impl<'a, 'b> CreateFixedDelegationCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(
             *self.delegator.key,
             true,
@@ -301,11 +321,14 @@ impl<'a, 'b> CreateFixedDelegationCpi<'a, 'b> {
             *self.system_program.key,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(*payer.key, true));
+        }
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = CreateFixedDelegationInstructionData::new()
@@ -319,13 +342,16 @@ impl<'a, 'b> CreateFixedDelegationCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.delegator.clone());
         account_infos.push(self.subscription_authority.clone());
         account_infos.push(self.delegation_account.clone());
         account_infos.push(self.delegatee.clone());
         account_infos.push(self.system_program.clone());
+        if let Some(payer) = self.payer {
+            account_infos.push(payer.clone());
+        }
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -347,6 +373,7 @@ impl<'a, 'b> CreateFixedDelegationCpi<'a, 'b> {
 ///   2. `[writable]` delegation_account
 ///   3. `[]` delegatee
 ///   4. `[]` system_program
+///   5. `[writable, signer, optional]` payer
 #[derive(Clone, Debug)]
 pub struct CreateFixedDelegationCpiBuilder<'a, 'b> {
     instruction: Box<CreateFixedDelegationCpiBuilderInstruction<'a, 'b>>,
@@ -361,6 +388,7 @@ impl<'a, 'b> CreateFixedDelegationCpiBuilder<'a, 'b> {
             delegation_account: None,
             delegatee: None,
             system_program: None,
+            payer: None,
             fixed_delegation: None,
             __remaining_accounts: Vec::new(),
         });
@@ -403,6 +431,13 @@ impl<'a, 'b> CreateFixedDelegationCpiBuilder<'a, 'b> {
         system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
+        self
+    }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<&'b solana_account_info::AccountInfo<'a>>) -> &mut Self {
+        self.instruction.payer = payer;
         self
     }
     #[inline(always)]
@@ -472,6 +507,8 @@ impl<'a, 'b> CreateFixedDelegationCpiBuilder<'a, 'b> {
                 .instruction
                 .system_program
                 .expect("system_program is not set"),
+
+            payer: self.instruction.payer,
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -489,6 +526,7 @@ struct CreateFixedDelegationCpiBuilderInstruction<'a, 'b> {
     delegation_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     delegatee: Option<&'b solana_account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     fixed_delegation: Option<CreateFixedDelegationData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/create_plan.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/create_plan.rs
@@ -24,6 +24,8 @@ pub struct CreatePlan {
     pub system_program: solana_address::Address,
     /// The token program
     pub token_program: solana_address::Address,
+    /// Optional sponsor that funds the plan rent. Defaults to the merchant/signer when omitted; delete_plan refunds the owner, not the payer.
+    pub payer: Option<solana_address::Address>,
 }
 
 impl CreatePlan {
@@ -37,7 +39,7 @@ impl CreatePlan {
         args: CreatePlanInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.merchant, true));
         accounts.push(solana_instruction::AccountMeta::new(self.plan_pda, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -52,6 +54,9 @@ impl CreatePlan {
             self.token_program,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(payer, true));
+        }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = CreatePlanInstructionData::new().try_to_vec().unwrap();
         let mut args = args.try_to_vec().unwrap();
@@ -106,6 +111,7 @@ impl CreatePlanInstructionArgs {
 ///   2. `[]` token_mint
 ///   3. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   4. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   5. `[writable, signer, optional]` payer
 #[derive(Clone, Debug, Default)]
 pub struct CreatePlanBuilder {
     merchant: Option<solana_address::Address>,
@@ -113,6 +119,7 @@ pub struct CreatePlanBuilder {
     token_mint: Option<solana_address::Address>,
     system_program: Option<solana_address::Address>,
     token_program: Option<solana_address::Address>,
+    payer: Option<solana_address::Address>,
     plan_data: Option<PlanData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -153,6 +160,13 @@ impl CreatePlanBuilder {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account]`
+    /// Optional sponsor that funds the plan rent. Defaults to the merchant/signer when omitted; delete_plan refunds the owner, not the payer.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<solana_address::Address>) -> &mut Self {
+        self.payer = payer;
+        self
+    }
     #[inline(always)]
     pub fn plan_data(&mut self, plan_data: PlanData) -> &mut Self {
         self.plan_data = Some(plan_data);
@@ -185,6 +199,7 @@ impl CreatePlanBuilder {
             token_program: self.token_program.unwrap_or(solana_address::address!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
+            payer: self.payer,
         };
         let args = CreatePlanInstructionArgs {
             plan_data: self.plan_data.clone().expect("plan_data is not set"),
@@ -206,6 +221,8 @@ pub struct CreatePlanCpiAccounts<'a, 'b> {
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// The token program
     pub token_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the plan rent. Defaults to the merchant/signer when omitted; delete_plan refunds the owner, not the payer.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
 /// `create_plan` CPI instruction.
@@ -222,6 +239,8 @@ pub struct CreatePlanCpi<'a, 'b> {
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// The token program
     pub token_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the plan rent. Defaults to the merchant/signer when omitted; delete_plan refunds the owner, not the payer.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreatePlanInstructionArgs,
 }
@@ -239,6 +258,7 @@ impl<'a, 'b> CreatePlanCpi<'a, 'b> {
             token_mint: accounts.token_mint,
             system_program: accounts.system_program,
             token_program: accounts.token_program,
+            payer: accounts.payer,
             __args: args,
         }
     }
@@ -265,7 +285,7 @@ impl<'a, 'b> CreatePlanCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(
             *self.merchant.key,
             true,
@@ -286,11 +306,14 @@ impl<'a, 'b> CreatePlanCpi<'a, 'b> {
             *self.token_program.key,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(*payer.key, true));
+        }
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = CreatePlanInstructionData::new().try_to_vec().unwrap();
@@ -302,13 +325,16 @@ impl<'a, 'b> CreatePlanCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.merchant.clone());
         account_infos.push(self.plan_pda.clone());
         account_infos.push(self.token_mint.clone());
         account_infos.push(self.system_program.clone());
         account_infos.push(self.token_program.clone());
+        if let Some(payer) = self.payer {
+            account_infos.push(payer.clone());
+        }
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -330,6 +356,7 @@ impl<'a, 'b> CreatePlanCpi<'a, 'b> {
 ///   2. `[]` token_mint
 ///   3. `[]` system_program
 ///   4. `[]` token_program
+///   5. `[writable, signer, optional]` payer
 #[derive(Clone, Debug)]
 pub struct CreatePlanCpiBuilder<'a, 'b> {
     instruction: Box<CreatePlanCpiBuilderInstruction<'a, 'b>>,
@@ -344,6 +371,7 @@ impl<'a, 'b> CreatePlanCpiBuilder<'a, 'b> {
             token_mint: None,
             system_program: None,
             token_program: None,
+            payer: None,
             plan_data: None,
             __remaining_accounts: Vec::new(),
         });
@@ -386,6 +414,13 @@ impl<'a, 'b> CreatePlanCpiBuilder<'a, 'b> {
         token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
+        self
+    }
+    /// `[optional account]`
+    /// Optional sponsor that funds the plan rent. Defaults to the merchant/signer when omitted; delete_plan refunds the owner, not the payer.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<&'b solana_account_info::AccountInfo<'a>>) -> &mut Self {
+        self.instruction.payer = payer;
         self
     }
     #[inline(always)]
@@ -452,6 +487,8 @@ impl<'a, 'b> CreatePlanCpiBuilder<'a, 'b> {
                 .instruction
                 .token_program
                 .expect("token_program is not set"),
+
+            payer: self.instruction.payer,
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -469,6 +506,7 @@ struct CreatePlanCpiBuilderInstruction<'a, 'b> {
     token_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     plan_data: Option<PlanData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/create_recurring_delegation.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/create_recurring_delegation.rs
@@ -24,6 +24,8 @@ pub struct CreateRecurringDelegation {
     pub delegatee: solana_address::Address,
     /// The system program
     pub system_program: solana_address::Address,
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    pub payer: Option<solana_address::Address>,
 }
 
 impl CreateRecurringDelegation {
@@ -40,7 +42,7 @@ impl CreateRecurringDelegation {
         args: CreateRecurringDelegationInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.delegator, true));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.subscription_authority,
@@ -58,6 +60,9 @@ impl CreateRecurringDelegation {
             self.system_program,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(payer, true));
+        }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = CreateRecurringDelegationInstructionData::new()
             .try_to_vec()
@@ -114,6 +119,7 @@ impl CreateRecurringDelegationInstructionArgs {
 ///   2. `[writable]` delegation_account
 ///   3. `[]` delegatee
 ///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   5. `[writable, signer, optional]` payer
 #[derive(Clone, Debug, Default)]
 pub struct CreateRecurringDelegationBuilder {
     delegator: Option<solana_address::Address>,
@@ -121,6 +127,7 @@ pub struct CreateRecurringDelegationBuilder {
     delegation_account: Option<solana_address::Address>,
     delegatee: Option<solana_address::Address>,
     system_program: Option<solana_address::Address>,
+    payer: Option<solana_address::Address>,
     recurring_delegation: Option<CreateRecurringDelegationData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -163,6 +170,13 @@ impl CreateRecurringDelegationBuilder {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<solana_address::Address>) -> &mut Self {
+        self.payer = payer;
+        self
+    }
     #[inline(always)]
     pub fn recurring_delegation(
         &mut self,
@@ -200,6 +214,7 @@ impl CreateRecurringDelegationBuilder {
             system_program: self
                 .system_program
                 .unwrap_or(solana_address::address!("11111111111111111111111111111111")),
+            payer: self.payer,
         };
         let args = CreateRecurringDelegationInstructionArgs {
             recurring_delegation: self
@@ -224,6 +239,8 @@ pub struct CreateRecurringDelegationCpiAccounts<'a, 'b> {
     pub delegatee: &'b solana_account_info::AccountInfo<'a>,
     /// The system program
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
 /// `create_recurring_delegation` CPI instruction.
@@ -240,6 +257,8 @@ pub struct CreateRecurringDelegationCpi<'a, 'b> {
     pub delegatee: &'b solana_account_info::AccountInfo<'a>,
     /// The system program
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateRecurringDelegationInstructionArgs,
 }
@@ -257,6 +276,7 @@ impl<'a, 'b> CreateRecurringDelegationCpi<'a, 'b> {
             delegation_account: accounts.delegation_account,
             delegatee: accounts.delegatee,
             system_program: accounts.system_program,
+            payer: accounts.payer,
             __args: args,
         }
     }
@@ -283,7 +303,7 @@ impl<'a, 'b> CreateRecurringDelegationCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(
             *self.delegator.key,
             true,
@@ -304,11 +324,14 @@ impl<'a, 'b> CreateRecurringDelegationCpi<'a, 'b> {
             *self.system_program.key,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(*payer.key, true));
+        }
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = CreateRecurringDelegationInstructionData::new()
@@ -322,13 +345,16 @@ impl<'a, 'b> CreateRecurringDelegationCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.delegator.clone());
         account_infos.push(self.subscription_authority.clone());
         account_infos.push(self.delegation_account.clone());
         account_infos.push(self.delegatee.clone());
         account_infos.push(self.system_program.clone());
+        if let Some(payer) = self.payer {
+            account_infos.push(payer.clone());
+        }
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -350,6 +376,7 @@ impl<'a, 'b> CreateRecurringDelegationCpi<'a, 'b> {
 ///   2. `[writable]` delegation_account
 ///   3. `[]` delegatee
 ///   4. `[]` system_program
+///   5. `[writable, signer, optional]` payer
 #[derive(Clone, Debug)]
 pub struct CreateRecurringDelegationCpiBuilder<'a, 'b> {
     instruction: Box<CreateRecurringDelegationCpiBuilderInstruction<'a, 'b>>,
@@ -364,6 +391,7 @@ impl<'a, 'b> CreateRecurringDelegationCpiBuilder<'a, 'b> {
             delegation_account: None,
             delegatee: None,
             system_program: None,
+            payer: None,
             recurring_delegation: None,
             __remaining_accounts: Vec::new(),
         });
@@ -406,6 +434,13 @@ impl<'a, 'b> CreateRecurringDelegationCpiBuilder<'a, 'b> {
         system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
+        self
+    }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<&'b solana_account_info::AccountInfo<'a>>) -> &mut Self {
+        self.instruction.payer = payer;
         self
     }
     #[inline(always)]
@@ -478,6 +513,8 @@ impl<'a, 'b> CreateRecurringDelegationCpiBuilder<'a, 'b> {
                 .instruction
                 .system_program
                 .expect("system_program is not set"),
+
+            payer: self.instruction.payer,
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -495,6 +532,7 @@ struct CreateRecurringDelegationCpiBuilderInstruction<'a, 'b> {
     delegation_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     delegatee: Option<&'b solana_account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     recurring_delegation: Option<CreateRecurringDelegationData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/delete_plan.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/delete_plan.rs
@@ -180,8 +180,8 @@ impl<'a, 'b> DeletePlanCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = DeletePlanInstructionData::new().try_to_vec().unwrap();

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/init_subscription_authority.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/init_subscription_authority.rs
@@ -25,6 +25,8 @@ pub struct InitSubscriptionAuthority {
     pub system_program: solana_address::Address,
     /// Token program
     pub token_program: solana_address::Address,
+    /// Optional sponsor that funds the account rent. Defaults to the owner/signer when omitted.
+    pub payer: Option<solana_address::Address>,
 }
 
 impl InitSubscriptionAuthority {
@@ -37,7 +39,7 @@ impl InitSubscriptionAuthority {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.owner, true));
         accounts.push(solana_instruction::AccountMeta::new(
             self.subscription_authority,
@@ -56,6 +58,9 @@ impl InitSubscriptionAuthority {
             self.token_program,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(payer, true));
+        }
         accounts.extend_from_slice(remaining_accounts);
         let data = InitSubscriptionAuthorityInstructionData::new()
             .try_to_vec()
@@ -100,6 +105,7 @@ impl Default for InitSubscriptionAuthorityInstructionData {
 ///   3. `[writable]` user_ata
 ///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   5. `[]` token_program
+///   6. `[writable, signer, optional]` payer
 #[derive(Clone, Debug, Default)]
 pub struct InitSubscriptionAuthorityBuilder {
     owner: Option<solana_address::Address>,
@@ -108,6 +114,7 @@ pub struct InitSubscriptionAuthorityBuilder {
     user_ata: Option<solana_address::Address>,
     system_program: Option<solana_address::Address>,
     token_program: Option<solana_address::Address>,
+    payer: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
@@ -155,6 +162,13 @@ impl InitSubscriptionAuthorityBuilder {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the owner/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<solana_address::Address>) -> &mut Self {
+        self.payer = payer;
+        self
+    }
     /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
@@ -183,6 +197,7 @@ impl InitSubscriptionAuthorityBuilder {
                 .system_program
                 .unwrap_or(solana_address::address!("11111111111111111111111111111111")),
             token_program: self.token_program.expect("token_program is not set"),
+            payer: self.payer,
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
@@ -203,6 +218,8 @@ pub struct InitSubscriptionAuthorityCpiAccounts<'a, 'b> {
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// Token program
     pub token_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the owner/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
 /// `init_subscription_authority` CPI instruction.
@@ -221,6 +238,8 @@ pub struct InitSubscriptionAuthorityCpi<'a, 'b> {
     pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// Token program
     pub token_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the owner/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
 impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
@@ -236,6 +255,7 @@ impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
             user_ata: accounts.user_ata,
             system_program: accounts.system_program,
             token_program: accounts.token_program,
+            payer: accounts.payer,
         }
     }
     #[inline(always)]
@@ -261,7 +281,7 @@ impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.owner.key, true));
         accounts.push(solana_instruction::AccountMeta::new(
             *self.subscription_authority.key,
@@ -283,11 +303,14 @@ impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
             *self.token_program.key,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(*payer.key, true));
+        }
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = InitSubscriptionAuthorityInstructionData::new()
@@ -299,7 +322,7 @@ impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(8 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.owner.clone());
         account_infos.push(self.subscription_authority.clone());
@@ -307,6 +330,9 @@ impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
         account_infos.push(self.user_ata.clone());
         account_infos.push(self.system_program.clone());
         account_infos.push(self.token_program.clone());
+        if let Some(payer) = self.payer {
+            account_infos.push(payer.clone());
+        }
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -329,6 +355,7 @@ impl<'a, 'b> InitSubscriptionAuthorityCpi<'a, 'b> {
 ///   3. `[writable]` user_ata
 ///   4. `[]` system_program
 ///   5. `[]` token_program
+///   6. `[writable, signer, optional]` payer
 #[derive(Clone, Debug)]
 pub struct InitSubscriptionAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<InitSubscriptionAuthorityCpiBuilderInstruction<'a, 'b>>,
@@ -344,6 +371,7 @@ impl<'a, 'b> InitSubscriptionAuthorityCpiBuilder<'a, 'b> {
             user_ata: None,
             system_program: None,
             token_program: None,
+            payer: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -394,6 +422,13 @@ impl<'a, 'b> InitSubscriptionAuthorityCpiBuilder<'a, 'b> {
         token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
+        self
+    }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the owner/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<&'b solana_account_info::AccountInfo<'a>>) -> &mut Self {
+        self.instruction.payer = payer;
         self
     }
     /// Add an additional account to the instruction.
@@ -453,6 +488,8 @@ impl<'a, 'b> InitSubscriptionAuthorityCpiBuilder<'a, 'b> {
                 .instruction
                 .token_program
                 .expect("token_program is not set"),
+
+            payer: self.instruction.payer,
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,
@@ -470,6 +507,7 @@ struct InitSubscriptionAuthorityCpiBuilderInstruction<'a, 'b> {
     user_ata: Option<&'b solana_account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/mod.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/mod.rs
@@ -6,6 +6,7 @@
 //!
 
 pub(crate) mod r#cancel_subscription;
+pub(crate) mod r#cancel_subscription_now;
 pub(crate) mod r#close_subscription_authority;
 pub(crate) mod r#create_fixed_delegation;
 pub(crate) mod r#create_plan;
@@ -13,7 +14,10 @@ pub(crate) mod r#create_recurring_delegation;
 pub(crate) mod r#delete_plan;
 pub(crate) mod r#init_subscription_authority;
 pub(crate) mod r#resume_subscription;
+pub(crate) mod r#revoke_abandoned_delegation;
+pub(crate) mod r#revoke_abandoned_subscription;
 pub(crate) mod r#revoke_delegation;
+pub(crate) mod r#revoke_subscription_authority;
 pub(crate) mod r#subscribe;
 pub(crate) mod r#transfer_fixed;
 pub(crate) mod r#transfer_recurring;
@@ -21,6 +25,7 @@ pub(crate) mod r#transfer_subscription;
 pub(crate) mod r#update_plan;
 
 pub use self::r#cancel_subscription::*;
+pub use self::r#cancel_subscription_now::*;
 pub use self::r#close_subscription_authority::*;
 pub use self::r#create_fixed_delegation::*;
 pub use self::r#create_plan::*;
@@ -28,7 +33,10 @@ pub use self::r#create_recurring_delegation::*;
 pub use self::r#delete_plan::*;
 pub use self::r#init_subscription_authority::*;
 pub use self::r#resume_subscription::*;
+pub use self::r#revoke_abandoned_delegation::*;
+pub use self::r#revoke_abandoned_subscription::*;
 pub use self::r#revoke_delegation::*;
+pub use self::r#revoke_subscription_authority::*;
 pub use self::r#subscribe::*;
 pub use self::r#transfer_fixed::*;
 pub use self::r#transfer_recurring::*;

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/resume_subscription.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/resume_subscription.rs
@@ -5,6 +5,7 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use crate::generated::subscriptions::generated::types::ResumeData;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -19,6 +20,8 @@ pub struct ResumeSubscription {
     pub plan_pda: solana_address::Address,
     /// The subscription PDA being resumed
     pub subscription_pda: solana_address::Address,
+    /// The subscriber's SubscriptionAuthority PDA for the plan's mint
+    pub subscription_authority: solana_address::Address,
     /// The event authority PDA
     pub event_authority: solana_address::Address,
     /// This program (for self-CPI)
@@ -26,16 +29,20 @@ pub struct ResumeSubscription {
 }
 
 impl ResumeSubscription {
-    pub fn instruction(&self) -> solana_instruction::Instruction {
-        self.instruction_with_remaining_accounts(&[])
+    pub fn instruction(
+        &self,
+        args: ResumeSubscriptionInstructionArgs,
+    ) -> solana_instruction::Instruction {
+        self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
+        args: ResumeSubscriptionInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.subscriber,
             true,
@@ -49,6 +56,10 @@ impl ResumeSubscription {
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
+            self.subscription_authority,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.event_authority,
             false,
         ));
@@ -57,9 +68,11 @@ impl ResumeSubscription {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = ResumeSubscriptionInstructionData::new()
+        let mut data = ResumeSubscriptionInstructionData::new()
             .try_to_vec()
             .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -90,6 +103,17 @@ impl Default for ResumeSubscriptionInstructionData {
     }
 }
 
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+pub struct ResumeSubscriptionInstructionArgs {
+    pub resume_data: ResumeData,
+}
+
+impl ResumeSubscriptionInstructionArgs {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
+}
+
 /// Instruction builder for `ResumeSubscription`.
 ///
 /// ### Accounts:
@@ -97,15 +121,18 @@ impl Default for ResumeSubscriptionInstructionData {
 ///   0. `[signer]` subscriber
 ///   1. `[]` plan_pda
 ///   2. `[writable]` subscription_pda
-///   3. `[optional]` event_authority (default to `3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7`)
-///   4. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
+///   3. `[]` subscription_authority
+///   4. `[]` event_authority
+///   5. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
 #[derive(Clone, Debug, Default)]
 pub struct ResumeSubscriptionBuilder {
     subscriber: Option<solana_address::Address>,
     plan_pda: Option<solana_address::Address>,
     subscription_pda: Option<solana_address::Address>,
+    subscription_authority: Option<solana_address::Address>,
     event_authority: Option<solana_address::Address>,
     self_program: Option<solana_address::Address>,
+    resume_data: Option<ResumeData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
@@ -131,7 +158,15 @@ impl ResumeSubscriptionBuilder {
         self.subscription_pda = Some(subscription_pda);
         self
     }
-    /// `[optional account, default to '3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7']`
+    /// The subscriber's SubscriptionAuthority PDA for the plan's mint
+    #[inline(always)]
+    pub fn subscription_authority(
+        &mut self,
+        subscription_authority: solana_address::Address,
+    ) -> &mut Self {
+        self.subscription_authority = Some(subscription_authority);
+        self
+    }
     /// The event authority PDA
     #[inline(always)]
     pub fn event_authority(&mut self, event_authority: solana_address::Address) -> &mut Self {
@@ -143,6 +178,11 @@ impl ResumeSubscriptionBuilder {
     #[inline(always)]
     pub fn self_program(&mut self, self_program: solana_address::Address) -> &mut Self {
         self.self_program = Some(self_program);
+        self
+    }
+    #[inline(always)]
+    pub fn resume_data(&mut self, resume_data: ResumeData) -> &mut Self {
+        self.resume_data = Some(resume_data);
         self
     }
     /// Add an additional account to the instruction.
@@ -166,15 +206,19 @@ impl ResumeSubscriptionBuilder {
             subscriber: self.subscriber.expect("subscriber is not set"),
             plan_pda: self.plan_pda.expect("plan_pda is not set"),
             subscription_pda: self.subscription_pda.expect("subscription_pda is not set"),
-            event_authority: self.event_authority.unwrap_or(solana_address::address!(
-                "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
-            )),
+            subscription_authority: self
+                .subscription_authority
+                .expect("subscription_authority is not set"),
+            event_authority: self.event_authority.expect("event_authority is not set"),
             self_program: self.self_program.unwrap_or(solana_address::address!(
                 "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
             )),
         };
+        let args = ResumeSubscriptionInstructionArgs {
+            resume_data: self.resume_data.clone().expect("resume_data is not set"),
+        };
 
-        accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
+        accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
     }
 }
 
@@ -186,6 +230,8 @@ pub struct ResumeSubscriptionCpiAccounts<'a, 'b> {
     pub plan_pda: &'b solana_account_info::AccountInfo<'a>,
     /// The subscription PDA being resumed
     pub subscription_pda: &'b solana_account_info::AccountInfo<'a>,
+    /// The subscriber's SubscriptionAuthority PDA for the plan's mint
+    pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The event authority PDA
     pub event_authority: &'b solana_account_info::AccountInfo<'a>,
     /// This program (for self-CPI)
@@ -202,24 +248,31 @@ pub struct ResumeSubscriptionCpi<'a, 'b> {
     pub plan_pda: &'b solana_account_info::AccountInfo<'a>,
     /// The subscription PDA being resumed
     pub subscription_pda: &'b solana_account_info::AccountInfo<'a>,
+    /// The subscriber's SubscriptionAuthority PDA for the plan's mint
+    pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The event authority PDA
     pub event_authority: &'b solana_account_info::AccountInfo<'a>,
     /// This program (for self-CPI)
     pub self_program: &'b solana_account_info::AccountInfo<'a>,
+    /// The arguments for the instruction.
+    pub __args: ResumeSubscriptionInstructionArgs,
 }
 
 impl<'a, 'b> ResumeSubscriptionCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_account_info::AccountInfo<'a>,
         accounts: ResumeSubscriptionCpiAccounts<'a, 'b>,
+        args: ResumeSubscriptionInstructionArgs,
     ) -> Self {
         Self {
             __program: program,
             subscriber: accounts.subscriber,
             plan_pda: accounts.plan_pda,
             subscription_pda: accounts.subscription_pda,
+            subscription_authority: accounts.subscription_authority,
             event_authority: accounts.event_authority,
             self_program: accounts.self_program,
+            __args: args,
         }
     }
     #[inline(always)]
@@ -245,7 +298,7 @@ impl<'a, 'b> ResumeSubscriptionCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.subscriber.key,
             true,
@@ -259,6 +312,10 @@ impl<'a, 'b> ResumeSubscriptionCpi<'a, 'b> {
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
+            *self.subscription_authority.key,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.event_authority.key,
             false,
         ));
@@ -269,24 +326,27 @@ impl<'a, 'b> ResumeSubscriptionCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
-        let data = ResumeSubscriptionInstructionData::new()
+        let mut data = ResumeSubscriptionInstructionData::new()
             .try_to_vec()
             .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.subscriber.clone());
         account_infos.push(self.plan_pda.clone());
         account_infos.push(self.subscription_pda.clone());
+        account_infos.push(self.subscription_authority.clone());
         account_infos.push(self.event_authority.clone());
         account_infos.push(self.self_program.clone());
         remaining_accounts
@@ -308,8 +368,9 @@ impl<'a, 'b> ResumeSubscriptionCpi<'a, 'b> {
 ///   0. `[signer]` subscriber
 ///   1. `[]` plan_pda
 ///   2. `[writable]` subscription_pda
-///   3. `[]` event_authority
-///   4. `[]` self_program
+///   3. `[]` subscription_authority
+///   4. `[]` event_authority
+///   5. `[]` self_program
 #[derive(Clone, Debug)]
 pub struct ResumeSubscriptionCpiBuilder<'a, 'b> {
     instruction: Box<ResumeSubscriptionCpiBuilderInstruction<'a, 'b>>,
@@ -322,8 +383,10 @@ impl<'a, 'b> ResumeSubscriptionCpiBuilder<'a, 'b> {
             subscriber: None,
             plan_pda: None,
             subscription_pda: None,
+            subscription_authority: None,
             event_authority: None,
             self_program: None,
+            resume_data: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -352,6 +415,15 @@ impl<'a, 'b> ResumeSubscriptionCpiBuilder<'a, 'b> {
         self.instruction.subscription_pda = Some(subscription_pda);
         self
     }
+    /// The subscriber's SubscriptionAuthority PDA for the plan's mint
+    #[inline(always)]
+    pub fn subscription_authority(
+        &mut self,
+        subscription_authority: &'b solana_account_info::AccountInfo<'a>,
+    ) -> &mut Self {
+        self.instruction.subscription_authority = Some(subscription_authority);
+        self
+    }
     /// The event authority PDA
     #[inline(always)]
     pub fn event_authority(
@@ -368,6 +440,11 @@ impl<'a, 'b> ResumeSubscriptionCpiBuilder<'a, 'b> {
         self_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.self_program = Some(self_program);
+        self
+    }
+    #[inline(always)]
+    pub fn resume_data(&mut self, resume_data: ResumeData) -> &mut Self {
+        self.instruction.resume_data = Some(resume_data);
         self
     }
     /// Add an additional account to the instruction.
@@ -404,6 +481,13 @@ impl<'a, 'b> ResumeSubscriptionCpiBuilder<'a, 'b> {
     #[allow(clippy::clone_on_copy)]
     #[allow(clippy::vec_init_then_push)]
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program_error::ProgramResult {
+        let args = ResumeSubscriptionInstructionArgs {
+            resume_data: self
+                .instruction
+                .resume_data
+                .clone()
+                .expect("resume_data is not set"),
+        };
         let instruction = ResumeSubscriptionCpi {
             __program: self.instruction.__program,
 
@@ -416,6 +500,11 @@ impl<'a, 'b> ResumeSubscriptionCpiBuilder<'a, 'b> {
                 .subscription_pda
                 .expect("subscription_pda is not set"),
 
+            subscription_authority: self
+                .instruction
+                .subscription_authority
+                .expect("subscription_authority is not set"),
+
             event_authority: self
                 .instruction
                 .event_authority
@@ -425,6 +514,7 @@ impl<'a, 'b> ResumeSubscriptionCpiBuilder<'a, 'b> {
                 .instruction
                 .self_program
                 .expect("self_program is not set"),
+            __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,
@@ -439,8 +529,10 @@ struct ResumeSubscriptionCpiBuilderInstruction<'a, 'b> {
     subscriber: Option<&'b solana_account_info::AccountInfo<'a>>,
     plan_pda: Option<&'b solana_account_info::AccountInfo<'a>>,
     subscription_pda: Option<&'b solana_account_info::AccountInfo<'a>>,
+    subscription_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     event_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     self_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    resume_data: Option<ResumeData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/revoke_abandoned_delegation.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/revoke_abandoned_delegation.rs
@@ -8,18 +8,20 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
-pub const REVOKE_DELEGATION_DISCRIMINATOR: u8 = 3;
+pub const REVOKE_ABANDONED_DELEGATION_DISCRIMINATOR: u8 = 15;
 
 /// Accounts.
 #[derive(Debug)]
-pub struct RevokeDelegation {
-    /// The delegator revoking the delegation (receives rent)
-    pub authority: solana_address::Address,
-    /// The delegation PDA to close
+pub struct RevokeAbandonedDelegation {
+    /// The recorded payer reclaiming rent
+    pub payer: solana_address::Address,
+    /// The fixed or recurring delegation PDA to close
     pub delegation_account: solana_address::Address,
+    /// The delegation's recorded SubscriptionAuthority PDA (may be closed)
+    pub subscription_authority: solana_address::Address,
 }
 
-impl RevokeDelegation {
+impl RevokeAbandonedDelegation {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
@@ -29,14 +31,20 @@ impl RevokeDelegation {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_instruction::AccountMeta::new(self.authority, true));
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
         accounts.push(solana_instruction::AccountMeta::new(
             self.delegation_account,
             false,
         ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            self.subscription_authority,
+            false,
+        ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = RevokeDelegationInstructionData::new().try_to_vec().unwrap();
+        let data = RevokeAbandonedDelegationInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -47,13 +55,13 @@ impl RevokeDelegation {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct RevokeDelegationInstructionData {
+pub struct RevokeAbandonedDelegationInstructionData {
     discriminator: u8,
 }
 
-impl RevokeDelegationInstructionData {
+impl RevokeAbandonedDelegationInstructionData {
     pub fn new() -> Self {
-        Self { discriminator: 3 }
+        Self { discriminator: 15 }
     }
 
     pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
@@ -61,39 +69,50 @@ impl RevokeDelegationInstructionData {
     }
 }
 
-impl Default for RevokeDelegationInstructionData {
+impl Default for RevokeAbandonedDelegationInstructionData {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Instruction builder for `RevokeDelegation`.
+/// Instruction builder for `RevokeAbandonedDelegation`.
 ///
 /// ### Accounts:
 ///
-///   0. `[writable, signer]` authority
+///   0. `[writable, signer]` payer
 ///   1. `[writable]` delegation_account
+///   2. `[]` subscription_authority
 #[derive(Clone, Debug, Default)]
-pub struct RevokeDelegationBuilder {
-    authority: Option<solana_address::Address>,
+pub struct RevokeAbandonedDelegationBuilder {
+    payer: Option<solana_address::Address>,
     delegation_account: Option<solana_address::Address>,
+    subscription_authority: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
-impl RevokeDelegationBuilder {
+impl RevokeAbandonedDelegationBuilder {
     pub fn new() -> Self {
         Self::default()
     }
-    /// The delegator revoking the delegation (receives rent)
+    /// The recorded payer reclaiming rent
     #[inline(always)]
-    pub fn authority(&mut self, authority: solana_address::Address) -> &mut Self {
-        self.authority = Some(authority);
+    pub fn payer(&mut self, payer: solana_address::Address) -> &mut Self {
+        self.payer = Some(payer);
         self
     }
-    /// The delegation PDA to close
+    /// The fixed or recurring delegation PDA to close
     #[inline(always)]
     pub fn delegation_account(&mut self, delegation_account: solana_address::Address) -> &mut Self {
         self.delegation_account = Some(delegation_account);
+        self
+    }
+    /// The delegation's recorded SubscriptionAuthority PDA (may be closed)
+    #[inline(always)]
+    pub fn subscription_authority(
+        &mut self,
+        subscription_authority: solana_address::Address,
+    ) -> &mut Self {
+        self.subscription_authority = Some(subscription_authority);
         self
     }
     /// Add an additional account to the instruction.
@@ -113,44 +132,52 @@ impl RevokeDelegationBuilder {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_instruction::Instruction {
-        let accounts = RevokeDelegation {
-            authority: self.authority.expect("authority is not set"),
+        let accounts = RevokeAbandonedDelegation {
+            payer: self.payer.expect("payer is not set"),
             delegation_account: self
                 .delegation_account
                 .expect("delegation_account is not set"),
+            subscription_authority: self
+                .subscription_authority
+                .expect("subscription_authority is not set"),
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
     }
 }
 
-/// `revoke_delegation` CPI accounts.
-pub struct RevokeDelegationCpiAccounts<'a, 'b> {
-    /// The delegator revoking the delegation (receives rent)
-    pub authority: &'b solana_account_info::AccountInfo<'a>,
-    /// The delegation PDA to close
+/// `revoke_abandoned_delegation` CPI accounts.
+pub struct RevokeAbandonedDelegationCpiAccounts<'a, 'b> {
+    /// The recorded payer reclaiming rent
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
+    /// The fixed or recurring delegation PDA to close
     pub delegation_account: &'b solana_account_info::AccountInfo<'a>,
+    /// The delegation's recorded SubscriptionAuthority PDA (may be closed)
+    pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
-/// `revoke_delegation` CPI instruction.
-pub struct RevokeDelegationCpi<'a, 'b> {
+/// `revoke_abandoned_delegation` CPI instruction.
+pub struct RevokeAbandonedDelegationCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_account_info::AccountInfo<'a>,
-    /// The delegator revoking the delegation (receives rent)
-    pub authority: &'b solana_account_info::AccountInfo<'a>,
-    /// The delegation PDA to close
+    /// The recorded payer reclaiming rent
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
+    /// The fixed or recurring delegation PDA to close
     pub delegation_account: &'b solana_account_info::AccountInfo<'a>,
+    /// The delegation's recorded SubscriptionAuthority PDA (may be closed)
+    pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
-impl<'a, 'b> RevokeDelegationCpi<'a, 'b> {
+impl<'a, 'b> RevokeAbandonedDelegationCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_account_info::AccountInfo<'a>,
-        accounts: RevokeDelegationCpiAccounts<'a, 'b>,
+        accounts: RevokeAbandonedDelegationCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
-            authority: accounts.authority,
+            payer: accounts.payer,
             delegation_account: accounts.delegation_account,
+            subscription_authority: accounts.subscription_authority,
         }
     }
     #[inline(always)]
@@ -176,13 +203,14 @@ impl<'a, 'b> RevokeDelegationCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_instruction::AccountMeta::new(
-            *self.authority.key,
-            true,
-        ));
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        accounts.push(solana_instruction::AccountMeta::new(*self.payer.key, true));
         accounts.push(solana_instruction::AccountMeta::new(
             *self.delegation_account.key,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            *self.subscription_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
@@ -192,17 +220,20 @@ impl<'a, 'b> RevokeDelegationCpi<'a, 'b> {
                 is_signer: remaining_account.2,
             })
         });
-        let data = RevokeDelegationInstructionData::new().try_to_vec().unwrap();
+        let data = RevokeAbandonedDelegationInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
-        account_infos.push(self.authority.clone());
+        account_infos.push(self.payer.clone());
         account_infos.push(self.delegation_account.clone());
+        account_infos.push(self.subscription_authority.clone());
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -215,40 +246,51 @@ impl<'a, 'b> RevokeDelegationCpi<'a, 'b> {
     }
 }
 
-/// Instruction builder for `RevokeDelegation` via CPI.
+/// Instruction builder for `RevokeAbandonedDelegation` via CPI.
 ///
 /// ### Accounts:
 ///
-///   0. `[writable, signer]` authority
+///   0. `[writable, signer]` payer
 ///   1. `[writable]` delegation_account
+///   2. `[]` subscription_authority
 #[derive(Clone, Debug)]
-pub struct RevokeDelegationCpiBuilder<'a, 'b> {
-    instruction: Box<RevokeDelegationCpiBuilderInstruction<'a, 'b>>,
+pub struct RevokeAbandonedDelegationCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeAbandonedDelegationCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a, 'b> RevokeDelegationCpiBuilder<'a, 'b> {
+impl<'a, 'b> RevokeAbandonedDelegationCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
-        let instruction = Box::new(RevokeDelegationCpiBuilderInstruction {
+        let instruction = Box::new(RevokeAbandonedDelegationCpiBuilderInstruction {
             __program: program,
-            authority: None,
+            payer: None,
             delegation_account: None,
+            subscription_authority: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
     }
-    /// The delegator revoking the delegation (receives rent)
+    /// The recorded payer reclaiming rent
     #[inline(always)]
-    pub fn authority(&mut self, authority: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
-        self.instruction.authority = Some(authority);
+    pub fn payer(&mut self, payer: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.payer = Some(payer);
         self
     }
-    /// The delegation PDA to close
+    /// The fixed or recurring delegation PDA to close
     #[inline(always)]
     pub fn delegation_account(
         &mut self,
         delegation_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegation_account = Some(delegation_account);
+        self
+    }
+    /// The delegation's recorded SubscriptionAuthority PDA (may be closed)
+    #[inline(always)]
+    pub fn subscription_authority(
+        &mut self,
+        subscription_authority: &'b solana_account_info::AccountInfo<'a>,
+    ) -> &mut Self {
+        self.instruction.subscription_authority = Some(subscription_authority);
         self
     }
     /// Add an additional account to the instruction.
@@ -285,15 +327,20 @@ impl<'a, 'b> RevokeDelegationCpiBuilder<'a, 'b> {
     #[allow(clippy::clone_on_copy)]
     #[allow(clippy::vec_init_then_push)]
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program_error::ProgramResult {
-        let instruction = RevokeDelegationCpi {
+        let instruction = RevokeAbandonedDelegationCpi {
             __program: self.instruction.__program,
 
-            authority: self.instruction.authority.expect("authority is not set"),
+            payer: self.instruction.payer.expect("payer is not set"),
 
             delegation_account: self
                 .instruction
                 .delegation_account
                 .expect("delegation_account is not set"),
+
+            subscription_authority: self
+                .instruction
+                .subscription_authority
+                .expect("subscription_authority is not set"),
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,
@@ -303,10 +350,11 @@ impl<'a, 'b> RevokeDelegationCpiBuilder<'a, 'b> {
 }
 
 #[derive(Clone, Debug)]
-struct RevokeDelegationCpiBuilderInstruction<'a, 'b> {
+struct RevokeAbandonedDelegationCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
-    authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     delegation_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    subscription_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/revoke_abandoned_subscription.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/revoke_abandoned_subscription.rs
@@ -5,53 +5,52 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
-use crate::generated::subscriptions::generated::types::UpdatePlanData;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
-pub const UPDATE_PLAN_DISCRIMINATOR: u8 = 8;
+pub const REVOKE_ABANDONED_SUBSCRIPTION_DISCRIMINATOR: u8 = 16;
 
 /// Accounts.
 #[derive(Debug)]
-pub struct UpdatePlan {
-    /// The plan owner updating the plan
-    pub owner: solana_address::Address,
-    /// The plan PDA being updated
+pub struct RevokeAbandonedSubscription {
+    /// The recorded payer reclaiming rent
+    pub payer: solana_address::Address,
+    /// The abandoned subscription PDA to close
+    pub subscription_account: solana_address::Address,
+    /// The subscriber's recorded SubscriptionAuthority PDA for the plan's mint (may be closed)
+    pub subscription_authority: solana_address::Address,
+    /// The plan the subscription belongs to; provides the mint
     pub plan_pda: solana_address::Address,
-    /// The event authority PDA
-    pub event_authority: solana_address::Address,
-    /// This program (for self-CPI)
-    pub self_program: solana_address::Address,
 }
 
-impl UpdatePlan {
-    pub fn instruction(&self, args: UpdatePlanInstructionArgs) -> solana_instruction::Instruction {
-        self.instruction_with_remaining_accounts(args, &[])
+impl RevokeAbandonedSubscription {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
+        self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        args: UpdatePlanInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.owner, true,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new(self.plan_pda, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.event_authority,
+        accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
+        accounts.push(solana_instruction::AccountMeta::new(
+            self.subscription_account,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.self_program,
+            self.subscription_authority,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            self.plan_pda,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = UpdatePlanInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
-        data.append(&mut args);
+        let data = RevokeAbandonedSubscriptionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -62,13 +61,13 @@ impl UpdatePlan {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct UpdatePlanInstructionData {
+pub struct RevokeAbandonedSubscriptionInstructionData {
     discriminator: u8,
 }
 
-impl UpdatePlanInstructionData {
+impl RevokeAbandonedSubscriptionInstructionData {
     pub fn new() -> Self {
-        Self { discriminator: 8 }
+        Self { discriminator: 16 }
     }
 
     pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
@@ -76,73 +75,61 @@ impl UpdatePlanInstructionData {
     }
 }
 
-impl Default for UpdatePlanInstructionData {
+impl Default for RevokeAbandonedSubscriptionInstructionData {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct UpdatePlanInstructionArgs {
-    pub update_plan_data: UpdatePlanData,
-}
-
-impl UpdatePlanInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
-        borsh::to_vec(self)
-    }
-}
-
-/// Instruction builder for `UpdatePlan`.
+/// Instruction builder for `RevokeAbandonedSubscription`.
 ///
 /// ### Accounts:
 ///
-///   0. `[signer]` owner
-///   1. `[writable]` plan_pda
-///   2. `[]` event_authority
-///   3. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
+///   0. `[writable, signer]` payer
+///   1. `[writable]` subscription_account
+///   2. `[]` subscription_authority
+///   3. `[]` plan_pda
 #[derive(Clone, Debug, Default)]
-pub struct UpdatePlanBuilder {
-    owner: Option<solana_address::Address>,
+pub struct RevokeAbandonedSubscriptionBuilder {
+    payer: Option<solana_address::Address>,
+    subscription_account: Option<solana_address::Address>,
+    subscription_authority: Option<solana_address::Address>,
     plan_pda: Option<solana_address::Address>,
-    event_authority: Option<solana_address::Address>,
-    self_program: Option<solana_address::Address>,
-    update_plan_data: Option<UpdatePlanData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
-impl UpdatePlanBuilder {
+impl RevokeAbandonedSubscriptionBuilder {
     pub fn new() -> Self {
         Self::default()
     }
-    /// The plan owner updating the plan
+    /// The recorded payer reclaiming rent
     #[inline(always)]
-    pub fn owner(&mut self, owner: solana_address::Address) -> &mut Self {
-        self.owner = Some(owner);
+    pub fn payer(&mut self, payer: solana_address::Address) -> &mut Self {
+        self.payer = Some(payer);
         self
     }
-    /// The plan PDA being updated
+    /// The abandoned subscription PDA to close
+    #[inline(always)]
+    pub fn subscription_account(
+        &mut self,
+        subscription_account: solana_address::Address,
+    ) -> &mut Self {
+        self.subscription_account = Some(subscription_account);
+        self
+    }
+    /// The subscriber's recorded SubscriptionAuthority PDA for the plan's mint (may be closed)
+    #[inline(always)]
+    pub fn subscription_authority(
+        &mut self,
+        subscription_authority: solana_address::Address,
+    ) -> &mut Self {
+        self.subscription_authority = Some(subscription_authority);
+        self
+    }
+    /// The plan the subscription belongs to; provides the mint
     #[inline(always)]
     pub fn plan_pda(&mut self, plan_pda: solana_address::Address) -> &mut Self {
         self.plan_pda = Some(plan_pda);
-        self
-    }
-    /// The event authority PDA
-    #[inline(always)]
-    pub fn event_authority(&mut self, event_authority: solana_address::Address) -> &mut Self {
-        self.event_authority = Some(event_authority);
-        self
-    }
-    /// `[optional account, default to 'De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44']`
-    /// This program (for self-CPI)
-    #[inline(always)]
-    pub fn self_program(&mut self, self_program: solana_address::Address) -> &mut Self {
-        self.self_program = Some(self_program);
-        self
-    }
-    #[inline(always)]
-    pub fn update_plan_data(&mut self, update_plan_data: UpdatePlanData) -> &mut Self {
-        self.update_plan_data = Some(update_plan_data);
         self
     }
     /// Add an additional account to the instruction.
@@ -162,66 +149,58 @@ impl UpdatePlanBuilder {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_instruction::Instruction {
-        let accounts = UpdatePlan {
-            owner: self.owner.expect("owner is not set"),
+        let accounts = RevokeAbandonedSubscription {
+            payer: self.payer.expect("payer is not set"),
+            subscription_account: self
+                .subscription_account
+                .expect("subscription_account is not set"),
+            subscription_authority: self
+                .subscription_authority
+                .expect("subscription_authority is not set"),
             plan_pda: self.plan_pda.expect("plan_pda is not set"),
-            event_authority: self.event_authority.expect("event_authority is not set"),
-            self_program: self.self_program.unwrap_or(solana_address::address!(
-                "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
-            )),
-        };
-        let args = UpdatePlanInstructionArgs {
-            update_plan_data: self
-                .update_plan_data
-                .clone()
-                .expect("update_plan_data is not set"),
         };
 
-        accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
+        accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
     }
 }
 
-/// `update_plan` CPI accounts.
-pub struct UpdatePlanCpiAccounts<'a, 'b> {
-    /// The plan owner updating the plan
-    pub owner: &'b solana_account_info::AccountInfo<'a>,
-    /// The plan PDA being updated
+/// `revoke_abandoned_subscription` CPI accounts.
+pub struct RevokeAbandonedSubscriptionCpiAccounts<'a, 'b> {
+    /// The recorded payer reclaiming rent
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
+    /// The abandoned subscription PDA to close
+    pub subscription_account: &'b solana_account_info::AccountInfo<'a>,
+    /// The subscriber's recorded SubscriptionAuthority PDA for the plan's mint (may be closed)
+    pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
+    /// The plan the subscription belongs to; provides the mint
     pub plan_pda: &'b solana_account_info::AccountInfo<'a>,
-    /// The event authority PDA
-    pub event_authority: &'b solana_account_info::AccountInfo<'a>,
-    /// This program (for self-CPI)
-    pub self_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
-/// `update_plan` CPI instruction.
-pub struct UpdatePlanCpi<'a, 'b> {
+/// `revoke_abandoned_subscription` CPI instruction.
+pub struct RevokeAbandonedSubscriptionCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_account_info::AccountInfo<'a>,
-    /// The plan owner updating the plan
-    pub owner: &'b solana_account_info::AccountInfo<'a>,
-    /// The plan PDA being updated
+    /// The recorded payer reclaiming rent
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
+    /// The abandoned subscription PDA to close
+    pub subscription_account: &'b solana_account_info::AccountInfo<'a>,
+    /// The subscriber's recorded SubscriptionAuthority PDA for the plan's mint (may be closed)
+    pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
+    /// The plan the subscription belongs to; provides the mint
     pub plan_pda: &'b solana_account_info::AccountInfo<'a>,
-    /// The event authority PDA
-    pub event_authority: &'b solana_account_info::AccountInfo<'a>,
-    /// This program (for self-CPI)
-    pub self_program: &'b solana_account_info::AccountInfo<'a>,
-    /// The arguments for the instruction.
-    pub __args: UpdatePlanInstructionArgs,
 }
 
-impl<'a, 'b> UpdatePlanCpi<'a, 'b> {
+impl<'a, 'b> RevokeAbandonedSubscriptionCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_account_info::AccountInfo<'a>,
-        accounts: UpdatePlanCpiAccounts<'a, 'b>,
-        args: UpdatePlanInstructionArgs,
+        accounts: RevokeAbandonedSubscriptionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
-            owner: accounts.owner,
+            payer: accounts.payer,
+            subscription_account: accounts.subscription_account,
+            subscription_authority: accounts.subscription_authority,
             plan_pda: accounts.plan_pda,
-            event_authority: accounts.event_authority,
-            self_program: accounts.self_program,
-            __args: args,
         }
     }
     #[inline(always)]
@@ -248,20 +227,17 @@ impl<'a, 'b> UpdatePlanCpi<'a, 'b> {
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.owner.key,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(*self.payer.key, true));
         accounts.push(solana_instruction::AccountMeta::new(
+            *self.subscription_account.key,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            *self.subscription_authority.key,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.plan_pda.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.event_authority.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.self_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
@@ -271,9 +247,9 @@ impl<'a, 'b> UpdatePlanCpi<'a, 'b> {
                 is_signer: remaining_account.2,
             })
         });
-        let mut data = UpdatePlanInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
-        data.append(&mut args);
+        let data = RevokeAbandonedSubscriptionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::generated::subscriptions::SUBSCRIPTIONS_ID,
@@ -282,10 +258,10 @@ impl<'a, 'b> UpdatePlanCpi<'a, 'b> {
         };
         let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
-        account_infos.push(self.owner.clone());
+        account_infos.push(self.payer.clone());
+        account_infos.push(self.subscription_account.clone());
+        account_infos.push(self.subscription_authority.clone());
         account_infos.push(self.plan_pda.clone());
-        account_infos.push(self.event_authority.clone());
-        account_infos.push(self.self_program.clone());
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -298,65 +274,59 @@ impl<'a, 'b> UpdatePlanCpi<'a, 'b> {
     }
 }
 
-/// Instruction builder for `UpdatePlan` via CPI.
+/// Instruction builder for `RevokeAbandonedSubscription` via CPI.
 ///
 /// ### Accounts:
 ///
-///   0. `[signer]` owner
-///   1. `[writable]` plan_pda
-///   2. `[]` event_authority
-///   3. `[]` self_program
+///   0. `[writable, signer]` payer
+///   1. `[writable]` subscription_account
+///   2. `[]` subscription_authority
+///   3. `[]` plan_pda
 #[derive(Clone, Debug)]
-pub struct UpdatePlanCpiBuilder<'a, 'b> {
-    instruction: Box<UpdatePlanCpiBuilderInstruction<'a, 'b>>,
+pub struct RevokeAbandonedSubscriptionCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeAbandonedSubscriptionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a, 'b> UpdatePlanCpiBuilder<'a, 'b> {
+impl<'a, 'b> RevokeAbandonedSubscriptionCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
-        let instruction = Box::new(UpdatePlanCpiBuilderInstruction {
+        let instruction = Box::new(RevokeAbandonedSubscriptionCpiBuilderInstruction {
             __program: program,
-            owner: None,
+            payer: None,
+            subscription_account: None,
+            subscription_authority: None,
             plan_pda: None,
-            event_authority: None,
-            self_program: None,
-            update_plan_data: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
     }
-    /// The plan owner updating the plan
+    /// The recorded payer reclaiming rent
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
-        self.instruction.owner = Some(owner);
+    pub fn payer(&mut self, payer: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.payer = Some(payer);
         self
     }
-    /// The plan PDA being updated
+    /// The abandoned subscription PDA to close
+    #[inline(always)]
+    pub fn subscription_account(
+        &mut self,
+        subscription_account: &'b solana_account_info::AccountInfo<'a>,
+    ) -> &mut Self {
+        self.instruction.subscription_account = Some(subscription_account);
+        self
+    }
+    /// The subscriber's recorded SubscriptionAuthority PDA for the plan's mint (may be closed)
+    #[inline(always)]
+    pub fn subscription_authority(
+        &mut self,
+        subscription_authority: &'b solana_account_info::AccountInfo<'a>,
+    ) -> &mut Self {
+        self.instruction.subscription_authority = Some(subscription_authority);
+        self
+    }
+    /// The plan the subscription belongs to; provides the mint
     #[inline(always)]
     pub fn plan_pda(&mut self, plan_pda: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.plan_pda = Some(plan_pda);
-        self
-    }
-    /// The event authority PDA
-    #[inline(always)]
-    pub fn event_authority(
-        &mut self,
-        event_authority: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.event_authority = Some(event_authority);
-        self
-    }
-    /// This program (for self-CPI)
-    #[inline(always)]
-    pub fn self_program(
-        &mut self,
-        self_program: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.self_program = Some(self_program);
-        self
-    }
-    #[inline(always)]
-    pub fn update_plan_data(&mut self, update_plan_data: UpdatePlanData) -> &mut Self {
-        self.instruction.update_plan_data = Some(update_plan_data);
         self
     }
     /// Add an additional account to the instruction.
@@ -393,30 +363,22 @@ impl<'a, 'b> UpdatePlanCpiBuilder<'a, 'b> {
     #[allow(clippy::clone_on_copy)]
     #[allow(clippy::vec_init_then_push)]
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program_error::ProgramResult {
-        let args = UpdatePlanInstructionArgs {
-            update_plan_data: self
-                .instruction
-                .update_plan_data
-                .clone()
-                .expect("update_plan_data is not set"),
-        };
-        let instruction = UpdatePlanCpi {
+        let instruction = RevokeAbandonedSubscriptionCpi {
             __program: self.instruction.__program,
 
-            owner: self.instruction.owner.expect("owner is not set"),
+            payer: self.instruction.payer.expect("payer is not set"),
+
+            subscription_account: self
+                .instruction
+                .subscription_account
+                .expect("subscription_account is not set"),
+
+            subscription_authority: self
+                .instruction
+                .subscription_authority
+                .expect("subscription_authority is not set"),
 
             plan_pda: self.instruction.plan_pda.expect("plan_pda is not set"),
-
-            event_authority: self
-                .instruction
-                .event_authority
-                .expect("event_authority is not set"),
-
-            self_program: self
-                .instruction
-                .self_program
-                .expect("self_program is not set"),
-            __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,
@@ -426,13 +388,12 @@ impl<'a, 'b> UpdatePlanCpiBuilder<'a, 'b> {
 }
 
 #[derive(Clone, Debug)]
-struct UpdatePlanCpiBuilderInstruction<'a, 'b> {
+struct RevokeAbandonedSubscriptionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
-    owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    subscription_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    subscription_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     plan_pda: Option<&'b solana_account_info::AccountInfo<'a>>,
-    event_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
-    self_program: Option<&'b solana_account_info::AccountInfo<'a>>,
-    update_plan_data: Option<UpdatePlanData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/revoke_subscription_authority.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/revoke_subscription_authority.rs
@@ -8,20 +8,26 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
-pub const CLOSE_SUBSCRIPTION_AUTHORITY_DISCRIMINATOR: u8 = 6;
+pub const REVOKE_SUBSCRIPTION_AUTHORITY_DISCRIMINATOR: u8 = 14;
 
 /// Accounts.
 #[derive(Debug)]
-pub struct CloseSubscriptionAuthority {
-    /// The user who owns the SubscriptionAuthority PDA (receives rent)
+pub struct RevokeSubscriptionAuthority {
+    /// The ATA owner: revokes the program's delegate and, when still open, closes the SubscriptionAuthority PDA (receives rent when self-funded)
     pub user: solana_address::Address,
-    /// The SubscriptionAuthority PDA to close
+    /// The user's ATA whose delegate is being revoked
+    pub user_ata: solana_address::Address,
+    /// The token mint of the user's ATA
+    pub token_mint: solana_address::Address,
+    /// Token program
+    pub token_program: solana_address::Address,
+    /// The SubscriptionAuthority PDA. Closed when still open; ignored when already closed.
     pub subscription_authority: solana_address::Address,
-    /// Optional rent recipient, required when the recorded payer differs from the user. Must match the stored payer.
+    /// Optional rent recipient, required when the SubscriptionAuthority is still open and its recorded payer differs from the user. Must match the stored payer.
     pub receiver: Option<solana_address::Address>,
 }
 
-impl CloseSubscriptionAuthority {
+impl RevokeSubscriptionAuthority {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
@@ -31,8 +37,17 @@ impl CloseSubscriptionAuthority {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.user, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.user_ata, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            self.token_mint,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            self.token_program,
+            false,
+        ));
         accounts.push(solana_instruction::AccountMeta::new(
             self.subscription_authority,
             false,
@@ -41,7 +56,7 @@ impl CloseSubscriptionAuthority {
             accounts.push(solana_instruction::AccountMeta::new(receiver, false));
         }
         accounts.extend_from_slice(remaining_accounts);
-        let data = CloseSubscriptionAuthorityInstructionData::new()
+        let data = RevokeSubscriptionAuthorityInstructionData::new()
             .try_to_vec()
             .unwrap();
 
@@ -54,13 +69,13 @@ impl CloseSubscriptionAuthority {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct CloseSubscriptionAuthorityInstructionData {
+pub struct RevokeSubscriptionAuthorityInstructionData {
     discriminator: u8,
 }
 
-impl CloseSubscriptionAuthorityInstructionData {
+impl RevokeSubscriptionAuthorityInstructionData {
     pub fn new() -> Self {
-        Self { discriminator: 6 }
+        Self { discriminator: 14 }
     }
 
     pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
@@ -68,38 +83,62 @@ impl CloseSubscriptionAuthorityInstructionData {
     }
 }
 
-impl Default for CloseSubscriptionAuthorityInstructionData {
+impl Default for RevokeSubscriptionAuthorityInstructionData {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Instruction builder for `CloseSubscriptionAuthority`.
+/// Instruction builder for `RevokeSubscriptionAuthority`.
 ///
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` user
-///   1. `[writable]` subscription_authority
-///   2. `[writable, optional]` receiver
+///   1. `[writable]` user_ata
+///   2. `[]` token_mint
+///   3. `[]` token_program
+///   4. `[writable]` subscription_authority
+///   5. `[writable, optional]` receiver
 #[derive(Clone, Debug, Default)]
-pub struct CloseSubscriptionAuthorityBuilder {
+pub struct RevokeSubscriptionAuthorityBuilder {
     user: Option<solana_address::Address>,
+    user_ata: Option<solana_address::Address>,
+    token_mint: Option<solana_address::Address>,
+    token_program: Option<solana_address::Address>,
     subscription_authority: Option<solana_address::Address>,
     receiver: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
-impl CloseSubscriptionAuthorityBuilder {
+impl RevokeSubscriptionAuthorityBuilder {
     pub fn new() -> Self {
         Self::default()
     }
-    /// The user who owns the SubscriptionAuthority PDA (receives rent)
+    /// The ATA owner: revokes the program's delegate and, when still open, closes the SubscriptionAuthority PDA (receives rent when self-funded)
     #[inline(always)]
     pub fn user(&mut self, user: solana_address::Address) -> &mut Self {
         self.user = Some(user);
         self
     }
-    /// The SubscriptionAuthority PDA to close
+    /// The user's ATA whose delegate is being revoked
+    #[inline(always)]
+    pub fn user_ata(&mut self, user_ata: solana_address::Address) -> &mut Self {
+        self.user_ata = Some(user_ata);
+        self
+    }
+    /// The token mint of the user's ATA
+    #[inline(always)]
+    pub fn token_mint(&mut self, token_mint: solana_address::Address) -> &mut Self {
+        self.token_mint = Some(token_mint);
+        self
+    }
+    /// Token program
+    #[inline(always)]
+    pub fn token_program(&mut self, token_program: solana_address::Address) -> &mut Self {
+        self.token_program = Some(token_program);
+        self
+    }
+    /// The SubscriptionAuthority PDA. Closed when still open; ignored when already closed.
     #[inline(always)]
     pub fn subscription_authority(
         &mut self,
@@ -109,7 +148,7 @@ impl CloseSubscriptionAuthorityBuilder {
         self
     }
     /// `[optional account]`
-    /// Optional rent recipient, required when the recorded payer differs from the user. Must match the stored payer.
+    /// Optional rent recipient, required when the SubscriptionAuthority is still open and its recorded payer differs from the user. Must match the stored payer.
     #[inline(always)]
     pub fn receiver(&mut self, receiver: Option<solana_address::Address>) -> &mut Self {
         self.receiver = receiver;
@@ -132,8 +171,11 @@ impl CloseSubscriptionAuthorityBuilder {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_instruction::Instruction {
-        let accounts = CloseSubscriptionAuthority {
+        let accounts = RevokeSubscriptionAuthority {
             user: self.user.expect("user is not set"),
+            user_ata: self.user_ata.expect("user_ata is not set"),
+            token_mint: self.token_mint.expect("token_mint is not set"),
+            token_program: self.token_program.expect("token_program is not set"),
             subscription_authority: self
                 .subscription_authority
                 .expect("subscription_authority is not set"),
@@ -144,36 +186,51 @@ impl CloseSubscriptionAuthorityBuilder {
     }
 }
 
-/// `close_subscription_authority` CPI accounts.
-pub struct CloseSubscriptionAuthorityCpiAccounts<'a, 'b> {
-    /// The user who owns the SubscriptionAuthority PDA (receives rent)
+/// `revoke_subscription_authority` CPI accounts.
+pub struct RevokeSubscriptionAuthorityCpiAccounts<'a, 'b> {
+    /// The ATA owner: revokes the program's delegate and, when still open, closes the SubscriptionAuthority PDA (receives rent when self-funded)
     pub user: &'b solana_account_info::AccountInfo<'a>,
-    /// The SubscriptionAuthority PDA to close
+    /// The user's ATA whose delegate is being revoked
+    pub user_ata: &'b solana_account_info::AccountInfo<'a>,
+    /// The token mint of the user's ATA
+    pub token_mint: &'b solana_account_info::AccountInfo<'a>,
+    /// Token program
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
+    /// The SubscriptionAuthority PDA. Closed when still open; ignored when already closed.
     pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
-    /// Optional rent recipient, required when the recorded payer differs from the user. Must match the stored payer.
+    /// Optional rent recipient, required when the SubscriptionAuthority is still open and its recorded payer differs from the user. Must match the stored payer.
     pub receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
-/// `close_subscription_authority` CPI instruction.
-pub struct CloseSubscriptionAuthorityCpi<'a, 'b> {
+/// `revoke_subscription_authority` CPI instruction.
+pub struct RevokeSubscriptionAuthorityCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_account_info::AccountInfo<'a>,
-    /// The user who owns the SubscriptionAuthority PDA (receives rent)
+    /// The ATA owner: revokes the program's delegate and, when still open, closes the SubscriptionAuthority PDA (receives rent when self-funded)
     pub user: &'b solana_account_info::AccountInfo<'a>,
-    /// The SubscriptionAuthority PDA to close
+    /// The user's ATA whose delegate is being revoked
+    pub user_ata: &'b solana_account_info::AccountInfo<'a>,
+    /// The token mint of the user's ATA
+    pub token_mint: &'b solana_account_info::AccountInfo<'a>,
+    /// Token program
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
+    /// The SubscriptionAuthority PDA. Closed when still open; ignored when already closed.
     pub subscription_authority: &'b solana_account_info::AccountInfo<'a>,
-    /// Optional rent recipient, required when the recorded payer differs from the user. Must match the stored payer.
+    /// Optional rent recipient, required when the SubscriptionAuthority is still open and its recorded payer differs from the user. Must match the stored payer.
     pub receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
-impl<'a, 'b> CloseSubscriptionAuthorityCpi<'a, 'b> {
+impl<'a, 'b> RevokeSubscriptionAuthorityCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_account_info::AccountInfo<'a>,
-        accounts: CloseSubscriptionAuthorityCpiAccounts<'a, 'b>,
+        accounts: RevokeSubscriptionAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
             user: accounts.user,
+            user_ata: accounts.user_ata,
+            token_mint: accounts.token_mint,
+            token_program: accounts.token_program,
             subscription_authority: accounts.subscription_authority,
             receiver: accounts.receiver,
         }
@@ -201,8 +258,20 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.user.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
+            *self.user_ata.key,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            *self.token_mint.key,
+            false,
+        ));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
+            *self.token_program.key,
+            false,
+        ));
         accounts.push(solana_instruction::AccountMeta::new(
             *self.subscription_authority.key,
             false,
@@ -217,7 +286,7 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpi<'a, 'b> {
                 is_signer: remaining_account.2,
             })
         });
-        let data = CloseSubscriptionAuthorityInstructionData::new()
+        let data = RevokeSubscriptionAuthorityInstructionData::new()
             .try_to_vec()
             .unwrap();
 
@@ -226,9 +295,12 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.user.clone());
+        account_infos.push(self.user_ata.clone());
+        account_infos.push(self.token_mint.clone());
+        account_infos.push(self.token_program.clone());
         account_infos.push(self.subscription_authority.clone());
         if let Some(receiver) = self.receiver {
             account_infos.push(receiver.clone());
@@ -245,36 +317,66 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpi<'a, 'b> {
     }
 }
 
-/// Instruction builder for `CloseSubscriptionAuthority` via CPI.
+/// Instruction builder for `RevokeSubscriptionAuthority` via CPI.
 ///
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` user
-///   1. `[writable]` subscription_authority
-///   2. `[writable, optional]` receiver
+///   1. `[writable]` user_ata
+///   2. `[]` token_mint
+///   3. `[]` token_program
+///   4. `[writable]` subscription_authority
+///   5. `[writable, optional]` receiver
 #[derive(Clone, Debug)]
-pub struct CloseSubscriptionAuthorityCpiBuilder<'a, 'b> {
-    instruction: Box<CloseSubscriptionAuthorityCpiBuilderInstruction<'a, 'b>>,
+pub struct RevokeSubscriptionAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeSubscriptionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a, 'b> CloseSubscriptionAuthorityCpiBuilder<'a, 'b> {
+impl<'a, 'b> RevokeSubscriptionAuthorityCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
-        let instruction = Box::new(CloseSubscriptionAuthorityCpiBuilderInstruction {
+        let instruction = Box::new(RevokeSubscriptionAuthorityCpiBuilderInstruction {
             __program: program,
             user: None,
+            user_ata: None,
+            token_mint: None,
+            token_program: None,
             subscription_authority: None,
             receiver: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
     }
-    /// The user who owns the SubscriptionAuthority PDA (receives rent)
+    /// The ATA owner: revokes the program's delegate and, when still open, closes the SubscriptionAuthority PDA (receives rent when self-funded)
     #[inline(always)]
     pub fn user(&mut self, user: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.user = Some(user);
         self
     }
-    /// The SubscriptionAuthority PDA to close
+    /// The user's ATA whose delegate is being revoked
+    #[inline(always)]
+    pub fn user_ata(&mut self, user_ata: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.user_ata = Some(user_ata);
+        self
+    }
+    /// The token mint of the user's ATA
+    #[inline(always)]
+    pub fn token_mint(
+        &mut self,
+        token_mint: &'b solana_account_info::AccountInfo<'a>,
+    ) -> &mut Self {
+        self.instruction.token_mint = Some(token_mint);
+        self
+    }
+    /// Token program
+    #[inline(always)]
+    pub fn token_program(
+        &mut self,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
+    ) -> &mut Self {
+        self.instruction.token_program = Some(token_program);
+        self
+    }
+    /// The SubscriptionAuthority PDA. Closed when still open; ignored when already closed.
     #[inline(always)]
     pub fn subscription_authority(
         &mut self,
@@ -284,7 +386,7 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpiBuilder<'a, 'b> {
         self
     }
     /// `[optional account]`
-    /// Optional rent recipient, required when the recorded payer differs from the user. Must match the stored payer.
+    /// Optional rent recipient, required when the SubscriptionAuthority is still open and its recorded payer differs from the user. Must match the stored payer.
     #[inline(always)]
     pub fn receiver(
         &mut self,
@@ -327,10 +429,19 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpiBuilder<'a, 'b> {
     #[allow(clippy::clone_on_copy)]
     #[allow(clippy::vec_init_then_push)]
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program_error::ProgramResult {
-        let instruction = CloseSubscriptionAuthorityCpi {
+        let instruction = RevokeSubscriptionAuthorityCpi {
             __program: self.instruction.__program,
 
             user: self.instruction.user.expect("user is not set"),
+
+            user_ata: self.instruction.user_ata.expect("user_ata is not set"),
+
+            token_mint: self.instruction.token_mint.expect("token_mint is not set"),
+
+            token_program: self
+                .instruction
+                .token_program
+                .expect("token_program is not set"),
 
             subscription_authority: self
                 .instruction
@@ -347,9 +458,12 @@ impl<'a, 'b> CloseSubscriptionAuthorityCpiBuilder<'a, 'b> {
 }
 
 #[derive(Clone, Debug)]
-struct CloseSubscriptionAuthorityCpiBuilderInstruction<'a, 'b> {
+struct RevokeSubscriptionAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     user: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_ata: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     subscription_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/subscribe.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/subscribe.rs
@@ -30,6 +30,8 @@ pub struct Subscribe {
     pub event_authority: solana_address::Address,
     /// This program (for self-CPI)
     pub self_program: solana_address::Address,
+    /// Optional sponsor that funds the account rent. Defaults to the subscriber/signer when omitted.
+    pub payer: Option<solana_address::Address>,
 }
 
 impl Subscribe {
@@ -43,7 +45,7 @@ impl Subscribe {
         args: SubscribeInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.subscriber, true));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.merchant,
@@ -73,6 +75,9 @@ impl Subscribe {
             self.self_program,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(payer, true));
+        }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = SubscribeInstructionData::new().try_to_vec().unwrap();
         let mut args = args.try_to_vec().unwrap();
@@ -128,8 +133,9 @@ impl SubscribeInstructionArgs {
 ///   3. `[writable]` subscription_pda
 ///   4. `[]` subscription_authority_pda
 ///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   6. `[optional]` event_authority (default to `3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7`)
+///   6. `[]` event_authority
 ///   7. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
+///   8. `[writable, signer, optional]` payer
 #[derive(Clone, Debug, Default)]
 pub struct SubscribeBuilder {
     subscriber: Option<solana_address::Address>,
@@ -140,6 +146,7 @@ pub struct SubscribeBuilder {
     system_program: Option<solana_address::Address>,
     event_authority: Option<solana_address::Address>,
     self_program: Option<solana_address::Address>,
+    payer: Option<solana_address::Address>,
     subscribe_data: Option<SubscribeData>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -188,7 +195,6 @@ impl SubscribeBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// `[optional account, default to '3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7']`
     /// The event authority PDA
     #[inline(always)]
     pub fn event_authority(&mut self, event_authority: solana_address::Address) -> &mut Self {
@@ -200,6 +206,13 @@ impl SubscribeBuilder {
     #[inline(always)]
     pub fn self_program(&mut self, self_program: solana_address::Address) -> &mut Self {
         self.self_program = Some(self_program);
+        self
+    }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the subscriber/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<solana_address::Address>) -> &mut Self {
+        self.payer = payer;
         self
     }
     #[inline(always)]
@@ -235,12 +248,11 @@ impl SubscribeBuilder {
             system_program: self
                 .system_program
                 .unwrap_or(solana_address::address!("11111111111111111111111111111111")),
-            event_authority: self.event_authority.unwrap_or(solana_address::address!(
-                "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
-            )),
+            event_authority: self.event_authority.expect("event_authority is not set"),
             self_program: self.self_program.unwrap_or(solana_address::address!(
                 "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
             )),
+            payer: self.payer,
         };
         let args = SubscribeInstructionArgs {
             subscribe_data: self
@@ -271,6 +283,8 @@ pub struct SubscribeCpiAccounts<'a, 'b> {
     pub event_authority: &'b solana_account_info::AccountInfo<'a>,
     /// This program (for self-CPI)
     pub self_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the subscriber/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
 
 /// `subscribe` CPI instruction.
@@ -293,6 +307,8 @@ pub struct SubscribeCpi<'a, 'b> {
     pub event_authority: &'b solana_account_info::AccountInfo<'a>,
     /// This program (for self-CPI)
     pub self_program: &'b solana_account_info::AccountInfo<'a>,
+    /// Optional sponsor that funds the account rent. Defaults to the subscriber/signer when omitted.
+    pub payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: SubscribeInstructionArgs,
 }
@@ -313,6 +329,7 @@ impl<'a, 'b> SubscribeCpi<'a, 'b> {
             system_program: accounts.system_program,
             event_authority: accounts.event_authority,
             self_program: accounts.self_program,
+            payer: accounts.payer,
             __args: args,
         }
     }
@@ -339,7 +356,7 @@ impl<'a, 'b> SubscribeCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(
             *self.subscriber.key,
             true,
@@ -372,11 +389,14 @@ impl<'a, 'b> SubscribeCpi<'a, 'b> {
             *self.self_program.key,
             false,
         ));
+        if let Some(payer) = self.payer {
+            accounts.push(solana_instruction::AccountMeta::new(*payer.key, true));
+        }
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = SubscribeInstructionData::new().try_to_vec().unwrap();
@@ -388,7 +408,7 @@ impl<'a, 'b> SubscribeCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(9 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(10 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.subscriber.clone());
         account_infos.push(self.merchant.clone());
@@ -398,6 +418,9 @@ impl<'a, 'b> SubscribeCpi<'a, 'b> {
         account_infos.push(self.system_program.clone());
         account_infos.push(self.event_authority.clone());
         account_infos.push(self.self_program.clone());
+        if let Some(payer) = self.payer {
+            account_infos.push(payer.clone());
+        }
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -422,6 +445,7 @@ impl<'a, 'b> SubscribeCpi<'a, 'b> {
 ///   5. `[]` system_program
 ///   6. `[]` event_authority
 ///   7. `[]` self_program
+///   8. `[writable, signer, optional]` payer
 #[derive(Clone, Debug)]
 pub struct SubscribeCpiBuilder<'a, 'b> {
     instruction: Box<SubscribeCpiBuilderInstruction<'a, 'b>>,
@@ -439,6 +463,7 @@ impl<'a, 'b> SubscribeCpiBuilder<'a, 'b> {
             system_program: None,
             event_authority: None,
             self_program: None,
+            payer: None,
             subscribe_data: None,
             __remaining_accounts: Vec::new(),
         });
@@ -508,6 +533,13 @@ impl<'a, 'b> SubscribeCpiBuilder<'a, 'b> {
         self_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.self_program = Some(self_program);
+        self
+    }
+    /// `[optional account]`
+    /// Optional sponsor that funds the account rent. Defaults to the subscriber/signer when omitted.
+    #[inline(always)]
+    pub fn payer(&mut self, payer: Option<&'b solana_account_info::AccountInfo<'a>>) -> &mut Self {
+        self.instruction.payer = payer;
         self
     }
     #[inline(always)]
@@ -589,6 +621,8 @@ impl<'a, 'b> SubscribeCpiBuilder<'a, 'b> {
                 .instruction
                 .self_program
                 .expect("self_program is not set"),
+
+            payer: self.instruction.payer,
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -609,6 +643,7 @@ struct SubscribeCpiBuilderInstruction<'a, 'b> {
     system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     event_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     self_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
     subscribe_data: Option<SubscribeData>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/transfer_fixed.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/transfer_fixed.rs
@@ -141,7 +141,7 @@ impl TransferFixedInstructionArgs {
 ///   4. `[]` token_mint
 ///   5. `[]` token_program
 ///   6. `[signer]` delegatee
-///   7. `[optional]` event_authority (default to `3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7`)
+///   7. `[]` event_authority
 ///   8. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
 #[derive(Clone, Debug, Default)]
 pub struct TransferFixedBuilder {
@@ -207,7 +207,6 @@ impl TransferFixedBuilder {
         self.delegatee = Some(delegatee);
         self
     }
-    /// `[optional account, default to '3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7']`
     /// The event authority PDA
     #[inline(always)]
     pub fn event_authority(&mut self, event_authority: solana_address::Address) -> &mut Self {
@@ -253,9 +252,7 @@ impl TransferFixedBuilder {
             token_mint: self.token_mint.expect("token_mint is not set"),
             token_program: self.token_program.expect("token_program is not set"),
             delegatee: self.delegatee.expect("delegatee is not set"),
-            event_authority: self.event_authority.unwrap_or(solana_address::address!(
-                "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
-            )),
+            event_authority: self.event_authority.expect("event_authority is not set"),
             self_program: self.self_program.unwrap_or(solana_address::address!(
                 "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
             )),
@@ -402,8 +399,8 @@ impl<'a, 'b> TransferFixedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = TransferFixedInstructionData::new().try_to_vec().unwrap();

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/transfer_recurring.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/transfer_recurring.rs
@@ -143,7 +143,7 @@ impl TransferRecurringInstructionArgs {
 ///   4. `[]` token_mint
 ///   5. `[]` token_program
 ///   6. `[signer]` delegatee
-///   7. `[optional]` event_authority (default to `3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7`)
+///   7. `[]` event_authority
 ///   8. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
 #[derive(Clone, Debug, Default)]
 pub struct TransferRecurringBuilder {
@@ -209,7 +209,6 @@ impl TransferRecurringBuilder {
         self.delegatee = Some(delegatee);
         self
     }
-    /// `[optional account, default to '3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7']`
     /// The event authority PDA
     #[inline(always)]
     pub fn event_authority(&mut self, event_authority: solana_address::Address) -> &mut Self {
@@ -255,9 +254,7 @@ impl TransferRecurringBuilder {
             token_mint: self.token_mint.expect("token_mint is not set"),
             token_program: self.token_program.expect("token_program is not set"),
             delegatee: self.delegatee.expect("delegatee is not set"),
-            event_authority: self.event_authority.unwrap_or(solana_address::address!(
-                "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
-            )),
+            event_authority: self.event_authority.expect("event_authority is not set"),
             self_program: self.self_program.unwrap_or(solana_address::address!(
                 "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
             )),
@@ -404,8 +401,8 @@ impl<'a, 'b> TransferRecurringCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = TransferRecurringInstructionData::new()

--- a/rust/crates/kit/src/generated/subscriptions/generated/instructions/transfer_subscription.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/instructions/transfer_subscription.rs
@@ -150,7 +150,7 @@ impl TransferSubscriptionInstructionArgs {
 ///   5. `[signer]` caller
 ///   6. `[]` token_mint
 ///   7. `[]` token_program
-///   8. `[optional]` event_authority (default to `3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7`)
+///   8. `[]` event_authority
 ///   9. `[optional]` self_program (default to `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`)
 #[derive(Clone, Debug, Default)]
 pub struct TransferSubscriptionBuilder {
@@ -223,7 +223,6 @@ impl TransferSubscriptionBuilder {
         self.token_program = Some(token_program);
         self
     }
-    /// `[optional account, default to '3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7']`
     /// The event authority PDA
     #[inline(always)]
     pub fn event_authority(&mut self, event_authority: solana_address::Address) -> &mut Self {
@@ -270,9 +269,7 @@ impl TransferSubscriptionBuilder {
             caller: self.caller.expect("caller is not set"),
             token_mint: self.token_mint.expect("token_mint is not set"),
             token_program: self.token_program.expect("token_program is not set"),
-            event_authority: self.event_authority.unwrap_or(solana_address::address!(
-                "3Hnj4BYoDgtpBuqXfiy7Y8cNa3jXaNd4oqgSXBzkMcH7"
-            )),
+            event_authority: self.event_authority.expect("event_authority is not set"),
             self_program: self.self_program.unwrap_or(solana_address::address!(
                 "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
             )),
@@ -428,8 +425,8 @@ impl<'a, 'b> TransferSubscriptionCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = TransferSubscriptionInstructionData::new()

--- a/rust/crates/kit/src/generated/subscriptions/generated/types/cancel_subscription_now_data.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/types/cancel_subscription_now_data.rs
@@ -7,16 +7,8 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_address::Address;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct UpdatePlanData {
-    pub status: u8,
-    pub end_ts: i64,
-    pub pullers: [Address; 4],
-    pub metadata_uri: [u8; 128],
-    pub expected_created_at: i64,
-    pub expected_end_ts: i64,
-    pub expected_pullers: [Address; 4],
-    pub expected_metadata_uri: [u8; 128],
+pub struct CancelSubscriptionNowData {
+    pub expected_current_period_start_ts: i64,
 }

--- a/rust/crates/kit/src/generated/subscriptions/generated/types/mod.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/types/mod.rs
@@ -6,23 +6,27 @@
 //!
 
 pub(crate) mod r#account_discriminator;
+pub(crate) mod r#cancel_subscription_now_data;
 pub(crate) mod r#create_fixed_delegation_data;
 pub(crate) mod r#create_recurring_delegation_data;
 pub(crate) mod r#header;
 pub(crate) mod r#plan_data;
 pub(crate) mod r#plan_status;
 pub(crate) mod r#plan_terms;
+pub(crate) mod r#resume_data;
 pub(crate) mod r#subscribe_data;
 pub(crate) mod r#transfer_data;
 pub(crate) mod r#update_plan_data;
 
 pub use self::r#account_discriminator::*;
+pub use self::r#cancel_subscription_now_data::*;
 pub use self::r#create_fixed_delegation_data::*;
 pub use self::r#create_recurring_delegation_data::*;
 pub use self::r#header::*;
 pub use self::r#plan_data::*;
 pub use self::r#plan_status::*;
 pub use self::r#plan_terms::*;
+pub use self::r#resume_data::*;
 pub use self::r#subscribe_data::*;
 pub use self::r#transfer_data::*;
 pub use self::r#update_plan_data::*;

--- a/rust/crates/kit/src/generated/subscriptions/generated/types/resume_data.rs
+++ b/rust/crates/kit/src/generated/subscriptions/generated/types/resume_data.rs
@@ -7,16 +7,8 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_address::Address;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-pub struct UpdatePlanData {
-    pub status: u8,
-    pub end_ts: i64,
-    pub pullers: [Address; 4],
-    pub metadata_uri: [u8; 128],
-    pub expected_created_at: i64,
-    pub expected_end_ts: i64,
-    pub expected_pullers: [Address; 4],
-    pub expected_metadata_uri: [u8; 128],
+pub struct ResumeData {
+    pub expected_expires_at_ts: i64,
 }

--- a/rust/crates/kit/src/mpp/program/subscriptions.rs
+++ b/rust/crates/kit/src/mpp/program/subscriptions.rs
@@ -373,6 +373,7 @@ pub fn build_create_plan_ix(
         token_mint: to_addr(&accounts.token_mint),
         system_program: to_addr(&system_program),
         token_program: to_addr(&accounts.token_program),
+        payer: None,
     }
     .instruction(CreatePlanInstructionArgs { plan_data });
     ix.program_id = to_addr(&program_id);
@@ -418,17 +419,9 @@ pub fn build_subscribe_ix(
         system_program: to_addr(&system_program),
         event_authority: to_addr(&accounts.event_authority),
         self_program: to_addr(&program_id),
+        payer: accounts.payer.map(|payer| to_addr(&payer)),
     };
-    // The optional payer rides as a trailing (writable, signer) account, exactly
-    // as the program's `resolve_optional_payer` expects.
-    let remaining: Vec<AccountMeta> = accounts
-        .payer
-        .map(|payer| vec![AccountMeta::new(to_addr(&payer), true)])
-        .unwrap_or_default();
-    let mut ix = gen.instruction_with_remaining_accounts(
-        SubscribeInstructionArgs { subscribe_data },
-        &remaining,
-    );
+    let mut ix = gen.instruction(SubscribeInstructionArgs { subscribe_data });
     ix.program_id = to_addr(&program_id);
     ix
 }
@@ -535,6 +528,7 @@ pub fn build_initialize_subscription_authority_ix(
         user_ata: to_addr(&accounts.user_ata),
         system_program: to_addr(&system_program),
         token_program: to_addr(&accounts.token_program),
+        payer: None,
     }
     .instruction();
     ix.program_id = to_addr(&program_id);

--- a/rust/crates/kit/src/mpp/server/subscription.rs
+++ b/rust/crates/kit/src/mpp/server/subscription.rs
@@ -38,8 +38,10 @@ use solana_transaction::Transaction;
 use crate::mpp::error::Error;
 use crate::mpp::expires;
 use crate::mpp::program::subscriptions::{
-    find_subscription_pda, parse_pubkey, INSTRUCTION_SUBSCRIBE, INSTRUCTION_TRANSFER_SUBSCRIPTION,
-    SUBSCRIPTIONS_PROGRAM_ID,
+    find_subscription_pda, parse_pubkey, ASSOCIATED_TOKEN_PROGRAM_ID, COMPUTE_BUDGET_PROGRAM_ID,
+    INSTRUCTION_INITIALIZE_SUBSCRIPTION_AUTHORITY, INSTRUCTION_SUBSCRIBE,
+    INSTRUCTION_TRANSFER_SUBSCRIPTION, MEMO_PROGRAM_ID, SUBSCRIPTIONS_PROGRAM_ID,
+    SYSTEM_PROGRAM_ID,
 };
 use crate::mpp::protocol::core::{
     compute_challenge_id, Base64UrlJson, PaymentChallenge, PaymentCredential, Receipt, ReceiptKind,
@@ -448,7 +450,13 @@ impl SubscriptionServer {
                 })?;
                 let mut tx = decode_base64_transaction(tx_b64)?;
                 let subscriber = extract_subscriber_from_tx(&tx, &request, &self.config)?;
-                validate_activation_scope(&tx, &request, &self.program_id)?;
+                validate_activation_scope(
+                    &tx,
+                    &request,
+                    &self.program_id,
+                    subscriber,
+                    &self.config,
+                )?;
 
                 if fee_payer_configured {
                     co_sign_as_fee_payer(&mut tx, self.config.fee_payer_signer.as_ref().unwrap())
@@ -479,9 +487,27 @@ impl SubscriptionServer {
                     self.fetch_subscription_creation_signature(&delegation_pda)
                         .await
                         .ok()
+                        .or_else(|| tx.signatures.first().map(ToString::to_string))
                 } else {
                     Some(self.broadcast_and_confirm(&tx).await?.to_string())
                 };
+                if let Some(signature) = sig.as_deref() {
+                    let key = format!("solana-subscription:consumed:{signature}");
+                    let inserted = self
+                        .store
+                        .put_if_absent(&key, serde_json::Value::Bool(true))
+                        .await
+                        .map_err(|e| {
+                            VerificationError::new(format!(
+                                "Failed to reserve activation signature: {e}"
+                            ))
+                        })?;
+                    if !inserted {
+                        return Err(VerificationError::signature_consumed(
+                            "Activation signature already consumed",
+                        ));
+                    }
+                }
                 (subscriber, sig)
             }
             "signature" => {
@@ -768,7 +794,8 @@ fn extract_subscriber_from_tx(
         // account_keys[0] is the fee-payer (the server's wallet); the
         // subscriber is the next signer that's neither the fee-payer
         // nor the puller.
-        for k in keys.iter().skip(1) {
+        let required_signers = tx.message.header.num_required_signatures as usize;
+        for k in keys.iter().take(required_signers).skip(1) {
             if *k != puller && *k != fp {
                 return Ok(*k);
             }
@@ -794,27 +821,160 @@ fn extract_subscriber_from_tx(
 /// program, with Subscribe ordered before TransferSubscription.
 fn validate_activation_scope(
     tx: &Transaction,
-    _request: &SubscriptionRequest,
+    request: &SubscriptionRequest,
     program_id_str: &str,
+    subscriber: Pubkey,
+    config: &SubscriptionConfig,
 ) -> Result<(), VerificationError> {
     let program_id = parse_pubkey(program_id_str, "program_id")
         .map_err(|e| VerificationError::new(e.to_string()))?;
     let keys = &tx.message.account_keys;
 
+    if config.fee_payer {
+        let expected_fee_payer = config
+            .fee_payer_signer
+            .as_ref()
+            .map(|signer| signer.pubkey())
+            .or_else(|| {
+                config
+                    .fee_payer_pubkey
+                    .as_deref()
+                    .and_then(|key| parse_pubkey(key, "fee_payer_key").ok())
+            })
+            .ok_or_else(|| {
+                VerificationError::invalid_payload(
+                    "fee_payer=true requires a configured fee-payer pubkey",
+                )
+            })?;
+        if keys.first() != Some(&expected_fee_payer) {
+            return Err(VerificationError::invalid_payload(format!(
+                "Activation transaction fee payer must be {expected_fee_payer}"
+            )));
+        }
+    }
+
+    let compute_budget_program = parse_pubkey(COMPUTE_BUDGET_PROGRAM_ID, "compute_budget_program")
+        .map_err(|e| VerificationError::new(e.to_string()))?;
+    let associated_token_program =
+        parse_pubkey(ASSOCIATED_TOKEN_PROGRAM_ID, "associated_token_program")
+            .map_err(|e| VerificationError::new(e.to_string()))?;
+    let memo_program = parse_pubkey(MEMO_PROGRAM_ID, "memo_program")
+        .map_err(|e| VerificationError::new(e.to_string()))?;
+    let system_program = parse_pubkey(SYSTEM_PROGRAM_ID, "system_program")
+        .map_err(|e| VerificationError::new(e.to_string()))?;
+    let mint =
+        parse_pubkey(&config.mint, "mint").map_err(|e| VerificationError::new(e.to_string()))?;
+    let token_program = parse_pubkey(&config.token_program, "token_program")
+        .map_err(|e| VerificationError::new(e.to_string()))?;
+
     let mut subscribe_idx: Option<usize> = None;
     let mut transfer_idx: Option<usize> = None;
+    let mut init_idx: Option<usize> = None;
+    let mut ata_idx: Option<usize> = None;
+    let mut saw_memo = false;
+    let mut saw_compute_limit = false;
+    let mut saw_compute_price = false;
     for (i, ix) in tx.message.instructions.iter().enumerate() {
         let prog_idx = ix.program_id_index as usize;
         if prog_idx >= keys.len() {
+            return Err(VerificationError::invalid_payload(
+                "Activation instruction has an invalid program index",
+            ));
+        }
+        let instruction_program = keys[prog_idx];
+
+        if instruction_program == compute_budget_program {
+            match ix.data.as_slice() {
+                [2, units @ ..] if units.len() == 4 => {
+                    if saw_compute_limit {
+                        return Err(VerificationError::invalid_payload(
+                            "Activation tx contains multiple compute-unit-limit instructions",
+                        ));
+                    }
+                    saw_compute_limit = true;
+                    let units = u32::from_le_bytes(units.try_into().unwrap());
+                    if units > 400_000 {
+                        return Err(VerificationError::invalid_payload(
+                            "Activation compute unit limit exceeds 400000",
+                        ));
+                    }
+                }
+                [3, price @ ..] if price.len() == 8 => {
+                    if saw_compute_price {
+                        return Err(VerificationError::invalid_payload(
+                            "Activation tx contains multiple compute-unit-price instructions",
+                        ));
+                    }
+                    saw_compute_price = true;
+                    let price = u64::from_le_bytes(price.try_into().unwrap());
+                    let max_price = if config.fee_payer { 10_000 } else { 5_000_000 };
+                    if price > max_price {
+                        return Err(VerificationError::invalid_payload(
+                            "Activation compute unit price exceeds cap",
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(VerificationError::invalid_payload(
+                        "Unsupported compute-budget instruction in activation tx",
+                    ))
+                }
+            }
             continue;
         }
-        if keys[prog_idx] != program_id {
+
+        if instruction_program == memo_program {
+            if saw_memo || request.external_id.as_deref() != std::str::from_utf8(&ix.data).ok() {
+                return Err(VerificationError::invalid_payload(
+                    "Activation memo does not match challenge externalId",
+                ));
+            }
+            saw_memo = true;
             continue;
+        }
+
+        if instruction_program == associated_token_program {
+            if ata_idx.is_some() || ix.data.as_slice() != [1] || ix.accounts.len() != 6 {
+                return Err(VerificationError::invalid_payload(
+                    "Only one idempotent subscriber ATA creation is allowed in activation tx",
+                ));
+            }
+            let account = |position: usize| -> Option<Pubkey> {
+                ix.accounts
+                    .get(position)
+                    .and_then(|index| keys.get(*index as usize))
+                    .copied()
+            };
+            if account(2) != Some(subscriber)
+                || account(3) != Some(mint)
+                || account(4) != Some(system_program)
+                || account(5) != Some(token_program)
+            {
+                return Err(VerificationError::invalid_payload(
+                    "ATA creation does not match the activation subscriber and mint",
+                ));
+            }
+            ata_idx = Some(i);
+            continue;
+        }
+
+        if instruction_program != program_id {
+            return Err(VerificationError::invalid_payload(format!(
+                "Unsupported program {instruction_program} in activation tx"
+            )));
         }
         let Some(disc) = ix.data.first().copied() else {
-            continue;
+            return Err(VerificationError::invalid_payload(
+                "Activation tx contains an empty subscriptions-program instruction",
+            ));
         };
-        if disc == INSTRUCTION_SUBSCRIBE {
+        if disc == INSTRUCTION_INITIALIZE_SUBSCRIPTION_AUTHORITY {
+            if init_idx.replace(i).is_some() {
+                return Err(VerificationError::invalid_payload(
+                    "Activation tx contains multiple initialize_subscription_authority instructions",
+                ));
+            }
+        } else if disc == INSTRUCTION_SUBSCRIBE {
             if subscribe_idx.is_some() {
                 return Err(VerificationError::invalid_payload(
                     "Activation tx contains multiple subscribe instructions",
@@ -828,6 +988,10 @@ fn validate_activation_scope(
                 ));
             }
             transfer_idx = Some(i);
+        } else {
+            return Err(VerificationError::invalid_payload(format!(
+                "Unsupported subscriptions instruction {disc} in activation tx"
+            )));
         }
     }
 
@@ -844,6 +1008,16 @@ fn validate_activation_scope(
             "subscribe must precede transfer_subscription in activation tx",
         ));
     }
+    if init_idx.is_some_and(|idx| idx > subscribe) || ata_idx.is_some_and(|idx| idx > subscribe) {
+        return Err(VerificationError::invalid_payload(
+            "Activation setup instructions must precede subscribe",
+        ));
+    }
+    if request.external_id.is_some() != saw_memo {
+        return Err(VerificationError::invalid_payload(
+            "Activation transaction memo does not match challenge externalId",
+        ));
+    }
     Ok(())
 }
 
@@ -856,16 +1030,12 @@ async fn co_sign_as_fee_payer(
     signer: &Arc<dyn solana_keychain::SolanaSigner>,
 ) -> Result<(), VerificationError> {
     let pubkey = signer.pubkey();
-    let idx = tx
-        .message
-        .account_keys
-        .iter()
-        .position(|k| *k == pubkey)
-        .ok_or_else(|| {
-            VerificationError::invalid_payload(
-                "Fee payer pubkey not present in activation transaction",
-            )
-        })?;
+    if tx.message.account_keys.first() != Some(&pubkey) {
+        return Err(VerificationError::invalid_payload(
+            "Configured fee payer must occupy account_keys[0]",
+        ));
+    }
+    let idx = 0;
     let msg_bytes = tx.message_data();
     let sig_bytes = signer
         .sign_message(&msg_bytes)
@@ -997,6 +1167,8 @@ fn now_unix_secs() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solana_instruction::{AccountMeta, Instruction};
+    use solana_message::Message;
     use solana_pubkey::Pubkey;
 
     fn keypair_base58() -> String {
@@ -1255,6 +1427,60 @@ mod tests {
     fn decode_subscription_delegation_rejects_short_data() {
         let short = vec![0u8; 50];
         assert!(decode_subscription_delegation(&short).is_err());
+    }
+
+    #[test]
+    fn activation_scope_rejects_extra_instruction_to_another_program() {
+        let subscriber = Pubkey::new_unique();
+        let program_id = Pubkey::new_unique();
+        let subscribe = Instruction {
+            program_id,
+            accounts: vec![AccountMeta::new(subscriber, true)],
+            data: vec![INSTRUCTION_SUBSCRIBE],
+        };
+        let foreign = Instruction {
+            program_id: Pubkey::from_str_const(SYSTEM_PROGRAM_ID),
+            accounts: vec![AccountMeta::new(subscriber, true)],
+            data: vec![2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+        };
+        let transfer = Instruction {
+            program_id,
+            accounts: vec![AccountMeta::new_readonly(subscriber, false)],
+            data: vec![INSTRUCTION_TRANSFER_SUBSCRIPTION],
+        };
+        let tx = Transaction::new_unsigned(Message::new(
+            &[subscribe, foreign, transfer],
+            Some(&subscriber),
+        ));
+        let config = make_config();
+        let err = validate_activation_scope(
+            &tx,
+            &SubscriptionRequest::default(),
+            &program_id.to_string(),
+            subscriber,
+            &config,
+        )
+        .unwrap_err();
+        assert!(err.message.contains("Unsupported program"));
+    }
+
+    #[test]
+    fn sponsored_subscriber_must_be_a_required_signer() {
+        let fee_payer = Pubkey::new_unique();
+        let non_signer = Pubkey::new_unique();
+        let instruction = Instruction {
+            program_id: Pubkey::new_unique(),
+            accounts: vec![AccountMeta::new_readonly(non_signer, false)],
+            data: vec![INSTRUCTION_SUBSCRIBE],
+        };
+        let tx = Transaction::new_unsigned(Message::new(&[instruction], Some(&fee_payer)));
+        let mut config = make_config();
+        config.fee_payer = true;
+        config.fee_payer_pubkey = Some(fee_payer.to_string());
+
+        let err =
+            extract_subscriber_from_tx(&tx, &SubscriptionRequest::default(), &config).unwrap_err();
+        assert!(err.message.contains("Could not identify subscriber"));
     }
 
     #[test]

--- a/rust/crates/kit/src/mpp/server/subscription.rs
+++ b/rust/crates/kit/src/mpp/server/subscription.rs
@@ -38,7 +38,8 @@ use solana_transaction::Transaction;
 use crate::mpp::error::Error;
 use crate::mpp::expires;
 use crate::mpp::program::subscriptions::{
-    find_subscription_pda, parse_pubkey, ASSOCIATED_TOKEN_PROGRAM_ID, COMPUTE_BUDGET_PROGRAM_ID,
+    find_event_authority_pda, find_subscription_authority_pda, find_subscription_pda, parse_pubkey,
+    ASSOCIATED_TOKEN_PROGRAM_ID, COMPUTE_BUDGET_PROGRAM_ID,
     INSTRUCTION_INITIALIZE_SUBSCRIPTION_AUTHORITY, INSTRUCTION_SUBSCRIBE,
     INSTRUCTION_TRANSFER_SUBSCRIPTION, MEMO_PROGRAM_ID, SUBSCRIPTIONS_PROGRAM_ID,
     SYSTEM_PROGRAM_ID,
@@ -493,16 +494,25 @@ impl SubscriptionServer {
                 };
                 if let Some(signature) = sig.as_deref() {
                     let key = format!("solana-subscription:consumed:{signature}");
+                    let binding = serde_json::json!({
+                        "challengeId": credential.challenge.id,
+                    });
                     let inserted = self
                         .store
-                        .put_if_absent(&key, serde_json::Value::Bool(true))
+                        .put_if_absent(&key, binding.clone())
                         .await
                         .map_err(|e| {
                             VerificationError::new(format!(
                                 "Failed to reserve activation signature: {e}"
                             ))
                         })?;
-                    if !inserted {
+                    if !inserted
+                        && self.store.get(&key).await.map_err(|e| {
+                            VerificationError::new(format!(
+                                "Failed to load activation reservation: {e}"
+                            ))
+                        })? != Some(binding)
+                    {
                         return Err(VerificationError::signature_consumed(
                             "Activation signature already consumed",
                         ));
@@ -866,6 +876,8 @@ fn validate_activation_scope(
         parse_pubkey(&config.mint, "mint").map_err(|e| VerificationError::new(e.to_string()))?;
     let token_program = parse_pubkey(&config.token_program, "token_program")
         .map_err(|e| VerificationError::new(e.to_string()))?;
+    let puller = parse_pubkey(&config.puller, "puller")
+        .map_err(|e| VerificationError::new(e.to_string()))?;
 
     let mut subscribe_idx: Option<usize> = None;
     let mut transfer_idx: Option<usize> = None;
@@ -985,6 +997,62 @@ fn validate_activation_scope(
             if transfer_idx.is_some() {
                 return Err(VerificationError::invalid_payload(
                     "Activation tx contains multiple transfer_subscription instructions",
+                ));
+            }
+            if ix.accounts.len() != 10 || ix.data.len() != 73 {
+                return Err(VerificationError::invalid_payload(
+                    "transfer_subscription does not match the Codama v0.5 schema",
+                ));
+            }
+            let account = |position: usize| -> Option<Pubkey> {
+                ix.accounts
+                    .get(position)
+                    .and_then(|index| keys.get(*index as usize))
+                    .copied()
+            };
+            let recipient = parse_pubkey(&request.recipient, "recipient")
+                .map_err(|e| VerificationError::new(e.to_string()))?;
+            let plan_pda = parse_pubkey(&config.plan_id, "plan_id")
+                .map_err(|e| VerificationError::new(e.to_string()))?;
+            let expected_subscription =
+                find_subscription_pda(&plan_pda, &subscriber, &program_id).0;
+            let expected_authority =
+                find_subscription_authority_pda(&subscriber, &mint, &program_id).0;
+            let expected_delegator_ata = Pubkey::find_program_address(
+                &[subscriber.as_ref(), token_program.as_ref(), mint.as_ref()],
+                &associated_token_program,
+            )
+            .0;
+            let expected_receiver_ata = Pubkey::find_program_address(
+                &[recipient.as_ref(), token_program.as_ref(), mint.as_ref()],
+                &associated_token_program,
+            )
+            .0;
+            let expected_event_authority = find_event_authority_pda(&program_id).0;
+            if account(0) != Some(expected_subscription)
+                || account(1) != Some(plan_pda)
+                || account(2) != Some(expected_authority)
+                || account(3) != Some(expected_delegator_ata)
+                || account(4) != Some(expected_receiver_ata)
+                || account(5) != Some(puller)
+                || account(6) != Some(mint)
+                || account(7) != Some(token_program)
+                || account(8) != Some(expected_event_authority)
+                || account(9) != Some(program_id)
+            {
+                return Err(VerificationError::invalid_payload(
+                    "transfer_subscription accounts do not match the challenged activation",
+                ));
+            }
+            let amount = u64::from_le_bytes(ix.data[1..9].try_into().unwrap());
+            let delegator = Pubkey::new_from_array(ix.data[9..41].try_into().unwrap());
+            let transfer_mint = Pubkey::new_from_array(ix.data[41..73].try_into().unwrap());
+            let expected_amount = request.amount.parse::<u64>().map_err(|_| {
+                VerificationError::invalid_payload("Challenge amount must be a u64")
+            })?;
+            if amount != expected_amount || delegator != subscriber || transfer_mint != mint {
+                return Err(VerificationError::invalid_payload(
+                    "transfer_subscription data does not match the challenged activation",
                 ));
             }
             transfer_idx = Some(i);
@@ -1462,6 +1530,98 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.message.contains("Unsupported program"));
+    }
+
+    #[test]
+    fn activation_scope_rejects_transfer_to_wrong_recipient_ata() {
+        use crate::mpp::program::subscriptions::{
+            build_subscribe_ix, build_transfer_subscription_ix, SubscribeAccounts, SubscribeData,
+            TransferData, TransferSubscriptionAccounts,
+        };
+
+        let subscriber = Pubkey::new_unique();
+        let merchant = Pubkey::new_unique();
+        let puller = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let attacker = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let token_program =
+            Pubkey::from_str_const(crate::mpp::protocol::solana::programs::TOKEN_PROGRAM);
+        let program_id = Pubkey::new_unique();
+        let plan_pda = Pubkey::new_unique();
+        let subscription_pda = find_subscription_pda(&plan_pda, &subscriber, &program_id).0;
+        let authority = find_subscription_authority_pda(&subscriber, &mint, &program_id).0;
+        let event_authority = find_event_authority_pda(&program_id).0;
+        let associated_token_program = Pubkey::from_str_const(ASSOCIATED_TOKEN_PROGRAM_ID);
+        let ata = |owner: &Pubkey| {
+            Pubkey::find_program_address(
+                &[owner.as_ref(), token_program.as_ref(), mint.as_ref()],
+                &associated_token_program,
+            )
+            .0
+        };
+        let amount = 10_000_000;
+        let subscribe = build_subscribe_ix(
+            program_id,
+            SubscribeAccounts {
+                subscriber,
+                merchant,
+                plan_pda,
+                subscription_pda,
+                subscription_authority_pda: authority,
+                event_authority,
+                payer: None,
+            },
+            &SubscribeData {
+                plan_id: 1,
+                plan_bump: 1,
+                expected_mint: mint,
+                expected_amount: amount,
+                expected_period_hours: 720,
+                expected_created_at: 1,
+                expected_subscription_authority_init_id: 1,
+            },
+        );
+        let transfer = build_transfer_subscription_ix(
+            program_id,
+            TransferSubscriptionAccounts {
+                subscription_pda,
+                plan_pda,
+                subscription_authority: authority,
+                delegator_ata: ata(&subscriber),
+                receiver_ata: ata(&attacker),
+                caller: puller,
+                token_mint: mint,
+                token_program,
+                event_authority,
+            },
+            &TransferData {
+                amount,
+                delegator: subscriber,
+                mint,
+            },
+        );
+        let tx = Transaction::new_unsigned(Message::new(&[subscribe, transfer], Some(&subscriber)));
+        let config = SubscriptionConfig {
+            plan_id: plan_pda.to_string(),
+            mint: mint.to_string(),
+            token_program: token_program.to_string(),
+            puller: puller.to_string(),
+            recipient: recipient.to_string(),
+            challenge_binding_secret: "test-secret".into(),
+            realm: "test-realm".into(),
+            ..Default::default()
+        };
+        let request = SubscriptionRequest {
+            amount: amount.to_string(),
+            recipient: recipient.to_string(),
+            ..Default::default()
+        };
+
+        let err =
+            validate_activation_scope(&tx, &request, &program_id.to_string(), subscriber, &config)
+                .unwrap_err();
+        assert!(err.message.contains("accounts do not match"));
     }
 
     #[test]

--- a/skills/pay-sdk-implementation/codegen/package.json
+++ b/skills/pay-sdk-implementation/codegen/package.json
@@ -11,11 +11,11 @@
     "payment-channels:python": "tsx ./generate-payment-channels-client-py.ts"
   },
   "dependencies": {
-    "@codama/nodes-from-anchor": "^1.4.1",
+    "@codama/nodes-from-anchor": "^1.5.5",
     "@codama/renderers-go": "^2.0.0",
-    "@codama/renderers-js": "^2.3.0",
-    "@codama/renderers-rust": "^3.1.0",
-    "codama": "^1.6.0"
+    "@codama/renderers-js": "^2.4.0",
+    "@codama/renderers-rust": "^3.1.3",
+    "codama": "^1.10.2"
   },
   "devDependencies": {
     "tsx": "^4.20.6",

--- a/skills/pay-sdk-implementation/codegen/pnpm-lock.yaml
+++ b/skills/pay-sdk-implementation/codegen/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@codama/nodes-from-anchor':
-        specifier: ^1.4.1
-        version: 1.5.0(typescript@5.9.3)
+        specifier: ^1.5.5
+        version: 1.5.5(typescript@5.9.3)
       '@codama/renderers-go':
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.9.3)
       '@codama/renderers-js':
-        specifier: ^2.3.0
-        version: 2.3.0(typescript@5.9.3)
+        specifier: ^2.4.0
+        version: 2.4.0(typescript@5.9.3)
       '@codama/renderers-rust':
-        specifier: ^3.1.0
-        version: 3.1.0(typescript@5.9.3)
+        specifier: ^3.1.3
+        version: 3.1.3(typescript@5.9.3)
       codama:
-        specifier: ^1.6.0
-        version: 1.7.0
+        specifier: ^1.10.2
+        version: 1.10.2
     devDependencies:
       tsx:
         specifier: ^4.20.6
@@ -33,68 +33,68 @@ importers:
 
 packages:
 
-  '@codama/cli@1.5.2':
-    resolution: {integrity: sha512-d5b6+m0TFYsIii4ALPIWrC6vGNbTLCXOaBqZO5WdI522w4jlk2MQozuSDVhAMBWQjxt9QD/WOJer8PHYwa1rYA==}
+  '@codama/cli@1.6.2':
+    resolution: {integrity: sha512-UFrWJxtELsPHOoG8soVuUqv/nSSUebLccaN3WQ43+5J7pFBetscEUsoy20lzV2gxYEfvYf6JqyuIUXGDmtnj9g==}
+    hasBin: true
+
+  '@codama/errors@1.10.2':
+    resolution: {integrity: sha512-relp9Inq9QkhZ0JUklKujSFWLkVfQSsn2/ms303vsGVWlFBXQmoEsmZCVKgJ7k5APNBbsD8Hc9GGU4J+P05SLA==}
     hasBin: true
 
   '@codama/errors@1.7.0':
     resolution: {integrity: sha512-N1E4LT3XRYqHHJAnL+eVQ5V3Pc0uSPjsn4Xt6QEO6Fz1p0slF6hbD+/axkFUc7+lNCAfgnkKzhk+6SpFLU/WrQ==}
     hasBin: true
 
-  '@codama/errors@1.8.0':
-    resolution: {integrity: sha512-A0FNhbfS1PBSK0nS+g65IR8+OKkifuIJCCnLCUBXb+I/OYMGlJMycMpU4pwAEEGS5GAnue7D/llXE+KpUaMi8w==}
-    hasBin: true
-
   '@codama/fragments@0.1.0':
     resolution: {integrity: sha512-rWnSKw4UA9LS7mMQyzKnR1woibVEYrYgp66+i+JB+O1lnvU/i/KCH4TmoV+S6Y3ADL2WyznrwfDA3rBET6U5Cg==}
 
-  '@codama/fragments@0.1.1':
-    resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
+  '@codama/fragments@0.1.5':
+    resolution: {integrity: sha512-aisr+cdayABykLhysE1pcDWMJJZNAAWyi5NEzkMLpyTmQrhIK6Mca14gSJIw3a0uo3E5s5Zc4d6gsxRjfYpLuw==}
+
+  '@codama/node-types@1.10.2':
+    resolution: {integrity: sha512-qFHqpuCmAoJy9ggkLadtug2Nlmnai6LrEmr+sfsK6dEJVOFGMNBR4dxwheziOu/Sn9oWGfnFfKbzQIdWE0qHHg==}
 
   '@codama/node-types@1.7.0':
     resolution: {integrity: sha512-VDytcSgN6jOGEh4aJ1LgSnqCe1drSEUSdAeKOV92aU0MOYiDi2s2B18+Gx7dx40mex2GfVc3zamu7KGzTlxegA==}
 
-  '@codama/node-types@1.8.0':
-    resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
+  '@codama/nodes-from-anchor@1.5.5':
+    resolution: {integrity: sha512-+HQUKzQpSh8EHm+fwxXVTvhPI46yTm1HzLvRJK1mkTJ1w4bymknhyWsLn1NRVDcAIixPZLsvLKujJTn+8IcoZg==}
 
-  '@codama/nodes-from-anchor@1.5.0':
-    resolution: {integrity: sha512-zbDkjNgMk0EGxHIOOlIq/G2KfXQ7rQrfwogw56MR7nQs6UFGKXnNLJUXiq1m8s3CzfoucvTo49z4mNKTEcGDhQ==}
+  '@codama/nodes@1.10.2':
+    resolution: {integrity: sha512-wR2LKg6/GQ+ctgOiH9XPVb7ktq+gu7X/WEiCk45d4L1+P/JJh2kJeS/sMbktrgJNimcoO2G1Ms3+eUDjrwfo5g==}
 
   '@codama/nodes@1.7.0':
     resolution: {integrity: sha512-PZ1zI+SbE1PEaGEka0KjdFrAJ7e9O0kPG4CCGYhjsqUo76OBbINRjNVx7pkP4r8Ksa2r/BLbVIfZV1M/n5J5Kg==}
 
-  '@codama/nodes@1.8.0':
-    resolution: {integrity: sha512-rl+7BxYatAE6uq5h9b5fEilGLd3YeJaJxqgLDAvdKQ5pspq6ch5ww9NiigkwdvDYli1Yk56PRhMZdLsiZIVgAA==}
-
   '@codama/renderers-core@1.3.8':
     resolution: {integrity: sha512-xy9Qb5BLYTi1OyvlRhRD7n0HUevOQ3QcHSPq9N3kqoUOgL2ziXPXvoejzzLC0OkvA16M7WvK3ihNx/nf4UEClQ==}
 
-  '@codama/renderers-core@1.3.9':
-    resolution: {integrity: sha512-DwMxltM+cldAK+rgtE3jVOmrGZuP7fA/ZLu6vgrsQYBp5dkOXCyiGBdpAz0VlhxaN4lB5TzT2Ia+EVv5G4YdGQ==}
+  '@codama/renderers-core@1.4.0':
+    resolution: {integrity: sha512-JkqKWaN5nKampHgJ3jWh7u6kNPrwp7DB/lpkyS1hpL6NiC45tZGie6foaq8TnSTpaVPtVsL8Q46AP1MZpongpg==}
 
   '@codama/renderers-go@2.0.0':
     resolution: {integrity: sha512-RL/S2uLogQoa8uceassQhQseapOU+Cv46rI/OqBySV+6ncORboBbViYSA4/YXHKvFnslVwMv94DmDbTA/6dzRg==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/renderers-js@2.3.0':
-    resolution: {integrity: sha512-PSvoLATBx7EomzZgCXegPTn5TxaFjA+NIraNUx22vNZ6rxPxu5Tctq8KxeXaaPCnKLpBUKcwmhUPRO4QLNQlvg==}
+  '@codama/renderers-js@2.4.0':
+    resolution: {integrity: sha512-nLmLy8eSaBtnff5OE85SXvdL4rN4QSkCSZfZ4856zwnPndP/UzV/RBNoZOp1+muMj1VIKMZ1gXLzKQjDeYM3EA==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/renderers-rust@3.1.0':
-    resolution: {integrity: sha512-E/GSUCuiIpFj+ij3NbduH/h3sNDo39Bq14vj2atxdbbrPmu4clWvIEjXtbmP03qhudH73TxbYO8dWg/NwRi18A==}
+  '@codama/renderers-rust@3.1.3':
+    resolution: {integrity: sha512-z5hPKlqT/0umZOdVMZfRw03mfN/GkdZ0z646cIComcosDk4VKTO4AFr98sg1L/aO5MXfoBrTfNOqYzD1fyUotg==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/validators@1.7.0':
-    resolution: {integrity: sha512-PBWN4zLikf6sssZD6sDVN7ASbh++fzvZ5pluHu6VlSQDk7lFL3Gsh7P1Q5JgIuXkM2gFntzCrTJSStToDCAW3g==}
+  '@codama/validators@1.10.2':
+    resolution: {integrity: sha512-Ppf8qcbBMclncrTLZU/bxi2Y5Gf9cTg1SybHTIDankOholgRWzf8wdZ40Vc/BaphY223pHOUBXiEmwZ6eTRX7A==}
+
+  '@codama/visitors-core@1.10.2':
+    resolution: {integrity: sha512-hxoISIWUUiu9Ma97OxsXl3Db5qvYmqUm9JVCf6MCb/+uE5nd4U/jZuTIKQFLulitiGRWhQr8IJI16YgO79Nuyw==}
 
   '@codama/visitors-core@1.7.0':
     resolution: {integrity: sha512-ii1Z39ORzssMQdpxqpjaHCLbFwO4KZbI1SrsJ1e0r+0g03gxuYEA1H6RoxcrIOuUeOnqNtLb96cErrzHdrx23Q==}
 
-  '@codama/visitors-core@1.8.0':
-    resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
-
-  '@codama/visitors@1.7.0':
-    resolution: {integrity: sha512-wk8ufgX3AfKOnaok5H4y1UteLyY/WkDIhhKRE7y5MJqOn5JnxLgL9R4MU2+5TmZUF04sdwyUn6fPho0IqTq+BQ==}
+  '@codama/visitors@1.10.2':
+    resolution: {integrity: sha512-DUkpq9TEuevg4mEOW9fyBJiYHGzj6ByNtgVAyLRWcUEz6Mz3Qn8+lRDpqqVyuzRbAdurf9bWsO8ln+zswPP4hg==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -255,18 +255,9 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@noble/hashes@2.2.0':
-    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+  '@noble/hashes@2.4.0':
+    resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
     engines: {node: '>= 20.19.0'}
-
-  '@solana/codecs-core@5.5.1':
-    resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@solana/codecs-core@6.9.0':
     resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
@@ -277,20 +268,20 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@5.5.1':
-    resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
+  '@solana/codecs-core@7.1.1':
+    resolution: {integrity: sha512-C1UOAQ7LH8RuCTfaij6hthTZeBlpp8GuD2g9Nag/xgiNKJGvAfVrcorb+kO/sufdYI8Lu+BiVvPeKOjQDQiKqg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@5.5.1':
-    resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
+  '@solana/codecs-data-structures@7.1.1':
+    resolution: {integrity: sha512-MO+wMAuaatAQ96N3HhTsd7Uno+79rJw88P+OiU2n+pHK/rZuyu1yB2j12veqK4jUNWPR0aOyCuZ4rB2idrDjpg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -304,15 +295,12 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@5.5.1':
-    resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
+  '@solana/codecs-numbers@7.1.1':
+    resolution: {integrity: sha512-TWWrQq6Wp5Yf5bSc6RbxDDYCRUBBmRtRgjvUMHGp0P9K+4uFwxllRjSZFzBPHgXj3UTeZmFJdcoD271QhAgibg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
-      fastestsmallesttextencoderdecoder:
-        optional: true
       typescript:
         optional: true
 
@@ -328,21 +316,23 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@5.5.1':
-    resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
+  '@solana/codecs-strings@7.1.1':
+    resolution: {integrity: sha512-6qWl+atG60D2LmP47GyGapQFhVsG1sVhVrEaM3lV09vwrGOMeOZARZ4ObaQ5m6uQmM04G+f8dY9d17nCMbGHGg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
       typescript:
         optional: true
 
-  '@solana/errors@5.5.1':
-    resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
+  '@solana/codecs@7.1.1':
+    resolution: {integrity: sha512-1ZErMXzbbz7+jusem58dMO1haVWNlvFYKftc2dPhFu9MqlmZRfPS06GiZDjlLnD/6PHHBy7OKFMASoYw+fBAKg==}
     engines: {node: '>=20.18.0'}
-    hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -357,11 +347,30 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@5.5.1':
-    resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
+  '@solana/errors@7.1.1':
+    resolution: {integrity: sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fixed-points@7.1.1':
+    resolution: {integrity: sha512-qPj/V7kcFG/P0kuEa1U529+5L6mbkMwRIwvYBTDgBqPOt6wOdk9/c7Qn2VUQgSV0HgCXWxdHUdwaxBrYqO2ibg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/options@7.1.1':
+    resolution: {integrity: sha512-iuPpfMbnRFjC4IoAIpKNA9UpizomxjW0E3F1LxUYQHXm1vCoF78kThp4qqgx2V3DmDFbhXGtXGSJPwmDdpLoBg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -388,17 +397,17 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  codama@1.7.0:
-    resolution: {integrity: sha512-kPB7IPAJkPAllxHiPtNDv6+qhTvfRpetYJgxp1iVa4L+BxztmSXTKMZ3Bsjve4ArENvxuUY4GIAchOYqb3G6nw==}
+  codama@1.10.2:
+    resolution: {integrity: sha512-fm6bFmgTrd6wPJ8o758wVVCYSEmEOU7Ctvlm8TxZoyPG0DlRS94AqnG3yC0HODXfGMAbai6pCxe9D04n3yl5AQ==}
     hasBin: true
-
-  commander@14.0.2:
-    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
-    engines: {node: '>=20'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -528,14 +537,20 @@ packages:
 
 snapshots:
 
-  '@codama/cli@1.5.2':
+  '@codama/cli@1.6.2':
     dependencies:
-      '@codama/nodes': 1.7.0
-      '@codama/visitors': 1.7.0
-      '@codama/visitors-core': 1.7.0
-      commander: 14.0.3
+      '@codama/nodes': 1.10.2
+      '@codama/visitors': 1.10.2
+      '@codama/visitors-core': 1.10.2
+      commander: 15.0.0
       picocolors: 1.1.1
       prompts: 2.4.2
+
+  '@codama/errors@1.10.2':
+    dependencies:
+      '@codama/node-types': 1.10.2
+      commander: 15.0.0
+      picocolors: 1.1.1
 
   '@codama/errors@1.7.0':
     dependencies:
@@ -543,44 +558,38 @@ snapshots:
       commander: 14.0.3
       picocolors: 1.1.1
 
-  '@codama/errors@1.8.0':
-    dependencies:
-      '@codama/node-types': 1.8.0
-      commander: 14.0.3
-      picocolors: 1.1.1
-
   '@codama/fragments@0.1.0':
     dependencies:
       '@codama/errors': 1.7.0
 
-  '@codama/fragments@0.1.1':
+  '@codama/fragments@0.1.5':
     dependencies:
-      '@codama/errors': 1.8.0
+      '@codama/errors': 1.10.2
+
+  '@codama/node-types@1.10.2': {}
 
   '@codama/node-types@1.7.0': {}
 
-  '@codama/node-types@1.8.0': {}
-
-  '@codama/nodes-from-anchor@1.5.0(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.5.5(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors': 1.7.0
-      '@noble/hashes': 2.2.0
-      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      '@codama/visitors': 1.10.2
+      '@noble/hashes': 2.4.0
+      '@solana/codecs': 7.1.1(typescript@5.9.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
+
+  '@codama/nodes@1.10.2':
+    dependencies:
+      '@codama/errors': 1.10.2
+      '@codama/node-types': 1.10.2
 
   '@codama/nodes@1.7.0':
     dependencies:
       '@codama/errors': 1.7.0
       '@codama/node-types': 1.7.0
-
-  '@codama/nodes@1.8.0':
-    dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/node-types': 1.8.0
 
   '@codama/renderers-core@1.3.8':
     dependencies:
@@ -589,12 +598,12 @@ snapshots:
       '@codama/nodes': 1.7.0
       '@codama/visitors-core': 1.7.0
 
-  '@codama/renderers-core@1.3.9':
+  '@codama/renderers-core@1.4.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/fragments': 0.1.1
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.2
+      '@codama/fragments': 0.1.5
+      '@codama/nodes': 1.10.2
+      '@codama/visitors-core': 1.10.2
 
   '@codama/renderers-go@2.0.0(typescript@5.9.3)':
     dependencies:
@@ -609,27 +618,27 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/renderers-js@2.3.0(typescript@5.9.3)':
+  '@codama/renderers-js@2.4.0(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/renderers-core': 1.3.9
-      '@codama/visitors-core': 1.8.0
-      '@solana/codecs-strings': 6.9.0(typescript@5.9.3)
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      '@codama/renderers-core': 1.4.0
+      '@codama/visitors-core': 1.10.2
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
       prettier: 3.8.4
       semver: 7.8.1
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/renderers-rust@3.1.0(typescript@5.9.3)':
+  '@codama/renderers-rust@3.1.3(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/renderers-core': 1.3.8
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      '@codama/renderers-core': 1.4.0
+      '@codama/visitors-core': 1.10.2
       '@iarna/toml': 2.2.5
-      '@solana/codecs-strings': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
       nunjucks: 3.2.4
       semver: 7.8.1
     transitivePeerDependencies:
@@ -637,11 +646,17 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/validators@1.7.0':
+  '@codama/validators@1.10.2':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      '@codama/visitors-core': 1.10.2
+
+  '@codama/visitors-core@1.10.2':
+    dependencies:
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      json-stable-stringify: 1.3.0
 
   '@codama/visitors-core@1.7.0':
     dependencies:
@@ -649,17 +664,11 @@ snapshots:
       '@codama/nodes': 1.7.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors-core@1.8.0':
+  '@codama/visitors@1.10.2':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      json-stable-stringify: 1.3.0
-
-  '@codama/visitors@1.7.0':
-    dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      '@codama/visitors-core': 1.10.2
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
@@ -741,13 +750,7 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@noble/hashes@2.2.0': {}
-
-  '@solana/codecs-core@5.5.1(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 5.5.1(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
+  '@noble/hashes@2.4.0': {}
 
   '@solana/codecs-core@6.9.0(typescript@5.9.3)':
     dependencies:
@@ -755,18 +758,17 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-data-structures@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-core@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-data-structures@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -777,11 +779,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-numbers@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -793,24 +794,26 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-strings@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/options': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/fixed-points': 7.1.1(typescript@5.9.3)
+      '@solana/options': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@5.5.1(typescript@5.9.3)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.2
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@solana/errors@6.9.0(typescript@5.9.3)':
     dependencies:
@@ -819,13 +822,27 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/options@5.5.1(typescript@5.9.3)':
+  '@solana/errors@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/errors': 5.5.1(typescript@5.9.3)
+      chalk: 5.6.2
+      commander: 15.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fixed-points@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/options@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -854,17 +871,17 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  codama@1.7.0:
+  codama@1.10.2:
     dependencies:
-      '@codama/cli': 1.5.2
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/validators': 1.7.0
-      '@codama/visitors': 1.7.0
-
-  commander@14.0.2: {}
+      '@codama/cli': 1.6.2
+      '@codama/errors': 1.10.2
+      '@codama/nodes': 1.10.2
+      '@codama/validators': 1.10.2
+      '@codama/visitors': 1.10.2
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@5.1.0: {}
 

--- a/typescript/packages/mpp/package.json
+++ b/typescript/packages/mpp/package.json
@@ -31,11 +31,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@solana/addresses": "^6.10.0",
     "@solana-program/compute-budget": "^0.15.0",
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.11.0",
+    "@solana/addresses": "^6.10.0",
     "@solana/program-client-core": "^6.10.0",
+    "@solana/subscriptions": "^0.5.0",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/typescript/packages/mpp/src/__tests__/charge.test.ts
+++ b/typescript/packages/mpp/src/__tests__/charge.test.ts
@@ -1728,6 +1728,24 @@ test('pull: accepts valid native SOL transfer', async () => {
     expect(receipt.reference).toBe(SIGNATURE);
 });
 
+test('pull: identical challenge-bound retry recovers the settled receipt', async () => {
+    const method = charge({
+        recipient: RECIPIENT,
+        network: 'devnet',
+        rpcUrl: 'https://mock-rpc',
+        store,
+    });
+    mockServerBroadcastFetch(solTransferTx(RECIPIENT, 1000000));
+    const credential = transactionCredential(await buildSolPaymentTxBase64(RECIPIENT, 1000000), {
+        amount: '1000000',
+    });
+
+    const first = await method.verify({ credential, request: {} as any });
+    const recovered = await method.verify({ credential, request: {} as any });
+
+    expect(recovered.reference).toBe(first.reference);
+});
+
 test('pull: accepts native SOL externalId memo pre-broadcast and on-chain', async () => {
     const method = charge({
         recipient: RECIPIENT,

--- a/typescript/packages/mpp/src/__tests__/charge.test.ts
+++ b/typescript/packages/mpp/src/__tests__/charge.test.ts
@@ -31,6 +31,7 @@ import {
 } from '@solana/kit';
 import { buildChargeTransaction } from '../client/Charge.js';
 import { charge, interpretPostTimeoutStatus, verifyChargeTransaction } from '../server/Charge.js';
+import { transactionSignatureFromBase64 } from '../utils/transactions.js';
 import {
     ASSOCIATED_TOKEN_PROGRAM,
     CASH,
@@ -1682,17 +1683,18 @@ test('signature: throws when no TransferChecked instruction found (SPL)', async 
  *   2. getSignatureStatuses → returns confirmed
  *   3. getTransaction → returns parsed tx for verification
  */
-function mockServerBroadcastFetch(txResult: unknown, signature: string = SIGNATURE) {
+function mockServerBroadcastFetch(txResult: unknown, rpcMethods?: string[]) {
     globalThis.fetch = async (_url: RequestInfo | URL, init?: RequestInit) => {
         const body = JSON.parse(init?.body as string);
         const method = body.method;
+        rpcMethods?.push(method);
 
         if (method === 'simulateTransaction') {
             return rpcSuccess({ value: { err: null, logs: [] } });
         }
 
         if (method === 'sendTransaction') {
-            return rpcSuccess(signature);
+            return rpcSuccess(SIGNATURE);
         }
 
         if (method === 'getSignatureStatuses') {
@@ -1718,14 +1720,15 @@ test('pull: accepts valid native SOL transfer', async () => {
     });
 
     mockServerBroadcastFetch(solTransferTx(RECIPIENT, 1000000));
+    const transaction = await buildSolPaymentTxBase64(RECIPIENT, 1000000);
 
     const receipt = await method.verify({
-        credential: transactionCredential(await buildSolPaymentTxBase64(RECIPIENT, 1000000), { amount: '1000000' }),
+        credential: transactionCredential(transaction, { amount: '1000000' }),
         request: {} as any,
     });
 
     expect(receipt.status).toBe('success');
-    expect(receipt.reference).toBe(SIGNATURE);
+    expect(receipt.reference).toBe(transactionSignatureFromBase64(transaction));
 });
 
 test('pull: identical challenge-bound retry recovers the settled receipt', async () => {
@@ -1735,7 +1738,8 @@ test('pull: identical challenge-bound retry recovers the settled receipt', async
         rpcUrl: 'https://mock-rpc',
         store,
     });
-    mockServerBroadcastFetch(solTransferTx(RECIPIENT, 1000000));
+    const rpcMethods: string[] = [];
+    mockServerBroadcastFetch(solTransferTx(RECIPIENT, 1000000), rpcMethods);
     const credential = transactionCredential(await buildSolPaymentTxBase64(RECIPIENT, 1000000), {
         amount: '1000000',
     });
@@ -1744,6 +1748,8 @@ test('pull: identical challenge-bound retry recovers the settled receipt', async
     const recovered = await method.verify({ credential, request: {} as any });
 
     expect(recovered.reference).toBe(first.reference);
+    expect(rpcMethods.filter(method => method === 'simulateTransaction')).toHaveLength(1);
+    expect(rpcMethods.filter(method => method === 'sendTransaction')).toHaveLength(1);
 });
 
 test('pull: accepts native SOL externalId memo pre-broadcast and on-chain', async () => {
@@ -1869,8 +1875,9 @@ test('pull: accepts valid SPL token transfer', async () => {
 
     mockServerBroadcastFetch(splTransferTx(expectedAta, USDC_MINT, '1000000'));
 
+    const transaction = await buildSplPaymentTxBase64(RECIPIENT, USDC_MINT, '1000000');
     const receipt = await method.verify({
-        credential: transactionCredential(await buildSplPaymentTxBase64(RECIPIENT, USDC_MINT, '1000000'), {
+        credential: transactionCredential(transaction, {
             amount: '1000000',
             currency: USDC_MINT,
             decimals: 6,
@@ -1879,7 +1886,7 @@ test('pull: accepts valid SPL token transfer', async () => {
     });
 
     expect(receipt.status).toBe('success');
-    expect(receipt.reference).toBe(SIGNATURE);
+    expect(receipt.reference).toBe(transactionSignatureFromBase64(transaction));
 });
 
 test('pull: accepts SPL externalId memo pre-broadcast and on-chain', async () => {
@@ -2070,7 +2077,7 @@ test('client buildChargeTransaction creates verifier-compatible SPL transaction'
     });
 
     expect(receipt.status).toBe('success');
-    expect(receipt.reference).toBe(SIGNATURE);
+    expect(receipt.reference).toBe(transactionSignatureFromBase64(tx));
 });
 
 test('pull: accepts fee payer split recipient ATA creation', async () => {

--- a/typescript/packages/mpp/src/__tests__/replay.test.ts
+++ b/typescript/packages/mpp/src/__tests__/replay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { Store } from 'mppx/server';
 
-import { claimReplayKey, confirmReplayKey, reserveReplayKey } from '../server/replay.js';
+import { claimReplayKey, confirmReplayKey, inspectReplayKey, reserveReplayKey } from '../server/replay.js';
 
 describe('reserveReplayKey', () => {
     test('allows exactly one concurrent claimant', async () => {
@@ -26,5 +26,17 @@ describe('challenge-bound replay recovery', () => {
         await confirmReplayKey(store, key, 'challenge-a');
         await expect(claimReplayKey(store, key, 'challenge-a')).resolves.toBe('retry');
         await expect(claimReplayKey(store, key, 'challenge-b')).resolves.toBe('conflict');
+    });
+
+    test('distinguishes confirmed and expired records before settlement RPCs', async () => {
+        const store = Store.memory();
+        const key = 'solana-charge:consumed:recovery-signature';
+
+        await store.put(key, { binding: 'challenge-a', leaseUntil: 0, state: 'pending' });
+        await expect(inspectReplayKey(store, key, 'challenge-a')).resolves.toBe('expired');
+
+        await store.put(key, { binding: 'challenge-a', leaseUntil: 0, state: 'confirmed' });
+        await expect(inspectReplayKey(store, key, 'challenge-a')).resolves.toBe('retry');
+        await expect(inspectReplayKey(store, key, 'challenge-b')).resolves.toBe('conflict');
     });
 });

--- a/typescript/packages/mpp/src/__tests__/replay.test.ts
+++ b/typescript/packages/mpp/src/__tests__/replay.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest';
+import { Store } from 'mppx/server';
+
+import { reserveReplayKey } from '../server/replay.js';
+
+describe('reserveReplayKey', () => {
+    test('allows exactly one concurrent claimant', async () => {
+        const store = Store.memory();
+        const results = await Promise.all(
+            Array.from({ length: 16 }, () => reserveReplayKey(store, 'solana-charge:consumed:same-signature')),
+        );
+
+        expect(results.filter(Boolean)).toHaveLength(1);
+    });
+});

--- a/typescript/packages/mpp/src/__tests__/replay.test.ts
+++ b/typescript/packages/mpp/src/__tests__/replay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { Store } from 'mppx/server';
 
-import { reserveReplayKey } from '../server/replay.js';
+import { claimReplayKey, confirmReplayKey, reserveReplayKey } from '../server/replay.js';
 
 describe('reserveReplayKey', () => {
     test('allows exactly one concurrent claimant', async () => {
@@ -11,5 +11,20 @@ describe('reserveReplayKey', () => {
         );
 
         expect(results.filter(Boolean)).toHaveLength(1);
+    });
+});
+
+describe('challenge-bound replay recovery', () => {
+    test('allows the same challenge to resume and rejects a different challenge', async () => {
+        const store = Store.memory();
+        const key = 'solana-charge:consumed:same-signature';
+
+        await expect(claimReplayKey(store, key, 'challenge-a')).resolves.toBe('reserved');
+        await expect(claimReplayKey(store, key, 'challenge-a')).resolves.toBe('pending');
+        await expect(claimReplayKey(store, key, 'challenge-b')).resolves.toBe('conflict');
+
+        await confirmReplayKey(store, key, 'challenge-a');
+        await expect(claimReplayKey(store, key, 'challenge-a')).resolves.toBe('retry');
+        await expect(claimReplayKey(store, key, 'challenge-b')).resolves.toBe('conflict');
     });
 });

--- a/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
@@ -22,6 +22,7 @@ import {
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
+import { findAssociatedTokenPda } from '@solana-program/token';
 import { Store } from 'mppx/server';
 
 import {
@@ -95,6 +96,7 @@ async function buildActivationTransactionBase64(
             | 'no-transfer';
         feePayerKey?: string;
         memo?: string;
+        receiver?: string;
     } = {},
 ): Promise<{ subscriberAddress: string; transaction: string }> {
     const subscriber = await generateKeyPairSigner();
@@ -103,8 +105,25 @@ async function buildActivationTransactionBase64(
         data: new Uint8Array([SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR]),
         programAddress: address(SUBSCRIPTIONS_PROGRAM),
     };
+    const [recipientAta] = await findAssociatedTokenPda({
+        mint: address(MINT),
+        owner: address(options.receiver ?? RECIPIENT),
+        tokenProgram: address(TOKEN_PROGRAM),
+    });
     const transferIx: Instruction = {
-        accounts: [{ address: subscriber.address, role: AccountRole.READONLY }],
+        // Previous nine-account client layout. The verifier also accepts the
+        // Codama v0.5 ten-account layout and binds receiver_ata at slot 4.
+        accounts: [
+            { address: subscriber.address, role: AccountRole.READONLY },
+            { address: address(PLAN_ID), role: AccountRole.READONLY },
+            { address: subscriber.address, role: AccountRole.READONLY },
+            { address: subscriber.address, role: AccountRole.READONLY },
+            { address: subscriber.address, role: AccountRole.READONLY },
+            { address: subscriber.address, role: AccountRole.READONLY },
+            { address: recipientAta, role: AccountRole.WRITABLE },
+            { address: address(MINT), role: AccountRole.READONLY },
+            { address: address(TOKEN_PROGRAM), role: AccountRole.READONLY },
+        ],
         data: new Uint8Array([SUBSCRIPTIONS_TRANSFER_DISCRIMINATOR]),
         programAddress: address(SUBSCRIPTIONS_PROGRAM),
     };
@@ -385,54 +404,89 @@ describe('subscription().request()', () => {
 
 describe('validateActivationInstructions', () => {
     const challenge = {
-        methodDetails: { programId: SUBSCRIPTIONS_PROGRAM },
+        amount: '10000000',
+        methodDetails: {
+            mint: MINT,
+            programId: SUBSCRIPTIONS_PROGRAM,
+            tokenProgram: TOKEN_PROGRAM,
+        },
+        recipient: RECIPIENT,
     } as never;
 
     test('accepts a well-formed [subscribe, transfer_subscription] sequence', async () => {
-        const { transaction } = await buildActivationTransactionBase64();
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).not.toThrow();
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64();
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).resolves.toBeUndefined();
     });
 
     test('rejects a transaction missing subscribe', async () => {
-        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'no-subscribe' });
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(/missing subscribe/);
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            extraInstructions: 'no-subscribe',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/missing subscribe/);
     });
 
     test('rejects a transaction missing transfer_subscription', async () => {
-        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'no-transfer' });
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(
-            /missing transfer_subscription/,
-        );
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            extraInstructions: 'no-transfer',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/missing transfer_subscription/);
     });
 
     test('rejects multiple subscribe instructions', async () => {
-        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'duplicate-subscribe' });
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(/Multiple subscribe/);
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            extraInstructions: 'duplicate-subscribe',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/Multiple subscribe/);
     });
 
     test('rejects multiple transfer_subscription instructions', async () => {
-        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'duplicate-transfer' });
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(
-            /Multiple transfer_subscription/,
-        );
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            extraInstructions: 'duplicate-transfer',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/Multiple transfer_subscription/);
     });
 
     test('rejects an extra instruction to another program', async () => {
-        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'foreign-program' });
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(/Unsupported program/);
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            extraInstructions: 'foreign-program',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/Unsupported program/);
     });
 
     test('rejects when transfer_subscription precedes subscribe', async () => {
-        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'reorder' });
-        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(
-            /subscribe must precede/,
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            extraInstructions: 'reorder',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/subscribe must precede/);
+    });
+
+    test('rejects an undecodable base64 input', async () => {
+        await expect(__testing.validateActivationInstructions('not-a-real-tx', challenge, RECIPIENT)).rejects.toThrow(
+            /Invalid transaction/,
         );
     });
 
-    test('rejects an undecodable base64 input', () => {
-        expect(() => __testing.validateActivationInstructions('not-a-real-tx', challenge)).toThrow(
-            /Invalid transaction/,
-        );
+    test('rejects transfer_subscription to an ATA owned by another recipient', async () => {
+        const { subscriberAddress, transaction } = await buildActivationTransactionBase64({
+            receiver: '11111111111111111111111111111111',
+        });
+        await expect(
+            __testing.validateActivationInstructions(transaction, challenge, subscriberAddress),
+        ).rejects.toThrow(/receiver does not match the challenge recipient/);
     });
 });
 
@@ -770,33 +824,37 @@ describe('subscription().verify() (push mode)', () => {
             rpcUrl: 'https://mock-rpc',
             tokenProgram: TOKEN_PROGRAM,
         });
-        const receipt = await method.verify!({
-            credential: {
-                challenge: {
-                    id: 'test-challenge',
-                    request: {
-                        amount: '10000000',
-                        currency: MINT,
-                        externalId: 'order-99',
-                        methodDetails: {
-                            decimals: 6,
-                            mint: MINT,
-                            network: 'devnet',
-                            planId: PLAN_ID,
-                            programId: SUBSCRIPTIONS_PROGRAM,
-                            puller: PULLER,
-                            tokenProgram: TOKEN_PROGRAM,
-                        },
-                        periodCount: '30',
-                        periodUnit: 'day',
-                        recipient: RECIPIENT,
+        const credential = {
+            challenge: {
+                id: 'test-challenge',
+                request: {
+                    amount: '10000000',
+                    currency: MINT,
+                    externalId: 'order-99',
+                    methodDetails: {
+                        decimals: 6,
+                        mint: MINT,
+                        network: 'devnet',
+                        planId: PLAN_ID,
+                        programId: SUBSCRIPTIONS_PROGRAM,
+                        puller: PULLER,
+                        tokenProgram: TOKEN_PROGRAM,
                     },
+                    periodCount: '30',
+                    periodUnit: 'day',
+                    recipient: RECIPIENT,
                 },
-                payload: { transaction, type: 'transaction' },
-            } as never,
+            },
+            payload: { transaction, type: 'transaction' },
+        } as never;
+        const receipt = await method.verify!({
+            credential,
             request: {} as never,
         });
         expect((receipt as { status: string }).status).toBe('success');
+
+        const recovered = await method.verify!({ credential, request: {} as never });
+        expect((recovered as { reference: string }).reference).toBe((receipt as { reference: string }).reference);
     });
 
     test('rejects when on-chain delegation references a different plan', async () => {

--- a/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
@@ -28,6 +28,8 @@ import {
     SUBSCRIPTIONS_PROGRAM,
     SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR,
     SUBSCRIPTIONS_TRANSFER_DISCRIMINATOR,
+    MEMO_PROGRAM,
+    SYSTEM_PROGRAM,
     TOKEN_2022_PROGRAM,
     TOKEN_PROGRAM,
 } from '../constants.js';
@@ -61,11 +63,38 @@ function rpcSuccess(result: unknown) {
     });
 }
 
+function buildDelegationData(subscriber: string, plan: string, amountPulled: bigint): Uint8Array {
+    const data = new Uint8Array(155);
+    data[0] = 4;
+    data[1] = 1;
+    data[2] = 255;
+    data.set(__testing.decodeBase58(subscriber), 3);
+    data.set(__testing.decodeBase58(plan), 35);
+    writeU64Le(data, 107, 10_000_000n);
+    writeU64Le(data, 115, 720n);
+    writeU64Le(data, 131, amountPulled);
+    writeU64Le(data, 139, 1_737_216_000n);
+    return data;
+}
+
+function writeU64Le(buf: Uint8Array, offset: number, value: bigint) {
+    for (let i = 0; i < 8; i += 1) {
+        buf[offset + i] = Number((value >> BigInt(i * 8)) & 0xffn);
+    }
+}
+
 /** Build a compiled-message-style activation transaction (subscriber-signed). */
 async function buildActivationTransactionBase64(
     options: {
-        extraInstructions?: 'duplicate-subscribe' | 'duplicate-transfer' | 'reorder' | 'no-subscribe' | 'no-transfer';
+        extraInstructions?:
+            | 'duplicate-subscribe'
+            | 'duplicate-transfer'
+            | 'foreign-program'
+            | 'reorder'
+            | 'no-subscribe'
+            | 'no-transfer';
         feePayerKey?: string;
+        memo?: string;
     } = {},
 ): Promise<{ subscriberAddress: string; transaction: string }> {
     const subscriber = await generateKeyPairSigner();
@@ -79,6 +108,15 @@ async function buildActivationTransactionBase64(
         data: new Uint8Array([SUBSCRIPTIONS_TRANSFER_DISCRIMINATOR]),
         programAddress: address(SUBSCRIPTIONS_PROGRAM),
     };
+    const foreignIx: Instruction = {
+        accounts: [{ address: subscriber.address, role: AccountRole.WRITABLE_SIGNER }],
+        data: new Uint8Array([2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
+        programAddress: address(SYSTEM_PROGRAM),
+    };
+    const memoIx: Instruction = {
+        data: new TextEncoder().encode(options.memo ?? ''),
+        programAddress: address(MEMO_PROGRAM),
+    };
 
     let instructions: Instruction[];
     switch (options.extraInstructions) {
@@ -87,6 +125,9 @@ async function buildActivationTransactionBase64(
             break;
         case 'duplicate-transfer':
             instructions = [subscribeIx, transferIx, transferIx];
+            break;
+        case 'foreign-program':
+            instructions = [subscribeIx, foreignIx, transferIx];
             break;
         case 'reorder':
             instructions = [transferIx, subscribeIx];
@@ -100,6 +141,7 @@ async function buildActivationTransactionBase64(
         default:
             instructions = [subscribeIx, transferIx];
     }
+    if (options.memo !== undefined) instructions.push(memoIx);
 
     const txMessage = pipe(
         createTransactionMessage({ version: 0 }),
@@ -375,6 +417,11 @@ describe('validateActivationInstructions', () => {
         );
     });
 
+    test('rejects an extra instruction to another program', async () => {
+        const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'foreign-program' });
+        expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(/Unsupported program/);
+    });
+
     test('rejects when transfer_subscription precedes subscribe', async () => {
         const { transaction } = await buildActivationTransactionBase64({ extraInstructions: 'reorder' });
         expect(() => __testing.validateActivationInstructions(transaction, challenge)).toThrow(
@@ -447,6 +494,30 @@ describe('extractSubscriberFromTransaction', () => {
         } as never;
         expect(__testing.extractSubscriberFromTransaction(txBase64, challenge).toString()).toBe(subscriber.address);
     });
+
+    test('does not treat a non-signer account as the sponsored subscriber', async () => {
+        const feePayer = await generateKeyPairSigner();
+        const nonSigner = await generateKeyPairSigner();
+        const ix: Instruction = {
+            accounts: [{ address: nonSigner.address, role: AccountRole.READONLY }],
+            data: new Uint8Array([SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR]),
+            programAddress: address(SUBSCRIPTIONS_PROGRAM),
+        };
+        const txMessage = pipe(
+            createTransactionMessage({ version: 0 }),
+            msg => setTransactionMessageFeePayerSigner(feePayer, msg),
+            msg => setTransactionMessageLifetimeUsingBlockhash({ blockhash: BLOCKHASH, lastValidBlockHeight: 1n }, msg),
+            msg => appendTransactionMessageInstructions([ix], msg),
+        );
+        const signed = await partiallySignTransactionMessageWithSigners(txMessage);
+        const challenge = {
+            methodDetails: { feePayer: true, feePayerKey: feePayer.address, puller: PULLER },
+        } as never;
+
+        expect(() =>
+            __testing.extractSubscriberFromTransaction(getBase64EncodedWireTransaction(signed), challenge),
+        ).toThrow(/Could not identify subscriber/);
+    });
 });
 
 // ══════════════════════════════════════════════════════════════════════
@@ -455,52 +526,25 @@ describe('extractSubscriberFromTransaction', () => {
 
 describe('decodeSubscriptionDelegation', () => {
     test('reads each field at the expected offset', () => {
-        const data = new Uint8Array(1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8 + 8);
-        let off = 0;
-        data[off] = 1; // discriminator
-        off += 1;
-        // subscriber, delegatee, payer pubkeys — fill with distinct patterns
-        data.set(new Uint8Array(32).fill(0xaa), off);
-        off += 32;
-        data.set(new Uint8Array(32).fill(0xbb), off);
-        off += 32;
-        data.set(new Uint8Array(32).fill(0xcc), off);
-        off += 32;
-        // init_id u64
-        off += 8;
-        // plan_pda
-        data.set(new Uint8Array(32).fill(0xdd), off);
-        off += 32;
-        // mint
-        data.set(new Uint8Array(32).fill(0xee), off);
-        off += 32;
-        // amount_per_period u64 = 10_000_000
-        writeU64Le(data, off, 10_000_000n);
-        off += 8;
-        // period_hours u64 = 720
-        writeU64Le(data, off, 720n);
-        off += 8;
-        // current_period_start_ts i64 = 1737216000 (2025-01-18T16:00:00Z)
-        writeU64Le(data, off, 1737216000n);
-        off += 8;
-        // amount_pulled_in_period u64 = 10_000_000
-        writeU64Le(data, off, 10_000_000n);
+        const data = new Uint8Array(155);
+        data[0] = 4;
+        data[1] = 1;
+        data[2] = 255;
+        data.set(new Uint8Array(32).fill(0xaa), 3);
+        data.set(new Uint8Array(32).fill(0xbb), 35);
+        writeU64Le(data, 107, 10_000_000n);
+        writeU64Le(data, 115, 720n);
+        writeU64Le(data, 131, 10_000_000n);
+        writeU64Le(data, 139, 1_737_216_000n);
 
         const decoded = __testing.decodeSubscriptionDelegation(data);
         expect(decoded.subscriber).toBe(__testing.encodeBase58(new Uint8Array(32).fill(0xaa)));
-        expect(decoded.planPda).toBe(__testing.encodeBase58(new Uint8Array(32).fill(0xdd)));
-        expect(decoded.mint).toBe(__testing.encodeBase58(new Uint8Array(32).fill(0xee)));
+        expect(decoded.planPda).toBe(__testing.encodeBase58(new Uint8Array(32).fill(0xbb)));
         expect(decoded.amountPerPeriod).toBe('10000000');
         expect(decoded.periodHours).toBe(720);
         expect(decoded.currentPeriodStartTs).toBe(1737216000);
         expect(decoded.amountPulledInPeriod).toBe('10000000');
     });
-
-    function writeU64Le(buf: Uint8Array, offset: number, value: bigint) {
-        for (let i = 0; i < 8; i += 1) {
-            buf[offset + i] = Number((value >> BigInt(i * 8)) & 0xffn);
-        }
-    }
 });
 
 // ══════════════════════════════════════════════════════════════════════
@@ -552,24 +596,7 @@ describe('subscription().verify() (push mode)', () => {
 
         // Build a `SubscriptionDelegation` byte buffer with amount_pulled = 0 so
         // verify() raises "first-period charge not executed".
-        const data = new Uint8Array(1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8 + 8);
-        // Set subscriber bytes to match the activation tx signer (decoded base58).
-        const subscriberBytes = __testing.decodeBase58(subscriberAddress);
-        data.set(subscriberBytes, 1);
-        // plan_pda, mint left as zeros — verify will fail on plan mismatch before
-        // reaching amount checks. To exercise the "first charge" path we set them.
-        const planBytes = __testing.decodeBase58(PLAN_ID);
-        const mintBytes = __testing.decodeBase58(MINT);
-        data.set(planBytes, 1 + 32 * 3 + 8);
-        data.set(mintBytes, 1 + 32 * 3 + 8 + 32);
-        // amount_per_period = 10_000_000
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32, 10_000_000n);
-        // period_hours = 720
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8, 720n);
-        // current_period_start_ts = anything
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8 + 8, 1737216000n);
-        // amount_pulled_in_period = 0 (the failure we want to test)
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8, 0n);
+        const data = buildDelegationData(subscriberAddress, PLAN_ID, 0n);
 
         const accountB64 = Buffer.from(data).toString('base64');
 
@@ -702,16 +729,9 @@ describe('subscription().verify() (push mode)', () => {
     });
 
     test('returns a successful receipt when on-chain state matches the challenge (pull mode)', async () => {
-        const { transaction, subscriberAddress } = await buildActivationTransactionBase64();
+        const { transaction, subscriberAddress } = await buildActivationTransactionBase64({ memo: 'order-99' });
         const txSignature = '5J8KKfgKBLPDoCSk7B7TwAdSP3KtkfxYGYQH52SVgyM5XQXfeaG3xH8E3uYmGNLcoNNgWp3JjPdvzNwM4ZmJyREq';
-        const data = new Uint8Array(1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8 + 8);
-        data.set(__testing.decodeBase58(subscriberAddress), 1);
-        data.set(__testing.decodeBase58(PLAN_ID), 1 + 32 * 3 + 8);
-        data.set(__testing.decodeBase58(MINT), 1 + 32 * 3 + 8 + 32);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32, 10_000_000n);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8, 720n);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8 + 8, 1737216000n);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8, 10_000_000n);
+        const data = buildDelegationData(subscriberAddress, PLAN_ID, 10_000_000n);
         const accountB64 = Buffer.from(data).toString('base64');
 
         globalThis.fetch = async (_input, init) => {
@@ -782,14 +802,7 @@ describe('subscription().verify() (push mode)', () => {
     test('rejects when on-chain delegation references a different plan', async () => {
         const { transaction, subscriberAddress } = await buildActivationTransactionBase64();
         const wrongPlan = '11111111111111111111111111111111';
-        const data = new Uint8Array(1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8 + 8);
-        data.set(__testing.decodeBase58(subscriberAddress), 1);
-        data.set(__testing.decodeBase58(wrongPlan), 1 + 32 * 3 + 8);
-        data.set(__testing.decodeBase58(MINT), 1 + 32 * 3 + 8 + 32);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32, 10_000_000n);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8, 720n);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8 + 8, 1737216000n);
-        writeU64Le(data, 1 + 32 * 3 + 8 + 32 + 32 + 8 + 8 + 8, 10_000_000n);
+        const data = buildDelegationData(subscriberAddress, wrongPlan, 10_000_000n);
         const accountB64 = Buffer.from(data).toString('base64');
 
         globalThis.fetch = async (_input, init) => {
@@ -1074,6 +1087,69 @@ describe('subscription().verify() (push mode)', () => {
                 request: {} as never,
             }),
         ).rejects.toThrow(/already consumed/);
+    });
+
+    test('concurrent push-mode activation returns exactly one receipt', async () => {
+        const { transaction, subscriberAddress } = await buildActivationTransactionBase64();
+        const accountB64 = Buffer.from(buildDelegationData(subscriberAddress, PLAN_ID, 10_000_000n)).toString('base64');
+        globalThis.fetch = async (_input, init) => {
+            const body = JSON.parse(init?.body as string) as { method?: string };
+            if (body.method === 'getTransaction') {
+                await Promise.resolve();
+                return rpcSuccess({ meta: { err: null }, transaction: [transaction, 'base64'] });
+            }
+            if (body.method === 'getAccountInfo') {
+                return rpcSuccess({
+                    value: {
+                        data: [accountB64, 'base64'],
+                        executable: false,
+                        lamports: 0,
+                        owner: SUBSCRIPTIONS_PROGRAM,
+                        rentEpoch: 0,
+                    },
+                });
+            }
+            return rpcSuccess({});
+        };
+        const method = subscription({
+            decimals: 6,
+            mint: MINT,
+            network: 'devnet',
+            periodCount: 30,
+            periodUnit: 'day',
+            planId: PLAN_ID,
+            puller: PULLER,
+            recipient: RECIPIENT,
+            rpcUrl: 'https://mock-rpc',
+            store: Store.memory(),
+            tokenProgram: TOKEN_PROGRAM,
+        });
+        const credential = {
+            challenge: {
+                request: {
+                    amount: '10000000',
+                    currency: MINT,
+                    methodDetails: {
+                        decimals: 6,
+                        mint: MINT,
+                        planId: PLAN_ID,
+                        programId: SUBSCRIPTIONS_PROGRAM,
+                        puller: PULLER,
+                        tokenProgram: TOKEN_PROGRAM,
+                    },
+                    periodCount: '30',
+                    periodUnit: 'day',
+                    recipient: RECIPIENT,
+                },
+            },
+            payload: { signature: 'same-activation-signature', type: 'signature' },
+        } as never;
+
+        const results = await Promise.allSettled(
+            Array.from({ length: 16 }, () => method.verify!({ credential, request: {} as never })),
+        );
+        expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+        expect(results.filter(result => result.status === 'rejected')).toHaveLength(15);
     });
 
     test('rejects when push-mode getTransaction returns null', async () => {

--- a/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
+++ b/typescript/packages/mpp/src/__tests__/subscription-server.test.ts
@@ -788,8 +788,10 @@ describe('subscription().verify() (push mode)', () => {
         const data = buildDelegationData(subscriberAddress, PLAN_ID, 10_000_000n);
         const accountB64 = Buffer.from(data).toString('base64');
 
+        const rpcMethods: string[] = [];
         globalThis.fetch = async (_input, init) => {
             const body = JSON.parse(init?.body as string) as { method?: string };
+            if (body.method) rpcMethods.push(body.method);
             switch (body.method) {
                 case 'simulateTransaction':
                     return rpcSuccess({ value: { err: null, logs: [] } });
@@ -855,6 +857,8 @@ describe('subscription().verify() (push mode)', () => {
 
         const recovered = await method.verify!({ credential, request: {} as never });
         expect((recovered as { reference: string }).reference).toBe((receipt as { reference: string }).reference);
+        expect(rpcMethods.filter(method => method === 'simulateTransaction')).toHaveLength(1);
+        expect(rpcMethods.filter(method => method === 'sendTransaction')).toHaveLength(1);
     });
 
     test('rejects when on-chain delegation references a different plan', async () => {

--- a/typescript/packages/mpp/src/server/Charge.ts
+++ b/typescript/packages/mpp/src/server/Charge.ts
@@ -27,7 +27,7 @@ import { coSignBase64Transaction } from '../utils/transactions.js';
 import { PAYMENT_UI_JS } from './html-assets.gen.js';
 import { withKeyLock } from './keyLock.js';
 import { checkNetworkBlockhash } from './network-check.js';
-import { reserveReplayKey } from './replay.js';
+import { claimReplayKey, confirmReplayKey } from './replay.js';
 
 /**
  * Creates a Solana `charge` method for usage on the server.
@@ -785,15 +785,20 @@ async function verifyTransaction(
     // pays but the signature is never recorded, so a retry re-broadcasts (double
     // charge) or replays. Reserving here closes the replay window; the
     // post-timeout status recovery below rescues the false-negative case.
-    if (!(await reserveReplayKey(store, `solana-charge:consumed:${signature}`))) {
+    const replayKey = `solana-charge:consumed:${signature}`;
+    const replayBinding = JSON.stringify({ challengeId: credential.challenge.id ?? null, request: challenge });
+    const replayClaim = await claimReplayKey(store, replayKey, replayBinding);
+    if (replayClaim === 'conflict') {
         throw new Error('Transaction signature already consumed');
     }
+    if (replayClaim === 'pending') throw new Error('Transaction settlement is already in progress; retry shortly');
 
     // Wait for on-chain confirmation (with a definitive post-timeout status check).
     await waitForConfirmation(rpcUrl, signature);
 
     // Verify the confirmed transaction matches the challenge.
     await verifyOnChain(rpcUrl, signature, challenge, recipient);
+    await confirmReplayKey(store, replayKey, replayBinding);
 
     return Receipt.from({
         method: 'solana',

--- a/typescript/packages/mpp/src/server/Charge.ts
+++ b/typescript/packages/mpp/src/server/Charge.ts
@@ -27,6 +27,7 @@ import { coSignBase64Transaction } from '../utils/transactions.js';
 import { PAYMENT_UI_JS } from './html-assets.gen.js';
 import { withKeyLock } from './keyLock.js';
 import { checkNetworkBlockhash } from './network-check.js';
+import { reserveReplayKey } from './replay.js';
 
 /**
  * Creates a Solana `charge` method for usage on the server.
@@ -784,7 +785,9 @@ async function verifyTransaction(
     // pays but the signature is never recorded, so a retry re-broadcasts (double
     // charge) or replays. Reserving here closes the replay window; the
     // post-timeout status recovery below rescues the false-negative case.
-    await store.put(`solana-charge:consumed:${signature}`, true);
+    if (!(await reserveReplayKey(store, `solana-charge:consumed:${signature}`))) {
+        throw new Error('Transaction signature already consumed');
+    }
 
     // Wait for on-chain confirmation (with a definitive post-timeout status check).
     await waitForConfirmation(rpcUrl, signature);

--- a/typescript/packages/mpp/src/server/Charge.ts
+++ b/typescript/packages/mpp/src/server/Charge.ts
@@ -23,11 +23,11 @@ import {
     validateNetwork,
 } from '../constants.js';
 import * as Methods from '../Methods.js';
-import { coSignBase64Transaction } from '../utils/transactions.js';
+import { coSignBase64Transaction, transactionSignatureFromBase64 } from '../utils/transactions.js';
 import { PAYMENT_UI_JS } from './html-assets.gen.js';
 import { withKeyLock } from './keyLock.js';
 import { checkNetworkBlockhash } from './network-check.js';
-import { claimReplayKey, confirmReplayKey } from './replay.js';
+import { claimReplayKey, confirmReplayKey, inspectReplayKey } from './replay.js';
 
 /**
  * Creates a Solana `charge` method for usage on the server.
@@ -773,28 +773,40 @@ async function verifyTransaction(
         txToSend = await coSignBase64Transaction(signer, clientTxBase64);
     }
 
-    // Simulate before broadcast to catch failures without wasting fees.
-    await simulateTransaction(rpcUrl, txToSend);
-
-    // Broadcast the (now fully-signed) transaction.
-    const signature = await broadcastTransaction(rpcUrl, txToSend);
-
-    // Audit #3: reserve the signature BETWEEN broadcast and confirmation polling.
-    // If we only marked it consumed after confirmation+verify (as before), a tx
-    // that landed during a confirmation-poll timeout could be lost — the user
-    // pays but the signature is never recorded, so a retry re-broadcasts (double
-    // charge) or replays. Reserving here closes the replay window; the
-    // post-timeout status recovery below rescues the false-negative case.
+    const signature = transactionSignatureFromBase64(txToSend);
     const replayKey = `solana-charge:consumed:${signature}`;
     const replayBinding = JSON.stringify({ challengeId: credential.challenge.id ?? null, request: challenge });
-    const replayClaim = await claimReplayKey(store, replayKey, replayBinding);
-    if (replayClaim === 'conflict') {
+    const replayStatus = await inspectReplayKey(store, replayKey, replayBinding);
+    if (replayStatus === 'conflict') {
         throw new Error('Transaction signature already consumed');
     }
-    if (replayClaim === 'pending') throw new Error('Transaction settlement is already in progress; retry shortly');
+    if (replayStatus === 'pending') throw new Error('Transaction settlement is already in progress; retry shortly');
 
-    // Wait for on-chain confirmation (with a definitive post-timeout status check).
-    await waitForConfirmation(rpcUrl, signature);
+    let needsConfirmation = replayStatus !== 'retry';
+    if (replayStatus === 'expired') {
+        const recoveryClaim = await claimReplayKey(store, replayKey, replayBinding);
+        if (recoveryClaim === 'conflict') throw new Error('Transaction signature already consumed');
+        if (recoveryClaim === 'pending') {
+            throw new Error('Transaction settlement is already in progress; retry shortly');
+        }
+        needsConfirmation = recoveryClaim !== 'retry';
+    } else if (replayStatus === 'available') {
+        // Only a transaction with no prior settlement state reaches preflight
+        // and broadcast. Exact-wire retries recover by signature above, even
+        // after their blockhash or account-state preconditions have changed.
+        await simulateTransaction(rpcUrl, txToSend);
+        await broadcastTransaction(rpcUrl, txToSend);
+        const replayClaim = await claimReplayKey(store, replayKey, replayBinding);
+        if (replayClaim === 'conflict') throw new Error('Transaction signature already consumed');
+        if (replayClaim === 'pending') {
+            throw new Error('Transaction settlement is already in progress; retry shortly');
+        }
+        needsConfirmation = replayClaim !== 'retry';
+    }
+
+    if (needsConfirmation) {
+        await waitForConfirmation(rpcUrl, signature);
+    }
 
     // Verify the confirmed transaction matches the challenge.
     await verifyOnChain(rpcUrl, signature, challenge, recipient);

--- a/typescript/packages/mpp/src/server/Subscription.ts
+++ b/typescript/packages/mpp/src/server/Subscription.ts
@@ -8,6 +8,7 @@ import {
     type TransactionPartialSigner,
 } from '@solana/kit';
 import { getSubscriptionDelegationDecoder, SUBSCRIPTION_SIZE } from '@solana/subscriptions';
+import { findAssociatedTokenPda } from '@solana-program/token';
 import { Method, Receipt, Store } from 'mppx';
 
 import {
@@ -15,8 +16,8 @@ import {
     COMPUTE_BUDGET_PROGRAM,
     DEFAULT_RPC_URLS,
     MEMO_PROGRAM,
-    SUBSCRIPTIONS_PROGRAM,
     SUBSCRIPTIONS_INIT_AUTHORITY_DISCRIMINATOR,
+    SUBSCRIPTIONS_PROGRAM,
     SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR,
     SUBSCRIPTIONS_TRANSFER_DISCRIMINATOR,
     SYSTEM_PROGRAM,
@@ -26,7 +27,7 @@ import {
 import * as Methods from '../Methods.js';
 import { deriveSubscriptionPda, mapSubscriptionPeriodToHours } from '../shared/subscription.js';
 import { coSignBase64Transaction } from '../utils/transactions.js';
-import { reserveReplayKey } from './replay.js';
+import { claimReplayKey, confirmReplayKey, reserveReplayKey } from './replay.js';
 
 /**
  * Creates a Solana `subscription` method for usage on the server.
@@ -166,7 +167,8 @@ export function subscription(parameters: subscription.Parameters) {
                 throw new Error('type="signature" credentials cannot be used with fee sponsorship (feePayer: true)');
             }
 
-            const subscriberAddress = await settleActivation(cred, challenge, rpcUrl, store, signer, payloadType);
+            const settlement = await settleActivation(cred, challenge, rpcUrl, store, signer, payloadType);
+            const subscriberAddress = settlement.subscriberAddress;
 
             const subscriptionPda = await deriveSubscriptionPda({
                 planPda: address(challenge.methodDetails.planId),
@@ -201,6 +203,10 @@ export function subscription(parameters: subscription.Parameters) {
             }
             if (delegation.amountPulledInPeriod !== challenge.amount) {
                 throw new Error('Activation transaction did not execute the first-period charge');
+            }
+
+            if (settlement.replay) {
+                await confirmReplayKey(store, settlement.replay.key, settlement.replay.binding);
             }
 
             const periodLengthSeconds = expectedPeriodHours * 3600;
@@ -256,7 +262,7 @@ async function settleActivation(
     store: Store.Store,
     signer: TransactionPartialSigner | undefined,
     payloadType: 'signature' | 'transaction',
-): Promise<string> {
+): Promise<{ replay?: { binding: string; key: string }; subscriberAddress: string }> {
     if (payloadType === 'transaction') {
         const { transaction: clientTxBase64 } = credential.payload;
         if (!clientTxBase64) {
@@ -264,7 +270,7 @@ async function settleActivation(
         }
 
         const subscriber = extractSubscriberFromTransaction(clientTxBase64, challenge);
-        validateActivationInstructions(clientTxBase64, challenge, subscriber);
+        await validateActivationInstructions(clientTxBase64, challenge, subscriber);
 
         let txToSend = clientTxBase64;
         if (signer) {
@@ -276,11 +282,15 @@ async function settleActivation(
 
         await simulateTransaction(rpcUrl, txToSend);
         const signature = await broadcastTransaction(rpcUrl, txToSend);
-        if (!(await reserveReplayKey(store, `solana-subscription:consumed:${signature}`))) {
+        const key = `solana-subscription:consumed:${signature}`;
+        const binding = JSON.stringify({ challengeId: credential.challenge.id ?? null, request: challenge });
+        const replayClaim = await claimReplayKey(store, key, binding);
+        if (replayClaim === 'conflict') {
             throw new Error('Activation signature already consumed');
         }
+        if (replayClaim === 'pending') throw new Error('Activation settlement is already in progress; retry shortly');
         await waitForConfirmation(rpcUrl, signature);
-        return subscriber;
+        return { replay: { binding, key }, subscriberAddress: subscriber };
     }
 
     // ── Push mode (type="signature") ──
@@ -297,12 +307,12 @@ async function settleActivation(
     if (tx.meta?.err) throw new Error('Transaction failed on-chain');
     const [transactionBase64] = tx.transaction;
     const subscriber = extractSubscriberFromTransaction(transactionBase64, challenge);
-    validateActivationInstructions(transactionBase64, challenge, subscriber);
+    await validateActivationInstructions(transactionBase64, challenge, subscriber);
 
     if (!(await reserveReplayKey(store, consumedKey))) {
         throw new Error('Activation signature already consumed');
     }
-    return subscriber;
+    return { subscriberAddress: subscriber };
 }
 
 // ── Transaction parsing (lightweight, pre-broadcast) ──
@@ -364,11 +374,11 @@ function extractSubscriberFromTransaction(clientTxBase64: string, challenge: Cha
     return firstAccount;
 }
 
-function validateActivationInstructions(
+async function validateActivationInstructions(
     clientTxBase64: string,
     challenge: ChallengeRequest,
     subscriber?: string,
-): void {
+): Promise<void> {
     const message = decodeCompiledMessage(clientTxBase64);
 
     if (message.addressTableLookups?.length) {
@@ -448,6 +458,39 @@ function validateActivationInstructions(
             subscribeIndex = index;
         } else if (ix.data[0] === SUBSCRIPTIONS_TRANSFER_DISCRIMINATOR) {
             if (sawTransferSubscription) throw new Error('Multiple transfer_subscription instructions found');
+            if (!subscriber) throw new Error('Cannot validate transfer_subscription without subscriber');
+            const expectedRecipientAta = (
+                await findAssociatedTokenPda({
+                    mint: address(challenge.methodDetails.mint),
+                    owner: address(challenge.recipient),
+                    tokenProgram: address(challenge.methodDetails.tokenProgram),
+                })
+            )[0];
+            // Codama v0.5 uses receiver_ata at account 4. Retain the previous
+            // nine-account client layout at account 6 during its migration,
+            // but bind either accepted shape to the challenged recipient ATA.
+            const receiverPosition = ix.accountIndices.length === 10 ? 4 : ix.accountIndices.length === 9 ? 6 : -1;
+            if (
+                receiverPosition < 0 ||
+                message.staticAccounts[ix.accountIndices[receiverPosition]] !== expectedRecipientAta
+            ) {
+                throw new Error('transfer_subscription receiver does not match the challenge recipient');
+            }
+            // Codama v0.5 TransferData is discriminator + amount + delegator +
+            // mint. Validate it whenever the current schema is presented.
+            if (ix.data.length === 73) {
+                if (readU64Le(ix.data, 1) !== BigInt(challenge.amount)) {
+                    throw new Error('transfer_subscription amount does not match the challenge');
+                }
+                if (encodeBase58(ix.data.slice(9, 41)) !== subscriber) {
+                    throw new Error('transfer_subscription delegator does not match subscriber');
+                }
+                if (encodeBase58(ix.data.slice(41, 73)) !== challenge.methodDetails.mint) {
+                    throw new Error('transfer_subscription mint does not match the challenge');
+                }
+            } else if (ix.data.length !== 1) {
+                throw new Error('Invalid transfer_subscription instruction data');
+            }
             sawTransferSubscription = true;
             transferIndex = index;
         } else {

--- a/typescript/packages/mpp/src/server/Subscription.ts
+++ b/typescript/packages/mpp/src/server/Subscription.ts
@@ -26,8 +26,8 @@ import {
 } from '../constants.js';
 import * as Methods from '../Methods.js';
 import { deriveSubscriptionPda, mapSubscriptionPeriodToHours } from '../shared/subscription.js';
-import { coSignBase64Transaction } from '../utils/transactions.js';
-import { claimReplayKey, confirmReplayKey, reserveReplayKey } from './replay.js';
+import { coSignBase64Transaction, transactionSignatureFromBase64 } from '../utils/transactions.js';
+import { claimReplayKey, confirmReplayKey, inspectReplayKey, reserveReplayKey } from './replay.js';
 
 /**
  * Creates a Solana `subscription` method for usage on the server.
@@ -280,16 +280,38 @@ async function settleActivation(
             txToSend = await coSignBase64Transaction(signer, clientTxBase64);
         }
 
-        await simulateTransaction(rpcUrl, txToSend);
-        const signature = await broadcastTransaction(rpcUrl, txToSend);
+        const signature = transactionSignatureFromBase64(txToSend);
         const key = `solana-subscription:consumed:${signature}`;
         const binding = JSON.stringify({ challengeId: credential.challenge.id ?? null, request: challenge });
-        const replayClaim = await claimReplayKey(store, key, binding);
-        if (replayClaim === 'conflict') {
+        const replayStatus = await inspectReplayKey(store, key, binding);
+        if (replayStatus === 'conflict') {
             throw new Error('Activation signature already consumed');
         }
-        if (replayClaim === 'pending') throw new Error('Activation settlement is already in progress; retry shortly');
-        await waitForConfirmation(rpcUrl, signature);
+        if (replayStatus === 'pending') {
+            throw new Error('Activation settlement is already in progress; retry shortly');
+        }
+
+        let needsConfirmation = replayStatus !== 'retry';
+        if (replayStatus === 'expired') {
+            const recoveryClaim = await claimReplayKey(store, key, binding);
+            if (recoveryClaim === 'conflict') throw new Error('Activation signature already consumed');
+            if (recoveryClaim === 'pending') {
+                throw new Error('Activation settlement is already in progress; retry shortly');
+            }
+            needsConfirmation = recoveryClaim !== 'retry';
+        } else if (replayStatus === 'available') {
+            await simulateTransaction(rpcUrl, txToSend);
+            await broadcastTransaction(rpcUrl, txToSend);
+            const replayClaim = await claimReplayKey(store, key, binding);
+            if (replayClaim === 'conflict') throw new Error('Activation signature already consumed');
+            if (replayClaim === 'pending') {
+                throw new Error('Activation settlement is already in progress; retry shortly');
+            }
+            needsConfirmation = replayClaim !== 'retry';
+        }
+        if (needsConfirmation) {
+            await waitForConfirmation(rpcUrl, signature);
+        }
         return { replay: { binding, key }, subscriberAddress: subscriber };
     }
 

--- a/typescript/packages/mpp/src/server/Subscription.ts
+++ b/typescript/packages/mpp/src/server/Subscription.ts
@@ -7,19 +7,26 @@ import {
     isTransactionPartialSigner,
     type TransactionPartialSigner,
 } from '@solana/kit';
+import { getSubscriptionDelegationDecoder, SUBSCRIPTION_SIZE } from '@solana/subscriptions';
 import { Method, Receipt, Store } from 'mppx';
 
 import {
+    ASSOCIATED_TOKEN_PROGRAM,
+    COMPUTE_BUDGET_PROGRAM,
     DEFAULT_RPC_URLS,
+    MEMO_PROGRAM,
     SUBSCRIPTIONS_PROGRAM,
+    SUBSCRIPTIONS_INIT_AUTHORITY_DISCRIMINATOR,
     SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR,
     SUBSCRIPTIONS_TRANSFER_DISCRIMINATOR,
+    SYSTEM_PROGRAM,
     TOKEN_2022_PROGRAM,
     TOKEN_PROGRAM,
 } from '../constants.js';
 import * as Methods from '../Methods.js';
 import { deriveSubscriptionPda, mapSubscriptionPeriodToHours } from '../shared/subscription.js';
 import { coSignBase64Transaction } from '../utils/transactions.js';
+import { reserveReplayKey } from './replay.js';
 
 /**
  * Creates a Solana `subscription` method for usage on the server.
@@ -182,11 +189,6 @@ export function subscription(parameters: subscription.Parameters) {
                     `SubscriptionDelegation plan mismatch: expected ${challenge.methodDetails.planId}, got ${delegation.planPda}`,
                 );
             }
-            if (delegation.mint !== challenge.methodDetails.mint) {
-                throw new Error(
-                    `SubscriptionDelegation mint mismatch: expected ${challenge.methodDetails.mint}, got ${delegation.mint}`,
-                );
-            }
             if (delegation.amountPerPeriod !== challenge.amount) {
                 throw new Error(
                     `SubscriptionDelegation amount mismatch: expected ${challenge.amount}, got ${delegation.amountPerPeriod}`,
@@ -262,18 +264,22 @@ async function settleActivation(
         }
 
         const subscriber = extractSubscriberFromTransaction(clientTxBase64, challenge);
-        validateActivationInstructions(clientTxBase64, challenge);
+        validateActivationInstructions(clientTxBase64, challenge, subscriber);
 
         let txToSend = clientTxBase64;
         if (signer) {
+            if (challenge.methodDetails.feePayerKey !== signer.address) {
+                throw new Error('Configured fee-payer signer does not match challenge feePayerKey');
+            }
             txToSend = await coSignBase64Transaction(signer, clientTxBase64);
         }
 
         await simulateTransaction(rpcUrl, txToSend);
         const signature = await broadcastTransaction(rpcUrl, txToSend);
+        if (!(await reserveReplayKey(store, `solana-subscription:consumed:${signature}`))) {
+            throw new Error('Activation signature already consumed');
+        }
         await waitForConfirmation(rpcUrl, signature);
-
-        await store.put(`solana-subscription:consumed:${signature}`, true);
         return subscriber;
     }
 
@@ -283,39 +289,33 @@ async function settleActivation(
         throw new Error('Missing signature in credential payload');
     }
     const consumedKey = `solana-subscription:consumed:${signature}`;
-    if (await store.get(consumedKey)) {
+    if ((await store.get(consumedKey)) !== null) {
         throw new Error('Activation signature already consumed');
     }
-
     const tx = await fetchTransactionRaw(rpcUrl, signature);
     if (!tx) throw new Error('Transaction not found or not yet confirmed');
     if (tx.meta?.err) throw new Error('Transaction failed on-chain');
+    const [transactionBase64] = tx.transaction;
+    const subscriber = extractSubscriberFromTransaction(transactionBase64, challenge);
+    validateActivationInstructions(transactionBase64, challenge, subscriber);
 
-    // The subscriber is the first signer that is not the fee payer (when
-    // fee sponsorship is in play) or simply the fee payer otherwise.
-    const accountKeys = tx.transaction.message.accountKeys ?? [];
-    if (accountKeys.length === 0) {
-        throw new Error('Transaction has no account keys');
+    if (!(await reserveReplayKey(store, consumedKey))) {
+        throw new Error('Activation signature already consumed');
     }
-    const firstAccount = typeof accountKeys[0] === 'string' ? accountKeys[0] : accountKeys[0].pubkey;
-    const subscriber = firstAccount;
-
-    await store.put(consumedKey, true);
     return subscriber;
 }
 
 // ── Transaction parsing (lightweight, pre-broadcast) ──
 //
-// v0: we extract the subscriber and assert the transaction touches the
-// subscriptions program identified by `methodDetails.programId`. Full
-// instruction allowlist enforcement (one subscribe, one transfer_subscription,
-// in order, with re-derived PDAs) lives in `validateActivationInstructions`
-// and is intentionally lightweight in v0; on-chain enforcement is the source
-// of truth for amount/period/destination correctness.
+// Decode once at this boundary so subscriber extraction and the instruction
+// allowlist operate on the same canonical compiled-message representation.
+// Account-state correctness is verified against the resulting delegation
+// after confirmation.
 
 type CompiledMessage = {
     addressTableLookups?: readonly unknown[];
     instructions: readonly CompiledInstruction[];
+    signerAccounts: readonly string[];
     staticAccounts: readonly string[];
 };
 
@@ -329,7 +329,11 @@ function decodeCompiledMessage(clientTxBase64: string): CompiledMessage {
     try {
         const txBytes = getBase64Codec().encode(clientTxBase64);
         const decoded = getTransactionDecoder().decode(txBytes);
-        return getCompiledTransactionMessageDecoder().decode(decoded.messageBytes) as unknown as CompiledMessage;
+        const message = getCompiledTransactionMessageDecoder().decode(decoded.messageBytes) as unknown as Omit<
+            CompiledMessage,
+            'signerAccounts'
+        >;
+        return { ...message, signerAccounts: Object.keys(decoded.signatures) };
     } catch (e) {
         throw new Error(`Invalid transaction: ${e instanceof Error ? e.message : String(e)}`);
     }
@@ -340,24 +344,31 @@ function extractSubscriberFromTransaction(clientTxBase64: string, challenge: Cha
     if (message.staticAccounts.length === 0) {
         throw new Error('Transaction has no static accounts');
     }
+    const firstAccount = message.staticAccounts[0];
 
     // When fee sponsorship is in play, the first signer is the server's fee
     // payer; the subscriber is the next signer that is not the puller.
     if (challenge.methodDetails.feePayer && challenge.methodDetails.feePayerKey) {
-        for (const account of message.staticAccounts.slice(1)) {
+        if (firstAccount !== challenge.methodDetails.feePayerKey) {
+            throw new Error(`Transaction fee payer must be ${challenge.methodDetails.feePayerKey}`);
+        }
+        for (const account of message.signerAccounts.slice(1)) {
             if (account !== challenge.methodDetails.puller) return account;
         }
         throw new Error('Could not identify subscriber among transaction signers');
     }
 
-    const firstAccount = message.staticAccounts[0];
     if (challenge.methodDetails.puller && firstAccount === challenge.methodDetails.puller) {
         throw new Error('Subscriber cannot be the server puller');
     }
     return firstAccount;
 }
 
-function validateActivationInstructions(clientTxBase64: string, challenge: ChallengeRequest): void {
+function validateActivationInstructions(
+    clientTxBase64: string,
+    challenge: ChallengeRequest,
+    subscriber?: string,
+): void {
     const message = decodeCompiledMessage(clientTxBase64);
 
     if (message.addressTableLookups?.length) {
@@ -370,12 +381,68 @@ function validateActivationInstructions(clientTxBase64: string, challenge: Chall
     let sawTransferSubscription = false;
     let subscribeIndex = -1;
     let transferIndex = -1;
+    let sawInitializeAuthority = false;
+    let sawMemo = false;
+    let sawComputeUnitLimit = false;
+    let sawComputeUnitPrice = false;
 
     for (const [index, ix] of message.instructions.entries()) {
         const program = message.staticAccounts[ix.programAddressIndex];
-        if (program !== programId) continue;
-        if (ix.data.length === 0) continue;
-        if (ix.data[0] === SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR) {
+        if (program === COMPUTE_BUDGET_PROGRAM) {
+            if (ix.data[0] === 2 && ix.data.length === 5) {
+                if (sawComputeUnitLimit) throw new Error('Multiple compute-unit-limit instructions found');
+                sawComputeUnitLimit = true;
+                if (readU32Le(ix.data, 1) > 400_000) throw new Error('Activation compute unit limit exceeds 400000');
+                continue;
+            }
+            if (ix.data[0] === 3 && ix.data.length === 9) {
+                if (sawComputeUnitPrice) throw new Error('Multiple compute-unit-price instructions found');
+                sawComputeUnitPrice = true;
+                const maxPrice = challenge.methodDetails.feePayer ? 10_000n : 5_000_000n;
+                if (readU64Le(ix.data, 1) > maxPrice) throw new Error('Activation compute unit price exceeds cap');
+                continue;
+            }
+            throw new Error('Unsupported compute-budget instruction in activation transaction');
+        }
+
+        if (program === MEMO_PROGRAM) {
+            if (sawMemo) throw new Error('Multiple memo instructions found');
+            sawMemo = true;
+            const expectedMemo = challenge.externalId;
+            if (!expectedMemo || new TextDecoder().decode(ix.data) !== expectedMemo) {
+                throw new Error('Activation memo does not match challenge externalId');
+            }
+            continue;
+        }
+
+        if (program === ASSOCIATED_TOKEN_PROGRAM) {
+            if (ix.data.length !== 1 || ix.data[0] !== 1) {
+                throw new Error('Only idempotent ATA creation is allowed in activation transaction');
+            }
+            if (!subscriber || ix.accountIndices.length !== 6) {
+                throw new Error('Invalid ATA creation instruction in activation transaction');
+            }
+            const account = (position: number) => message.staticAccounts[ix.accountIndices[position]];
+            if (
+                account(2) !== subscriber ||
+                account(3) !== challenge.methodDetails.mint ||
+                account(4) !== SYSTEM_PROGRAM ||
+                account(5) !== challenge.methodDetails.tokenProgram
+            ) {
+                throw new Error('ATA creation does not match the activation subscriber and mint');
+            }
+            continue;
+        }
+
+        if (program !== programId) {
+            throw new Error(`Unsupported program ${program ?? '<invalid>'} in activation transaction`);
+        }
+        if (ix.data.length === 0) throw new Error('Empty subscriptions-program instruction');
+        if (ix.data[0] === SUBSCRIPTIONS_INIT_AUTHORITY_DISCRIMINATOR) {
+            if (sawInitializeAuthority)
+                throw new Error('Multiple initialize_subscription_authority instructions found');
+            sawInitializeAuthority = true;
+        } else if (ix.data[0] === SUBSCRIPTIONS_SUBSCRIBE_DISCRIMINATOR) {
             if (sawSubscribe) throw new Error('Multiple subscribe instructions found');
             sawSubscribe = true;
             subscribeIndex = index;
@@ -383,6 +450,8 @@ function validateActivationInstructions(clientTxBase64: string, challenge: Chall
             if (sawTransferSubscription) throw new Error('Multiple transfer_subscription instructions found');
             sawTransferSubscription = true;
             transferIndex = index;
+        } else {
+            throw new Error(`Unsupported subscriptions instruction ${ix.data[0]} in activation transaction`);
         }
     }
 
@@ -392,19 +461,20 @@ function validateActivationInstructions(clientTxBase64: string, challenge: Chall
     if (transferIndex < subscribeIndex) {
         throw new Error('subscribe must precede transfer_subscription in activation transaction');
     }
+    if (challenge.externalId && !sawMemo) {
+        throw new Error('Activation transaction is missing challenge externalId memo');
+    }
 }
 
-// ── On-chain SubscriptionDelegation decoding (v0) ──
+// ── On-chain SubscriptionDelegation decoding ──
 //
-// v0 deserialization reads the fields this profile needs by offset. The
-// definitive schema lives in the subscriptions program's Codama client; a
-// follow-up should adopt that typed client and replace this manual decoder.
+// Keep account layout handling in the official Codama-generated SDK. This
+// avoids duplicating offsets here when the subscription program evolves.
 
 type SubscriptionDelegation = {
     amountPerPeriod: string;
     amountPulledInPeriod: string;
     currentPeriodStartTs: number;
-    mint: string;
     periodHours: number;
     planPda: string;
     subscriber: string;
@@ -422,45 +492,21 @@ async function fetchSubscriptionDelegation(
     return decodeSubscriptionDelegation(data);
 }
 
-// Offsets correspond to the subscriptions program's
-// SubscriptionDelegation layout (see /Users/ludo/Coding/solana-program/
-// subscriptions/program/src/state/subscription_delegation.rs). This is a
-// minimum-viable decoder: it reads only the fields needed for activation
-// verification. Replace with the Codama client in v0.1.
-const SUBSCRIPTION_DELEGATION_DISCRIMINATOR_LEN = 1;
-const PUBKEY_LEN = 32;
-
 function decodeSubscriptionDelegation(data: Uint8Array): SubscriptionDelegation {
-    let offset = SUBSCRIPTION_DELEGATION_DISCRIMINATOR_LEN;
-    // Header: delegator (subscriber), delegatee, payer (sponsor), init_id (u64)
-    const subscriber = encodeBase58(data.subarray(offset, offset + PUBKEY_LEN));
-    offset += PUBKEY_LEN;
-    // delegatee
-    offset += PUBKEY_LEN;
-    // payer
-    offset += PUBKEY_LEN;
-    // init_id u64
-    offset += 8;
-    const planPda = encodeBase58(data.subarray(offset, offset + PUBKEY_LEN));
-    offset += PUBKEY_LEN;
-    const mint = encodeBase58(data.subarray(offset, offset + PUBKEY_LEN));
-    offset += PUBKEY_LEN;
-    const amountPerPeriod = readU64Le(data, offset).toString();
-    offset += 8;
-    const periodHours = Number(readU64Le(data, offset));
-    offset += 8;
-    const currentPeriodStartTs = Number(readI64Le(data, offset));
-    offset += 8;
-    const amountPulledInPeriod = readU64Le(data, offset).toString();
+    if (data.length !== SUBSCRIPTION_SIZE) {
+        throw new Error(
+            `Unexpected SubscriptionDelegation account length: ${data.length} bytes (expected ${SUBSCRIPTION_SIZE})`,
+        );
+    }
+    const decoded = getSubscriptionDelegationDecoder().decode(data);
 
     return {
-        amountPerPeriod,
-        amountPulledInPeriod,
-        currentPeriodStartTs,
-        mint,
-        periodHours,
-        planPda,
-        subscriber,
+        amountPerPeriod: decoded.terms.amount.toString(),
+        amountPulledInPeriod: decoded.amountPulledInPeriod.toString(),
+        currentPeriodStartTs: Number(decoded.currentPeriodStartTs),
+        periodHours: Number(decoded.terms.periodHours),
+        planPda: decoded.header.delegatee,
+        subscriber: decoded.header.delegator,
     };
 }
 
@@ -472,9 +518,8 @@ function readU64Le(data: Uint8Array, offset: number): bigint {
     return value;
 }
 
-function readI64Le(data: Uint8Array, offset: number): bigint {
-    const u = readU64Le(data, offset);
-    return u >= 1n << 63n ? u - (1n << 64n) : u;
+function readU32Le(data: Uint8Array, offset: number): number {
+    return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(offset, true);
 }
 
 // ── Base58/base64url helpers (minimal, dependency-free) ──
@@ -541,11 +586,7 @@ function base64UrlEncodeNoPadding(bytes: Uint8Array): string {
 
 type RawTransaction = {
     meta: { err: unknown } | null;
-    transaction: {
-        message: {
-            accountKeys: Array<string | { pubkey: string }>;
-        };
-    };
+    transaction: [string, 'base64'];
 };
 
 async function fetchTransactionRaw(rpcUrl: string, signature: string): Promise<RawTransaction | null> {
@@ -554,7 +595,7 @@ async function fetchTransactionRaw(rpcUrl: string, signature: string): Promise<R
             id: 1,
             jsonrpc: '2.0',
             method: 'getTransaction',
-            params: [signature, { commitment: 'confirmed', encoding: 'jsonParsed', maxSupportedTransactionVersion: 0 }],
+            params: [signature, { commitment: 'confirmed', encoding: 'base64', maxSupportedTransactionVersion: 0 }],
         }),
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',

--- a/typescript/packages/mpp/src/server/replay.ts
+++ b/typescript/packages/mpp/src/server/replay.ts
@@ -5,9 +5,69 @@ import { withKeyLock } from './keyLock.js';
 type AtomicStore = Store.Store & {
     update?<T>(
         key: string,
-        fn: (current: unknown | null) => { op: 'noop'; result: T } | { op: 'set'; result: T; value: unknown },
+        fn: (current: unknown) => { op: 'noop'; result: T } | { op: 'set'; result: T; value: unknown },
     ): Promise<T>;
 };
+
+type ReplayRecord = {
+    binding: string;
+    leaseUntil: number;
+    state: 'confirmed' | 'pending';
+};
+
+export type ReplayClaim = 'conflict' | 'pending' | 'reserved' | 'retry';
+
+const PENDING_LEASE_MS = 45_000;
+
+function isReplayRecord(value: unknown): value is ReplayRecord {
+    if (typeof value !== 'object' || value === null) return false;
+    const record = value as Partial<ReplayRecord>;
+    return (
+        typeof record.binding === 'string' &&
+        typeof record.leaseUntil === 'number' &&
+        (record.state === 'pending' || record.state === 'confirmed')
+    );
+}
+
+/**
+ * Reserve a proof for one challenge-bound settlement.
+ *
+ * An identical retry may resume confirmation and receipt construction, while
+ * a different challenge attempting to reuse the same proof is rejected.
+ */
+export async function claimReplayKey(store: Store.Store, key: string, binding: string): Promise<ReplayClaim> {
+    const now = Date.now();
+    const fresh: ReplayRecord = { binding, leaseUntil: now + PENDING_LEASE_MS, state: 'pending' };
+    const classify = (current: unknown): ReplayClaim => {
+        if (current === null) return 'reserved';
+        if (!isReplayRecord(current) || current.binding !== binding) return 'conflict';
+        if (current.state === 'confirmed') return 'retry';
+        return current.leaseUntil <= now ? 'reserved' : 'pending';
+    };
+    const atomicStore = store as AtomicStore;
+    if (typeof atomicStore.update === 'function') {
+        return await atomicStore.update(key, current => {
+            const result = classify(current);
+            return result === 'reserved' ? { op: 'set', result, value: fresh } : { op: 'noop', result };
+        });
+    }
+
+    return await withKeyLock(key, async () => {
+        const current = await store.get(key);
+        const result = classify(current);
+        if (result === 'reserved') await store.put(key, fresh);
+        return result;
+    });
+}
+
+/** Mark a challenge-bound proof as fully verified and receipt-ready. */
+export async function confirmReplayKey(store: Store.Store, key: string, binding: string): Promise<void> {
+    const current = await store.get(key);
+    if (!isReplayRecord(current) || current.binding !== binding) {
+        throw new Error('Replay reservation changed before settlement completed');
+    }
+    await store.put(key, { binding, leaseUntil: current.leaseUntil, state: 'confirmed' } satisfies ReplayRecord);
+}
 
 /** Atomically reserves a replay key, falling back to a process-local lock for legacy stores. */
 export async function reserveReplayKey(store: Store.Store, key: string): Promise<boolean> {

--- a/typescript/packages/mpp/src/server/replay.ts
+++ b/typescript/packages/mpp/src/server/replay.ts
@@ -1,0 +1,28 @@
+import { Store } from 'mppx';
+
+import { withKeyLock } from './keyLock.js';
+
+type AtomicStore = Store.Store & {
+    update?<T>(
+        key: string,
+        fn: (current: unknown | null) => { op: 'noop'; result: T } | { op: 'set'; result: T; value: unknown },
+    ): Promise<T>;
+};
+
+/** Atomically reserves a replay key, falling back to a process-local lock for legacy stores. */
+export async function reserveReplayKey(store: Store.Store, key: string): Promise<boolean> {
+    const atomicStore = store as AtomicStore;
+    if (typeof atomicStore.update === 'function') {
+        return await atomicStore.update(key, current =>
+            current === null ? { op: 'set', result: true, value: true } : { op: 'noop', result: false },
+        );
+    }
+
+    // Older custom stores expose only get/put/delete. This closes the race
+    // within one runtime; multi-process deployments must provide update().
+    return await withKeyLock(key, async () => {
+        if ((await store.get(key)) !== null) return false;
+        await store.put(key, true);
+        return true;
+    });
+}

--- a/typescript/packages/mpp/src/server/replay.ts
+++ b/typescript/packages/mpp/src/server/replay.ts
@@ -16,6 +16,7 @@ type ReplayRecord = {
 };
 
 export type ReplayClaim = 'conflict' | 'pending' | 'reserved' | 'retry';
+export type ReplayStatus = 'available' | 'conflict' | 'expired' | 'pending' | 'retry';
 
 const PENDING_LEASE_MS = 45_000;
 
@@ -27,6 +28,15 @@ function isReplayRecord(value: unknown): value is ReplayRecord {
         typeof record.leaseUntil === 'number' &&
         (record.state === 'pending' || record.state === 'confirmed')
     );
+}
+
+/** Inspect a challenge-bound proof without renewing an expired settlement lease. */
+export async function inspectReplayKey(store: Store.Store, key: string, binding: string): Promise<ReplayStatus> {
+    const current = await store.get(key);
+    if (current === null) return 'available';
+    if (!isReplayRecord(current) || current.binding !== binding) return 'conflict';
+    if (current.state === 'confirmed') return 'retry';
+    return current.leaseUntil <= Date.now() ? 'expired' : 'pending';
 }
 
 /**

--- a/typescript/packages/mpp/src/server/replay.ts
+++ b/typescript/packages/mpp/src/server/replay.ts
@@ -18,7 +18,10 @@ type ReplayRecord = {
 export type ReplayClaim = 'conflict' | 'pending' | 'reserved' | 'retry';
 export type ReplayStatus = 'available' | 'conflict' | 'expired' | 'pending' | 'retry';
 
-const PENDING_LEASE_MS = 45_000;
+// Keep recovery outside the complete settlement window, including confirmation
+// polling and post-confirmation account verification. This matches the Python
+// adapter's worst-case lease and prevents a retry from overlapping its owner.
+const PENDING_LEASE_MS = 21 * 60 * 1_000;
 
 function isReplayRecord(value: unknown): value is ReplayRecord {
     if (typeof value !== 'object' || value === null) return false;

--- a/typescript/packages/mpp/src/utils/transactions.ts
+++ b/typescript/packages/mpp/src/utils/transactions.ts
@@ -2,9 +2,16 @@ import {
     type Base64EncodedWireTransaction,
     getBase64Codec,
     getBase64EncodedWireTransaction,
+    getSignatureFromTransaction,
     getTransactionDecoder,
+    type Signature,
     type TransactionPartialSigner,
 } from '@solana/kit';
+
+/** Return the deterministic transaction signature from a base64 wire transaction. */
+export function transactionSignatureFromBase64(transaction: string): Signature {
+    return getSignatureFromTransaction(getTransactionDecoder().decode(getBase64Codec().encode(transaction)));
+}
 
 /**
  * Decode a base64 wire transaction, co-sign it with a TransactionPartialSigner,

--- a/typescript/packages/pay-kit/package.json
+++ b/typescript/packages/pay-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay-kit",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "description": "Building blocks for Agentic payments (x402, MPP, AP2)",
     "repository": {
         "type": "git",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@solana/program-client-core':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/subscriptions':
+        specifier: ^0.5.0
+        version: 0.5.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -109,7 +112,7 @@ importers:
         version: 0.11.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/keychain-memory':
         specifier: ^1.3.0
-        version: 1.3.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+        version: 1.3.0(@solana/addresses@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit':
         specifier: '>=6.5.0'
         version: 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1029,6 +1032,12 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.3.0
 
+  '@solana-program/record@0.3.0':
+    resolution: {integrity: sha512-q8z86INfXRQ5357qgVBrw05vC+u3xg8Vb4E1gEwnYUvAkL3cbJSjWVfTlGRiGWYmPNq/FYIWbsFrhsxXyhaJ+w==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana-program/system@0.12.0':
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
@@ -1039,11 +1048,27 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.4.0
 
+  '@solana-program/system@0.13.0':
+    resolution: {integrity: sha512-Id6QQxCG7ByImXPD5X/c3Ag2kySD+49aJ9waIkfxyUFyokhMQgxYQAx2rKuaygaBlaBQY6VVfBS46pqxZV+99A==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana-program/token-2022@0.11.0':
     resolution: {integrity: sha512-4yhSajmlZdMl98vJvt63kW6L0ERtV7UFcfZGJFyUVfTMxTrgghp8BNyhh5S1Ho3p4yHqfgL4N9VgVQ9GCnqqbg==}
     peerDependencies:
       '@solana/kit': ^6.0.0
       '@solana/sysvars': ^5.0
+      '@solana/zk-sdk': ^0.4.2
+    peerDependenciesMeta:
+      '@solana/zk-sdk':
+        optional: true
+
+  '@solana-program/token-2022@0.14.1':
+    resolution: {integrity: sha512-8yDF8xgEYU3HyfT4o7nLKHKMWQr3r2+1zBFojWYMkRyVh6YjuPO6Sxzf+p9trvL9Ddwp0d8SvqmMdYeErBZROA==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+      '@solana/sysvars': ^7.0.0
       '@solana/zk-sdk': ^0.4.2
     peerDependenciesMeta:
       '@solana/zk-sdk':
@@ -1065,6 +1090,12 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.5.0
 
+  '@solana-program/token@0.15.0':
+    resolution: {integrity: sha512-SeLm08EYIfT453I6lo7wTGgfMbz1s7bJ1jSHFHBFebSJHD3xF46zRgMxq3YKRlr/RM8jN0cG8SjZVu+IDvMxEA==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
     peerDependencies:
@@ -1074,6 +1105,11 @@ packages:
     resolution: {integrity: sha512-MKyeapz8P7SqkkC7h53ARFLoanb59ylVzokSMyINDH7hxY3JyiZs92/VfPa/qedhLAEHLd8jcc8sQ3pr3GyXtw==}
     peerDependencies:
       '@solana/kit': ^5.0
+
+  '@solana-program/zk-elgamal-proof@0.3.2':
+    resolution: {integrity: sha512-bCiRVKtqYZpajgC2RVypZL4A0xHjQYVEsVSNMTtPJ1jjE5KOUvsXhnngGMYShK6BHv+fQP4F8QKvEVW/HOSFAg==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
 
   '@solana/accounts@5.5.1':
     resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
@@ -1086,6 +1122,15 @@ packages:
 
   '@solana/accounts@6.10.0':
     resolution: {integrity: sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/accounts@7.1.1':
+    resolution: {integrity: sha512-7sy9VIFMdmu/7+2kVBRMU6mEvYx/DDjfam8DsBXbh+JszaTNZH3V8FutQYHRxrca3jxiumVfsy5USwKfVg8ElQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1111,6 +1156,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/addresses@7.1.1':
+    resolution: {integrity: sha512-/Tk2aTOT7UEcaJrdEcB3+SK09v5cZ/92NWqHBzEobxusTPNoeOFxa3MwV74Q1MgPecWdLz7TPreEhAKpcvV/vw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/assertions@5.5.1':
     resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
     engines: {node: '>=20.18.0'}
@@ -1122,6 +1176,15 @@ packages:
 
   '@solana/assertions@6.10.0':
     resolution: {integrity: sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@7.1.1':
+    resolution: {integrity: sha512-tD07UKuw5i9Tw5xloVH+TUMrLzbHKixaB4DlGXumMEQU+JbYRPtFNqtMlrpVLuVM45nkbPfFp2Da0sXNRIqFHA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1147,6 +1210,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-core@7.1.1':
+    resolution: {integrity: sha512-C1UOAQ7LH8RuCTfaij6hthTZeBlpp8GuD2g9Nag/xgiNKJGvAfVrcorb+kO/sufdYI8Lu+BiVvPeKOjQDQiKqg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-data-structures@5.5.1':
     resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
     engines: {node: '>=20.18.0'}
@@ -1158,6 +1230,15 @@ packages:
 
   '@solana/codecs-data-structures@6.10.0':
     resolution: {integrity: sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-data-structures@7.1.1':
+    resolution: {integrity: sha512-MO+wMAuaatAQ96N3HhTsd7Uno+79rJw88P+OiU2n+pHK/rZuyu1yB2j12veqK4jUNWPR0aOyCuZ4rB2idrDjpg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1183,6 +1264,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-numbers@7.1.1':
+    resolution: {integrity: sha512-TWWrQq6Wp5Yf5bSc6RbxDDYCRUBBmRtRgjvUMHGp0P9K+4uFwxllRjSZFzBPHgXj3UTeZmFJdcoD271QhAgibg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-strings@5.5.1':
     resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
     engines: {node: '>=20.18.0'}
@@ -1197,6 +1287,18 @@ packages:
 
   '@solana/codecs-strings@6.10.0':
     resolution: {integrity: sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@7.1.1':
+    resolution: {integrity: sha512-6qWl+atG60D2LmP47GyGapQFhVsG1sVhVrEaM3lV09vwrGOMeOZARZ4ObaQ5m6uQmM04G+f8dY9d17nCMbGHGg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -1245,6 +1347,16 @@ packages:
       typescript:
         optional: true
 
+  '@solana/errors@7.1.1':
+    resolution: {integrity: sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/eslint-config-solana@6.0.0':
     resolution: {integrity: sha512-tl3C2ZK8buItUQNVCwnveR2iiLALr5XZ8cevswbTDQN1SA29xQWPFRYR/JPyXLd7iOGNAo4HwvIoxNmkLjdZsQ==}
     deprecated: It has been replaced by @solana-config/eslint, part of the js-configs monorepo (https://github.com/solana-foundation/js-configs). Please migrate to the new package; this one will no longer receive updates.
@@ -1281,8 +1393,26 @@ packages:
       typescript:
         optional: true
 
+  '@solana/fixed-points@7.1.1':
+    resolution: {integrity: sha512-qPj/V7kcFG/P0kuEa1U529+5L6mbkMwRIwvYBTDgBqPOt6wOdk9/c7Qn2VUQgSV0HgCXWxdHUdwaxBrYqO2ibg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/functional@6.10.0':
     resolution: {integrity: sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/functional@7.1.1':
+    resolution: {integrity: sha512-AnFohvUHGrqAu3kTxxC0rZyU4JddA08hOUZ1/DT9XogCZWetBpNJktX9uNuXQe+sN4FKTX2MfL//iBFBAsxtDA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1299,8 +1429,26 @@ packages:
       typescript:
         optional: true
 
+  '@solana/instruction-plans@7.1.1':
+    resolution: {integrity: sha512-KQGpsjeDflMcbKCdcF4KZVHcotYMS94DveRs0ZiBOsxb45dgkYrFmQ6ExJ/2exUOVF/rlp73knAP5ACrPMIAzA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/instructions@6.10.0':
     resolution: {integrity: sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@7.1.1':
+    resolution: {integrity: sha512-VxMpJI++RTwaqSBLIP1GTjOPLtlYOqxOJ93ug6DlSdu9jku8M/or77DiXDUi62VmEh3bbsECR646vTJXUaPArw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1336,11 +1484,25 @@ packages:
       typescript:
         optional: true
 
+  '@solana/keys@7.1.1':
+    resolution: {integrity: sha512-Rx+vzWAXUa/Ko7W6wG1HOG9B3nQFZ5dALz113WoAmBZf7iQvaLG7U4ECDM/ydR+Nbdy6wYww7zQKRIye+1d+Nw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/kit-client-rpc@0.8.0':
     resolution: {integrity: sha512-YD9x3hZ9TKR8r5evmkfURI1e2BtIudnd6zUWXEakMLi0FhvUfdtPrWjQsHw5ngWUv9Ns9yYlI+h3DEY0xmweUg==}
     deprecated: 'Deprecated: use createClient from @solana/kit with payer() from @solana/kit-plugin-signer and solanaRpc() from @solana/kit-plugin-rpc instead. See the README for migration.'
     peerDependencies:
       '@solana/kit': ^6.4.0
+
+  '@solana/kit-plugin-instruction-plan@0.13.0':
+    resolution: {integrity: sha512-9RA94e0LLtVLN+bvGclpu8l0lAXGOGS72DxPIQ1VyGZs7vK/WTwPOqKnWhjJs2Cv/SDJ2xsCAhYkXr0UltVrOg==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
 
   '@solana/kit-plugin-instruction-plan@0.8.0':
     resolution: {integrity: sha512-/wgyycjhaeMKUuYAymKUGZ+sF3U+rrFHQa80Rz5etThUmVOufR94lnJzRMw9KMzc1kbfOZ+45O2IcceMyTs72A==}
@@ -1353,10 +1515,20 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.4.0
 
+  '@solana/kit-plugin-rpc@0.15.0':
+    resolution: {integrity: sha512-Abymr7WLP9yQ6ixCCv+tKzjoWpAkxJ90JWzL+pfkTAFGTpVk9N0myhMcO2ohl6yztJRMOxsw1CXWjcVecxxUlg==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana/kit-plugin-rpc@0.8.0':
     resolution: {integrity: sha512-XIg4BqWHwVIVEqEBXN1zZ7BUkjCYmGYUXu8KAjPGvQcJg+gY6oOAWyr5APcbjbWZqzpq6axN5lvC3hhuAJwOXw==}
     peerDependencies:
       '@solana/kit': ^6.4.0
+
+  '@solana/kit-plugin-signer@0.13.0':
+    resolution: {integrity: sha512-Vtlyt2Td8WfeQvC30yOU7a+CFo4+loMCSQKUFwvSQvbpKG39S6UyQc1euhcvtwCbJRZR3m5nAZvHayQ1rxeUkA==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
 
   '@solana/kit@6.10.0':
     resolution: {integrity: sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==}
@@ -1385,8 +1557,26 @@ packages:
       typescript:
         optional: true
 
+  '@solana/nominal-types@7.1.1':
+    resolution: {integrity: sha512-do4rmmOlSplVYN92zV6nROJxkiRn0c7juoH1lka2Pmq+cAC3QhQXKYAwWffTFYDJJDO9qCOh00uv2hhSZi6RDw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/offchain-messages@6.10.0':
     resolution: {integrity: sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/offchain-messages@7.1.1':
+    resolution: {integrity: sha512-Py0/8HaIF0y+KSXHAWdQYDdZlGNoaqOZonTFuGKyDsrkgvod3wRc0cpZ5I/D/Rei4tVpvjNUfCXLpyoiJAZ7kg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1430,6 +1620,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/plugin-interfaces@7.1.1':
+    resolution: {integrity: sha512-2SHkGiftGmxg5xA5esxbwiY5wf+BOUsJG5rxD64/SHadUMaN3L0SDUSJfAXETJq5dCmVWxWGGPf2yVox4RIfdA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/prettier-config-solana@0.0.6':
     resolution: {integrity: sha512-/s55hDoAyh5QyltQh/jjNK3AgACEq885+DnC6lYhrmYZiV6I0iHITWYnKd8d23KRKs/RBjlaQH54MiafeoI9hw==}
     deprecated: This package is deprecated. It has been replaced by @solana-config/prettier, part of the @solana-foundation/js-configs monorepo (https://github.com/solana-foundation/js-configs). Please migrate to the new package; this one will no longer receive updates.
@@ -1438,6 +1637,15 @@ packages:
 
   '@solana/program-client-core@6.10.0':
     resolution: {integrity: sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/program-client-core@7.1.1':
+    resolution: {integrity: sha512-zoMq8Qg6psj6tFYpA35xKhSrF/LpdiVflV6nKohxZg3ocwtRqRhQfbY8/mjCA9EfH8vqvsn5il5CnxALRqmJJA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1463,6 +1671,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/promises@7.1.1':
+    resolution: {integrity: sha512-d3lhCfiFwiVyTRR6zhy1lcjDIh+l0a5gp1WPe64Vfa2gP0myC8P5C1Tknfjrp4d97DF3uBPqKAb5vV8hahNcNA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-api@6.10.0':
     resolution: {integrity: sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==}
     engines: {node: '>=20.18.0'}
@@ -1472,8 +1689,26 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-api@7.1.1':
+    resolution: {integrity: sha512-ELGIqNbz8apeAxCLdD1PEPAnu6KtgHmWvUbH4VqqNg2jgWquyUOfTI5rblvdflx2Hcb7GK05w8/iiUaknOQKnw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-parsed-types@6.10.0':
     resolution: {integrity: sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-parsed-types@7.1.1':
+    resolution: {integrity: sha512-DiQSj2rNnhOKOTs6YDjQ2y4KuOkv8lh6moLFiQnY0+TvanJrGrQjxLSrHdCUQxymQcUxzrraZL9k6vxNzId4gw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1499,6 +1734,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-spec-types@7.1.1':
+    resolution: {integrity: sha512-FDDgXfAPfq28sQNnGhZr/+2kp5QTTcNZ5m/Q9y9Jrlux6brdPsbf9Sh1Q/lgz7i76arzNW/rzRY125RzqGWANg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-spec@5.5.1':
     resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
     engines: {node: '>=20.18.0'}
@@ -1510,6 +1754,15 @@ packages:
 
   '@solana/rpc-spec@6.10.0':
     resolution: {integrity: sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@7.1.1':
+    resolution: {integrity: sha512-1FwhgL18qasRYlWffdBNIUoxQyGLzdh3YMQW3y33M61vk/q1ldEGJRypV9B/SrXmxwqDiUbQ+m+zgainCTp1ZA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1544,6 +1797,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-spec@7.1.1':
+    resolution: {integrity: sha512-yrqd+fV2Ae4hkzXX42aKRmTrz3FwvzKqO4h0ahs88dzSvXpy8l6Svu1k+uRgMlZ64g2P83jfQW+3Pj5fBoxmdw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-subscriptions@6.10.0':
     resolution: {integrity: sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==}
     engines: {node: '>=20.18.0'}
@@ -1555,6 +1817,15 @@ packages:
 
   '@solana/rpc-transformers@6.10.0':
     resolution: {integrity: sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transformers@7.1.1':
+    resolution: {integrity: sha512-k8a/JZFso/nvPBgurOGJ/ZC6sXCtYE3lCvTj95i29pl45C4SgjdetJrAH/pWEEhQXcxaJs7OLBGmCh2enazlJw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1589,6 +1860,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-types@7.1.1':
+    resolution: {integrity: sha512-yHlSUWgynaaqevuqipGhhcZnmFVNs+F6KIlbUZ0kQY6NMVtaSzx5AQrtQjbtAQzNRsRTDYkKuQg8nOruiDoseQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc@6.10.0':
     resolution: {integrity: sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==}
     engines: {node: '>=20.18.0'}
@@ -1607,6 +1887,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/signers@7.1.1':
+    resolution: {integrity: sha512-UfWYnAglm21q5hS3Op1bU5mYiWfx0VesovZcIur0uYPc3EJlfBVikl8pf745x+bB77xG6lIzNbb+99t48SQbkg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/subscribable@6.10.0':
     resolution: {integrity: sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==}
     engines: {node: '>=20.18.0'}
@@ -1615,6 +1904,20 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/subscribable@7.1.1':
+    resolution: {integrity: sha512-l4Wzc2L+7WQPeC/kaCiia1aaUY/SJJdrNHnLibKchS2pb7YbF7J2OygsweHXliWCVpG0jZwcvIVpusgygbZQLw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscriptions@0.5.0':
+    resolution: {integrity: sha512-N7mA5U3rqak9sSbAfB/iYGlgbuIjwGUHfNDlQRGqgXIACnxPcvA3e6f6cHkD0GITstRNxX+rg9uyE1FGGlw/Jw==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
 
   '@solana/sysvars@5.5.1':
     resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
@@ -1627,6 +1930,15 @@ packages:
 
   '@solana/sysvars@6.10.0':
     resolution: {integrity: sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@7.1.1':
+    resolution: {integrity: sha512-EscE/HKbBRKedG6AtQ0t9LOX87bw409viferac5YSuvuDxtZvbMpCCJs89uEQPVpgvHtjMJhfsjEwMK97uG9pA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1652,8 +1964,26 @@ packages:
       typescript:
         optional: true
 
+  '@solana/transaction-messages@7.1.1':
+    resolution: {integrity: sha512-UBgd/TU0c8blrYDC9sD9P+wgmOOEK4OdODxD8CxB7oumN4ZAENv20u0AdZuvu1n4OwWwc1ikhtKjwg18e4wTIg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/transactions@6.10.0':
     resolution: {integrity: sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@7.1.1':
+    resolution: {integrity: sha512-jop8y4+xiDJlocRLxqN++33Z5PDTe72HwmtgGrcIuGB4zq7U/lUX0uZM1JVcs9d3lJ3wBy2CcLTCyoYb78Swhg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -4919,11 +5249,19 @@ snapshots:
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
+  '@solana-program/record@0.3.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
   '@solana-program/system@0.12.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   '@solana-program/system@0.12.2(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
@@ -4933,6 +5271,14 @@ snapshots:
       '@solana-program/zk-elgamal-proof': 0.1.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
+  '@solana-program/token-2022@0.14.1(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@solana-program/record': 0.3.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
   '@solana-program/token-2022@0.6.1(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
@@ -4949,6 +5295,11 @@ snapshots:
       '@solana-program/system': 0.12.2(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
+  '@solana-program/token@0.15.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
   '@solana-program/token@0.9.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -4956,6 +5307,11 @@ snapshots:
   '@solana-program/zk-elgamal-proof@0.1.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana-program/system': 0.12.2(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   '@solana/accounts@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -4979,6 +5335,19 @@ snapshots:
       '@solana/errors': 6.10.0(typescript@5.9.3)
       '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
       '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/accounts@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5008,6 +5377,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/addresses@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/assertions@5.5.1(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@5.9.3)
@@ -5020,6 +5401,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/assertions@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/codecs-core@5.5.1(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@5.9.3)
@@ -5029,6 +5416,12 @@ snapshots:
   '@solana/codecs-core@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-core@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5048,6 +5441,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-data-structures@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/codecs-numbers@5.5.1(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
@@ -5059,6 +5460,13 @@ snapshots:
     dependencies:
       '@solana/codecs-core': 6.10.0(typescript@5.9.3)
       '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5076,6 +5484,15 @@ snapshots:
       '@solana/codecs-core': 6.10.0(typescript@5.9.3)
       '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
       '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
@@ -5119,6 +5536,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/errors@7.1.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 15.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/eslint-config-solana@6.0.0(@eslint/js@9.39.4)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.4))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.4))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(globals@16.5.0)(jest@30.3.0(@types/node@25.5.0))(typescript-eslint@8.57.1(eslint@9.39.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.4
@@ -5146,7 +5570,18 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/fixed-points@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/functional@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/functional@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5163,6 +5598,19 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/instruction-plans@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/instructions@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.10.0(typescript@5.9.3)
@@ -5170,23 +5618,30 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/keychain-core@1.3.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana/instructions@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/keychain-memory@1.3.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana/keychain-core@1.3.0(@solana/addresses@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/keychain-core': 1.3.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@6.10.0(typescript@5.9.3))(@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
+  '@solana/keychain-memory@1.3.0(@solana/addresses@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keychain-core': 1.3.0(@solana/addresses@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/codecs-core@7.1.1(typescript@5.9.3))(@solana/codecs-strings@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/keys@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/signers@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/transactions@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
@@ -5203,12 +5658,29 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/keys@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/kit-client-rpc@0.8.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/kit-plugin-instruction-plan': 0.8.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit-plugin-payer': 0.8.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit-plugin-rpc': 0.8.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+
+  '@solana/kit-plugin-instruction-plan@0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   '@solana/kit-plugin-instruction-plan@0.8.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -5218,7 +5690,16 @@ snapshots:
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
+  '@solana/kit-plugin-rpc@0.15.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+
   '@solana/kit-plugin-rpc@0.8.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana/kit-plugin-signer@0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
@@ -5264,6 +5745,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/nominal-types@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/offchain-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -5274,6 +5759,21 @@ snapshots:
       '@solana/errors': 6.10.0(typescript@5.9.3)
       '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/offchain-messages@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5321,6 +5821,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/plugin-interfaces@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/prettier-config-solana@0.0.6(prettier@3.8.1)':
     dependencies:
       prettier: 3.8.1
@@ -5341,6 +5856,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/program-client-core@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/plugin-interfaces': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-api': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/programs@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -5351,6 +5882,10 @@ snapshots:
       - fastestsmallesttextencoderdecoder
 
   '@solana/promises@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/promises@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5372,7 +5907,29 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-api@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-parsed-types@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-parsed-types@7.1.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5381,6 +5938,12 @@ snapshots:
       typescript: 5.9.3
 
   '@solana/rpc-spec-types@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec-types@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5396,6 +5959,14 @@ snapshots:
       '@solana/errors': 6.10.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
       '@solana/subscribable': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5435,6 +6006,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/rpc-subscriptions-spec@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/rpc-subscriptions@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@5.9.3)
@@ -5462,6 +6042,18 @@ snapshots:
       '@solana/nominal-types': 6.10.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
       '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transformers@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5503,6 +6095,20 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-types@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/fixed-points': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@5.9.3)
@@ -5535,12 +6141,49 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/signers@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/offchain-messages': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/subscribable@6.10.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@5.9.3)
       '@solana/promises': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/subscribable@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/subscriptions@0.5.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana-program/token': 0.15.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.14.1(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-rpc': 0.15.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/program-client-core': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+      - '@solana/zk-sdk'
+      - fastestsmallesttextencoderdecoder
+      - typescript
 
   '@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -5561,6 +6204,19 @@ snapshots:
       '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
       '@solana/errors': 6.10.0(typescript@5.9.3)
       '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/sysvars@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5601,6 +6257,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/transaction-messages@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -5615,6 +6287,25 @@ snapshots:
       '@solana/nominal-types': 6.10.0(typescript@5.9.3)
       '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@x402/core': file:.x402-vendor/x402-core-2.23.0.tgz
   '@hono/node-server': '>=2.0.10'
   fast-uri: '>=4.1.4'
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   ip-address: '>=10.3.1'
   js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'
@@ -91,7 +91,7 @@ importers:
         version: 25.5.0
       mppx:
         specifier: ^0.8.15
-        version: 0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
+        version: 0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
       surfpool-sdk:
         specifier: ^1.2.0
         version: 1.2.0
@@ -118,7 +118,7 @@ importers:
         version: 6.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       mppx:
         specifier: '>=0.5.5'
-        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
+        version: 0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
     devDependencies:
       '@solana/mpp':
         specifier: workspace:^
@@ -533,7 +533,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3044,8 +3044,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3552,7 +3552,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -3571,7 +3571,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
       viem: '>=2.54.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -4737,9 +4737,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@2.0.11(hono@4.13.1)':
+  '@hono/node-server@2.0.11(hono@4.13.7)':
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
 
   '@humanfs/core@0.19.1': {}
 
@@ -4971,7 +4971,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.13.1)
+      '@hono/node-server': 2.0.11(hono@4.13.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4981,7 +4981,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7426,7 +7426,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.13.1: {}
+  hono@4.13.7: {}
 
   html-escaper@2.0.2: {}
 
@@ -8062,7 +8062,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
-  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
+  mppx@0.5.5(@cfworker/json-schema@4.1.1)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
@@ -8073,14 +8073,14 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1
-      hono: 4.13.1
+      hono: 4.13.7
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - openapi-types
       - supports-color
       - typescript
 
-  mppx@0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.1)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
+  mppx@0.8.15(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.13.7)(typescript@5.9.3)(viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0
@@ -8091,7 +8091,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1
-      hono: 4.13.1
+      hono: 4.13.7
     transitivePeerDependencies:
       - typescript
 

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ overrides:
   # fast-uri/hono/ip-address floors below track advisories reached via
   # @modelcontextprotocol/sdk (see `pnpm why <pkg>`); bump as new CVEs land.
   fast-uri: '>=4.1.4'
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   ip-address: '>=10.3.1'
   js-yaml: '>=5.2.2'
   path-to-regexp: '>=8.4.0'


### PR DESCRIPTION
## Summary

- enforce strict subscription activation instruction and account allowlists in Rust and TypeScript, including binding the transfer receiver to the challenged recipient
- add challenge-bound pending/confirmed replay state for TypeScript charge and subscription settlement, with idempotent receipt recovery
- require Lua x402 confirmation before success and preserve safe pending/confirmed recovery state
- keep Python x402 replay markers durable after ambiguous post-broadcast confirmation failures
- refresh the subscriptions IDL and Codama-generated Rust client from upstream v0.5.0, and use the latest official TypeScript account decoder
- bump each SDK incrementally for the next release: TypeScript 0.10.0, Python 0.8.0, and Rust 0.7.0
- refresh the harness lockfile and raise the Hono override to its patched 4.13.5 release

Compatibility note: the v0.5.0 TypeScript subscriptions package declares a Kit 7 peer while MPP remains on Kit 6.10. This PR only uses its isolated account decoder; instruction-builder adoption should land with the Kit 7 migration.

## Test Plan

- TypeScript: 528 tests; lint, typecheck, formatting, and both package builds
- Rust: 73 subscription-focused tests with client and server features
- Python: 1242 passed, 1 skipped; Pyright and Ruff checks clean for the touched files
- Lua: lint clean; 603 passed, 1 skipped
- TypeScript harness: typecheck and server-package startup import
- production dependency audit: no known vulnerabilities
- existing Go, Kotlin, PHP, Ruby, and Swift CI suites
