### PR TITLE
fix(mpp): validate Ruby expires as RFC 3339

### DIFF
--- a/ruby/lib/pay_core/rfc3339_parser.rb
+++ b/ruby/lib/pay_core/rfc3339_parser.rb
@@ -8,15 +8,15 @@ module PayCore
   #
   # @see https://datatracker.ietf.org/doc/html/rfc3339 RFC 3339 Date and Time on the Internet
   module Rfc3339Parser
-    # Strict RFC 3339 date-time (sec 5.6) without leap-second support
-    # at the parse layer. Year is exactly 4 digits; T literal accepted
-    # upper or lower (per parse SHOULD); fractional seconds 1..9 digits.
+    # Strict RFC 3339 date-time (sec 5.6). Year is exactly 4 digits; T literal
+    # accepted upper or lower (per parse SHOULD); time-secfrac is "." 1*DIGIT,
+    # so the digit count is unbounded here and clamped after the match.
     REGEX = /\A
       (\d{4})-(\d{2})-(\d{2})         # full-date
       [Tt]
       (\d{2}):(\d{2}):(\d{2})         # partial-time
-      (?:\.(\d{1,9}))?                # time-secfrac
-      (Z|z|[+-]\d{2}:\d{2})           # time-offset
+      (?:\.(\d+))?                    # time-secfrac
+      (?:[Zz]|([+-]\d{2}):(\d{2}))    # time-offset
       \z/x
     private_constant :REGEX
 
@@ -35,22 +35,32 @@ module PayCore
       hour, minute, second = match[4].to_i, match[5].to_i, match[6].to_i
       return nil if month < 1 || month > 12
       return nil if day < 1 || day > 31
-      # RFC 3339 section 5.7 allows seconds = 60 for positive leap seconds;
-      # PHP, Lua, and Go SDKs all accept the value at parse-time. Reject only
-      # at 61 so a credential timestamped at exactly 23:59:60 UTC parses.
       return nil if hour > 23 || minute > 59 || second > 60
+      # time-numoffset bounds the offset at 23:59, but Time.iso8601 reads
+      # +00:60 as +01:00 — a silent hour shift in the instant an expiry is
+      # compared against, so the offset is ranged before it is delegated.
+      return nil if match[8] && (match[8].delete("+-").to_i > 23 || match[9].to_i > 59)
       return nil if year > 9999
       return nil unless Date.valid_date?(year, month, day)
 
-      # Time.iso8601 rejects lowercase 't' / 'z' separators that the regex
-      # above accepts (RFC 3339 sec 5.6 allows both cases; ISO 8601 strict
-      # requires uppercase). Normalize before delegating so a credential
-      # timestamped as ``2099-01-01t00:00:00z`` parses instead of
-      # falling into the rescue. PHP already does this; matching here.
-      normalized = value
-        .sub(/(\d)t(\d)/, "\\1T\\2")
-        .sub(/z\z/, "Z")
-      Time.iso8601(normalized)
+      # Rebuilt from the captures rather than delegated verbatim: Time.iso8601
+      # rejects the lowercase t/z that sec 5.6 allows, keeps sub-nanosecond
+      # secfrac as a Rational no other SDK can carry, and rolls seconds = 60
+      # forward into the next minute instead of clamping it.
+      leap_second = second == 60
+      secfrac = match[7] ? ".#{match[7][0, 9]}" : ""
+      secfrac = ".999999999" if leap_second
+      offset = match[8] ? "#{match[8]}:#{match[9]}" : "Z"
+      parsed = Time.iso8601("#{match[1]}-#{match[2]}-#{match[3]}T#{match[4]}:#{match[5]}:" \
+                            "#{leap_second ? "59" : match[6]}#{secfrac}#{offset}")
+      return parsed unless leap_second
+
+      # RFC 3339 sec 5.7: a leap second only ever ends a UTC month, and the
+      # offset is applied before that is judged. Matches the TypeScript SDK.
+      utc = parsed.getutc
+      return nil unless utc.hour == 23 && utc.min == 59 && utc.day == Date.new(utc.year, utc.month, -1).day
+
+      parsed
     rescue ArgumentError
       nil
     end

