### PR TITLE
fix(mpp): validate Python expires as RFC 3339

### DIFF
--- a/python/src/solana_pay_kit/protocols/mpp/core/types.py
+++ b/python/src/solana_pay_kit/protocols/mpp/core/types.py
@@ -53,7 +53,10 @@ def _parse_rfc3339(value: str) -> datetime:
     parsed = datetime.fromisoformat(normalized)
     if leap_second:
         # RFC 3339 §5.7: a leap second only ever ends a UTC month.
-        utc = parsed.astimezone(UTC)
+        try:
+            utc = parsed.astimezone(UTC)
+        except OverflowError as exc:
+            raise ValueError(f"leap second not representable in UTC: {value!r}") from exc
         if (utc.hour, utc.minute) != (23, 59) or utc.day != calendar.monthrange(utc.year, utc.month)[1]:
             raise ValueError(f"leap second not at a UTC month end: {value!r}")
     return parsed

--- a/python/src/solana_pay_kit/protocols/mpp/core/types.py
+++ b/python/src/solana_pay_kit/protocols/mpp/core/types.py
@@ -31,6 +31,8 @@ def _parse_rfc3339(value: str) -> datetime:
 
     Raises :class:`ValueError` on anything looser than RFC 3339 (e.g. a space
     instead of ``T``, a missing offset, or an invalid month/day combination).
