### PR TITLE
fix(mpp): validate Lua expires as RFC 3339

### DIFF
--- a/lua/pay_kit/protocols/mpp/expires.lua
+++ b/lua/pay_kit/protocols/mpp/expires.lua
@@ -21,33 +21,43 @@ local function days_in_month(year, month)
   return 31
 end
 
+-- RFC 3339 sec 5.7: `:60` is inserted only at 23:59:60 UTC on a month's last day. Offset first, so the check reads the instant denoted.
+local function is_leap_second_instant(year, month, day, hour, min, offset_secs)
+  local tod = hour * 3600 + min * 60 + offset_secs
+  if tod < 0 then
+    day, tod = day - 1, tod + 86400
+  elseif tod >= 86400 then
+    day, tod = day + 1, tod - 86400
+  end
+  if day < 1 then
+    month = month - 1
+    if month < 1 then month, year = 12, year - 1 end
+    day = days_in_month(year, month)
+  elseif day > days_in_month(year, month) then
+    day = 1
+    month = month + 1
+    if month > 12 then month, year = 1, year + 1 end
+  end
+  return tod == 86340 and day == days_in_month(year, month)
+end
+
 -- Strict RFC 3339 date-time grammar (sec 5.6).
--- Accepts: T/t separator, Z/z or +/-HH:MM offset, optional 1..9 digit fractional seconds.
+-- Accepts: T/t separator, Z/z or +/-HH:MM offset, `time-secfrac = "." 1*DIGIT` of any length.
 -- Rejects: missing time-offset, lowercase compat from older parser only, calendar dates that do not exist, year > 9999.
 function M.parse_rfc3339(value)
   if type(value) ~= 'string' then
     return nil, 'invalid RFC3339 timestamp'
   end
-  -- RFC 3339 sec 5.6 grammar: optional `time-secfrac = "." 1*DIGIT`. The dot must be
-  -- accompanied by at least one digit. Match the fractional component as one optional
-  -- group so a bare dot (e.g. "2099-01-01T00:00:00.Z") fails parsing rather than being
-  -- silently accepted as zero fractional seconds (diverges from PHP/Ruby strict parsers).
+  -- `time-secfrac = "." 1*DIGIT` (sec 5.6): no digit cap, a bare dot is still not a fraction, and the digits truncate, never round.
   local year, month, day, hour, min, sec, rest = value:match(
     '^(%d%d%d%d)%-(%d%d)%-(%d%d)[Tt](%d%d):(%d%d):(%d%d)(.*)$'
   )
   if not year then
     return nil, 'invalid RFC3339 timestamp'
   end
-  local frac, offset = rest:match('^%.(%d+)([Zz%+%-][%d:]*)$')
-  if not frac then
-    frac = ''
-    offset = rest:match('^([Zz%+%-][%d:]*)$')
-    if not offset then
-      return nil, 'invalid RFC3339 timestamp'
-    end
-  end
-  if #frac > 9 then
-    return nil, 'fractional seconds exceed 9 digits'
+  local offset = rest:match('^%.%d+([Zz%+%-][%d:]*)$') or rest:match('^([Zz%+%-][%d:]*)$')
+  if not offset then
+    return nil, 'invalid RFC3339 timestamp'
   end
   year = tonumber(year)
   month = tonumber(month)
@@ -62,10 +72,6 @@ function M.parse_rfc3339(value)
   if month < 1 or month > 12 then
     return nil, 'invalid RFC3339 month'
   end
-  -- RFC 3339 §5.7 allows sec = 60 for positive leap seconds. The
-  -- broader RFC requires that a leap second be inserted only at
-  -- 23:59:60 UTC; we accept the value at the parser level and let
-  -- downstream consumers reject the rare time-of-day combinations.
   if hour > 23 or min > 59 or sec > 60 then
     return nil, 'invalid RFC3339 time-of-day'
   end
@@ -90,6 +96,10 @@ function M.parse_rfc3339(value)
     if sign == '+' then
       offset_secs = -offset_secs
     end