--- a/ruby/lib/pay_core/rfc3339_parser.rb
+++ b/ruby/lib/pay_core/rfc3339_parser.rb
@@ -10,7 +10,7 @@ module PayCore
   module Rfc3339Parser
     # Strict RFC 3339 date-time (sec 5.6). Year is exactly 4 digits; T literal
     # accepted upper or lower (per parse SHOULD); time-secfrac is "." 1*DIGIT,
-    # so the digit count is unbounded here and clamped after the match.
+    # so the digit count is unbounded here and truncated after the match.
     REGEX = /\A
       (\d{4})-(\d{2})-(\d{2})         # full-date
       [Tt]

--- a/ruby/lib/pay_core/rfc3339_parser.rb
+++ b/ruby/lib/pay_core/rfc3339_parser.rb
@@ -8,9 +8,7 @@ module PayCore
   #
   # @see https://datatracker.ietf.org/doc/html/rfc3339 RFC 3339 Date and Time on the Internet
   module Rfc3339Parser
-    # Strict RFC 3339 date-time (sec 5.6). Year is exactly 4 digits; T literal
-    # accepted upper or lower (per parse SHOULD); time-secfrac is "." 1*DIGIT,
-    # so the digit count is unbounded here and truncated after the match.
+    # Strict RFC 3339 date-time (sec 5.6); secfrac digits unbounded, truncated after the match.
     REGEX = /\A
       (\d{4})-(\d{2})-(\d{2})         # full-date
       [Tt]
@@ -36,17 +34,12 @@ module PayCore
       return nil if month < 1 || month > 12
       return nil if day < 1 || day > 31
       return nil if hour > 23 || minute > 59 || second > 60
-      # time-numoffset bounds the offset at 23:59, but Time.iso8601 reads
-      # +00:60 as +01:00 — a silent hour shift in the instant an expiry is
-      # compared against, so the offset is ranged before it is delegated.
       return nil if match[8] && (match[8].delete("+-").to_i > 23 || match[9].to_i > 59)
       return nil if year > 9999
       return nil unless Date.valid_date?(year, month, day)
 
-      # Rebuilt from the captures rather than delegated verbatim: Time.iso8601
-      # rejects the lowercase t/z that sec 5.6 allows, keeps sub-nanosecond
-      # secfrac as a Rational no other SDK can carry, and rolls seconds = 60
-      # forward into the next minute instead of clamping it.
+      # Time.iso8601 rejects lowercase t/z, reads +00:60 as +01:00 and rolls :60
+      # into the next minute, so the input is ranged and rebuilt before delegating.
       leap_second = second == 60
       secfrac = match[7] ? ".#{match[7][0, 9]}" : ""
       secfrac = ".999999999" if leap_second
@@ -55,8 +48,6 @@ module PayCore
                             "#{leap_second ? "59" : match[6]}#{secfrac}#{offset}")
       return parsed unless leap_second
 
-      # RFC 3339 sec 5.7: a leap second only ever ends a UTC month, and the
-      # offset is applied before that is judged. Matches the TypeScript SDK.
       utc = parsed.getutc
       return nil unless utc.hour == 23 && utc.min == 59 && utc.day == Date.new(utc.year, utc.month, -1).day
 

--- a/ruby/test/pay_core/expires_rfc3339_test.rb
+++ b/ruby/test/pay_core/expires_rfc3339_test.rb
@@ -57,11 +57,8 @@ class ExpiresRfc3339Test < Minitest::Test
     refute_nil parser.parse("2099-01-01T00:00:00-08:00") # negative offset
   end
 