+    Accepts ``23:59:60`` at a UTC month end, which §5.7 requires rather than
+    permits, and clamps it to ``23:59:59.999999``.
     Mirrors the F6 lock that landed on Ruby + PHP + Lua in PR #99 / #102.
     """
     match = _RFC3339_RE.match(value)
@@ -50,7 +52,7 @@ def _parse_rfc3339(value: str) -> datetime:
         normalized = normalized[: match.start(6)] + "59.999999" + normalized[secfrac_end:]
     parsed = datetime.fromisoformat(normalized)
     if leap_second:
-        # RFC 3339 §5.8: a leap second only ever ends a UTC month.
+        # RFC 3339 §5.7: a leap second only ever ends a UTC month.
         utc = parsed.astimezone(UTC)
         if (utc.hour, utc.minute) != (23, 59) or utc.day != calendar.monthrange(utc.year, utc.month)[1]:
             raise ValueError(f"leap second not at a UTC month end: {value!r}")

--- a/python/src/solana_pay_kit/protocols/mpp/core/types.py
+++ b/python/src/solana_pay_kit/protocols/mpp/core/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import calendar
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -35,13 +36,25 @@ def _parse_rfc3339(value: str) -> datetime:
     match = _RFC3339_RE.match(value)
     if match is None:
         raise ValueError(f"not a valid RFC 3339 timestamp: {value!r}")
+    if match.group(8) is not None and (int(match.group(9)) > 23 or int(match.group(10)) > 59):
+        raise ValueError(f"offset out of range: {value!r}")
     # Delegate the calendar arithmetic to datetime.fromisoformat after we have
     # confirmed the lexical grammar. Normalize the case of the T/Z markers so
     # fromisoformat (Python 3.11+) accepts the value.
     normalized = value.replace("t", "T").replace("z", "Z")
     if normalized.endswith("Z"):
         normalized = normalized[:-1] + "+00:00"
-    return datetime.fromisoformat(normalized)
+    leap_second = match.group(6) == "60"
+    if leap_second:
+        secfrac_end = match.end(7) if match.group(7) else match.end(6)
+        normalized = normalized[: match.start(6)] + "59.999999" + normalized[secfrac_end:]
+    parsed = datetime.fromisoformat(normalized)
+    if leap_second:
+        # RFC 3339 §5.8: a leap second only ever ends a UTC month.
+        utc = parsed.astimezone(UTC)
+        if (utc.hour, utc.minute) != (23, 59) or utc.day != calendar.monthrange(utc.year, utc.month)[1]:
+            raise ValueError(f"leap second not at a UTC month end: {value!r}")
+    return parsed
 
 
 @dataclass

--- a/python/tests/test_expires.py
+++ b/python/tests/test_expires.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+
 from solana_pay_kit.protocols.mpp.core.expires import days, hours, minutes, seconds, weeks
 
 
@@ -130,3 +132,37 @@ class TestStrictRFC3339:
         # Lexically valid RFC 3339 shape, but month 13 fails the calendar
         # check delegated to datetime.fromisoformat.
         assert self._make_challenge("2099-13-01T00:00:00Z").is_expired() is True
+
+    def _parse(self, value: str) -> datetime:
+        from solana_pay_kit.protocols.mpp.core.types import _parse_rfc3339
+
+        return _parse_rfc3339(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "1990-12-31T23:59:60Z",
+            "1990-12-31T15:59:60-08:00",
+            "1998-12-31T23:59:60Z",
+            "1998-12-31T15:59:60.123-08:00",
+            "1999-01-01T00:59:60+01:00",
+            "1972-06-30T23:59:60Z",
+        ],
+    )
+    def test_leap_second_at_utc_month_end_accepted(self, value):
+        parsed = self._parse(value).astimezone(UTC)
+        assert (parsed.hour, parsed.minute, parsed.second) == (23, 59, 59)
+
+    @pytest.mark.parametrize("value", ["1998-12-31T23:58:60Z", "2026-06-15T12:30:60Z"])
+    def test_leap_second_away_from_a_utc_month_end_rejected(self, value):
+        with pytest.raises(ValueError):
+            self._parse(value)
+
+    @pytest.mark.parametrize("value", ["1990-12-31T10:00:00+10:60", "2026-01-29T12:00:00+00:60"])
+    def test_offset_minute_out_of_range_rejected(self, value):
+        with pytest.raises(ValueError):
+            self._parse(value)
+
+    def test_year_0000_rejected(self):
+        with pytest.raises(ValueError):
+            self._parse("0000-01-01T00:00:00Z")

--- a/python/tests/test_expires.py
+++ b/python/tests/test_expires.py
@@ -158,6 +158,11 @@ class TestStrictRFC3339:
         with pytest.raises(ValueError):
             self._parse(value)
 
+    @pytest.mark.parametrize("value", ["0001-01-01T00:59:60+01:00", "9999-12-31T23:59:60-00:01"])
+    def test_leap_second_spilling_past_datetime_range_rejected(self, value):
+        with pytest.raises(ValueError):
+            self._parse(value)
+
     @pytest.mark.parametrize(
         "value",
         ["1990-12-31T10:00:00+10:60", "2026-01-29T12:00:00+00:60", "2026-01-29T12:00:00+24:00"],

--- a/python/tests/test_expires.py
+++ b/python/tests/test_expires.py
@@ -153,16 +153,20 @@ class TestStrictRFC3339:
         parsed = self._parse(value).astimezone(UTC)
         assert (parsed.hour, parsed.minute, parsed.second) == (23, 59, 59)
 
-    @pytest.mark.parametrize("value", ["1998-12-31T23:58:60Z", "2026-06-15T12:30:60Z"])
+    @pytest.mark.parametrize("value", ["1998-12-31T23:58:60Z", "1998-12-30T23:59:60Z"])
     def test_leap_second_away_from_a_utc_month_end_rejected(self, value):
         with pytest.raises(ValueError):
             self._parse(value)
 
-    @pytest.mark.parametrize("value", ["1990-12-31T10:00:00+10:60", "2026-01-29T12:00:00+00:60"])
-    def test_offset_minute_out_of_range_rejected(self, value):
-        with pytest.raises(ValueError):
+    @pytest.mark.parametrize(
+        "value",
+        ["1990-12-31T10:00:00+10:60", "2026-01-29T12:00:00+00:60", "2026-01-29T12:00:00+24:00"],
+    )
+    def test_offset_out_of_range_rejected(self, value):
+        with pytest.raises(ValueError, match="offset out of range"):
             self._parse(value)
 
     def test_year_0000_rejected(self):
+        """datetime.MINYEAR is 1, so 0000 raises here while rfc3339.test.ts:44 accepts it."""
         with pytest.raises(ValueError):
             self._parse("0000-01-01T00:00:00Z")


### PR DESCRIPTION
## Summary

Addresses the Python issues in #284, landing the same rule as #313 does for TypeScript. `_parse_rfc3339` accepted three things RFC 3339 does not, and rejected one it does:

- **`23:59:60` is now accepted at a UTC month end** and clamped to `23:59:59.999999`, matching the leap-second handling in #313. A leap second anywhere else (`23:58:60`, a non-month-end day) raises.
- **Offset bounds are checked on the regex groups before `fromisoformat`.** This matters: `fromisoformat` normalises `+10:60` to `+11:00` rather than rejecting it, so the lexical check has to come first. `+24:00` and `+00:60` now raise.
- **The `year_0000` vector stays red on Python.** `datetime` cannot represent year 0, so it raises — an unparseable expiry reads as expired, fail-closed. Pinned by a test, so it's a decision rather than a gap. #313 asserts the opposite for TypeScript (`rfc3339.test.ts:44`), so that row of #284 will not agree across the two SDKs.

One function edited in place — no new module, no call-site churn.

## Test Plan

- `pytest python/tests` — **1255 passed, 1 skipped**
- `ruff check src tests` — all checks passed; `ruff format --check` — clean
- `pyright` — 0 errors
- 11 new cases in `TestStrictRFC3339`: leap second accepted at month end (6 offsets), rejected away from one, rejected when it spills past `datetime`'s range, offset out of range (3), and year `0000`.
