### PR TITLE
fix(mpp): validate Go expires as RFC 3339

### DIFF
--- a/go/protocols/mpp/wire/challenge.go
+++ b/go/protocols/mpp/wire/challenge.go
@@ -13,9 +13,15 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
+	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// time.Parse alone is looser than RFC 3339 §5.6 (comma secfrac, offsets past
+// 23:59) and stricter (no leap second); the grammar gate closes that gap.
+var rfc3339DateTime = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:(\d{2})(?:\.\d+)?(?:[Zz]|[+-](\d{2}):(\d{2}))$`)
 
 // PaymentChallenge is sent by a server via WWW-Authenticate.
 type PaymentChallenge struct {
@@ -111,11 +117,40 @@ func (c PaymentChallenge) IsExpired(now time.Time) bool {
 	if strings.TrimSpace(c.Expires) == "" {
 		return false
 	}
-	expiresAt, err := time.Parse(time.RFC3339, c.Expires)
+	expiresAt, err := parseRFC3339(c.Expires)
 	if err != nil {
 		return true
 	}
 	return !expiresAt.After(now.UTC())
+}
+
+// parseRFC3339 matches the TypeScript and Python SDKs: a leap second is
+// accepted only where it ends a UTC month (§5.7) and clamps to the last
+// instant of :59, so every SDK reads the same expiry off the same wire.
+func parseRFC3339(value string) (time.Time, error) {
+	m := rfc3339DateTime.FindStringSubmatch(value)
+	if m == nil {
+		return time.Time{}, fmt.Errorf("not an RFC 3339 date-time: %q", value)
+	}
+	if m[2] > "23" || m[3] > "59" {
+		return time.Time{}, fmt.Errorf("offset out of range: %q", value)
+	}
+	leapSecond := m[1] == "60"
+	if leapSecond {
+		value = value[:17] + "59" + value[19:]
+	}
+	parsed, err := time.Parse(time.RFC3339, strings.ToUpper(value))
+	if err != nil {
+		return time.Time{}, err
+	}
+	if leapSecond {
+		utc := parsed.UTC()
+		if utc.Hour() != 23 || utc.Minute() != 59 || utc.AddDate(0, 0, 1).Month() == utc.Month() {
+			return time.Time{}, fmt.Errorf("leap second not at a UTC month end: %q", value)
+		}
+		parsed = parsed.Truncate(time.Second).Add(time.Second - time.Nanosecond)
+	}
+	return parsed, nil
 }
 
 // NewPaymentCredential creates a typed credential payload.

--- a/go/protocols/mpp/wire/challenge_test.go
+++ b/go/protocols/mpp/wire/challenge_test.go
@@ -89,6 +89,35 @@ func TestIsExpiredRFC3339Corpus(t *testing.T) {
 	}
 }
 
+// The leap second maps to the last nanosecond of :59, not the start of it, so
+// the challenge is still live at .999999998 and dead from .999999999 on
+// (IsExpired is inclusive at equality). One nanosecond either way pins it.
+func TestIsExpiredLeapSecondBoundary(t *testing.T) {
+	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1"})
+	mapped := time.Date(1990, 12, 31, 23, 59, 59, 999999999, time.UTC)
+	tests := []struct {
+		name    string
+		expires string
+		now     time.Time
+		expired bool
+	}{
+		{"z_one_ns_before_mapped", "1990-12-31T23:59:60Z", mapped.Add(-time.Nanosecond), false},
+		{"z_at_mapped", "1990-12-31T23:59:60Z", mapped, true},
+		{"z_one_ns_after_mapped", "1990-12-31T23:59:60Z", mapped.Add(time.Nanosecond), true},
+		{"offset_one_ns_before_mapped", "1990-12-31T15:59:60-08:00", mapped.Add(-time.Nanosecond), false},
+		{"offset_at_mapped", "1990-12-31T15:59:60-08:00", mapped, true},
+		{"offset_one_ns_after_mapped", "1990-12-31T15:59:60-08:00", mapped.Add(time.Nanosecond), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			challenge := NewChallengeWithSecretFull("s", "r", NewMethodName("solana"), NewIntentName("charge"), request, tc.expires, "", "", nil)
+			if expired := challenge.IsExpired(tc.now); expired != tc.expired {
+				t.Fatalf("IsExpired(%q) at %s = %v, want %v", tc.expires, tc.now.Format(time.RFC3339Nano), expired, tc.expired)
+			}
+		})
+	}
+}
+
 func TestIsExpiredInvalidTimestamp(t *testing.T) {
 	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1"})
 	challenge := NewChallengeWithSecretFull("s", "r", NewMethodName("solana"), NewIntentName("charge"), request, "not-a-date", "", "", nil)

--- a/go/protocols/mpp/wire/challenge_test.go
+++ b/go/protocols/mpp/wire/challenge_test.go
@@ -75,6 +75,8 @@ func TestIsExpiredRFC3339Corpus(t *testing.T) {
 		{"rfc_5_8_example_leap_second_z", "1990-12-31T23:59:60Z", true},
 		{"secfrac_comma_separator", "2021-09-29T16:04:33,5Z", false},
 		{"leap_second_not_at_utc_month_end", "1998-12-31T23:58:60Z", false},
+		{"leap_second_not_on_utc_month_last_day", "1998-12-30T23:59:60Z", false},
+		{"leap_second_not_in_utc_hour_23", "1998-12-31T22:59:60Z", false},
 		{"day_out_of_range", "2026-02-30T00:00:00Z", false},
 	}
 	for _, tc := range tests {

--- a/go/protocols/mpp/wire/challenge_test.go
+++ b/go/protocols/mpp/wire/challenge_test.go
@@ -51,6 +51,42 @@ func TestIsExpiredEmptyString(t *testing.T) {
 	}
 }
 
+func TestIsExpiredRFC3339Corpus(t *testing.T) {
+	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1"})
+	before := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		expires string
+		accept  bool
+	}{
+		{"jsts_date_time_005", "1998-12-31T23:59:60Z", true},
+		{"jsts_date_time_006", "1998-12-31T15:59:60.123-08:00", true},
+		{"jsts_date_time_011", "1990-12-31T15:59:59-24:00", false},
+		{"jsts_date_time_015", "1990-12-31T10:00:00+10:60", false},
+		{"jsts_date_time_017", "1963-06-19t08:30:06.283185z", true},
+		{"leap_second_june_month_end", "1972-06-30T23:59:60Z", true},
+		{"leap_second_offset_rolls_local_date_forward", "1999-01-01T00:59:60+01:00", true},
+		{"lowercase_t_and_z", "1985-04-12t23:20:50.52z", true},
+		{"lowercase_t_separator", "1985-04-12t23:20:50.52Z", true},
+		{"lowercase_z_offset", "1985-04-12T23:20:50.52z", true},
+		{"offset_hour_out_of_range", "2026-01-29T12:00:00+24:00", false},
+		{"offset_minute_out_of_range", "2026-01-29T12:00:00+00:60", false},
+		{"rfc_5_8_example_leap_second_offset", "1990-12-31T15:59:60-08:00", true},
+		{"rfc_5_8_example_leap_second_z", "1990-12-31T23:59:60Z", true},
+		{"secfrac_comma_separator", "2021-09-29T16:04:33,5Z", false},
+		{"leap_second_not_at_utc_month_end", "1998-12-31T23:58:60Z", false},
+		{"day_out_of_range", "2026-02-30T00:00:00Z", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			challenge := NewChallengeWithSecretFull("s", "r", NewMethodName("solana"), NewIntentName("charge"), request, tc.expires, "", "", nil)
+			if expired := challenge.IsExpired(before); expired == tc.accept {
+				t.Fatalf("IsExpired(%q) = %v, want %v", tc.expires, expired, !tc.accept)
+			}
+		})
+	}
+}
+
 func TestIsExpiredInvalidTimestamp(t *testing.T) {
 	request, _ := NewBase64URLJSONValue(map[string]string{"amount": "1"})
 	challenge := NewChallengeWithSecretFull("s", "r", NewMethodName("solana"), NewIntentName("charge"), request, "not-a-date", "", "", nil)


### PR DESCRIPTION
Addresses the Go issues in #284.

## Summary

`PaymentChallenge.IsExpired` parsed `expires` with `time.Parse(time.RFC3339, …)`, which is
looser than RFC 3339 §5.6 in two places and stricter in one; against the shared harness
corpus Go diverged on 16 vectors. This closes 15 by putting a §5.6 grammar in front of
`time.Parse`, the same shape as #313 (TypeScript) and #315 (Python):

- accepts lowercase `t` and `z` (§5.6 note)
- rejects a comma secfrac separator
- rejects offsets past ±23:59, which `time.Parse` let through
- accepts `:60` only at a UTC month end (§5.7), clamped to the last instant of `:59`,
  as TypeScript and Python do

Anything refused reads as expired — fail-closed, as before.

**Not changed: an empty `expires` still reads as not expired.** The corpus rejects the
empty string, but `client/charge.go` says the protocol allows omitting it, and flipping
it fails 11 client signing tests. Left as-is; flagged on #284 for a decision.

## Test Plan

- `TestIsExpiredRFC3339Corpus`: 15 corpus vectors + 2 branch rows. On `main` 15/15 fail; here 0.
- `go test ./...` 21 ok · `golangci-lint run` 0 issues · `gofmt -l` empty · coverage 92.1% (floor 91)
- No vector file added; `expires.json` lands with #282.