-  # The 18 rows #284 lists as Ruby-divergent, keyed by the shared corpus's own
-  # vector names so a row here greps to a row there.
+  # The 18 vectors #284 lists as Ruby-divergent, keyed by corpus name.
   RFC3339_CORPUS = [
-    # time-secfrac is "." 1*DIGIT, so any digit count parses; digits past
-    # nanosecond precision are dropped and never decide the verdict.
     ["go_longfrac_10digits_0000000000", "2021-09-29T16:04:33.0000000000Z", true],
     ["go_longfrac_10digits_0000000001", "2021-09-29T16:04:33.0000000001Z", true],
     ["go_longfrac_10digits_0123456789", "2021-09-29T16:04:33.0123456789Z", true],
@@ -75,13 +72,9 @@ class ExpiresRfc3339Test < Minitest::Test
     ["jsts_date_time_026", "1985-04-12T00:59:59.999999999999999Z", true],
     ["secfrac_10_digits", "2026-01-29T12:00:00.1234567890Z", true],
     ["secfrac_19_digits_exceeds_int64", "2026-01-29T12:00:00.9999999999999999999Z", true],
-    # The offset applies first: seconds = 60 survives only where the instant is
-    # 23:59:60 UTC on the last day of a UTC month.
     ["jsts_date_time_008", "1998-12-31T23:58:60Z", false],
     ["jsts_date_time_009", "1998-12-31T22:59:60Z", false],
     ["leap_second_offset_rolls_local_date_forward_wrong_offset", "1999-01-01T00:59:60+02:00", false],
-    # time-numoffset bounds the offset at 23:59; Time.iso8601 silently reads
-    # +00:60 as +01:00, which shifts the instant an expiry is compared against.
     ["jsts_date_time_015", "1990-12-31T10:00:00+10:60", false],
     ["offset_minute_out_of_range", "2026-01-29T12:00:00+00:60", false]
   ].freeze
@@ -100,13 +93,10 @@ class ExpiresRfc3339Test < Minitest::Test
   def test_rfc3339_parser_leap_second_maps_to_the_last_instant_of_59
     parser = ::PayCore::Rfc3339Parser
     mapped = Time.utc(1998, 12, 31, 23, 59, 59, Rational(999_999_999, 1000))
-    # Both spellings of the same UTC month-end leap second, so the offset form
-    # is pinned as accepted and not merely as "not rejected by the clamp".
     assert_equal mapped, parser.parse("1998-12-31T23:59:60Z")
     assert_equal mapped, parser.parse("1999-01-01T00:59:60+01:00")
     assert_nil parser.parse("1998-12-30T23:59:60Z"), "leap second off the UTC month end"
-    # Truncation, not rounding: rounding would carry into the next second.
-    assert_equal Rational(999_999_999, 1_000_000_000), parser.parse("2021-09-29T16:04:33.9999999999Z").subsec
+    assert_equal Rational(999_999_999, 1_000_000_000), parser.parse("2021-09-29T16:04:33.9999999999Z").subsec, "truncated, not rounded"
   end
 
   def test_expires_strict_rfc3339_branches

--- a/ruby/test/pay_core/expires_rfc3339_test.rb
+++ b/ruby/test/pay_core/expires_rfc3339_test.rb
@@ -57,6 +57,57 @@ class ExpiresRfc3339Test < Minitest::Test
     refute_nil parser.parse("2099-01-01T00:00:00-08:00") # negative offset
   end
 