+  end
+
+  if sec == 60 and not is_leap_second_instant(year, month, day, hour, min, offset_secs) then
+    return nil, 'invalid RFC3339 leap second'
   end
 
   local days = days_from_civil(year, month, day)

--- a/lua/tests/expires_rfc3339_spec.lua
+++ b/lua/tests/expires_rfc3339_spec.lua
@@ -36,11 +36,9 @@ t.test('expires.parse_rfc3339 rejects non-string input', function()
   t.assert_true(err ~= nil)
 end)
 
-t.test('expires.parse_rfc3339 rejects fractional seconds longer than 9 digits', function()
+t.test('expires.parse_rfc3339 accepts fractional seconds longer than 9 digits', function()
   local expires = require('pay_kit.protocols.mpp.expires')
-  local value, err = expires.parse_rfc3339('2099-01-01T00:00:00.1234567890Z')
-  t.assert_true(value == nil)
-  t.assert_true(err and err:find('fractional'))
+  t.assert_equal(expires.parse_rfc3339('2099-01-01T00:00:00.1234567890Z'), 4070908800)
 end)
 
 t.test('expires.parse_rfc3339 rejects out-of-range offset hours', function()
@@ -59,4 +57,58 @@ end)
 t.test('expires.is_expired returns true on unparseable input', function()
   local expires = require('pay_kit.protocols.mpp.expires')
   t.assert_equal(expires.is_expired('not-a-timestamp', 0), true)
+end)
+
+-- solana-foundation/pay-kit#284, the Lua rows: 13 RC-3 (`time-secfrac` is
+-- `"." 1*DIGIT` with no upper bound, RFC 3339 sec 5.6) and 3 RC-2 (`:60` is a
+-- positive leap second only at 23:59:60 UTC on a month's last day, sec 5.7).
+-- One test per checkbox row, named for the vector.
+
+local RC3_ACCEPT = {
+  { 'go_longfrac_10digits_0000000000', '2021-09-29T16:04:33.0000000000Z' },
+  { 'go_longfrac_10digits_0000000001', '2021-09-29T16:04:33.0000000001Z' },
+  { 'go_longfrac_10digits_0123456789', '2021-09-29T16:04:33.0123456789Z' },
+  { 'go_longfrac_10digits_1000000000', '2021-09-29T16:04:33.1000000000Z' },
+  { 'go_longfrac_10digits_1000000009', '2021-09-29T16:04:33.1000000009Z' },
+  { 'go_longfrac_10digits_9999999999', '2021-09-29T16:04:33.9999999999Z' },
+  { 'go_longfrac_11digits_00123456789', '2021-09-29T16:04:33.00123456789Z' },
+  { 'go_longfrac_11digits_10000000000', '2021-09-29T16:04:33.10000000000Z' },
+  { 'go_longfrac_12digits_000123456789', '2021-09-29T16:04:33.000123456789Z' },
+  { 'go_longfrac_16digits_9999999999999999', '2021-09-29T16:04:33.9999999999999999Z' },
+  { 'jsts_date_time_026', '1985-04-12T00:59:59.999999999999999Z', 482115599 },
+  { 'secfrac_10_digits', '2026-01-29T12:00:00.1234567890Z', 1769688000 },
+  { 'secfrac_19_digits_exceeds_int64', '2026-01-29T12:00:00.9999999999999999999Z', 1769688000 },
+}
+
+local RC2_REJECT = {
+  { 'jsts_date_time_008', '1998-12-31T23:58:60Z' },
+  { 'jsts_date_time_009', '1998-12-31T22:59:60Z' },
+  { 'leap_second_offset_rolls_local_date_forward_wrong_offset', '1999-01-01T00:59:60+02:00' },
+}
+
+for _, row in ipairs(RC3_ACCEPT) do
+  t.test('#284 RC-3 ' .. row[1] .. ' parses and truncates to whole seconds', function()
+    local expires = require('pay_kit.protocols.mpp.expires')
+    t.assert_equal(expires.parse_rfc3339(row[2]), row[3] or 1632931473, row[1])
+  end)
+end
+
+for _, row in ipairs(RC2_REJECT) do
+  t.test('#284 RC-2 ' .. row[1] .. ' is rejected as a non-leap-second :60', function()
+    local expires = require('pay_kit.protocols.mpp.expires')
+    local value, err = expires.parse_rfc3339(row[2])
+    t.assert_true(value == nil, row[1])
+    t.assert_true(err and err:find('leap second'), row[1])
+  end)
+end
+
+t.test('#284 the leap seconds the corpus accepts still parse', function()
+  -- Not Lua divergences; pinned so the RC-2 rule cannot over-reject.
+  local expires = require('pay_kit.protocols.mpp.expires')
+  for _, value in ipairs({
+    '1998-12-31T23:59:60Z', '1998-12-31T15:59:60.123-08:00', '1972-06-30T23:59:60Z',
+    '1999-01-01T00:59:60+01:00', '1990-12-31T15:59:60-08:00', '1990-12-31T23:59:60Z',
+  }) do
+    t.assert_true(expires.parse_rfc3339(value) ~= nil, value)
+  end
 end)

--- a/lua/tests/expires_rfc3339_spec.lua
+++ b/lua/tests/expires_rfc3339_spec.lua
@@ -59,10 +59,7 @@ t.test('expires.is_expired returns true on unparseable input', function()
   t.assert_equal(expires.is_expired('not-a-timestamp', 0), true)
 end)
 
--- solana-foundation/pay-kit#284, the Lua rows: 13 RC-3 (`time-secfrac` is
--- `"." 1*DIGIT` with no upper bound, RFC 3339 sec 5.6) and 3 RC-2 (`:60` is a
--- positive leap second only at 23:59:60 UTC on a month's last day, sec 5.7).
--- One test per checkbox row, named for the vector.
+-- The Lua rows on issue #284: 13 RC-3 (secfrac digit cap) and 3 RC-2 (:60 off a leap-second instant), one test per row.
 
 local RC3_ACCEPT = {
   { 'go_longfrac_10digits_0000000000', '2021-09-29T16:04:33.0000000000Z' },
@@ -103,7 +100,6 @@ for _, row in ipairs(RC2_REJECT) do
 end
 
 t.test('#284 the leap seconds the corpus accepts still parse', function()
-  -- Not Lua divergences; pinned so the RC-2 rule cannot over-reject.
   local expires = require('pay_kit.protocols.mpp.expires')
   for _, value in ipairs({
     '1998-12-31T23:59:60Z', '1998-12-31T15:59:60.123-08:00', '1972-06-30T23:59:60Z',
@@ -111,4 +107,10 @@ t.test('#284 the leap seconds the corpus accepts still parse', function()
   }) do
     t.assert_true(expires.parse_rfc3339(value) ~= nil, value)
   end
+end)
+
+t.test('#284 RC-2 an offset that rolls the UTC day forward off the month end rejects', function()
+  -- 1998-12-31T23:59:60-08:00 is 1999-01-01T07:59:60Z, not a leap-second instant.
+  local expires = require('pay_kit.protocols.mpp.expires')
+  t.assert_true(expires.parse_rfc3339('1998-12-31T23:59:60-08:00') == nil)
 end)


### PR DESCRIPTION
## Summary

Conform `expires.parse_rfc3339` to the #284 vectors (16 added, all passing).

- Leap second: `:60` parses only at 23:59:60 UTC on a month's last day (RFC 3339 §5.7); the offset is applied before the check, so offset forms of a real leap instant pass and non-instants are rejected.
- Fractional seconds: accept `1*DIGIT` instead of capping at 9; truncated to whole seconds as before.
- One leap rule at one site; no other parser behaviour changed.

## Test Plan

- `luacheck pay_kit/ plugins/ tests/` — 0 warnings / 0 errors
- `busted` via `tests/run.lua` — 623 pass / 1 skip / 0 fail, line coverage 90.75 % (floor 90)
- Vectors mirror the Go/Ruby/Python/PHP rows from #284