+  # The 18 rows #284 lists as Ruby-divergent, keyed by the shared corpus's own
+  # vector names so a row here greps to a row there.
+  RFC3339_CORPUS = [
+    # time-secfrac is "." 1*DIGIT, so any digit count parses; digits past
+    # nanosecond precision are dropped and never decide the verdict.
+    ["go_longfrac_10digits_0000000000", "2021-09-29T16:04:33.0000000000Z", true],
+    ["go_longfrac_10digits_0000000001", "2021-09-29T16:04:33.0000000001Z", true],
+    ["go_longfrac_10digits_0123456789", "2021-09-29T16:04:33.0123456789Z", true],
+    ["go_longfrac_10digits_1000000000", "2021-09-29T16:04:33.1000000000Z", true],
+    ["go_longfrac_10digits_1000000009", "2021-09-29T16:04:33.1000000009Z", true],
+    ["go_longfrac_10digits_9999999999", "2021-09-29T16:04:33.9999999999Z", true],
+    ["go_longfrac_11digits_00123456789", "2021-09-29T16:04:33.00123456789Z", true],
+    ["go_longfrac_11digits_10000000000", "2021-09-29T16:04:33.10000000000Z", true],
+    ["go_longfrac_12digits_000123456789", "2021-09-29T16:04:33.000123456789Z", true],
+    ["go_longfrac_16digits_9999999999999999", "2021-09-29T16:04:33.9999999999999999Z", true],
+    ["jsts_date_time_026", "1985-04-12T00:59:59.999999999999999Z", true],
+    ["secfrac_10_digits", "2026-01-29T12:00:00.1234567890Z", true],
+    ["secfrac_19_digits_exceeds_int64", "2026-01-29T12:00:00.9999999999999999999Z", true],
+    # The offset applies first: seconds = 60 survives only where the instant is
+    # 23:59:60 UTC on the last day of a UTC month.
+    ["jsts_date_time_008", "1998-12-31T23:58:60Z", false],
+    ["jsts_date_time_009", "1998-12-31T22:59:60Z", false],
+    ["leap_second_offset_rolls_local_date_forward_wrong_offset", "1999-01-01T00:59:60+02:00", false],
+    # time-numoffset bounds the offset at 23:59; Time.iso8601 silently reads
+    # +00:60 as +01:00, which shifts the instant an expiry is compared against.
+    ["jsts_date_time_015", "1990-12-31T10:00:00+10:60", false],
+    ["offset_minute_out_of_range", "2026-01-29T12:00:00+00:60", false]
+  ].freeze
+
+  def test_rfc3339_parser_conforms_to_the_shared_corpus
+    parser = ::PayCore::Rfc3339Parser
+    RFC3339_CORPUS.each do |name, input, accept|
+      if accept
+        refute_nil parser.parse(input), name
+      else
+        assert_nil parser.parse(input), name
+      end
+    end
+  end
+
+  def test_rfc3339_parser_leap_second_maps_to_the_last_instant_of_59
+    parser = ::PayCore::Rfc3339Parser
+    mapped = Time.utc(1998, 12, 31, 23, 59, 59, Rational(999_999_999, 1000))
+    # Both spellings of the same UTC month-end leap second, so the offset form
+    # is pinned as accepted and not merely as "not rejected by the clamp".
+    assert_equal mapped, parser.parse("1998-12-31T23:59:60Z")
+    assert_equal mapped, parser.parse("1999-01-01T00:59:60+01:00")
+    # Truncation, not rounding: rounding would carry into the next second.
+    assert_equal Rational(999_999_999, 1_000_000_000), parser.parse("2021-09-29T16:04:33.9999999999Z").subsec
+  end
+
   def test_expires_strict_rfc3339_branches
     # Lowercase t accepted.
     c1 = PayKit::Protocols::Mpp::Protocol::Core::Challenge.with_secret(secret_key: "s", realm: "api", method: "solana", intent: "charge", request: {}, expires: "2099-01-01t00:00:00Z")

--- a/ruby/test/pay_core/expires_rfc3339_test.rb
+++ b/ruby/test/pay_core/expires_rfc3339_test.rb
@@ -104,6 +104,7 @@ class ExpiresRfc3339Test < Minitest::Test
     # is pinned as accepted and not merely as "not rejected by the clamp".
     assert_equal mapped, parser.parse("1998-12-31T23:59:60Z")
     assert_equal mapped, parser.parse("1999-01-01T00:59:60+01:00")
+    assert_nil parser.parse("1998-12-30T23:59:60Z"), "leap second off the UTC month end"
     # Truncation, not rounding: rounding would carry into the next second.
     assert_equal Rational(999_999_999, 1_000_000_000), parser.parse("2021-09-29T16:04:33.9999999999Z").subsec
   end


### PR DESCRIPTION
Addresses the Ruby issues in #284.

## Summary

`PayCore::Rfc3339Parser.parse` diverged from the shared corpus on 18 vectors. Same rules as #313, #315 and #317:

- `time-secfrac` is `"." 1*DIGIT` — no digit cap; past nanoseconds, truncated not rounded.
- `:60` only at a UTC month end (§5.7), offset applied first, clamped to the last instant of `:59`.
- Offsets past ±23:59 rejected before `Time.iso8601`, which reads `+00:60` as `+01:00`.

Unparseable stays fail-closed. `headers.rb:85` raises on a bad receipt timestamp, so the two rejections above now raise there.

## Test Plan

18 corpus vectors under their corpus names, 0/18 on main → 18/18 here. `bundle exec ruby -Itest test/run.rb`: 452 runs, 0 failures. standardrb and bundle-audit clean.
